### PR TITLE
Refactor: Remove postgres dependencies from most extenddb commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ __pycache__/
 .coverage
 dist/
 .venv/
+.idea/
+*.iml
 pdfs/
 docs/rendered/
 discussions/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,7 @@ dependencies = [
  "syslog-tracing",
  "time",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -955,11 +956,14 @@ dependencies = [
  "base64 0.22.1",
  "bigdecimal",
  "extenddb-core",
+ "futures",
  "inventory",
  "serde_json",
  "thiserror 2.0.18",
  "time",
+ "toml",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -975,6 +979,7 @@ dependencies = [
  "extenddb-auth",
  "extenddb-core",
  "extenddb-storage",
+ "futures",
  "inventory",
  "rand 0.9.4",
  "serde",
@@ -1053,6 +1058,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1117,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,8 +1145,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ anyhow = "1"
 # Async
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
+futures = "0.3"
 
 # HTTP
 axum = { version = "0.8", features = ["macros"] }

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -27,6 +27,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
 time = { workspace = true }
+toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 syslog-tracing = { workspace = true }

--- a/crates/bin/src/cmd_catalog_check.rs
+++ b/crates/bin/src/cmd_catalog_check.rs
@@ -65,7 +65,7 @@ pub async fn run(args: CatalogCheckArgs) -> anyhow::Result<()> {
     // Connect to catalog.
     let catalog_pool = PgPoolOptions::new()
         .max_connections(2)
-        .connect(&app_config.storage.postgres.connection_string)
+        .connect(app_config.storage.connection_config())
         .await
         .map_err(|e| anyhow::anyhow!("Cannot connect to catalog: {e}"))?;
     println!("Connected to catalog.");

--- a/crates/bin/src/cmd_destroy.rs
+++ b/crates/bin/src/cmd_destroy.rs
@@ -6,9 +6,6 @@
 //! Reads config, enumerates tables, requires `--yes` to confirm, drops both databases.
 
 use clap::Args;
-use extenddb_storage::bootstrapper::{BootstrapConfig, Bootstrapper};
-use extenddb_storage_postgres::PostgresBootstrapper;
-use extenddb_storage_postgres::parse_connection_string;
 
 use crate::config;
 
@@ -41,34 +38,28 @@ pub async fn run(args: DestroyArgs) -> anyhow::Result<()> {
         );
     }
     let app_config = config::load(&args.config)?;
-    let parts = parse_connection_string(&app_config.storage.postgres.connection_string)?;
+    let backend = &app_config.storage._backend;
 
-    // Defense-in-depth: validate identifiers used in format!-based DDL.
-    config::validate_pg_identifier(&parts.database, "catalog database name")?;
-    config::validate_pg_identifier(&args.pg_user, "--pg-user")?;
+    // Collect CLI args for backend-specific parsing
+    let cli_args: Vec<String> = std::env::args().collect();
 
     println!("=== extenddb destroy ===");
     println!("Config:           {}", args.config);
-    println!("Catalog database: {}", parts.database);
-    println!("PostgreSQL:       {}:{}", parts.host, parts.port);
     println!();
 
     // Create bootstrap store for catalog queries and database teardown.
-    let bootstrap = PostgresBootstrapper::connect(BootstrapConfig {
-        host: parts.host.clone(),
-        port: parts.port,
-        admin_user: args.pg_user.clone(),
-        admin_password: args.pg_pass.clone(),
-        app_user: parts.user.clone(),
-        app_password: parts.password.clone(),
-        catalog_db: parts.database.clone(),
-        data_db: String::new(), // Not known yet; will be read from catalog.
-    })
-    .await;
+    let bootstrap =
+        extenddb_storage::bootstrapper::create_bootstrapper(backend, &args.config, &cli_args).await;
 
     let mut data_db = String::new();
 
     if let Ok(ref bs) = bootstrap {
+        let catalog_db = bs.catalog_database_name();
+        let endpoint = bs.endpoint_info();
+        println!("Catalog database: {catalog_db}");
+        println!("{backend}:         {endpoint}");
+        println!();
+
         println!("--- Tables in catalog:");
         let tables = bs.list_table_names().await.unwrap_or_default();
         if tables.is_empty() {
@@ -105,24 +96,15 @@ pub async fn run(args: DestroyArgs) -> anyhow::Result<()> {
     // connects to the `postgres` database, so we can reuse it.
     if !data_db.is_empty() {
         // Defense-in-depth: validate even though this came from the catalog.
-        config::validate_pg_identifier(&data_db, "data database name")?;
+        config::validate_identifier(backend, &data_db, "data database name")?;
     }
 
     // Reconnect as admin for DDL operations (the catalog pool must be dropped
     // before we can DROP DATABASE).
     drop(bootstrap);
-    let bs = PostgresBootstrapper::connect(BootstrapConfig {
-        host: parts.host,
-        port: parts.port,
-        admin_user: args.pg_user,
-        admin_password: args.pg_pass,
-        app_user: parts.user,
-        app_password: parts.password,
-        catalog_db: parts.database,
-        data_db: data_db.clone(),
-    })
-    .await
-    .map_err(|e| anyhow::anyhow!("Cannot connect as admin: {e:?}"))?;
+    let bs = extenddb_storage::bootstrapper::create_bootstrapper(backend, &args.config, &cli_args)
+        .await
+        .map_err(|e| anyhow::anyhow!("Cannot connect as admin: {e:?}"))?;
 
     bs.drop_databases(&data_db)
         .await

--- a/crates/bin/src/cmd_destroy.rs
+++ b/crates/bin/src/cmd_destroy.rs
@@ -53,15 +53,15 @@ pub async fn run(args: DestroyArgs) -> anyhow::Result<()> {
 
     let mut data_db = String::new();
 
-    if let Ok(ref bs) = bootstrap {
-        let catalog_db = bs.catalog_database_name();
-        let endpoint = bs.endpoint_info();
+    if let Ok(ref bootstrap) = bootstrap {
+        let catalog_db = bootstrap.catalog_database_name();
+        let endpoint = bootstrap.endpoint_info();
         println!("Catalog database: {catalog_db}");
         println!("{backend}:         {endpoint}");
         println!();
 
         println!("--- Tables in catalog:");
-        let tables = bs.list_table_names().await.unwrap_or_default();
+        let tables = bootstrap.list_table_names().await.unwrap_or_default();
         if tables.is_empty() {
             println!("  (none)");
         } else {
@@ -71,7 +71,7 @@ pub async fn run(args: DestroyArgs) -> anyhow::Result<()> {
         }
 
         // Get data database name.
-        if let Ok(Some(db)) = bs.get_data_db_name().await {
+        if let Ok(Some(db)) = bootstrap.get_data_db_name().await {
             data_db = db;
             println!();
             println!("Data database:    {data_db}");
@@ -102,11 +102,11 @@ pub async fn run(args: DestroyArgs) -> anyhow::Result<()> {
     // Reconnect as admin for DDL operations (the catalog pool must be dropped
     // before we can DROP DATABASE).
     drop(bootstrap);
-    let bs = extenddb_storage::bootstrapper::create_bootstrapper(backend, &args.config, &cli_args)
+    let bootstrap = extenddb_storage::bootstrapper::create_bootstrapper(backend, &args.config, &cli_args)
         .await
         .map_err(|e| anyhow::anyhow!("Cannot connect as admin: {e:?}"))?;
 
-    bs.drop_databases(&data_db)
+    bootstrap.drop_databases(&data_db)
         .await
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
 

--- a/crates/bin/src/cmd_init.rs
+++ b/crates/bin/src/cmd_init.rs
@@ -126,6 +126,16 @@ pub async fn run(args: InitArgs) -> anyhow::Result<u8> {
 
     println!("=== extenddb init (backend: {backend}) ===");
 
+    // Check config file conflict early, before any database work
+    if Path::new(&args.config).exists() && !args.overwrite {
+        eprintln!(
+            "Error: Config file \"{}\" already exists. \
+             Use --overwrite to delete and regenerate it.",
+            args.config
+        );
+        return Ok(255);
+    }
+
     // Collect CLI args for backend-specific parsing
     let cli_args: Vec<String> = std::env::args().collect();
 
@@ -247,22 +257,11 @@ pub async fn run(args: InitArgs) -> anyhow::Result<u8> {
     // Generate or update extenddb.toml.
     let catalog_url = bootstrapper.catalog_connection_url();
     let config_path = &args.config;
-    let overwrite = args.overwrite;
 
     if Path::new(config_path).exists() {
-        if overwrite {
-            std::fs::remove_file(config_path)?;
-            generate_config(config_path, &catalog_url, &bind_addr, docs_dir.as_deref())?;
-        } else {
-            eprintln!(
-                "Error: Config file \"{config_path}\" already exists. \
-                 Use --overwrite to delete and regenerate it."
-            );
-            return Ok(255);
-        }
-    } else {
-        generate_config(config_path, &catalog_url, &bind_addr, docs_dir.as_deref())?;
+        std::fs::remove_file(config_path)?;
     }
+    generate_config(config_path, &catalog_url, &bind_addr, docs_dir.as_deref())?;
 
     println!(
         "\n=== extenddb init complete ===\nStart the server with: extenddb serve --config {}",

--- a/crates/bin/src/cmd_migrate.rs
+++ b/crates/bin/src/cmd_migrate.rs
@@ -6,9 +6,6 @@
 //! Reads current catalog version, runs pending migrations, and reports the result.
 
 use clap::Args;
-use extenddb_storage::bootstrapper::{BootstrapConfig, Bootstrapper};
-use extenddb_storage_postgres::PostgresBootstrapper;
-use extenddb_storage_postgres::parse_connection_string;
 
 use crate::config;
 
@@ -17,6 +14,14 @@ pub struct MigrateArgs {
     /// Path to configuration file
     #[arg(short, long, default_value = "extenddb.toml")]
     config: String,
+
+    /// PostgreSQL admin user (for catalog migrations)
+    #[arg(long)]
+    pg_user: Option<String>,
+
+    /// PostgreSQL admin password
+    #[arg(long)]
+    pg_pass: Option<String>,
 
     /// Confirm migration (required, no interactive prompt)
     #[arg(long)]
@@ -32,22 +37,20 @@ pub async fn run(args: MigrateArgs) -> anyhow::Result<()> {
         );
     }
     let app_config = config::load(&args.config)?;
-    let parts = parse_connection_string(&app_config.storage.postgres.connection_string)?;
+    let backend = &app_config.storage._backend;
 
     println!("=== extenddb migrate ===");
     println!("Config:           {}", args.config);
     println!();
 
-    let bootstrap = PostgresBootstrapper::new(BootstrapConfig {
-        host: parts.host,
-        port: parts.port,
-        admin_user: parts.user.clone(),
-        admin_password: Some(parts.password.clone()),
-        app_user: parts.user,
-        app_password: parts.password,
-        catalog_db: parts.database,
-        data_db: String::new(),
-    });
+    // Collect CLI args for backend-specific parsing
+    let cli_args: Vec<String> = std::env::args().collect();
+
+    // Create bootstrapper via registry
+    let bootstrap =
+        extenddb_storage::bootstrapper::create_bootstrapper(backend, &args.config, &cli_args)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
     // Show current version.
     println!("--- Checking current catalog version...");

--- a/crates/bin/src/cmd_serve.rs
+++ b/crates/bin/src/cmd_serve.rs
@@ -12,9 +12,7 @@ use extenddb_auth::BuiltinAuthProvider;
 use extenddb_server::AppState;
 use extenddb_storage::management_store::SettingsStore;
 use extenddb_storage_postgres::DbCredentialStore;
-use extenddb_storage_postgres::{
-    CATALOG_VERSION, PostgresCatalogStore, PostgresConfig, PostgresEngine,
-};
+use extenddb_storage_postgres::{PostgresCatalogStore, PostgresConfig, PostgresEngine};
 use syslog_tracing::{Facility, Options, Syslog};
 use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, reload, util::SubscriberInitExt};
 
@@ -86,15 +84,19 @@ pub fn run(args: &ServeArgs) -> anyhow::Result<()> {
     // D-2: Print startup banner to stdout before daemonizing so the user
     // gets confirmation the server is starting. P57 Bug 4 fix: say "starting"
     // not "listening" — the server isn't actually accepting connections yet.
+    let backend = &app_config.storage._backend;
+    let catalog_version = extenddb_storage::operations::catalog_version(backend)
+        .unwrap_or_else(|_| "unknown".to_string());
     println!(
         "extenddb {} (catalog {}) starting on {}",
         env!("CARGO_PKG_VERSION"),
-        CATALOG_VERSION,
+        catalog_version,
         bind_addr,
     );
     println!(
-        "  storage: postgres ({})",
-        config::redact_password(&app_config.storage.postgres.connection_string),
+        "  storage: {} ({})",
+        backend,
+        config::redact_password(backend, app_config.storage.connection_config()),
     );
 
     // D-3: Write PID file so `extenddb status` can report the daemon PID.
@@ -166,7 +168,8 @@ async fn serve(
     // server (e.g., Postgres connection failure). The PID file was already
     // written by Daemonize in run().
     let pid_path = pid_file_path(&run_dir, port);
-    let result = serve_inner(app_config, std_listener, port, run_dir).await;
+    let backend = app_config.storage._backend.clone();
+    let result = serve_inner(app_config, std_listener, port, run_dir, backend).await;
     if let Err(ref e) = result {
         let _ = std::fs::remove_file(&pid_path);
         // P57 Bug 7: Log fatal errors to syslog. After daemonize, stderr is
@@ -185,7 +188,11 @@ async fn serve_inner(
     std_listener: TcpListener,
     port: u16,
     run_dir: String,
+    backend: String,
 ) -> anyhow::Result<()> {
+    let catalog_version = extenddb_storage::operations::catalog_version(&backend)
+        .unwrap_or_else(|_| "unknown".to_string());
+    
     // Init logging (REQ-LOG-003, REQ-LOG-006) — always syslog in daemon mode.
     // D-3: sqlx messages are controlled by an independent `sqlx_log_level`
     // runtime setting (default: warn). Both extenddb and sqlx messages use the
@@ -226,8 +233,8 @@ async fn serve_inner(
     }
 
     let pg_config = PostgresConfig {
-        connection_string: app_config.storage.postgres.connection_string.clone(),
-        pool_size: app_config.storage.postgres.pool_size,
+        connection_string: app_config.storage.connection_config().to_string(),
+        pool_size: app_config.storage.max_connections(),
         max_item_size_bytes: app_config.limits.max_item_size_bytes,
     };
     let storage = PostgresEngine::new(&pg_config, &app_config.server.region).await?;
@@ -255,12 +262,12 @@ async fn serve_inner(
     tracing::info!(
         "extenddb {} (catalog {}) starting — bind={}:{}, region={}, auth={}, catalog_db={}, data_db={}, log_output=syslog, log_level={}",
         env!("CARGO_PKG_VERSION"),
-        CATALOG_VERSION,
+        catalog_version,
         app_config.server.bind_addr,
         port,
         app_config.server.region,
         app_config.auth.provider,
-        config::redact_password(&app_config.storage.postgres.connection_string),
+        config::redact_password(&backend, app_config.storage.connection_config()),
         data_db_info,
         app_config.logging.level,
     );
@@ -301,15 +308,11 @@ async fn serve_inner(
     tokio::spawn(workers::capacity_warning_worker());
 
     // Management API: create pool for admin/account CRUD and authz queries.
-    let catalog_pool_size = app_config
-        .storage
-        .postgres
-        .catalog_pool_size
-        .unwrap_or(app_config.storage.postgres.pool_size);
+    let catalog_pool_size = app_config.storage.max_catalog_connections();
     let catalog_pool = sqlx::postgres::PgPoolOptions::new()
         .max_connections(catalog_pool_size)
         .min_connections(catalog_pool_size.min(2))
-        .connect(&app_config.storage.postgres.connection_string)
+        .connect(app_config.storage.connection_config())
         .await
         .map_err(|e| anyhow::anyhow!("Failed to create management API pool: {e}"))?;
 
@@ -460,7 +463,7 @@ async fn serve_inner(
             format!(
                 "{} · catalog {} · {}",
                 env!("CARGO_PKG_VERSION"),
-                CATALOG_VERSION,
+                catalog_version,
                 env!("EXTENDDB_GIT_HASH"),
             )
             .as_str(),

--- a/crates/bin/src/cmd_settings.rs
+++ b/crates/bin/src/cmd_settings.rs
@@ -8,10 +8,8 @@
 //! and `ops::READONLY_KEYS`.
 
 use clap::{Args, Subcommand};
-use sqlx::PgPool;
 
 use extenddb_storage::management_store::SettingsStore;
-use extenddb_storage_postgres::PostgresCatalogStore;
 
 use crate::config;
 
@@ -48,21 +46,26 @@ pub async fn run(args: SettingsArgs) -> anyhow::Result<()> {
         );
     }
     let app_config = config::load(&args.config)?;
-    let pool = PgPool::connect(&app_config.storage.postgres.connection_string).await?;
-    let store = PostgresCatalogStore::new(pool);
+    let backend = &app_config.storage._backend;
+    let store = extenddb_storage::settings_store::create_settings_store(
+        backend,
+        app_config.storage.connection_config(),
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to create settings store: {}", e))?;
 
     match args.action {
-        SettingsAction::List => list(&store).await,
-        SettingsAction::Get { key } => get(&store, &key).await,
-        SettingsAction::Set { key, value } => set(&store, &key, &value).await,
+        SettingsAction::List => list(store.as_ref()).await,
+        SettingsAction::Get { key } => get(store.as_ref(), &key).await,
+        SettingsAction::Set { key, value } => set(store.as_ref(), &key, &value).await,
     }
 }
 
-async fn list(store: &PostgresCatalogStore) -> anyhow::Result<()> {
+async fn list(store: &dyn SettingsStore) -> anyhow::Result<()> {
     let rows = store
         .list_settings()
         .await
-        .map_err(|e| anyhow::anyhow!("Failed to list settings: {e:?}"))?;
+        .map_err(|e| anyhow::anyhow!("Failed to list settings: {:?}", e))?;
 
     if rows.is_empty() {
         println!("No settings found.");
@@ -74,11 +77,11 @@ async fn list(store: &PostgresCatalogStore) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn get(store: &PostgresCatalogStore, key: &str) -> anyhow::Result<()> {
+async fn get(store: &dyn SettingsStore, key: &str) -> anyhow::Result<()> {
     let value = store
         .get_setting(key)
         .await
-        .map_err(|e| anyhow::anyhow!("Failed to get setting: {e:?}"))?;
+        .map_err(|e| anyhow::anyhow!("Failed to get setting: {:?}", e))?;
 
     if let Some(v) = value {
         println!("{v}");
@@ -89,7 +92,7 @@ async fn get(store: &PostgresCatalogStore, key: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn set(store: &PostgresCatalogStore, key: &str, value: &str) -> anyhow::Result<()> {
+async fn set(store: &dyn SettingsStore, key: &str, value: &str) -> anyhow::Result<()> {
     if READONLY_KEYS.contains(&key) {
         anyhow::bail!("Setting '{key}' is read-only and cannot be changed via this command.");
     }
@@ -114,7 +117,7 @@ async fn set(store: &PostgresCatalogStore, key: &str, value: &str) -> anyhow::Re
     store
         .set_setting(key, value)
         .await
-        .map_err(|e| anyhow::anyhow!("Failed to set setting: {e:?}"))?;
+        .map_err(|e| anyhow::anyhow!("Failed to set setting: {:?}", e))?;
 
     tracing::warn!(
         target: "extenddb::audit::settings",

--- a/crates/bin/src/cmd_verify.rs
+++ b/crates/bin/src/cmd_verify.rs
@@ -12,9 +12,6 @@
 //! abstraction would defeat the purpose of an independent health check.
 
 use clap::Args;
-use extenddb_storage_postgres::CATALOG_VERSION;
-use extenddb_storage_postgres::parse_connection_string;
-use sqlx::postgres::PgPoolOptions;
 
 use crate::config;
 
@@ -34,7 +31,17 @@ pub async fn run(args: VerifyArgs) -> anyhow::Result<()> {
         );
     }
     let app_config = config::load(&args.config)?;
-    let parts = parse_connection_string(&app_config.storage.postgres.connection_string)?;
+    let backend = &app_config.storage._backend;
+    let expected_version = extenddb_storage::operations::catalog_version(backend)
+        .unwrap_or_else(|_| "unknown".to_string());
+
+    // Parse connection string to get database name for display
+    let parts = extenddb_storage::operations::parse_connection_string(
+        backend,
+        app_config.storage.connection_config(),
+    )
+    .map_err(|e| anyhow::anyhow!("Failed to parse connection string: {}", e))?;
+
     let mut errors = 0u32;
 
     println!("=== extenddb verify ===");
@@ -42,87 +49,72 @@ pub async fn run(args: VerifyArgs) -> anyhow::Result<()> {
     println!("Catalog database: {}", parts.database);
     println!();
 
-    // Check 1: Catalog connection.
+    // Create settings and diagnostics store
     println!("--- Checking catalog connection...");
-    let catalog_pool = match PgPoolOptions::new()
-        .max_connections(1)
-        .connect(&app_config.storage.postgres.connection_string)
-        .await
+    let store = match extenddb_storage::settings_store::create_settings_store(
+        backend,
+        app_config.storage.connection_config(),
+    )
+    .await
     {
-        Ok(pool) => {
+        Ok(store) => {
             println!("  OK: Connected to catalog.");
-            pool
+            store
         }
         Err(e) => {
-            println!("  FAIL: Cannot connect to catalog database: {e}");
+            println!("  FAIL: Cannot connect to catalog database: {}", e);
             anyhow::bail!("Cannot proceed without catalog connection");
         }
     };
 
     // Check 2: Catalog version (D-10: strict parsing).
     println!("--- Checking catalog version...");
-    let version_row: Option<(String,)> =
-        sqlx::query_as("SELECT value FROM settings WHERE key = 'catalog_version'")
-            .fetch_optional(&catalog_pool)
-            .await?;
-    match version_row {
-        Some((v,)) => match v.parse::<extenddb_core::version::CatalogVersion>() {
-            Ok(found) if found == CATALOG_VERSION => {
-                println!("  OK: Catalog version {found}");
-            }
-            Ok(found) => {
-                println!("  WARN: Catalog version {found} (binary expects {CATALOG_VERSION})");
+    match store.get_setting("catalog_version").await {
+        Ok(Some(v)) => {
+            if v == expected_version {
+                println!("  OK: Catalog version {v}");
+            } else {
+                println!("  WARN: Catalog version {v} (binary expects {expected_version})");
                 errors += 1;
             }
-            Err(e) => {
-                println!("  FAIL: Malformed catalog version in database: {e}");
-                errors += 1;
-            }
-        },
-        None => {
+        }
+        Ok(None) => {
             println!("  FAIL: No catalog version found. Run 'extenddb init'.");
+            errors += 1;
+        }
+        Err(e) => {
+            println!("  FAIL: Failed to read catalog version: {:?}", e);
             errors += 1;
         }
     }
 
     // Check 3: Data database connection.
     println!("--- Checking data database...");
-    let data_conn: Result<Option<(String,)>, _> =
-        sqlx::query_as("SELECT value FROM settings WHERE key = 'data_database_connection_string'")
-            .fetch_optional(&catalog_pool)
-            .await;
 
-    let data_name: Result<Option<(String,)>, _> =
-        sqlx::query_as("SELECT value FROM settings WHERE key = 'data_database_name'")
-            .fetch_optional(&catalog_pool)
-            .await;
+    // Create diagnostics store (reuse for data DB test and table/index counts)
+    let diag_store = extenddb_storage::diagnostics_store::create_diagnostics_store(
+        backend,
+        app_config.storage.connection_config(),
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to create diagnostics store: {}", e))?;
 
-    if let (Ok(Some((conn,))), Ok(Some((db_name,)))) = (data_conn, data_name) {
-        match PgPoolOptions::new().max_connections(1).connect(&conn).await {
-            Ok(_) => println!("  OK: Connected to data database '{db_name}'."),
-            Err(e) => {
-                println!("  FAIL: Cannot connect to data database '{db_name}': {e}");
-                errors += 1;
-            }
+    match diag_store.test_data_database_connection().await {
+        Ok(db_name) => println!("  OK: Connected to data database '{db_name}'."),
+        Err(e) => {
+            println!("  FAIL: {}", e);
+            errors += 1;
         }
-    } else {
-        println!("  FAIL: No data database registered in catalog. Run 'extenddb init'.");
-        errors += 1;
     }
 
     // Check 4: Enumerate tables and indexes.
     println!("--- Enumerating tables...");
-    let table_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM tables")
-        .fetch_one(&catalog_pool)
-        .await
-        .unwrap_or((0,));
-    println!("  Tables: {}", table_count.0);
 
-    let index_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM indexes")
-        .fetch_one(&catalog_pool)
-        .await
-        .unwrap_or((0,));
-    println!("  Indexes: {}", index_count.0);
+    let table_count = diag_store.count_tables().await.unwrap_or(0);
+    println!("  Tables: {}", table_count);
+
+    let index_count = diag_store.count_indexes().await.unwrap_or(0);
+    println!("  Indexes: {}", index_count);
 
     println!();
     if errors == 0 {

--- a/crates/bin/src/config.rs
+++ b/crates/bin/src/config.rs
@@ -4,7 +4,6 @@
 //! Shared configuration types for the extenddb binary.
 
 use extenddb_core::limits::LimitsConfig;
-use extenddb_storage_postgres::PostgresStorageConfig;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -112,21 +111,75 @@ impl Default for TlsConfig {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone)]
 pub struct StorageConfig {
-    /// Storage backend selector (e.g. "postgres"). Only postgres is currently supported.
-    #[serde(default = "default_backend", rename = "backend")]
+    /// Storage backend selector (e.g. "postgres").
     pub _backend: String,
-    #[serde(default)]
-    pub postgres: PostgresStorageConfig,
+    /// Backend-specific configuration (trait object).
+    config: Box<dyn extenddb_storage::config::StorageConfig>,
+}
+
+impl StorageConfig {
+    /// Get the connection configuration string for this backend.
+    ///
+    /// Delegates to the backend-specific config trait object. This wrapper
+    /// provides a clean API without exposing the trait object to callers.
+    pub fn connection_config(&self) -> &str {
+        self.config.connection_config()
+    }
+
+    /// Get the maximum connections for data operations.
+    pub fn max_connections(&self) -> u32 {
+        self.config.max_connections()
+    }
+
+    /// Get the maximum connections for catalog operations.
+    pub fn max_catalog_connections(&self) -> u32 {
+        self.config.max_catalog_connections()
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StorageConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        // Deserialize into a raw TOML value first
+        let value: toml::Value = toml::Value::deserialize(deserializer)?;
+
+        // Extract the backend field
+        let backend = value
+            .get("backend")
+            .and_then(|v| v.as_str())
+            .unwrap_or("postgres")
+            .to_string();
+
+        // Get the backend-specific table (e.g., [storage.postgres])
+        let backend_table: &toml::Table = value
+            .get(&backend)
+            .and_then(|v| v.as_table())
+            .ok_or_else(|| {
+                D::Error::custom(format!("Missing [storage.{}] section in config", backend))
+            })?;
+
+        // Use the registry to deserialize the backend config
+        let config = extenddb_storage::config::deserialize_storage_config(&backend, backend_table)
+            .map_err(D::Error::custom)?;
+
+        Ok(StorageConfig {
+            _backend: backend,
+            config,
+        })
+    }
 }
 
 impl Default for StorageConfig {
     fn default() -> Self {
         Self {
             _backend: default_backend(),
-            postgres: PostgresStorageConfig::default(),
+            config: Box::new(extenddb_storage_postgres::PostgresStorageConfig::default()),
         }
     }
 }
@@ -237,17 +290,13 @@ pub fn load(config_path: &str) -> anyhow::Result<AppConfig> {
     Ok(config.try_deserialize()?)
 }
 
-/// Redact password from a `PostgreSQL` connection string for safe logging (REQ-LOG-002).
-pub fn redact_password(conn: &str) -> String {
-    if let Some(at) = conn.find('@') {
-        if let Some(colon) = conn[..at].rfind(':') {
-            let scheme_end = conn.find("://").map_or(0, |i| i + 3);
-            if colon >= scheme_end {
-                return format!("{}:***@{}", &conn[..colon], &conn[at + 1..]);
-            }
-        }
-    }
-    conn.to_owned()
+/// Redact password from a connection string for safe logging (REQ-LOG-002).
+///
+/// Uses the backend-specific operations engine to handle different connection
+/// string formats (PostgreSQL, Cassandra, etc.).
+pub fn redact_password(backend: &str, conn: &str) -> String {
+    extenddb_storage::operations::redact_connection_string(backend, conn)
+        .unwrap_or_else(|_| conn.to_owned())
 }
 
 /// Return the current OS username, falling back to given default username: e.g. `"postgres"`.
@@ -255,26 +304,18 @@ pub fn whoami(default: &str) -> String {
     std::env::var("USER").unwrap_or_else(|_| default.to_owned())
 }
 
-/// Validate that a string is safe to use as a double-quoted `PostgreSQL` identifier.
+/// Validate that a string is safe to use as a database identifier for DDL.
 ///
-/// Rejects strings containing double quotes, null bytes, or non-ASCII characters.
-/// This is a defense-in-depth measure for `format!`-based DDL where parameterized
+/// Delegates to the backend-specific operations engine. Rejects strings
+/// containing characters unsafe for `format!`-based DDL where parameterized
 /// queries are not supported (e.g. `CREATE DATABASE`, `DROP DATABASE`).
 ///
 /// # Errors
 ///
 /// Returns an error describing the invalid character found.
-pub fn validate_pg_identifier(name: &str, label: &str) -> anyhow::Result<()> {
-    if name.contains('"') {
-        anyhow::bail!("{label} must not contain double quotes");
-    }
-    if name.contains('\0') {
-        anyhow::bail!("{label} must not contain null bytes");
-    }
-    if !name.is_ascii() {
-        anyhow::bail!("{label} must contain only ASCII characters");
-    }
-    Ok(())
+pub fn validate_identifier(backend: &str, name: &str, label: &str) -> anyhow::Result<()> {
+    extenddb_storage::operations::validate_identifier(backend, name, label)
+        .map_err(|e| anyhow::anyhow!("{:?}", e))
 }
 
 /// Keys whose values must be redacted in configuration displays.
@@ -305,6 +346,7 @@ fn redact_if_sensitive(key: &str, val: &str) -> String {
 /// sensitive values (connection strings, passwords, keys).
 pub fn build_config_entries(cfg: &AppConfig) -> Vec<(String, String)> {
     let r = redact_if_sensitive;
+    let backend = &cfg.storage._backend;
     let mut entries = vec![
         ("server.bind_addr".into(), cfg.server.bind_addr.clone()),
         ("server.port".into(), cfg.server.port.to_string()),
@@ -329,19 +371,16 @@ pub fn build_config_entries(cfg: &AppConfig) -> Vec<(String, String)> {
                 .map_or("none".into(), |b| b.to_string()),
         ),
         (
-            "storage.postgres.connection_string".into(),
-            r("connection_string", &cfg.storage.postgres.connection_string),
+            format!("storage.{}.connection_string", backend),
+            r("connection_string", cfg.storage.connection_config()),
         ),
         (
-            "storage.postgres.pool_size".into(),
-            cfg.storage.postgres.pool_size.to_string(),
+            format!("storage.{}.pool_size", backend),
+            cfg.storage.max_connections().to_string(),
         ),
         (
-            "storage.postgres.catalog_pool_size".into(),
-            cfg.storage
-                .postgres
-                .catalog_pool_size
-                .map_or("default".into(), |n| n.to_string()),
+            format!("storage.{}.catalog_pool_size", backend),
+            cfg.storage.max_catalog_connections().to_string(),
         ),
         ("auth.provider".into(), cfg.auth.provider.clone()),
         ("logging.level".into(), cfg.logging.level.clone()),

--- a/crates/bin/src/main.rs
+++ b/crates/bin/src/main.rs
@@ -27,7 +27,6 @@ mod util;
 mod workers;
 
 use clap::{Parser, Subcommand};
-use extenddb_storage_postgres::CATALOG_VERSION;
 
 #[derive(Parser)]
 #[command(name = "extenddb", about = "ExtendDB — DynamoDB-compatible API server")]
@@ -107,7 +106,19 @@ fn main() -> anyhow::Result<()> {
 /// Print version, catalog version, git commit hash, and build timestamp.
 fn print_version() {
     println!("extenddb {}", env!("CARGO_PKG_VERSION"));
-    println!("catalog {CATALOG_VERSION}");
+
+    // Report catalog version(s) for all registered backend(s)
+    let backends = extenddb_storage::operations::list_operations_backends();
+    if backends.is_empty() {
+        println!("catalog unknown (no backends registered)");
+    } else {
+        for backend in backends {
+            let version = extenddb_storage::operations::catalog_version(backend)
+                .unwrap_or_else(|_| "unknown".to_string());
+            println!("catalog {} ({})", version, backend);
+        }
+    }
+
     println!("commit {}", env!("EXTENDDB_GIT_HASH"));
     println!("built {}", env!("EXTENDDB_BUILD_TIME"));
 }

--- a/crates/storage-postgres/Cargo.toml
+++ b/crates/storage-postgres/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = { workspace = true }
 extenddb-core = { workspace = true }
 extenddb-storage = { workspace = true }
 extenddb-auth = { workspace = true }
+futures = { workspace = true }
 inventory = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }

--- a/crates/storage-postgres/src/bootstrapper.rs
+++ b/crates/storage-postgres/src/bootstrapper.rs
@@ -412,6 +412,14 @@ impl Bootstrapper for PostgresBootstrapper {
         CATALOG_VERSION.to_string()
     }
 
+    fn catalog_database_name(&self) -> String {
+        self.config.catalog_db.clone()
+    }
+
+    fn endpoint_info(&self) -> String {
+        format!("{}:{}", self.config.host, self.config.port)
+    }
+
     fn catalog_connection_url(&self) -> String {
         self.app_connection_url(&self.config.catalog_db)
     }

--- a/crates/storage-postgres/src/catalog_store.rs
+++ b/crates/storage-postgres/src/catalog_store.rs
@@ -56,46 +56,129 @@ impl PostgresCatalogStore {
 // ── SettingsStore ──────────────────────────────────────────────────────
 
 impl extenddb_storage::management_store::SettingsStore for PostgresCatalogStore {
-    async fn get_setting(&self, key: &str) -> OpResult<Option<String>> {
-        let row: Option<(String,)> = sqlx::query_as("SELECT value FROM settings WHERE key = $1")
-            .bind(key)
-            .fetch_optional(&self.pool)
+    fn get_setting(&self, key: &str) -> futures::future::BoxFuture<'_, OpResult<Option<String>>> {
+        let key = key.to_string();
+        let pool = self.pool.clone();
+        Box::pin(async move {
+            let row: Option<(String,)> =
+                sqlx::query_as("SELECT value FROM settings WHERE key = $1")
+                    .bind(&key)
+                    .fetch_optional(&pool)
+                    .await
+                    .map_err(|e| {
+                        tracing::error!("get_setting: {e}");
+                        OpError::Internal("Database error".to_owned())
+                    })?;
+            Ok(row.map(|(v,)| v))
+        })
+    }
+
+    fn set_setting(&self, key: &str, value: &str) -> futures::future::BoxFuture<'_, OpResult<()>> {
+        let key = key.to_string();
+        let value = value.to_string();
+        let pool = self.pool.clone();
+        Box::pin(async move {
+            sqlx::query(
+                "INSERT INTO settings (key, value) VALUES ($1, $2) \
+                 ON CONFLICT (key) DO UPDATE SET value = $2",
+            )
+            .bind(&key)
+            .bind(&value)
+            .execute(&pool)
             .await
             .map_err(|e| {
-                tracing::error!("get_setting: {e}");
+                tracing::error!("set_setting: {e}");
                 OpError::Internal("Database error".to_owned())
             })?;
-        Ok(row.map(|(v,)| v))
+            Ok(())
+        })
     }
 
-    async fn set_setting(&self, key: &str, value: &str) -> OpResult<()> {
-        sqlx::query(
-            "INSERT INTO settings (key, value) VALUES ($1, $2) \
-             ON CONFLICT (key) DO UPDATE SET value = $2",
-        )
-        .bind(key)
-        .bind(value)
-        .execute(&self.pool)
-        .await
-        .map_err(|e| {
-            tracing::error!("set_setting: {e}");
-            OpError::Internal("Database error".to_owned())
-        })?;
-        Ok(())
-    }
-
-    async fn list_settings(&self) -> OpResult<Vec<(String, String)>> {
-        sqlx::query_as("SELECT key, value FROM settings ORDER BY key")
-            .fetch_all(&self.pool)
-            .await
-            .map_err(|e| {
-                tracing::error!("list_settings: {e}");
-                OpError::Internal("Database error".to_owned())
-            })
+    fn list_settings(&self) -> futures::future::BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        let pool = self.pool.clone();
+        Box::pin(async move {
+            sqlx::query_as("SELECT key, value FROM settings ORDER BY key")
+                .fetch_all(&pool)
+                .await
+                .map_err(|e| {
+                    tracing::error!("list_settings: {e}");
+                    OpError::Internal("Database error".to_owned())
+                })
+        })
     }
 
     fn cached_encryption_key(&self) -> Option<String> {
         self.encryption_key.as_ref().map(|k| k.to_string())
+    }
+}
+
+// ── DiagnosticsStore ───────────────────────────────────────────────────
+
+impl extenddb_storage::diagnostics::DiagnosticsStore for PostgresCatalogStore {
+    fn count_tables(
+        &self,
+    ) -> futures::future::BoxFuture<'_, extenddb_storage::diagnostics::DiagResult<i64>> {
+        let pool = self.pool.clone();
+        Box::pin(async move {
+            let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM tables")
+                .fetch_one(&pool)
+                .await
+                .map_err(|e| extenddb_storage::diagnostics::DiagError::QueryFailed(e.to_string()))?;
+            Ok(count)
+        })
+    }
+
+    fn count_indexes(
+        &self,
+    ) -> futures::future::BoxFuture<'_, extenddb_storage::diagnostics::DiagResult<i64>> {
+        let pool = self.pool.clone();
+        Box::pin(async move {
+            let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM indexes")
+                .fetch_one(&pool)
+                .await
+                .map_err(|e| extenddb_storage::diagnostics::DiagError::QueryFailed(e.to_string()))?;
+            Ok(count)
+        })
+    }
+
+    fn test_data_database_connection(
+        &self,
+    ) -> futures::future::BoxFuture<'_, extenddb_storage::diagnostics::DiagResult<String>> {
+        let pool = self.pool.clone();
+        Box::pin(async move {
+            // Get data database connection string and name from settings
+            let conn_row: Option<(String,)> = sqlx::query_as(
+                "SELECT value FROM settings WHERE key = 'data_database_connection_string'",
+            )
+            .fetch_optional(&pool)
+            .await
+            .map_err(|e| extenddb_storage::diagnostics::DiagError::QueryFailed(e.to_string()))?;
+
+            let name_row: Option<(String,)> =
+                sqlx::query_as("SELECT value FROM settings WHERE key = 'data_database_name'")
+                    .fetch_optional(&pool)
+                    .await
+                    .map_err(|e| {
+                        extenddb_storage::diagnostics::DiagError::QueryFailed(e.to_string())
+                    })?;
+
+            match (conn_row, name_row) {
+                (Some((conn,)), Some((name,))) => {
+                    // Test connection
+                    sqlx::postgres::PgPoolOptions::new()
+                        .max_connections(1)
+                        .connect(&conn)
+                        .await
+                        .map_err(|e| {
+                            extenddb_storage::diagnostics::DiagError::ConnectionFailed(e.to_string())
+                        })?;
+                    Ok(name)
+                }
+                _ => Err(extenddb_storage::diagnostics::DiagError::QueryFailed(
+                    "Data database not configured".to_string(),
+                )),
+            }
+        })
     }
 }
 

--- a/crates/storage-postgres/src/config.rs
+++ b/crates/storage-postgres/src/config.rs
@@ -89,3 +89,23 @@ pub fn parse_connection_string(conn: &str) -> anyhow::Result<ConnParts> {
         database: database.to_owned(),
     })
 }
+
+// ── StorageConfig trait implementation ────────────────────────────────
+
+impl extenddb_storage::config::StorageConfig for PostgresStorageConfig {
+    fn connection_config(&self) -> &str {
+        &self.connection_string
+    }
+
+    fn max_connections(&self) -> u32 {
+        self.pool_size
+    }
+
+    fn max_catalog_connections(&self) -> u32 {
+        self.catalog_pool_size.unwrap_or(self.pool_size)
+    }
+
+    fn clone_box(&self) -> Box<dyn extenddb_storage::config::StorageConfig> {
+        Box::new(self.clone())
+    }
+}

--- a/crates/storage-postgres/src/lib.rs
+++ b/crates/storage-postgres/src/lib.rs
@@ -22,6 +22,7 @@ pub(crate) mod gsi_queue;
 mod management_store;
 mod metadata_engine;
 mod migrations;
+mod operations;
 mod pg_util;
 mod stream_engine;
 mod table_engine;
@@ -45,6 +46,58 @@ inventory::submit! {
                 Ok(Box::new(store) as Box<dyn extenddb_storage::bootstrapper::Bootstrapper>)
             })
         }
+    }
+}
+
+// Auto-register PostgreSQL operations engine
+inventory::submit! {
+    extenddb_storage::operations::OperationsEngineRegistration {
+        name: "postgres",
+        operations: &operations::PostgresOperationsEngine,
+    }
+}
+
+// Auto-register PostgreSQL config deserializer
+inventory::submit! {
+    extenddb_storage::config::StorageConfigRegistration {
+        backend: "postgres",
+        deserializer: |table| {
+            let config: PostgresStorageConfig = table.clone().try_into()
+                .map_err(|e: toml::de::Error| format!("Failed to parse postgres config: {}", e))?;
+            Ok(Box::new(config) as Box<dyn extenddb_storage::config::StorageConfig>)
+        },
+    }
+}
+
+// Auto-register PostgreSQL settings store factory
+inventory::submit! {
+    extenddb_storage::settings_store::SettingsStoreRegistration {
+        backend: "postgres",
+        factory: |connection_string| {
+            let connection_string = connection_string.to_string();
+            Box::pin(async move {
+                let pool = sqlx::PgPool::connect(&connection_string)
+                    .await
+                    .map_err(|e| extenddb_storage::settings_store::SettingsStoreError::ConnectionFailed(e.to_string()))?;
+                Ok(Box::new(PostgresCatalogStore::new(pool)) as Box<dyn extenddb_storage::management_store::SettingsStore>)
+            })
+        },
+    }
+}
+
+// Auto-register PostgreSQL diagnostics store factory
+inventory::submit! {
+    extenddb_storage::diagnostics_store::DiagnosticsStoreRegistration {
+        backend: "postgres",
+        factory: |connection_string| {
+            let connection_string = connection_string.to_string();
+            Box::pin(async move {
+                let pool = sqlx::PgPool::connect(&connection_string)
+                    .await
+                    .map_err(|e| extenddb_storage::diagnostics_store::DiagnosticsStoreError::ConnectionFailed(e.to_string()))?;
+                Ok(Box::new(PostgresCatalogStore::new(pool)) as Box<dyn extenddb_storage::diagnostics::DiagnosticsStore>)
+            })
+        },
     }
 }
 

--- a/crates/storage-postgres/src/operations.rs
+++ b/crates/storage-postgres/src/operations.rs
@@ -1,0 +1,77 @@
+// Copyright 2026 DynamoDB Open contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! PostgreSQL implementation of `OperationsEngine`.
+
+use extenddb_storage::error::StorageError;
+use extenddb_storage::operations::{ConnectionParts, OperationsEngine};
+
+/// PostgreSQL operations engine for ddbo CLI commands.
+pub struct PostgresOperationsEngine;
+
+impl OperationsEngine for PostgresOperationsEngine {
+    fn parse_connection_string(&self, s: &str) -> Result<ConnectionParts, StorageError> {
+        let parts = crate::config::parse_connection_string(s)
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        // Convert ConnParts to ConnectionParts
+        Ok(ConnectionParts {
+            host: parts.host,
+            port: parts.port,
+            user: parts.user,
+            password: parts.password,
+            database: parts.database,
+        })
+    }
+
+    fn redact_connection_string(&self, s: &str) -> String {
+        // Redact password from postgresql://user:password@host:port/database
+        if let Some(at) = s.find('@') {
+            if let Some(colon) = s[..at].rfind(':') {
+                let scheme_end = s.find("://").map_or(0, |i| i + 3);
+                if colon >= scheme_end {
+                    return format!("{}:***@{}", &s[..colon], &s[at + 1..]);
+                }
+            }
+        }
+        s.to_owned()
+    }
+
+    fn validate_identifier(&self, name: &str, label: &str) -> Result<(), StorageError> {
+        // PostgreSQL identifier validation for format!-based DDL.
+        // Rejects double quotes, null bytes, and non-ASCII characters.
+        if name.contains('"') {
+            return Err(StorageError::Internal(format!(
+                "{label} must not contain double quotes"
+            )));
+        }
+        if name.contains('\0') {
+            return Err(StorageError::Internal(format!(
+                "{label} must not contain null bytes"
+            )));
+        }
+        if !name.is_ascii() {
+            return Err(StorageError::Internal(format!(
+                "{label} must contain only ASCII characters"
+            )));
+        }
+        Ok(())
+    }
+
+    fn catalog_version(&self) -> String {
+        crate::CATALOG_VERSION.to_string()
+    }
+
+    fn is_sensitive_key(&self, key: &str) -> bool {
+        let lower = key.to_lowercase();
+        [
+            "connection_string",
+            "password",
+            "secret",
+            "token",
+            "encryption_key",
+        ]
+        .iter()
+        .any(|pattern| lower.contains(pattern))
+    }
+}

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -12,8 +12,11 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 bigdecimal = { workspace = true }
 extenddb-core = { workspace = true }
+futures = { workspace = true }
 inventory = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }
+toml = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/storage/src/bootstrapper.rs
+++ b/crates/storage/src/bootstrapper.rs
@@ -102,6 +102,12 @@ pub trait Bootstrapper: Send + Sync {
     /// Get the expected catalog version for this binary.
     fn expected_catalog_version(&self) -> String;
 
+    /// Return the catalog database name for display.
+    fn catalog_database_name(&self) -> String;
+
+    /// Return endpoint information (host:port or contact points) for display.
+    fn endpoint_info(&self) -> String;
+
     /// Return the catalog connection URL for config file generation.
     fn catalog_connection_url(&self) -> String;
 }

--- a/crates/storage/src/config.rs
+++ b/crates/storage/src/config.rs
@@ -1,0 +1,63 @@
+// Copyright 2026 DynamoDB Open contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Storage configuration trait and registry for storage backends.
+
+/// Configuration interface for storage backends.
+///
+/// Each backend implements this trait to expose connection parameters
+/// in a backend-agnostic way. The bin crate uses these methods without
+/// knowing the concrete backend type.
+pub trait StorageConfig: Send + Sync + std::fmt::Debug {
+    /// Backend-specific connection configuration as a string.
+    ///
+    /// For PostgreSQL: connection string (postgresql://...)
+    /// For Cassandra: contact points (host1:port,host2:port)
+    /// For MongoDB: connection URI (mongodb://...)
+    /// For Redis: endpoint (host:port)
+    fn connection_config(&self) -> &str;
+
+    /// Maximum concurrent connections for data operations.
+    fn max_connections(&self) -> u32;
+
+    /// Maximum concurrent connections for catalog/management operations.
+    fn max_catalog_connections(&self) -> u32;
+
+    /// Clone this config into a boxed trait object.
+    fn clone_box(&self) -> Box<dyn StorageConfig>;
+}
+
+impl Clone for Box<dyn StorageConfig> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}
+
+/// Deserializer function type for storage configurations.
+///
+/// Takes a TOML table and returns a boxed `StorageConfig` trait object.
+pub type StorageConfigDeserializer = fn(&toml::Table) -> Result<Box<dyn StorageConfig>, String>;
+
+/// Registration entry for a storage config deserializer.
+pub struct StorageConfigRegistration {
+    pub backend: &'static str,
+    pub deserializer: StorageConfigDeserializer,
+}
+
+inventory::collect!(StorageConfigRegistration);
+
+/// Deserialize a storage configuration from a TOML table.
+///
+/// Looks up the registered deserializer for the given backend name
+/// and invokes it with the provided TOML table.
+pub fn deserialize_storage_config(
+    backend: &str,
+    table: &toml::Table,
+) -> Result<Box<dyn StorageConfig>, String> {
+    for reg in inventory::iter::<StorageConfigRegistration> {
+        if reg.backend == backend {
+            return (reg.deserializer)(table);
+        }
+    }
+    Err(format!("Unknown backend: {}", backend))
+}

--- a/crates/storage/src/diagnostics.rs
+++ b/crates/storage/src/diagnostics.rs
@@ -1,0 +1,43 @@
+// Copyright 2026 DynamoDB Open contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Diagnostics trait for deployment health checks and verification.
+
+use futures::future::BoxFuture;
+
+/// Result type for diagnostics operations.
+pub type DiagResult<T> = Result<T, DiagError>;
+
+/// Error type for diagnostics operations.
+#[derive(Debug)]
+pub enum DiagError {
+    ConnectionFailed(String),
+    QueryFailed(String),
+}
+
+impl std::fmt::Display for DiagError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConnectionFailed(msg) => write!(f, "Connection failed: {}", msg),
+            Self::QueryFailed(msg) => write!(f, "Query failed: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for DiagError {}
+
+/// Diagnostic and verification operations for deployment health checks.
+///
+/// Used by `ddbo verify` to check catalog integrity and enumerate resources.
+pub trait DiagnosticsStore: Send + Sync {
+    /// Count the number of DynamoDB tables in the catalog.
+    fn count_tables(&self) -> BoxFuture<'_, DiagResult<i64>>;
+
+    /// Count the number of secondary indexes in the catalog.
+    fn count_indexes(&self) -> BoxFuture<'_, DiagResult<i64>>;
+
+    /// Test connection to the data database.
+    ///
+    /// Returns the database name on success, or an error if connection fails.
+    fn test_data_database_connection(&self) -> BoxFuture<'_, DiagResult<String>>;
+}

--- a/crates/storage/src/diagnostics_store.rs
+++ b/crates/storage/src/diagnostics_store.rs
@@ -1,0 +1,55 @@
+// Copyright 2026 DynamoDB Open contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Diagnostics store factory registry for backend-agnostic instantiation.
+
+use crate::diagnostics::DiagnosticsStore;
+use futures::future::BoxFuture;
+
+/// Error type for diagnostics store creation.
+#[derive(Debug)]
+pub enum DiagnosticsStoreError {
+    BackendNotFound(String),
+    ConnectionFailed(String),
+}
+
+impl std::fmt::Display for DiagnosticsStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BackendNotFound(backend) => {
+                write!(
+                    f,
+                    "No diagnostics store factory registered for backend '{backend}'"
+                )
+            }
+            Self::ConnectionFailed(msg) => write!(f, "Failed to connect: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for DiagnosticsStoreError {}
+
+/// Factory function type for creating diagnostics stores.
+pub type DiagnosticsStoreFactory =
+    fn(&str) -> BoxFuture<'static, Result<Box<dyn DiagnosticsStore>, DiagnosticsStoreError>>;
+
+/// Registration entry for a diagnostics store factory.
+pub struct DiagnosticsStoreRegistration {
+    pub backend: &'static str,
+    pub factory: DiagnosticsStoreFactory,
+}
+
+inventory::collect!(DiagnosticsStoreRegistration);
+
+/// Create a diagnostics store for the given backend and connection string.
+pub async fn create_diagnostics_store(
+    backend: &str,
+    connection_string: &str,
+) -> Result<Box<dyn DiagnosticsStore>, DiagnosticsStoreError> {
+    for registration in inventory::iter::<DiagnosticsStoreRegistration> {
+        if registration.backend == backend {
+            return (registration.factory)(connection_string).await;
+        }
+    }
+    Err(DiagnosticsStoreError::BackendNotFound(backend.to_string()))
+}

--- a/crates/storage/src/hooks.rs
+++ b/crates/storage/src/hooks.rs
@@ -1,0 +1,40 @@
+// Copyright 2026 DynamoDB Open contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Backend-specific runtime hooks for worker spawning and initialization.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tracing_subscriber::{EnvFilter, Registry, reload};
+
+/// Context passed to ServerRuntimeHooks::spawn_workers.
+///
+/// Contains shared resources that backend-specific workers might need.
+pub struct WorkerContext {
+    pub metrics: Arc<extenddb_core::metrics::MetricsCollector>,
+    pub reload_handle: reload::Handle<EnvFilter, Registry>,
+    pub config_log_level: String,
+}
+
+/// Backend-specific runtime hooks for worker spawning and initialization.
+///
+/// Backends implement this trait to spawn workers that are tightly coupled
+/// to their implementation details (e.g., PostgreSQL's control plane poller,
+/// pool metrics, GSI delay polling).
+#[async_trait]
+pub trait ServerRuntimeHooks: Send + Sync {
+    /// Spawn backend-specific workers.
+    ///
+    /// Called after server components are created but before the HTTP server
+    /// starts. Backends can spawn workers that need access to backend-specific
+    /// state (connection pools, notify handles, etc.).
+    async fn spawn_workers(&self, ctx: &WorkerContext);
+
+    /// Get backend-specific info for logging (optional).
+    ///
+    /// Example: "data_db=ddbo_data" for PostgreSQL
+    fn backend_info(&self) -> Option<String> {
+        None
+    }
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -9,9 +9,14 @@
 
 pub mod authorization_store;
 pub mod bootstrapper;
+pub mod config;
+pub mod diagnostics;
+pub mod diagnostics_store;
 pub mod error;
-
+pub mod hooks;
 pub mod management_store;
+pub mod operations;
+pub mod settings_store;
 pub mod transact;
 
 pub use transact::{TransactGetOp, TransactWriteOp};
@@ -543,4 +548,49 @@ pub trait BackupEngine: Send + Sync {
         source_table_name: &str,
         target_table_name: &str,
     ) -> impl Future<Output = Result<TableDescription, StorageError>> + Send;
+}
+
+/// Supertrait combining all DynamoDB operation traits.
+///
+/// All storage backends must implement this to provide a complete
+/// DynamoDB-compatible API. This trait has NO additional methods beyond
+/// the trait bounds — backend-specific concerns belong in ServerRuntimeHooks.
+pub trait StorageEngine:
+    TableEngine + DataEngine + MetadataEngine + StreamEngine + BackupEngine + WorkerStore + Send + Sync
+{
+}
+
+// Blanket implementation: any type implementing all 6 traits is a StorageEngine
+impl<T> StorageEngine for T where
+    T: TableEngine
+        + DataEngine
+        + MetadataEngine
+        + StreamEngine
+        + BackupEngine
+        + WorkerStore
+        + Send
+        + Sync
+{
+}
+
+/// Supertrait combining all catalog/management operation traits.
+///
+/// All storage backends must implement this to provide management API
+/// functionality (accounts, users, groups, roles, policies, settings, metrics).
+pub trait CatalogStore:
+    management_store::ManagementStore
+    + management_store::AdminStore
+    + management_store::SettingsStore
+    + management_store::MetricsStore
+    + management_store::RateLimitStore
+    + authorization_store::AuthorizationStore
+    + Send
+    + Sync
+{
+    /// Get the cached encryption key (if available).
+    ///
+    /// Returns None if encryption key is not cached. This is used by
+    /// cmd_serve to construct the auth provider without re-querying
+    /// the settings table.
+    fn cached_encryption_key(&self) -> Option<String>;
 }

--- a/crates/storage/src/management_store/mod.rs
+++ b/crates/storage/src/management_store/mod.rs
@@ -31,18 +31,20 @@ pub use types::{
 
 use std::future::Future;
 
+use futures::future::BoxFuture;
+
 // ── Settings store ─────────────────────────────────────────────────────
 
 /// Runtime settings storage (e.g. `control_plane_delay_seconds`, `log_level`).
 pub trait SettingsStore: Send + Sync {
     /// Get a single setting value. Returns `None` if the key does not exist.
-    fn get_setting(&self, key: &str) -> impl Future<Output = OpResult<Option<String>>> + Send;
+    fn get_setting(&self, key: &str) -> BoxFuture<'_, OpResult<Option<String>>>;
 
     /// Set a setting value (upsert).
-    fn set_setting(&self, key: &str, value: &str) -> impl Future<Output = OpResult<()>> + Send;
+    fn set_setting(&self, key: &str, value: &str) -> BoxFuture<'_, OpResult<()>>;
 
     /// List all settings as `(key, value)` pairs, ordered by key.
-    fn list_settings(&self) -> impl Future<Output = OpResult<Vec<(String, String)>>> + Send;
+    fn list_settings(&self) -> BoxFuture<'_, OpResult<Vec<(String, String)>>>;
 
     /// P119: Get the cached encryption key if available. Returns `None` by
     /// default; backends that cache the key at startup override this.

--- a/crates/storage/src/operations.rs
+++ b/crates/storage/src/operations.rs
@@ -1,0 +1,106 @@
+// Copyright 2026 DynamoDB Open contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Backend operations for ddbo CLI commands.
+//!
+//! The `OperationsEngine` trait provides backend-specific operations needed
+//! by ddbo CLI commands (init, serve, destroy, verify, etc.). These operations
+//! support the ddbo platform lifecycle, runtime operations, and diagnostics.
+//!
+//! This is distinct from:
+//! - Data plane operations (PutItem, Query) — handled by `DataEngine`
+//! - Control plane operations (CreateTable) — handled by `TableEngine`
+//! - Management operations (IAM, accounts) — handled by `ManagementStore`
+
+use crate::error::StorageError;
+
+/// Backend-specific operations for ddbo CLI commands.
+pub trait OperationsEngine: Send + Sync {
+    /// Parse a backend-specific connection string into components.
+    fn parse_connection_string(&self, s: &str) -> Result<ConnectionParts, StorageError>;
+
+    /// Redact sensitive information from a connection string for logging.
+    fn redact_connection_string(&self, s: &str) -> String;
+
+    /// Validate an identifier (database name, table name, etc.) for DDL safety.
+    ///
+    /// This is used when constructing DDL statements with `format!` where
+    /// parameterized queries are not possible (e.g., CREATE DATABASE, DROP DATABASE).
+    fn validate_identifier(&self, name: &str, label: &str) -> Result<(), StorageError>;
+
+    /// Get the catalog schema version for this backend.
+    fn catalog_version(&self) -> String;
+
+    /// Check if a configuration key contains sensitive data that should be redacted.
+    fn is_sensitive_key(&self, key: &str) -> bool;
+}
+
+/// Parsed connection string components (backend-agnostic).
+#[derive(Debug, Clone)]
+pub struct ConnectionParts {
+    pub host: String,
+    pub port: u16,
+    pub user: String,
+    pub password: String,
+    pub database: String,
+}
+
+/// Registration entry for backend operations.
+pub struct OperationsEngineRegistration {
+    pub name: &'static str,
+    pub operations: &'static dyn OperationsEngine,
+}
+
+inventory::collect!(OperationsEngineRegistration);
+
+/// Get the operations engine for a backend by name.
+pub fn get_operations_engine(backend: &str) -> Result<&'static dyn OperationsEngine, StorageError> {
+    for reg in inventory::iter::<OperationsEngineRegistration> {
+        if reg.name == backend {
+            return Ok(reg.operations);
+        }
+    }
+
+    let available: Vec<&str> = inventory::iter::<OperationsEngineRegistration>()
+        .map(|r| r.name)
+        .collect();
+
+    Err(StorageError::Internal(format!(
+        "Unknown backend: {backend}. Available backends: {}",
+        available.join(", ")
+    )))
+}
+
+/// List all registered backend names.
+pub fn list_operations_backends() -> Vec<&'static str> {
+    inventory::iter::<OperationsEngineRegistration>()
+        .map(|r| r.name)
+        .collect()
+}
+
+// Convenience functions that delegate to the operations engine
+
+/// Get the catalog version for a backend.
+pub fn catalog_version(backend: &str) -> Result<String, StorageError> {
+    get_operations_engine(backend).map(|ops| ops.catalog_version())
+}
+
+/// Redact sensitive information from a connection string.
+pub fn redact_connection_string(backend: &str, s: &str) -> Result<String, StorageError> {
+    get_operations_engine(backend).map(|ops| ops.redact_connection_string(s))
+}
+
+/// Parse a connection string into components.
+pub fn parse_connection_string(backend: &str, s: &str) -> Result<ConnectionParts, StorageError> {
+    get_operations_engine(backend)?.parse_connection_string(s)
+}
+
+/// Validate an identifier for DDL safety.
+pub fn validate_identifier(backend: &str, name: &str, label: &str) -> Result<(), StorageError> {
+    get_operations_engine(backend)?.validate_identifier(name, label)
+}
+
+/// Check if a configuration key contains sensitive data.
+pub fn is_sensitive_key(backend: &str, key: &str) -> Result<bool, StorageError> {
+    get_operations_engine(backend).map(|ops| ops.is_sensitive_key(key))
+}

--- a/crates/storage/src/settings_store.rs
+++ b/crates/storage/src/settings_store.rs
@@ -1,0 +1,55 @@
+// Copyright 2026 DynamoDB Open contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Settings store factory registry for backend-agnostic instantiation.
+
+use crate::management_store::SettingsStore;
+use futures::future::BoxFuture;
+
+/// Error type for settings store creation.
+#[derive(Debug)]
+pub enum SettingsStoreError {
+    BackendNotFound(String),
+    ConnectionFailed(String),
+}
+
+impl std::fmt::Display for SettingsStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BackendNotFound(backend) => {
+                write!(
+                    f,
+                    "No settings store factory registered for backend '{backend}'"
+                )
+            }
+            Self::ConnectionFailed(msg) => write!(f, "Failed to connect: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for SettingsStoreError {}
+
+/// Factory function type for creating settings stores.
+pub type SettingsStoreFactory =
+    fn(&str) -> BoxFuture<'static, Result<Box<dyn SettingsStore>, SettingsStoreError>>;
+
+/// Registration entry for a settings store factory.
+pub struct SettingsStoreRegistration {
+    pub backend: &'static str,
+    pub factory: SettingsStoreFactory,
+}
+
+inventory::collect!(SettingsStoreRegistration);
+
+/// Create a settings store for the given backend and connection string.
+pub async fn create_settings_store(
+    backend: &str,
+    connection_string: &str,
+) -> Result<Box<dyn SettingsStore>, SettingsStoreError> {
+    for registration in inventory::iter::<SettingsStoreRegistration> {
+        if registration.backend == backend {
+            return (registration.factory)(connection_string).await;
+        }
+    }
+    Err(SettingsStoreError::BackendNotFound(backend.to_string()))
+}


### PR DESCRIPTION
Removing postgres dependencies from most extenddb commands. The basic strategy here is to use traits and factories to implement and load the appropriate implementations for various types of backend APIs based on the backend configured in extenddb.toml. The only command not addressed by this round of refactoring is cmd_serve, which has more entangled dependencies than the others.

OperationsEngine trait:
- Backend-agnostic utility functions (catalog_version, redact_connection_string, etc.)
- Registry pattern using inventory crate
- PostgreSQL implementation

Config and store abstractions:
- StorageConfig trait with registry-based deserialization
- SettingsStore and DiagnosticsStore factories
- Migrated commands: init, migrate, destroy, settings, verify, catalog_check

cmd_serve preparation:
- StorageEngine supertrait (blanket impl over 6 operation traits)
- CatalogStore supertrait (6 catalog traits + cached_encryption_key)
- ServerRuntimeHooks trait for backend-specific worker spawning

Status: 18 of 19 bin crate files are now backend-agnostic.
cmd_serve remains PostgreSQL-coupled pending resolution of RPITIT dyn-compatibility.
Additionally, documentation on implementing new backend engines will need to be updated.

Testing: Unit, comprehensive, ad-hoc