### PR TITLE
Fix/pg identifier overflow

### DIFF
--- a/crates/core/src/types/key_schema.rs
+++ b/crates/core/src/types/key_schema.rs
@@ -99,6 +99,8 @@ pub enum IndexType {
 pub struct IndexInfo {
     /// Name of the index.
     pub index_name: String,
+    /// Unique identifier for the index (used as PG table name suffix).
+    pub index_id: String,
     /// GSI or LSI.
     pub index_type: IndexType,
     /// Key schema of the index (HASH, optional RANGE).

--- a/crates/storage-postgres/migrations/001_schema.sql
+++ b/crates/storage-postgres/migrations/001_schema.sql
@@ -43,6 +43,7 @@ CREATE INDEX idx_tables_pending_transition
 -- Index metadata.
 CREATE TABLE IF NOT EXISTS indexes (
     table_id TEXT NOT NULL,
+    index_id TEXT NOT NULL DEFAULT gen_random_uuid()::text,
     index_name TEXT NOT NULL,
     index_type TEXT NOT NULL,
     key_schema JSONB NOT NULL,

--- a/crates/storage-postgres/src/backup_engine.rs
+++ b/crates/storage-postgres/src/backup_engine.rs
@@ -76,7 +76,7 @@ impl BackupEngine for PostgresEngine {
         );
 
         // Snapshot items from the data table.
-        let ddb_table = data_table_name(account_id, table_name);
+        let ddb_table = data_table_name(&table_id);
         let ddb_table_unquoted = ddb_table.trim_matches('"');
         let has_sk: bool = sqlx::query_scalar(
             "SELECT EXISTS(SELECT 1 FROM information_schema.columns \
@@ -394,8 +394,7 @@ impl BackupEngine for PostgresEngine {
         let desc = self.create_table(account_id, create_input).await?;
 
         let new_table_id = &desc.table_id;
-        let _ = new_table_id; // table_id not used for data table naming
-        let ddb_table = data_table_name(account_id, target_table_name);
+        let ddb_table = data_table_name(new_table_id);
         let ddb_table_unquoted = ddb_table.trim_matches('"');
 
         // Do NOT force ACTIVE — let the control plane handle the transition

--- a/crates/storage-postgres/src/create_table.rs
+++ b/crates/storage-postgres/src/create_table.rs
@@ -217,8 +217,7 @@ impl PostgresEngine {
 
             Self::create_data_table(
                 &mut data_tx,
-                account_id,
-                &input.table_name,
+                &table_id,
                 &input.key_schema,
                 &input.attribute_definitions,
             )
@@ -228,8 +227,7 @@ impl PostgresEngine {
                 for gsi in gsis {
                     Self::create_index_data_table(
                         &mut data_tx,
-                        account_id,
-                        &input.table_name,
+                        &table_id,
                         &gsi.index_name,
                         &gsi.key_schema,
                         &input.attribute_definitions,
@@ -243,8 +241,7 @@ impl PostgresEngine {
                 for lsi in lsis {
                     Self::create_index_data_table(
                         &mut data_tx,
-                        account_id,
-                        &input.table_name,
+                        &table_id,
                         &lsi.index_name,
                         &lsi.key_schema,
                         &input.attribute_definitions,

--- a/crates/storage-postgres/src/create_table.rs
+++ b/crates/storage-postgres/src/create_table.rs
@@ -102,6 +102,7 @@ impl PostgresEngine {
         // F-1: Store full ProvisionedThroughputDescription (not the input
         // ProvisionedThroughput) so DescribeTable can deserialize it without
         // failing on the missing NumberOfDecreasesToday field.
+        let mut gsi_index_ids: Vec<String> = Vec::new();
         if let Some(gsis) = &input.global_secondary_indexes {
             for gsi in gsis {
                 let gsi_ks = serde_json::to_value(&gsi.key_schema)
@@ -123,24 +124,28 @@ impl PostgresEngine {
                     .transpose()
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
 
+                let index_id = uuid::Uuid::new_v4().to_string();
                 sqlx::query(
                     r"INSERT INTO indexes
-                       (table_id, index_name, index_type, key_schema, projection,
+                       (table_id, index_name, index_id, index_type, key_schema, projection,
                         index_status, provisioned_throughput)
-                       VALUES ($1, $2, 'GSI', $3, $4, 'ACTIVE', $5)",
+                       VALUES ($1, $2, $3, 'GSI', $4, $5, 'ACTIVE', $6)",
                 )
                 .bind(&table_id)
                 .bind(&gsi.index_name)
+                .bind(&index_id)
                 .bind(&gsi_ks)
                 .bind(&gsi_proj)
                 .bind(&gsi_pt)
                 .execute(&mut *tx)
                 .await
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
+                gsi_index_ids.push(index_id);
             }
         }
 
         // Insert LSI metadata
+        let mut lsi_index_ids: Vec<String> = Vec::new();
         if let Some(lsis) = &input.local_secondary_indexes {
             for lsi in lsis {
                 let lsi_ks = serde_json::to_value(&lsi.key_schema)
@@ -148,19 +153,22 @@ impl PostgresEngine {
                 let lsi_proj = serde_json::to_value(&lsi.projection)
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
 
+                let index_id = uuid::Uuid::new_v4().to_string();
                 sqlx::query(
                     r"INSERT INTO indexes
-                       (table_id, index_name, index_type, key_schema, projection,
+                       (table_id, index_name, index_id, index_type, key_schema, projection,
                         index_status, provisioned_throughput)
-                       VALUES ($1, $2, 'LSI', $3, $4, 'ACTIVE', NULL)",
+                       VALUES ($1, $2, $3, 'LSI', $4, $5, 'ACTIVE', NULL)",
                 )
                 .bind(&table_id)
                 .bind(&lsi.index_name)
+                .bind(&index_id)
                 .bind(&lsi_ks)
                 .bind(&lsi_proj)
                 .execute(&mut *tx)
                 .await
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
+                lsi_index_ids.push(index_id);
             }
         }
 
@@ -224,11 +232,10 @@ impl PostgresEngine {
             .await?;
 
             if let Some(gsis) = &input.global_secondary_indexes {
-                for gsi in gsis {
+                for (i, gsi) in gsis.iter().enumerate() {
                     Self::create_index_data_table(
                         &mut data_tx,
-                        &table_id,
-                        &gsi.index_name,
+                        &gsi_index_ids[i],
                         &gsi.key_schema,
                         &input.attribute_definitions,
                         &input.key_schema,
@@ -238,11 +245,10 @@ impl PostgresEngine {
                 }
             }
             if let Some(lsis) = &input.local_secondary_indexes {
-                for lsi in lsis {
+                for (i, lsi) in lsis.iter().enumerate() {
                     Self::create_index_data_table(
                         &mut data_tx,
-                        &table_id,
-                        &lsi.index_name,
+                        &lsi_index_ids[i],
                         &lsi.key_schema,
                         &input.attribute_definitions,
                         &input.key_schema,

--- a/crates/storage-postgres/src/data/ddl.rs
+++ b/crates/storage-postgres/src/data/ddl.rs
@@ -31,12 +31,11 @@ impl PostgresEngine {
     /// into the DDL beyond the validated table name.
     pub(crate) async fn create_data_table(
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-        account_id: &str,
-        table_name: &str,
+        table_id: &str,
         key_schema: &[KeySchemaElement],
         attr_defs: &[AttributeDefinition],
     ) -> Result<(), StorageError> {
-        let ddb_table = data_table_name(account_id, table_name);
+        let ddb_table = data_table_name(table_id);
         let sk_infos = all_sort_key_info(key_schema, attr_defs);
 
         let ddl = if sk_infos.is_empty() {
@@ -103,10 +102,9 @@ impl PostgresEngine {
     /// Returns [`StorageError::Internal`] if the DDL execution fails.
     pub(crate) async fn drop_data_table(
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-        account_id: &str,
-        table_name: &str,
+        table_id: &str,
     ) -> Result<(), StorageError> {
-        let ddb_table = data_table_name(account_id, table_name);
+        let ddb_table = data_table_name(table_id);
         let ddl = format!("DROP TABLE IF EXISTS {ddb_table}");
         sqlx::query(&ddl)
             .execute(&mut **tx)
@@ -130,15 +128,14 @@ impl PostgresEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn create_index_data_table(
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-        account_id: &str,
-        table_name: &str,
+        table_id: &str,
         index_name: &str,
         index_key_schema: &[KeySchemaElement],
         attr_defs: &[AttributeDefinition],
         base_key_schema: &[KeySchemaElement],
         base_attr_defs: &[AttributeDefinition],
     ) -> Result<(), StorageError> {
-        let idx_table = index_table_name(account_id, table_name, index_name);
+        let idx_table = index_table_name(table_id, index_name);
 
         // Determine base table sort key columns for the uniqueness constraint
         let base_sks = all_sort_key_info(base_key_schema, base_attr_defs);
@@ -229,11 +226,10 @@ impl PostgresEngine {
     /// Drop a GSI/LSI data table.
     pub(crate) async fn drop_index_data_table(
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-        account_id: &str,
-        table_name: &str,
+        table_id: &str,
         index_name: &str,
     ) -> Result<(), StorageError> {
-        let idx_table = index_table_name(account_id, table_name, index_name);
+        let idx_table = index_table_name(table_id, index_name);
         let ddl = format!("DROP TABLE IF EXISTS {idx_table}");
         sqlx::query(&ddl)
             .execute(&mut **tx)

--- a/crates/storage-postgres/src/data/ddl.rs
+++ b/crates/storage-postgres/src/data/ddl.rs
@@ -128,14 +128,13 @@ impl PostgresEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn create_index_data_table(
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-        table_id: &str,
-        index_name: &str,
+        index_id: &str,
         index_key_schema: &[KeySchemaElement],
         attr_defs: &[AttributeDefinition],
         base_key_schema: &[KeySchemaElement],
         base_attr_defs: &[AttributeDefinition],
     ) -> Result<(), StorageError> {
-        let idx_table = index_table_name(table_id, index_name);
+        let idx_table = index_table_name(index_id);
 
         // Determine base table sort key columns for the uniqueness constraint
         let base_sks = all_sort_key_info(base_key_schema, base_attr_defs);
@@ -226,10 +225,9 @@ impl PostgresEngine {
     /// Drop a GSI/LSI data table.
     pub(crate) async fn drop_index_data_table(
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-        table_id: &str,
-        index_name: &str,
+        index_id: &str,
     ) -> Result<(), StorageError> {
-        let idx_table = index_table_name(table_id, index_name);
+        let idx_table = index_table_name(index_id);
         let ddl = format!("DROP TABLE IF EXISTS {idx_table}");
         sqlx::query(&ddl)
             .execute(&mut **tx)
@@ -342,8 +340,8 @@ impl PostgresEngine {
         table_id: &str,
         index_name: &str,
     ) -> Result<IndexInfo, StorageError> {
-        let idx_row: Option<(String, serde_json::Value, serde_json::Value)> = sqlx::query_as(
-            "SELECT index_type, key_schema, projection FROM indexes WHERE table_id = $1 AND index_name = $2",
+        let idx_row: Option<(String, String, serde_json::Value, serde_json::Value)> = sqlx::query_as(
+            "SELECT index_type, index_id, key_schema, projection FROM indexes WHERE table_id = $1 AND index_name = $2",
         )
         .bind(table_id)
         .bind(index_name)
@@ -351,7 +349,7 @@ impl PostgresEngine {
         .await
         .map_err(|e| StorageError::Internal(e.to_string()))?;
 
-        let (idx_type_str, ks_json, proj_json) =
+        let (idx_type_str, idx_id, ks_json, proj_json) =
             idx_row.ok_or_else(|| StorageError::IndexNotFound(index_name.to_owned()))?;
 
         let index_type = match idx_type_str.as_str() {
@@ -371,6 +369,7 @@ impl PostgresEngine {
 
         Ok(IndexInfo {
             index_name: index_name.to_owned(),
+            index_id: idx_id,
             index_type,
             key_schema,
             projection,

--- a/crates/storage-postgres/src/data/delete_item.rs
+++ b/crates/storage-postgres/src/data/delete_item.rs
@@ -26,7 +26,7 @@ impl PostgresEngine {
         maps: &ExpressionMaps,
         stream: Option<&StreamCapture>,
     ) -> Result<Option<Item>, StorageError> {
-        let ddb_table = data_table_name(&key_info.account_id, &key_info.table_name);
+        let ddb_table = data_table_name(&key_info.table_id);
 
         let pk_name = &key_info.key_schema[0].attribute_name;
         let pk_value = key
@@ -126,8 +126,7 @@ impl PostgresEngine {
                         .transpose()?;
                     sync_indexes(
                         &mut tx,
-                        &key_info.account_id,
-                        &key_info.table_name,
+                        &key_info.table_id,
                         &key_info.key_schema,
                         &key_info.attribute_definitions,
                         &indexes,
@@ -167,6 +166,7 @@ impl PostgresEngine {
                         pk_hash(pk_text.as_ref()),
                         &key_info.account_id,
                         &key_info.table_name,
+                        &key_info.table_id,
                         &key_info.key_schema,
                         &key_info.attribute_definitions,
                         &indexes,
@@ -264,8 +264,7 @@ impl PostgresEngine {
                         .transpose()?;
                     sync_indexes(
                         &mut tx,
-                        &key_info.account_id,
-                        &key_info.table_name,
+                        &key_info.table_id,
                         &key_info.key_schema,
                         &key_info.attribute_definitions,
                         &indexes,
@@ -305,6 +304,7 @@ impl PostgresEngine {
                         pk_hash(pk_text.as_ref()),
                         &key_info.account_id,
                         &key_info.table_name,
+                        &key_info.table_id,
                         &key_info.key_schema,
                         &key_info.attribute_definitions,
                         &indexes,

--- a/crates/storage-postgres/src/data/index.rs
+++ b/crates/storage-postgres/src/data/index.rs
@@ -124,8 +124,7 @@ pub(super) fn effective_delay(idx: &IndexMeta, system_default: u64) -> u64 {
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn sync_indexes(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-    account_id: &str,
-    table_name: &str,
+    table_id: &str,
     base_key_schema: &[KeySchemaElement],
     attr_defs: &[AttributeDefinition],
     indexes: &[IndexMeta],
@@ -137,7 +136,7 @@ pub(crate) async fn sync_indexes(
         if effective_delay(idx, system_default_delay) != 0 {
             continue; // Async — handled after commit.
         }
-        let idx_table = index_table_name(account_id, table_name, &idx.index_name);
+        let idx_table = index_table_name(table_id, &idx.index_name);
         let idx_sks = all_sort_key_info(&idx.key_schema, attr_defs);
         let base_sks = all_sort_key_info(base_key_schema, attr_defs);
 
@@ -182,6 +181,7 @@ pub(crate) async fn enqueue_async_indexes(
     pk_hash: u64,
     account_id: &str,
     table_name: &str,
+    table_id: &str,
     base_key_schema: &[KeySchemaElement],
     attr_defs: &[AttributeDefinition],
     indexes: &[IndexMeta],
@@ -199,6 +199,7 @@ pub(crate) async fn enqueue_async_indexes(
                 pk_hash,
                 account_id,
                 table_name,
+                table_id,
                 base_key_schema,
                 attr_defs,
                 &idx.index_name,

--- a/crates/storage-postgres/src/data/index.rs
+++ b/crates/storage-postgres/src/data/index.rs
@@ -19,6 +19,7 @@ use super::{all_sort_key_info, index_table_name};
 /// Metadata for a single index, used during write-path GSI/LSI sync.
 pub(crate) struct IndexMeta {
     pub(super) index_name: String,
+    pub(super) index_id: String,
     pub(super) key_schema: Vec<KeySchemaElement>,
     pub(super) projection: Projection,
     /// Per-GSI propagation delay in milliseconds. `None` means use system
@@ -31,8 +32,8 @@ pub(crate) async fn fetch_indexes_for_table(
     table_id: &str,
     pool: &sqlx::PgPool,
 ) -> Result<Vec<IndexMeta>, StorageError> {
-    let rows: Vec<(String, serde_json::Value, serde_json::Value, Option<i32>)> = sqlx::query_as(
-        "SELECT index_name, key_schema, projection, propagation_delay_ms FROM indexes WHERE table_id = $1",
+    let rows: Vec<(String, String, serde_json::Value, serde_json::Value, Option<i32>)> = sqlx::query_as(
+        "SELECT index_name, index_id, key_schema, projection, propagation_delay_ms FROM indexes WHERE table_id = $1",
     )
     .bind(table_id)
     .fetch_all(pool)
@@ -40,13 +41,14 @@ pub(crate) async fn fetch_indexes_for_table(
     .map_err(|e| StorageError::Internal(e.to_string()))?;
 
     rows.into_iter()
-        .map(|(name, ks_json, proj_json, delay)| {
+        .map(|(name, id, ks_json, proj_json, delay)| {
             let key_schema: Vec<KeySchemaElement> = serde_json::from_value(ks_json)
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
             let projection: Projection = serde_json::from_value(proj_json)
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
             Ok(IndexMeta {
                 index_name: name,
+                index_id: id,
                 key_schema,
                 projection,
                 propagation_delay_ms: delay,
@@ -124,7 +126,7 @@ pub(super) fn effective_delay(idx: &IndexMeta, system_default: u64) -> u64 {
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn sync_indexes(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-    table_id: &str,
+    _table_id: &str,
     base_key_schema: &[KeySchemaElement],
     attr_defs: &[AttributeDefinition],
     indexes: &[IndexMeta],
@@ -136,7 +138,7 @@ pub(crate) async fn sync_indexes(
         if effective_delay(idx, system_default_delay) != 0 {
             continue; // Async — handled after commit.
         }
-        let idx_table = index_table_name(table_id, &idx.index_name);
+        let idx_table = index_table_name(&idx.index_id);
         let idx_sks = all_sort_key_info(&idx.key_schema, attr_defs);
         let base_sks = all_sort_key_info(base_key_schema, attr_defs);
 
@@ -203,6 +205,7 @@ pub(crate) async fn enqueue_async_indexes(
                 base_key_schema,
                 attr_defs,
                 &idx.index_name,
+                &idx.index_id,
                 &idx.key_schema,
                 &idx.projection,
                 old_item,

--- a/crates/storage-postgres/src/data/mod.rs
+++ b/crates/storage-postgres/src/data/mod.rs
@@ -16,15 +16,13 @@ use extenddb_storage::error::StorageError;
 /// Includes `account_id` for multi-account isolation (Phase 12a).
 /// Table names are validated at the engine layer (alphanumeric + `_.-`),
 /// so this is safe for identifier construction.
-pub(crate) fn data_table_name(account_id: &str, table_name: &str) -> String {
-    format!("\"_ddb_{account_id}_{table_name}\"")
+pub(crate) fn data_table_name(table_id: &str) -> String {
+    format!("\"_ddb_{table_id}\"")
 }
 
 /// SQL table name for a GSI/LSI data table.
-///
-/// Uses `_ddb_<account>_<table>__gsi__<index>` naming convention.
-pub(crate) fn index_table_name(account_id: &str, table_name: &str, index_name: &str) -> String {
-    format!("\"_ddb_{account_id}_{table_name}__gsi__{index_name}\"")
+pub(crate) fn index_table_name(table_id: &str, index_name: &str) -> String {
+    format!("\"_ddb_{table_id}__gsi__{index_name}\"")
 }
 
 /// Look up all RANGE key attribute definitions from the key schema (preserving order).

--- a/crates/storage-postgres/src/data/mod.rs
+++ b/crates/storage-postgres/src/data/mod.rs
@@ -21,8 +21,8 @@ pub(crate) fn data_table_name(table_id: &str) -> String {
 }
 
 /// SQL table name for a GSI/LSI data table.
-pub(crate) fn index_table_name(table_id: &str, index_name: &str) -> String {
-    format!("\"_ddb_{table_id}__gsi__{index_name}\"")
+pub(crate) fn index_table_name(index_id: &str) -> String {
+    format!("\"_ddb_{index_id}\"")
 }
 
 /// Look up all RANGE key attribute definitions from the key schema (preserving order).

--- a/crates/storage-postgres/src/data/put_item.rs
+++ b/crates/storage-postgres/src/data/put_item.rs
@@ -26,7 +26,7 @@ impl PostgresEngine {
         maps: &ExpressionMaps,
         stream: Option<&StreamCapture>,
     ) -> Result<Option<Item>, StorageError> {
-        let ddb_table = data_table_name(&key_info.account_id, &key_info.table_name);
+        let ddb_table = data_table_name(&key_info.table_id);
 
         let pk_text = composite_pk_to_text(&item, &key_info.key_schema)?;
 
@@ -103,8 +103,7 @@ impl PostgresEngine {
                         .transpose()?;
                     sync_indexes(
                         &mut tx,
-                        &key_info.account_id,
-                        &key_info.table_name,
+                        &key_info.table_id,
                         &key_info.key_schema,
                         &key_info.attribute_definitions,
                         &indexes,
@@ -144,6 +143,7 @@ impl PostgresEngine {
                         pk_hash(pk_text.as_str()),
                         &key_info.account_id,
                         &key_info.table_name,
+                        &key_info.table_id,
                         &key_info.key_schema,
                         &key_info.attribute_definitions,
                         &indexes,
@@ -230,8 +230,7 @@ impl PostgresEngine {
                         .transpose()?;
                     sync_indexes(
                         &mut tx,
-                        &key_info.account_id,
-                        &key_info.table_name,
+                        &key_info.table_id,
                         &key_info.key_schema,
                         &key_info.attribute_definitions,
                         &indexes,
@@ -271,6 +270,7 @@ impl PostgresEngine {
                         pk_hash(pk_text.as_str()),
                         &key_info.account_id,
                         &key_info.table_name,
+                        &key_info.table_id,
                         &key_info.key_schema,
                         &key_info.attribute_definitions,
                         &indexes,
@@ -308,7 +308,7 @@ impl PostgresEngine {
         key_info: &TableKeyInfo,
         key: &Item,
     ) -> Result<Option<Item>, StorageError> {
-        let ddb_table = data_table_name(&key_info.account_id, &key_info.table_name);
+        let ddb_table = data_table_name(&key_info.table_id);
 
         let pk_name = &key_info.key_schema[0].attribute_name;
         let pk_value = key

--- a/crates/storage-postgres/src/data/query_scan.rs
+++ b/crates/storage-postgres/src/data/query_scan.rs
@@ -31,9 +31,9 @@ impl PostgresEngine {
         use std::fmt::Write;
 
         let ddb_table = if let Some(idx_name) = index_name {
-            index_table_name(&key_info.account_id, &key_info.table_name, idx_name)
+            index_table_name(&key_info.table_id, idx_name)
         } else {
-            data_table_name(&key_info.account_id, &key_info.table_name)
+            data_table_name(&key_info.table_id)
         };
 
         // Resolve partition key value(s) — for multi-part keys, encode
@@ -190,9 +190,9 @@ impl PostgresEngine {
         use std::fmt::Write;
 
         let ddb_table = if let Some(idx_name) = index_name {
-            index_table_name(&key_info.account_id, &key_info.table_name, idx_name)
+            index_table_name(&key_info.table_id, idx_name)
         } else {
-            data_table_name(&key_info.account_id, &key_info.table_name)
+            data_table_name(&key_info.table_id)
         };
         let sk_info_val = sk_info(&key_info.key_schema, &key_info.attribute_definitions);
 

--- a/crates/storage-postgres/src/data/query_scan.rs
+++ b/crates/storage-postgres/src/data/query_scan.rs
@@ -31,7 +31,10 @@ impl PostgresEngine {
         use std::fmt::Write;
 
         let ddb_table = if let Some(idx_name) = index_name {
-            index_table_name(&key_info.table_id, idx_name)
+            let idx_info = self
+                .fetch_index_info_by_table_id(&key_info.table_id, idx_name)
+                .await?;
+            index_table_name(&idx_info.index_id)
         } else {
             data_table_name(&key_info.table_id)
         };
@@ -190,7 +193,10 @@ impl PostgresEngine {
         use std::fmt::Write;
 
         let ddb_table = if let Some(idx_name) = index_name {
-            index_table_name(&key_info.table_id, idx_name)
+            let idx_info = self
+                .fetch_index_info_by_table_id(&key_info.table_id, idx_name)
+                .await?;
+            index_table_name(&idx_info.index_id)
         } else {
             data_table_name(&key_info.table_id)
         };

--- a/crates/storage-postgres/src/data/transactions.rs
+++ b/crates/storage-postgres/src/data/transactions.rs
@@ -199,6 +199,7 @@ impl PostgresEngine {
                     pk_hash(&pk_text),
                     &key_info.account_id,
                     &key_info.table_name,
+                    &key_info.table_id,
                     &key_info.key_schema,
                     &key_info.attribute_definitions,
                     indexes,
@@ -319,8 +320,7 @@ async fn execute_transact_write_op(
             if !indexes.is_empty() {
                 sync_indexes(
                     tx,
-                    &key_info.account_id,
-                    &key_info.table_name,
+                    &key_info.table_id,
                     &key_info.key_schema,
                     &key_info.attribute_definitions,
                     indexes,
@@ -364,8 +364,7 @@ async fn execute_transact_write_op(
             if !indexes.is_empty() {
                 sync_indexes(
                     tx,
-                    &key_info.account_id,
-                    &key_info.table_name,
+                    &key_info.table_id,
                     &key_info.key_schema,
                     &key_info.attribute_definitions,
                     indexes,
@@ -417,8 +416,7 @@ async fn execute_transact_write_op(
             if !indexes.is_empty() {
                 sync_indexes(
                     tx,
-                    &key_info.account_id,
-                    &key_info.table_name,
+                    &key_info.table_id,
                     &key_info.key_schema,
                     &key_info.attribute_definitions,
                     indexes,

--- a/crates/storage-postgres/src/data/tx_helpers.rs
+++ b/crates/storage-postgres/src/data/tx_helpers.rs
@@ -22,7 +22,7 @@ pub(super) async fn fetch_item_in_tx(
     key_info: &TableKeyInfo,
     key: &Item,
 ) -> Result<Option<Item>, StorageError> {
-    let ddb_table = data_table_name(&key_info.account_id, &key_info.table_name);
+    let ddb_table = data_table_name(&key_info.table_id);
     let pk_name = &key_info.key_schema[0].attribute_name;
     let pk_value = key
         .get(pk_name)
@@ -60,7 +60,7 @@ pub(super) async fn fetch_item_for_update(
     key_info: &TableKeyInfo,
     key: &Item,
 ) -> Result<Option<Item>, StorageError> {
-    let ddb_table = data_table_name(&key_info.account_id, &key_info.table_name);
+    let ddb_table = data_table_name(&key_info.table_id);
     let pk_name = &key_info.key_schema[0].attribute_name;
     let pk_value = key
         .get(pk_name)
@@ -99,7 +99,7 @@ pub(super) async fn upsert_item_in_tx(
     key_info: &TableKeyInfo,
     item: &Item,
 ) -> Result<(), StorageError> {
-    let ddb_table = data_table_name(&key_info.account_id, &key_info.table_name);
+    let ddb_table = data_table_name(&key_info.table_id);
     let pk_name = &key_info.key_schema[0].attribute_name;
     let pk_value = item
         .get(pk_name)
@@ -141,7 +141,7 @@ pub(super) async fn delete_item_in_tx(
     key_info: &TableKeyInfo,
     key: &Item,
 ) -> Result<(), StorageError> {
-    let ddb_table = data_table_name(&key_info.account_id, &key_info.table_name);
+    let ddb_table = data_table_name(&key_info.table_id);
     let pk_name = &key_info.key_schema[0].attribute_name;
     let pk_value = key
         .get(pk_name)

--- a/crates/storage-postgres/src/data/update_item.rs
+++ b/crates/storage-postgres/src/data/update_item.rs
@@ -29,7 +29,7 @@ impl PostgresEngine {
         maps: &ExpressionMaps,
         stream: Option<&StreamCapture>,
     ) -> Result<(Option<Item>, Option<Item>), StorageError> {
-        let ddb_table = data_table_name(&key_info.account_id, &key_info.table_name);
+        let ddb_table = data_table_name(&key_info.table_id);
 
         let pk_name = &key_info.key_schema[0].attribute_name;
         let pk_value = key
@@ -154,8 +154,7 @@ impl PostgresEngine {
         if !indexes.is_empty() {
             sync_indexes(
                 &mut tx,
-                &key_info.account_id,
-                &key_info.table_name,
+                &key_info.table_id,
                 &key_info.key_schema,
                 &key_info.attribute_definitions,
                 &indexes,
@@ -188,6 +187,7 @@ impl PostgresEngine {
                 pk_hash(pk_text.as_ref()),
                 &key_info.account_id,
                 &key_info.table_name,
+                &key_info.table_id,
                 &key_info.key_schema,
                 &key_info.attribute_definitions,
                 &indexes,

--- a/crates/storage-postgres/src/delete_table.rs
+++ b/crates/storage-postgres/src/delete_table.rs
@@ -97,10 +97,10 @@ impl PostgresEngine {
                 .await
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
             for idx_name in &index_names {
-                Self::drop_index_data_table(&mut data_tx, account_id, &input.table_name, idx_name)
+                Self::drop_index_data_table(&mut data_tx, &row.table_id, idx_name)
                     .await?;
             }
-            Self::drop_data_table(&mut data_tx, account_id, &input.table_name).await?;
+            Self::drop_data_table(&mut data_tx, &row.table_id).await?;
             data_tx
                 .commit()
                 .await

--- a/crates/storage-postgres/src/delete_table.rs
+++ b/crates/storage-postgres/src/delete_table.rs
@@ -48,7 +48,7 @@ impl PostgresEngine {
 
         // Fetch indexes for the response description.
         let index_rows: Vec<IndexRow> = sqlx::query_as(
-            r"SELECT index_name, index_type, key_schema, projection,
+            r"SELECT index_name, index_id, index_type, key_schema, projection,
                       index_status, provisioned_throughput
                FROM indexes WHERE table_id = $1",
         )
@@ -69,7 +69,7 @@ impl PostgresEngine {
         .map_err(|e| StorageError::Internal(e.to_string()))?;
         let delay_secs = delay_row.0;
 
-        let index_names: Vec<String> = index_rows.iter().map(|r| r.index_name.clone()).collect();
+        let index_ids: Vec<String> = index_rows.iter().map(|r| r.index_id.clone()).collect();
 
         if delay_secs < 1.0 {
             // Synchronous delete: remove tags, catalog row, and data tables inline.
@@ -96,8 +96,8 @@ impl PostgresEngine {
                 .begin()
                 .await
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
-            for idx_name in &index_names {
-                Self::drop_index_data_table(&mut data_tx, &row.table_id, idx_name)
+            for idx_id in &index_ids {
+                Self::drop_index_data_table(&mut data_tx, idx_id)
                     .await?;
             }
             Self::drop_data_table(&mut data_tx, &row.table_id).await?;

--- a/crates/storage-postgres/src/gsi_queue.rs
+++ b/crates/storage-postgres/src/gsi_queue.rs
@@ -42,8 +42,9 @@ fn is_undefined_table(err: &StorageError) -> bool {
 
 /// A pending GSI update operation.
 struct GsiUpdate {
-    account_id: String,
+    _account_id: String,
     table_name: String,
+    table_id: String,
     base_key_schema: Vec<KeySchemaElement>,
     attr_defs: Vec<AttributeDefinition>,
     index_name: String,
@@ -97,6 +98,7 @@ impl GsiQueue {
         pk_hash: u64,
         account_id: &str,
         table_name: &str,
+        table_id: &str,
         base_key_schema: &[KeySchemaElement],
         attr_defs: &[AttributeDefinition],
         index_name: &str,
@@ -107,8 +109,9 @@ impl GsiQueue {
         delay_ms: u64,
     ) {
         let update = GsiUpdate {
-            account_id: account_id.to_owned(),
+            _account_id: account_id.to_owned(),
             table_name: table_name.to_owned(),
+            table_id: table_id.to_owned(),
             base_key_schema: base_key_schema.to_vec(),
             attr_defs: attr_defs.to_vec(),
             index_name: index_name.to_owned(),
@@ -185,7 +188,7 @@ async fn worker(partition_id: usize, part: Arc<Partition>, pool: PgPool) {
 
 /// Apply a single GSI update within a transaction.
 async fn apply_gsi_update(pool: &PgPool, update: &GsiUpdate) -> Result<(), StorageError> {
-    let idx_table = index_table_name(&update.account_id, &update.table_name, &update.index_name);
+    let idx_table = index_table_name(&update.table_id, &update.index_name);
     let idx_sks = all_sort_key_info(&update.index_key_schema, &update.attr_defs);
     let base_sks = all_sort_key_info(&update.base_key_schema, &update.attr_defs);
 

--- a/crates/storage-postgres/src/gsi_queue.rs
+++ b/crates/storage-postgres/src/gsi_queue.rs
@@ -44,10 +44,11 @@ fn is_undefined_table(err: &StorageError) -> bool {
 struct GsiUpdate {
     _account_id: String,
     table_name: String,
-    table_id: String,
+    _table_id: String,
     base_key_schema: Vec<KeySchemaElement>,
     attr_defs: Vec<AttributeDefinition>,
     index_name: String,
+    index_id: String,
     index_key_schema: Vec<KeySchemaElement>,
     index_projection: Projection,
     old_item: Option<Item>,
@@ -102,6 +103,7 @@ impl GsiQueue {
         base_key_schema: &[KeySchemaElement],
         attr_defs: &[AttributeDefinition],
         index_name: &str,
+        index_id: &str,
         index_key_schema: &[KeySchemaElement],
         index_projection: &Projection,
         old_item: Option<&Item>,
@@ -111,10 +113,11 @@ impl GsiQueue {
         let update = GsiUpdate {
             _account_id: account_id.to_owned(),
             table_name: table_name.to_owned(),
-            table_id: table_id.to_owned(),
+            _table_id: table_id.to_owned(),
             base_key_schema: base_key_schema.to_vec(),
             attr_defs: attr_defs.to_vec(),
             index_name: index_name.to_owned(),
+            index_id: index_id.to_owned(),
             index_key_schema: index_key_schema.to_vec(),
             index_projection: index_projection.clone(),
             old_item: old_item.cloned(),
@@ -188,7 +191,7 @@ async fn worker(partition_id: usize, part: Arc<Partition>, pool: PgPool) {
 
 /// Apply a single GSI update within a transaction.
 async fn apply_gsi_update(pool: &PgPool, update: &GsiUpdate) -> Result<(), StorageError> {
-    let idx_table = index_table_name(&update.table_id, &update.index_name);
+    let idx_table = index_table_name(&update.index_id);
     let idx_sks = all_sort_key_info(&update.index_key_schema, &update.attr_defs);
     let base_sks = all_sort_key_info(&update.base_key_schema, &update.attr_defs);
 

--- a/crates/storage-postgres/src/metadata_engine.rs
+++ b/crates/storage-postgres/src/metadata_engine.rs
@@ -147,7 +147,15 @@ impl MetadataEngine for PostgresEngine {
         table_name: &str,
     ) -> Result<(), StorageError> {
         Self::validate_account_id(account_id)?;
-        let data_table = data::data_table_name(account_id, table_name);
+        let (table_id,): (String,) = sqlx::query_as(
+            "SELECT table_id FROM tables WHERE account_id = $1 AND table_name = $2",
+        )
+        .bind(account_id)
+        .bind(table_name)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let data_table = data::data_table_name(&table_id);
 
         // P54 Bug 1: Data tables live in the data database. Read size/count
         // from the data pool, then update the catalog on the catalog pool.
@@ -226,7 +234,15 @@ impl MetadataEngine for PostgresEngine {
         ttl_attribute: &str,
     ) -> Result<(), StorageError> {
         Self::validate_account_id(account_id)?;
-        let data_table = data::data_table_name(account_id, table_name);
+        let (table_id,): (String,) = sqlx::query_as(
+            "SELECT table_id FROM tables WHERE account_id = $1 AND table_name = $2",
+        )
+        .bind(account_id)
+        .bind(table_name)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let data_table = data::data_table_name(&table_id);
         // Strip quotes for index name (data_table_name returns quoted identifier).
         let bare_table = data_table.trim_matches('"');
         let index_name = format!("idx_ttl_{bare_table}");
@@ -259,7 +275,15 @@ impl MetadataEngine for PostgresEngine {
 
     async fn drop_ttl_index(&self, account_id: &str, table_name: &str) -> Result<(), StorageError> {
         Self::validate_account_id(account_id)?;
-        let data_table = data::data_table_name(account_id, table_name);
+        let (table_id,): (String,) = sqlx::query_as(
+            "SELECT table_id FROM tables WHERE account_id = $1 AND table_name = $2",
+        )
+        .bind(account_id)
+        .bind(table_name)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let data_table = data::data_table_name(&table_id);
         let bare_table = data_table.trim_matches('"');
         let index_name = format!("idx_ttl_{bare_table}");
 
@@ -291,7 +315,15 @@ impl MetadataEngine for PostgresEngine {
         limit: usize,
     ) -> Result<Vec<Item>, StorageError> {
         Self::validate_account_id(account_id)?;
-        let data_table = data::data_table_name(account_id, table_name);
+        let (table_id,): (String,) = sqlx::query_as(
+            "SELECT table_id FROM tables WHERE account_id = $1 AND table_name = $2",
+        )
+        .bind(account_id)
+        .bind(table_name)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let data_table = data::data_table_name(&table_id);
 
         let now_epoch = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/crates/storage-postgres/src/table_helpers.rs
+++ b/crates/storage-postgres/src/table_helpers.rs
@@ -46,11 +46,10 @@ pub(crate) struct IndexRow {
 impl PostgresEngine {
     /// SQL table name for a GSI data table (static version for use outside `data` module).
     pub(crate) fn index_table_name_static(
-        account_id: &str,
-        table_name: &str,
+        table_id: &str,
         index_name: &str,
     ) -> String {
-        data::index_table_name(account_id, table_name, index_name)
+        data::index_table_name(table_id, index_name)
     }
 
     /// Backfill existing items from the base table into a newly created GSI.
@@ -63,8 +62,7 @@ impl PostgresEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn backfill_gsi(
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-        account_id: &str,
-        table_name: &str,
+        table_id: &str,
         index_name: &str,
         index_key_schema: &[KeySchemaElement],
         attr_defs: &[AttributeDefinition],
@@ -74,8 +72,8 @@ impl PostgresEngine {
     ) -> Result<(), StorageError> {
         const BATCH_SIZE: i64 = 500;
 
-        let base_table = data::data_table_name(account_id, table_name);
-        let idx_table = data::index_table_name(account_id, table_name, index_name);
+        let base_table = data::data_table_name(table_id);
+        let idx_table = data::index_table_name(table_id, index_name);
 
         let idx_sks = data::all_sort_key_info(index_key_schema, attr_defs);
         let base_sks = data::all_sort_key_info(base_key_schema, base_attr_defs);

--- a/crates/storage-postgres/src/table_helpers.rs
+++ b/crates/storage-postgres/src/table_helpers.rs
@@ -36,6 +36,7 @@ pub(crate) struct TableRow {
 #[derive(sqlx::FromRow)]
 pub(crate) struct IndexRow {
     pub index_name: String,
+    pub index_id: String,
     pub index_type: String,
     pub key_schema: serde_json::Value,
     pub projection: serde_json::Value,
@@ -46,10 +47,9 @@ pub(crate) struct IndexRow {
 impl PostgresEngine {
     /// SQL table name for a GSI data table (static version for use outside `data` module).
     pub(crate) fn index_table_name_static(
-        table_id: &str,
-        index_name: &str,
+        index_id: &str,
     ) -> String {
-        data::index_table_name(table_id, index_name)
+        data::index_table_name(index_id)
     }
 
     /// Backfill existing items from the base table into a newly created GSI.
@@ -63,7 +63,7 @@ impl PostgresEngine {
     pub(crate) async fn backfill_gsi(
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
         table_id: &str,
-        index_name: &str,
+        index_id: &str,
         index_key_schema: &[KeySchemaElement],
         attr_defs: &[AttributeDefinition],
         base_key_schema: &[KeySchemaElement],
@@ -73,7 +73,7 @@ impl PostgresEngine {
         const BATCH_SIZE: i64 = 500;
 
         let base_table = data::data_table_name(table_id);
-        let idx_table = data::index_table_name(table_id, index_name);
+        let idx_table = data::index_table_name(index_id);
 
         let idx_sks = data::all_sort_key_info(index_key_schema, attr_defs);
         let base_sks = data::all_sort_key_info(base_key_schema, base_attr_defs);
@@ -163,7 +163,7 @@ impl PostgresEngine {
         let row = row.ok_or_else(|| StorageError::TableNotFound(table_name.to_owned()))?;
 
         let index_rows: Vec<IndexRow> = sqlx::query_as(
-            r"SELECT index_name, index_type, key_schema, projection,
+            r"SELECT index_name, index_id, index_type, key_schema, projection,
                       index_status, provisioned_throughput
                FROM indexes WHERE table_id = $1",
         )

--- a/crates/storage-postgres/src/update_table.rs
+++ b/crates/storage-postgres/src/update_table.rs
@@ -266,8 +266,7 @@ impl PostgresEngine {
 
                         Self::create_index_data_table(
                             &mut data_tx,
-                            account_id,
-                            &input.table_name,
+                            &table_id,
                             &create.index_name,
                             &create.key_schema,
                             effective_attr_defs,
@@ -278,8 +277,7 @@ impl PostgresEngine {
 
                         Self::backfill_gsi(
                             &mut data_tx,
-                            account_id,
-                            &input.table_name,
+                            &table_id,
                             &create.index_name,
                             &create.key_schema,
                             effective_attr_defs,
@@ -319,8 +317,7 @@ impl PostgresEngine {
 
                 if let Some(delete) = &update.delete {
                     let idx_table = Self::index_table_name_static(
-                        account_id,
-                        &input.table_name,
+                        &table_id,
                         &delete.index_name,
                     );
                     if let Err(e) = sqlx::query(&format!("DROP TABLE IF EXISTS {idx_table}"))

--- a/crates/storage-postgres/src/update_table.rs
+++ b/crates/storage-postgres/src/update_table.rs
@@ -152,6 +152,8 @@ impl PostgresEngine {
         }
 
         // Apply GSI updates (create/delete).
+        let mut created_index_ids: Vec<String> = Vec::new();
+        let mut deleted_index_ids: Vec<String> = Vec::new();
         if let Some(updates) = &input.global_secondary_index_updates {
             for update in updates {
                 if let Some(create) = &update.create {
@@ -180,29 +182,32 @@ impl PostgresEngine {
                         .transpose()
                         .map_err(|e| StorageError::Internal(e.to_string()))?;
 
+                    let index_id = uuid::Uuid::new_v4().to_string();
                     sqlx::query(
                         r"INSERT INTO indexes
-                           (table_id, index_name, index_type, key_schema, projection,
+                           (table_id, index_name, index_id, index_type, key_schema, projection,
                             index_status, provisioned_throughput)
-                           VALUES ($1, $2, 'GSI', $3, $4, 'ACTIVE', $5)",
+                           VALUES ($1, $2, $3, 'GSI', $4, $5, 'ACTIVE', $6)",
                     )
                     .bind(&table_id)
                     .bind(&create.index_name)
+                    .bind(&index_id)
                     .bind(&gsi_ks)
                     .bind(&gsi_proj)
                     .bind(&gsi_pt)
                     .execute(&mut *tx)
                     .await
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    created_index_ids.push(index_id);
 
                     // Create the index data table on the data pool (P54 Bug 1).
                     // Catalog metadata is committed first; data DDL follows.
                 }
 
                 if let Some(delete) = &update.delete {
-                    // Verify the index exists.
-                    let existing: Option<(String,)> = sqlx::query_as(
-                        "SELECT index_name FROM indexes WHERE table_id = $1 AND index_name = $2",
+                    // Verify the index exists and fetch its index_id.
+                    let existing: Option<(String, String)> = sqlx::query_as(
+                        "SELECT index_name, index_id FROM indexes WHERE table_id = $1 AND index_name = $2",
                     )
                     .bind(&table_id)
                     .bind(&delete.index_name)
@@ -210,9 +215,8 @@ impl PostgresEngine {
                     .await
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
 
-                    if existing.is_none() {
-                        return Err(StorageError::IndexNotFound(delete.index_name.clone()));
-                    }
+                    let (_, del_index_id) = existing
+                        .ok_or_else(|| StorageError::IndexNotFound(delete.index_name.clone()))?;
 
                     // Delete the index metadata.
                     sqlx::query("DELETE FROM indexes WHERE table_id = $1 AND index_name = $2")
@@ -221,6 +225,7 @@ impl PostgresEngine {
                         .execute(&mut *tx)
                         .await
                         .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    deleted_index_ids.push(del_index_id);
 
                     // Drop the index data table on the data pool after catalog commit.
                 }
@@ -255,8 +260,12 @@ impl PostgresEngine {
                 .as_deref()
                 .unwrap_or(&base_attr_defs);
 
+            let mut create_idx = 0usize;
+            let mut delete_idx = 0usize;
             for update in updates {
                 if let Some(create) = &update.create {
+                    let idx_id = &created_index_ids[create_idx];
+                    create_idx += 1;
                     let data_result = async {
                         let mut data_tx = self
                             .data_pool
@@ -266,8 +275,7 @@ impl PostgresEngine {
 
                         Self::create_index_data_table(
                             &mut data_tx,
-                            &table_id,
-                            &create.index_name,
+                            idx_id,
                             &create.key_schema,
                             effective_attr_defs,
                             &base_key_schema,
@@ -278,7 +286,7 @@ impl PostgresEngine {
                         Self::backfill_gsi(
                             &mut data_tx,
                             &table_id,
-                            &create.index_name,
+                            idx_id,
                             &create.key_schema,
                             effective_attr_defs,
                             &base_key_schema,
@@ -296,8 +304,6 @@ impl PostgresEngine {
                     .await;
 
                     if let Err(e) = data_result {
-                        // Data DDL failed. Clean up the catalog index metadata
-                        // so DescribeTable doesn't show a broken GSI.
                         tracing::error!(
                             "Failed to create data table for GSI '{}' on '{}', \
                              cleaning up catalog: {e}",
@@ -315,21 +321,16 @@ impl PostgresEngine {
                     }
                 }
 
-                if let Some(delete) = &update.delete {
-                    let idx_table = Self::index_table_name_static(
-                        &table_id,
-                        &delete.index_name,
-                    );
+                if update.delete.is_some() {
+                    let idx_id = &deleted_index_ids[delete_idx];
+                    delete_idx += 1;
+                    let idx_table = Self::index_table_name_static(idx_id);
                     if let Err(e) = sqlx::query(&format!("DROP TABLE IF EXISTS {idx_table}"))
                         .execute(&self.data_pool)
                         .await
                     {
-                        // Catalog metadata already deleted. The orphaned data
-                        // table wastes space but is harmless. Log a warning so
-                        // operators can clean up manually.
                         tracing::warn!(
-                            "Failed to drop data table for deleted GSI '{}' on '{}': {e}",
-                            delete.index_name,
+                            "Failed to drop data table for deleted GSI on '{}': {e}",
                             input.table_name,
                         );
                     }

--- a/crates/storage-postgres/src/worker_store.rs
+++ b/crates/storage-postgres/src/worker_store.rs
@@ -77,9 +77,9 @@ impl PostgresEngine {
         .map_err(|e| StorageError::Internal(e.to_string()))?;
 
         // Collect index names while the rows still exist.
-        let mut drop_info: Vec<(String, String, Vec<String>)> = Vec::new();
+        let mut drop_info: Vec<(String, Vec<String>)> = Vec::new();
 
-        for (acct_id, name, arn, table_id) in &candidates {
+        for (_acct_id, name, arn, table_id) in &candidates {
             let index_names: Vec<(String,)> =
                 sqlx::query_as("SELECT index_name FROM indexes WHERE table_id = $1")
                     .bind(table_id)
@@ -102,8 +102,7 @@ impl PostgresEngine {
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
 
             drop_info.push((
-                acct_id.clone(),
-                name.clone(),
+                table_id.clone(),
                 index_names.into_iter().map(|(n,)| n).collect(),
             ));
 
@@ -115,16 +114,16 @@ impl PostgresEngine {
             .map_err(|e| StorageError::Internal(e.to_string()))?;
 
         // P54 Bug 1: Drop data tables on the data pool after catalog commit.
-        for (acct_id, name, index_names) in &drop_info {
+        for (table_id, index_names) in &drop_info {
             let mut data_tx = self
                 .data_pool
                 .begin()
                 .await
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
             for idx_name in index_names {
-                Self::drop_index_data_table(&mut data_tx, acct_id, name, idx_name).await?;
+                Self::drop_index_data_table(&mut data_tx, table_id, idx_name).await?;
             }
-            Self::drop_data_table(&mut data_tx, acct_id, name).await?;
+            Self::drop_data_table(&mut data_tx, table_id).await?;
             data_tx
                 .commit()
                 .await

--- a/crates/storage-postgres/src/worker_store.rs
+++ b/crates/storage-postgres/src/worker_store.rs
@@ -76,12 +76,12 @@ impl PostgresEngine {
         .await
         .map_err(|e| StorageError::Internal(e.to_string()))?;
 
-        // Collect index names while the rows still exist.
+        // Collect index ids while the rows still exist.
         let mut drop_info: Vec<(String, Vec<String>)> = Vec::new();
 
         for (_acct_id, name, arn, table_id) in &candidates {
-            let index_names: Vec<(String,)> =
-                sqlx::query_as("SELECT index_name FROM indexes WHERE table_id = $1")
+            let index_ids: Vec<(String,)> =
+                sqlx::query_as("SELECT index_id FROM indexes WHERE table_id = $1")
                     .bind(table_id)
                     .fetch_all(&mut *tx)
                     .await
@@ -103,7 +103,7 @@ impl PostgresEngine {
 
             drop_info.push((
                 table_id.clone(),
-                index_names.into_iter().map(|(n,)| n).collect(),
+                index_ids.into_iter().map(|(n,)| n).collect(),
             ));
 
             transitions.push((name.clone(), "DELETING → deleted"));
@@ -114,14 +114,14 @@ impl PostgresEngine {
             .map_err(|e| StorageError::Internal(e.to_string()))?;
 
         // P54 Bug 1: Drop data tables on the data pool after catalog commit.
-        for (table_id, index_names) in &drop_info {
+        for (table_id, index_ids) in &drop_info {
             let mut data_tx = self
                 .data_pool
                 .begin()
                 .await
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
-            for idx_name in index_names {
-                Self::drop_index_data_table(&mut data_tx, table_id, idx_name).await?;
+            for idx_id in index_ids {
+                Self::drop_index_data_table(&mut data_tx, idx_id).await?;
             }
             Self::drop_data_table(&mut data_tx, table_id).await?;
             data_tx


### PR DESCRIPTION
CreateTable crashed with InternalServerError when the generated PostgreSQL identifier exceeded the 63-char `NAMEDATALEN` limit. The old naming scheme `_ddb_{account_id}_{table_name}__gsi__{index_name}` overflowed with moderately long table names (35+ chars with indexes).
  
Fix: use `_ddb_{table_id}` and `_ddb_{index_id}` (UUIDs, 41 chars) for all PG table names. Added `index_id` column to the indexes catalog table.
  
Accepts the full DynamoDB name range (255 chars for both table and index names) without restriction.