### PR TITLE
fix: LSI writes are always synchronous regardless of gsi_propagation_…

### DIFF
--- a/crates/storage-postgres/src/data/index.rs
+++ b/crates/storage-postgres/src/data/index.rs
@@ -19,6 +19,7 @@ use super::{all_sort_key_info, index_table_name};
 /// Metadata for a single index, used during write-path GSI/LSI sync.
 pub(crate) struct IndexMeta {
     pub(super) index_name: String,
+    pub(super) index_type: String,
     pub(super) key_schema: Vec<KeySchemaElement>,
     pub(super) projection: Projection,
     /// Per-GSI propagation delay in milliseconds. `None` means use system
@@ -31,8 +32,8 @@ pub(crate) async fn fetch_indexes_for_table(
     table_id: &str,
     pool: &sqlx::PgPool,
 ) -> Result<Vec<IndexMeta>, StorageError> {
-    let rows: Vec<(String, serde_json::Value, serde_json::Value, Option<i32>)> = sqlx::query_as(
-        "SELECT index_name, key_schema, projection, propagation_delay_ms FROM indexes WHERE table_id = $1",
+    let rows: Vec<(String, String, serde_json::Value, serde_json::Value, Option<i32>)> = sqlx::query_as(
+        "SELECT index_name, index_type, key_schema, projection, propagation_delay_ms FROM indexes WHERE table_id = $1",
     )
     .bind(table_id)
     .fetch_all(pool)
@@ -40,13 +41,14 @@ pub(crate) async fn fetch_indexes_for_table(
     .map_err(|e| StorageError::Internal(e.to_string()))?;
 
     rows.into_iter()
-        .map(|(name, ks_json, proj_json, delay)| {
+        .map(|(name, idx_type, ks_json, proj_json, delay)| {
             let key_schema: Vec<KeySchemaElement> = serde_json::from_value(ks_json)
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
             let projection: Projection = serde_json::from_value(proj_json)
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
             Ok(IndexMeta {
                 index_name: name,
+                index_type: idx_type,
                 key_schema,
                 projection,
                 propagation_delay_ms: delay,
@@ -134,8 +136,8 @@ pub(crate) async fn sync_indexes(
     system_default_delay: u64,
 ) -> Result<(), StorageError> {
     for idx in indexes {
-        if effective_delay(idx, system_default_delay) != 0 {
-            continue; // Async — handled after commit.
+        if idx.index_type != "LSI" && effective_delay(idx, system_default_delay) != 0 {
+            continue; // Async — handled after commit. LSIs are always synchronous.
         }
         let idx_table = index_table_name(account_id, table_name, &idx.index_name);
         let idx_sks = all_sort_key_info(&idx.key_schema, attr_defs);


### PR DESCRIPTION
…delay_ms

LSI updates were incorrectly subject to the GSI propagation delay, causing queries with `ConsistentRead: true` to return stale results. In DynamoDB, LSIs are always strongly consistent with the base table.
  
Fix: skip the delay check in `sync_indexes` for LSI index types. One-line change, LSIs are now always written within the same transaction as the base table write, matching DynamoDB semantics.