### PR TITLE
fix: SET on list index beyond bounds appends, reject missing intermed…

### DIFF
--- a/crates/core/src/expression/update_evaluator.rs
+++ b/crates/core/src/expression/update_evaluator.rs
@@ -435,10 +435,7 @@ fn set_nested(
                 if *idx < list.len() {
                     list[*idx] = value;
                 } else {
-                    return Err(DynamoDbError::ValidationException(
-                        "The provided expression refers to an attribute that does not exist in the item"
-                            .to_owned(),
-                    ));
+                    list.push(value);
                 }
             }
             _ => {
@@ -454,10 +451,13 @@ fn set_nested(
     match (&path[0], current) {
         (PathElement::Attribute(_), AttributeValue::M(map)) => {
             let name = resolve_attr_name(&path[0], maps)?;
-            let entry = map
-                .entry(name)
-                .or_insert_with(|| AttributeValue::M(BTreeMap::new()));
-            set_nested(entry, &path[1..], value, maps)
+            match map.get_mut(&name) {
+                Some(entry) => set_nested(entry, &path[1..], value, maps),
+                None => Err(DynamoDbError::ValidationException(
+                    "The document path provided in the update expression is invalid for update"
+                        .to_owned(),
+                )),
+            }
         }
         (PathElement::Index(idx), AttributeValue::L(list)) => {
             if *idx < list.len() {

--- a/crates/core/src/expression/update_evaluator_tests.rs
+++ b/crates/core/src/expression/update_evaluator_tests.rs
@@ -274,3 +274,70 @@ fn name_ref_in_update() {
     apply("SET #s = :v", &mut item, names, values).unwrap();
     assert_eq!(item.get("status"), Some(&AttributeValue::S("new".into())));
 }
+
+#[test]
+fn set_list_index_zero_on_empty_list() {
+    let mut item = BTreeMap::new();
+    item.insert("mylist".into(), AttributeValue::L(vec![]));
+    let mut values = HashMap::new();
+    values.insert("v".into(), AttributeValue::S("hello".into()));
+    apply("SET mylist[0] = :v", &mut item, HashMap::new(), values).unwrap();
+    assert_eq!(
+        item.get("mylist"),
+        Some(&AttributeValue::L(vec![AttributeValue::S("hello".into())]))
+    );
+}
+
+#[test]
+fn set_list_index_beyond_bounds_appends() {
+    let mut item = BTreeMap::new();
+    item.insert(
+        "mylist".into(),
+        AttributeValue::L(vec![
+            AttributeValue::S("a".into()),
+            AttributeValue::S("b".into()),
+            AttributeValue::S("c".into()),
+        ]),
+    );
+    let mut values = HashMap::new();
+    values.insert("v".into(), AttributeValue::S("appended".into()));
+    apply("SET mylist[99] = :v", &mut item, HashMap::new(), values).unwrap();
+    let list = match item.get("mylist") {
+        Some(AttributeValue::L(l)) => l,
+        _ => panic!("expected list"),
+    };
+    assert_eq!(list.len(), 4);
+    assert_eq!(list[3], AttributeValue::S("appended".into()));
+}
+
+#[test]
+fn set_list_index_within_bounds_replaces() {
+    let mut item = BTreeMap::new();
+    item.insert(
+        "mylist".into(),
+        AttributeValue::L(vec![
+            AttributeValue::S("a".into()),
+            AttributeValue::S("b".into()),
+        ]),
+    );
+    let mut values = HashMap::new();
+    values.insert("v".into(), AttributeValue::S("replaced".into()));
+    apply("SET mylist[1] = :v", &mut item, HashMap::new(), values).unwrap();
+    let list = match item.get("mylist") {
+        Some(AttributeValue::L(l)) => l,
+        _ => panic!("expected list"),
+    };
+    assert_eq!(list[1], AttributeValue::S("replaced".into()));
+}
+
+#[test]
+fn set_intermediate_map_path_missing_fails() {
+    let mut item = BTreeMap::new();
+    let mut inner = BTreeMap::new();
+    inner.insert("x".into(), AttributeValue::S("exists".into()));
+    item.insert("a".into(), AttributeValue::M(inner));
+    let mut values = HashMap::new();
+    values.insert("v".into(), AttributeValue::S("hello".into()));
+    let result = apply("SET a.b.c = :v", &mut item, HashMap::new(), values);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
…iate map paths

Two UpdateItem nested path behaviors that diverged from DynamoDB:
  
1. `SET list[N] where N >= list length` extenddb rejected with `ValidationException`. DynamoDB appends to the end of the list.

```
# list = ["a", "b", "c"]
SET list[5] = :v   →  ["a", "b", "c", "appended"]
SET list[0] = :v   →  on empty list, creates ["value"]
```

2. SET a.b.c where intermediate path b doesn't exist extenddb auto-created the intermediate map. DynamoDB rejects with:
  > "The document path provided in the update expression is invalid for update"
  
  Verified against real DynamoDB:
  

| Expression | Scenario | DynamoDB | extenddb (before) |
  |---|---|---|---|
  | `SET list[0] = :v` | empty list | appends | ❌ rejected |
  | `SET list[5] = :v` | 3-element list | appends at index 3 | ❌ rejected |
  | `SET list[1] = :v` | 2-element list | replaces index 1 | ✅ correct |
  | `SET a.b.c = :v` | `b` missing in map | rejects | ❌ auto-created `b` |
  

Tests: 4 unit tests added to update_evaluator_tests.rs