### PR TITLE
fix: align error messages with real DynamoDB responses

### DIFF
--- a/crates/core/src/error/messages.rs
+++ b/crates/core/src/error/messages.rs
@@ -39,7 +39,7 @@ pub fn error_message(key: ErrorMessageKey, args: &[&str]) -> String {
             )
         }
         ErrorMessageKey::TableNotFound => {
-            format!("Requested resource not found: Table: {} not found", args[0])
+            "Requested resource not found".to_owned()
         }
         ErrorMessageKey::TableAlreadyExists => {
             format!("Table already exists: {}", args[0])

--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -578,7 +578,7 @@ pub fn validate_key_only(
     let expected_count = key_schema.len();
     if key.len() != expected_count {
         return Err(DynamoDbError::ValidationException(
-            "The number of conditions on the keys is invalid".to_owned(),
+            "The provided key element does not match the schema".to_owned(),
         ));
     }
 

--- a/crates/engine/src/transact_write_helpers.rs
+++ b/crates/engine/src/transact_write_helpers.rs
@@ -268,7 +268,7 @@ pub(crate) fn validate_no_key_updates(
             for ks in &key_info.key_schema {
                 if ks.attribute_name == resolved {
                     return Err(DynamoDbError::ValidationException(format!(
-                        "One or more parameter values are not valid. Cannot update attribute {}. \
+                        "One or more parameter values were invalid: Cannot update attribute {}. \
                          This attribute is part of the key",
                         ks.attribute_name
                     )));

--- a/crates/engine/src/ttl.rs
+++ b/crates/engine/src/ttl.rs
@@ -166,7 +166,7 @@ fn validate_ttl_attribute_name(name: &str) -> Result<(), DynamoDbError> {
 fn storage_to_dynamo(e: StorageError) -> DynamoDbError {
     match e {
         StorageError::TableNotFound(name) => DynamoDbError::ResourceNotFoundException(format!(
-            "Requested resource not found: Table: {name} not found"
+            "Requested resource not found"
         )),
         StorageError::TableNotActive(name) => {
             DynamoDbError::ResourceInUseException(format!("Table {name} is not in ACTIVE state"))

--- a/crates/engine/src/update_item.rs
+++ b/crates/engine/src/update_item.rs
@@ -223,7 +223,7 @@ fn validate_no_key_updates(
             for ks in &key_info.key_schema {
                 if ks.attribute_name == resolved {
                     return Err(DynamoDbError::ValidationException(format!(
-                        "One or more parameter values are not valid. Cannot update attribute {}. \
+                        "One or more parameter values were invalid: Cannot update attribute {}. \
                          This attribute is part of the key",
                         ks.attribute_name
                     )));

--- a/crates/engine/src/update_table.rs
+++ b/crates/engine/src/update_table.rs
@@ -117,7 +117,7 @@ pub async fn handle_update_table<S: TableEngine>(
         .map_err(|e| match e {
             extenddb_storage::error::StorageError::TableNotFound(name) => {
                 DynamoDbError::ResourceNotFoundException(format!(
-                    "Requested resource not found: Table: {name} not found"
+                    "Requested resource not found"
                 ))
             }
             extenddb_storage::error::StorageError::TableNotActive(name) => {


### PR DESCRIPTION
Several error messages diverged from what real DynamoDB returns, breaking applications that parse error strings.

| Error | Before | After (matches DynamoDB) |
  |---|---|---|
  | Table not found | `Requested resource not found: Table: xyz not found` | `Requested resource not found` |
  | Key mismatch (missing range key) | `The number of conditions on the keys is invalid` | `The provided key element does not match the schema` |
  | Cannot update key attribute | `One or more parameter values are not valid. Cannot update attribute pk. This attribute is part of the key` | `One or more parameter values were invalid: Cannot update attribute pk. This attribute is part of the key` |