### PR TITLE
fix: reject unused ExpressionAttributeNames and ExpressionAttributeVa…

### DIFF
--- a/crates/core/src/expression/mod.rs
+++ b/crates/core/src/expression/mod.rs
@@ -24,7 +24,7 @@ pub use evaluator::evaluate_condition;
 pub use key_condition::{KeyCondition, SortKeyCondition, parse_key_condition};
 pub use parser::{parse_condition, parse_condition_with_depth_limit};
 pub use projection::{apply_projection, parse_projection};
-pub use resolver::{ExpressionMaps, resolve_element_name, resolve_name_ref, resolve_path};
+pub use resolver::{ExpressionMaps, collect_key_condition_refs, resolve_element_name, resolve_name_ref, resolve_path, validate_unused_attributes};
 pub use tokenizer::{Token, tokenize, tokenize_with_limit};
 pub use update_evaluator::apply_update;
 pub use update_parser::parse_update;

--- a/crates/core/src/expression/resolver.rs
+++ b/crates/core/src/expression/resolver.rs
@@ -185,3 +185,147 @@ pub fn resolve_element_name<'a>(
         )),
     }
 }
+
+/// Validate that all provided ExpressionAttributeNames/Values were used.
+///
+/// Collects `#name` and `:value` references from the given expressions,
+/// then checks that every key in `names`/`values` maps was referenced.
+pub fn validate_unused_attributes(
+    names: &HashMap<String, String>,
+    values: &HashMap<String, AttributeValue>,
+    exprs: &[&super::ast::Expr],
+    update_actions: &[&super::ast::UpdateAction],
+    key_condition_names: &std::collections::HashSet<String>,
+    key_condition_values: &std::collections::HashSet<String>,
+) -> Result<(), DynamoDbError> {
+    let mut used_names = key_condition_names.clone();
+    let mut used_values = key_condition_values.clone();
+
+    for expr in exprs {
+        collect_expr_refs(expr, &mut used_names, &mut used_values);
+    }
+    for action in update_actions {
+        collect_action_refs(action, &mut used_names, &mut used_values);
+    }
+
+    for key in names.keys() {
+        if !used_names.contains(key.strip_prefix('#').unwrap_or(key)) {
+            let display_key = if key.starts_with('#') { key.clone() } else { format!("#{key}") };
+            return Err(DynamoDbError::ValidationException(format!(
+                "Value provided in ExpressionAttributeNames unused in expressions: keys: {{{display_key}}}"
+            )));
+        }
+    }
+    for key in values.keys() {
+        if !used_values.contains(key.strip_prefix(':').unwrap_or(key)) {
+            let display_key = if key.starts_with(':') { key.clone() } else { format!(":{key}") };
+            return Err(DynamoDbError::ValidationException(format!(
+                "Value provided in ExpressionAttributeValues unused in expressions: keys: {{{display_key}}}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn collect_expr_refs(
+    expr: &super::ast::Expr,
+    names: &mut std::collections::HashSet<String>,
+    values: &mut std::collections::HashSet<String>,
+) {
+    use super::ast::Expr;
+    match expr {
+        Expr::Path(elements) => collect_path_refs(elements, names),
+        Expr::Placeholder(name) => { values.insert(name.clone()); }
+        Expr::Compare { left, right, .. } | Expr::Arithmetic { left, right, .. } => {
+            collect_expr_refs(left, names, values);
+            collect_expr_refs(right, names, values);
+        }
+        Expr::And(l, r) | Expr::Or(l, r) => {
+            collect_expr_refs(l, names, values);
+            collect_expr_refs(r, names, values);
+        }
+        Expr::Not(inner) => collect_expr_refs(inner, names, values),
+        Expr::Function { args, .. } => {
+            for arg in args { collect_expr_refs(arg, names, values); }
+        }
+        Expr::Between { operand, low, high } => {
+            collect_expr_refs(operand, names, values);
+            collect_expr_refs(low, names, values);
+            collect_expr_refs(high, names, values);
+        }
+        Expr::In { operand, list } => {
+            collect_expr_refs(operand, names, values);
+            for item in list { collect_expr_refs(item, names, values); }
+        }
+    }
+}
+
+fn collect_action_refs(
+    action: &super::ast::UpdateAction,
+    names: &mut std::collections::HashSet<String>,
+    values: &mut std::collections::HashSet<String>,
+) {
+    use super::ast::UpdateAction;
+    match action {
+        UpdateAction::Set { path, value }
+        | UpdateAction::Add { path, value }
+        | UpdateAction::Delete { path, value } => {
+            collect_path_refs(path, names);
+            collect_expr_refs(value, names, values);
+        }
+        UpdateAction::Remove { path } => collect_path_refs(path, names),
+    }
+}
+
+fn collect_path_refs(elements: &[PathElement], names: &mut std::collections::HashSet<String>) {
+    for el in elements {
+        if let PathElement::Attribute(name) = el {
+            if let Some(ref_name) = name.strip_prefix('#') {
+                names.insert(ref_name.to_owned());
+            }
+        }
+    }
+}
+
+/// Collect `#name` and `:value` references from a `KeyCondition`.
+///
+/// Returns `(used_names, used_values)` sets suitable for passing to
+/// `validate_unused_attributes`.
+pub fn collect_key_condition_refs(
+    kc: &super::key_condition::KeyCondition,
+) -> (std::collections::HashSet<String>, std::collections::HashSet<String>) {
+    let mut names = std::collections::HashSet::new();
+    let mut values = std::collections::HashSet::new();
+
+    collect_path_refs(&kc.pk_path, &mut names);
+    collect_expr_refs(&kc.pk_value, &mut names, &mut values);
+
+    if let Some(ref sk) = kc.sk_condition {
+        match sk {
+            super::key_condition::SortKeyCondition::Compare { path, value, .. } => {
+                collect_path_refs(path, &mut names);
+                collect_expr_refs(value, &mut names, &mut values);
+            }
+            super::key_condition::SortKeyCondition::Between { path, low, high } => {
+                collect_path_refs(path, &mut names);
+                collect_expr_refs(low, &mut names, &mut values);
+                collect_expr_refs(high, &mut names, &mut values);
+            }
+            super::key_condition::SortKeyCondition::BeginsWith { path, prefix } => {
+                collect_path_refs(path, &mut names);
+                collect_expr_refs(prefix, &mut names, &mut values);
+            }
+        }
+    }
+
+    for (path, expr) in &kc.extra_pk_conditions {
+        collect_path_refs(path, &mut names);
+        collect_expr_refs(expr, &mut names, &mut values);
+    }
+    for (path, expr) in &kc.extra_sk_conditions {
+        collect_path_refs(path, &mut names);
+        collect_expr_refs(expr, &mut names, &mut values);
+    }
+
+    (names, values)
+}

--- a/crates/engine/src/delete_item.rs
+++ b/crates/engine/src/delete_item.rs
@@ -56,6 +56,14 @@ pub async fn handle_delete_item<S: TableEngine + DataEngine>(
         &ctx.limits,
     )?;
 
+    if input.expected.is_none() || input.expected.as_ref().is_some_and(|m| m.is_empty()) {
+        let exprs: Vec<&extenddb_core::expression::Expr> = condition.iter().collect();
+        extenddb_core::expression::validate_unused_attributes(
+            &maps.names, &maps.values, &exprs, &[],
+            &std::collections::HashSet::new(), &std::collections::HashSet::new(),
+        )?;
+    }
+
     let return_old = input.return_values == ReturnValues::AllOld;
 
     let view_type = stream_capture::stream_view_type(&key_info);

--- a/crates/engine/src/put_item.rs
+++ b/crates/engine/src/put_item.rs
@@ -58,6 +58,14 @@ pub async fn handle_put_item<S: TableEngine + DataEngine>(
         &ctx.limits,
     )?;
 
+    if input.expected.is_none() || input.expected.as_ref().is_some_and(|m| m.is_empty()) {
+        let exprs: Vec<&extenddb_core::expression::Expr> = condition.iter().collect();
+        extenddb_core::expression::validate_unused_attributes(
+            &maps.names, &maps.values, &exprs, &[],
+            &std::collections::HashSet::new(), &std::collections::HashSet::new(),
+        )?;
+    }
+
     let return_old = input.return_values == ReturnValues::AllOld;
 
     // Capacity metering: full item size, rounded up to 1 KB.

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -162,6 +162,28 @@ pub async fn handle_query<S: TableEngine + DataEngine>(
         None
     };
 
+    // Validate unused expression attributes
+    {
+        let exprs: Vec<&extenddb_core::expression::Expr> = filter.iter().collect();
+        let (mut kc_names, kc_values) = extenddb_core::expression::collect_key_condition_refs(&key_condition);
+        // Collect #name refs from projection paths
+        if let Some(ref proj) = projection {
+            for path in proj {
+                for el in path {
+                    if let PathElement::Attribute(name) = el {
+                        if let Some(ref_name) = name.strip_prefix('#') {
+                            kc_names.insert(ref_name.to_owned());
+                        }
+                    }
+                }
+            }
+        }
+        extenddb_core::expression::validate_unused_attributes(
+            &maps.names, &maps.values, &exprs, &[],
+            &kc_names, &kc_values,
+        )?;
+    }
+
     // Validate Select vs ProjectionExpression and index requirements
     if let Some(Select::AllProjectedAttributes) = input.select {
         if index_info.is_none() {

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -141,6 +141,27 @@ pub async fn handle_scan<S: TableEngine + DataEngine>(
         None
     };
 
+    // Validate unused expression attributes
+    {
+        let exprs: Vec<&extenddb_core::expression::Expr> = filter.iter().collect();
+        let mut extra_names = std::collections::HashSet::new();
+        if let Some(ref proj) = projection {
+            for path in proj {
+                for el in path {
+                    if let extenddb_core::expression::PathElement::Attribute(name) = el {
+                        if let Some(ref_name) = name.strip_prefix('#') {
+                            extra_names.insert(ref_name.to_owned());
+                        }
+                    }
+                }
+            }
+        }
+        extenddb_core::expression::validate_unused_attributes(
+            &maps.names, &maps.values, &exprs, &[],
+            &extra_names, &std::collections::HashSet::new(),
+        )?;
+    }
+
     // Validate Select vs ProjectionExpression and index requirements
     if let Some(Select::AllProjectedAttributes) = input.select {
         if index_info.is_none() {

--- a/crates/engine/src/transact_get_items.rs
+++ b/crates/engine/src/transact_get_items.rs
@@ -109,18 +109,36 @@ pub async fn handle_transact_get_items<S: TableEngine + DataEngine>(
         .into_iter()
         .zip(input.transact_items.iter())
         .map(|(opt, tgi)| {
-            let item = match (opt, tgi.get.projection_expression.as_deref()) {
-                (Some(item), Some(proj_str)) => {
-                    let proj_tokens =
-                        tokenize_with_limit(proj_str, ctx.limits.max_expression_tokens)?;
-                    let projection = parse_projection(&proj_tokens)?;
-                    let maps =
-                        build_expression_maps(tgi.get.expression_attribute_names.as_ref(), None);
-                    Some(apply_projection(&item, &projection, &maps)?)
+            let maps =
+                build_expression_maps(tgi.get.expression_attribute_names.as_ref(), None);
+            // Validate unused expression attribute names
+            if let Some(ref proj_str) = tgi.get.projection_expression {
+                let proj_tokens =
+                    tokenize_with_limit(proj_str, ctx.limits.max_expression_tokens)?;
+                let projection = parse_projection(&proj_tokens)?;
+                let mut extra_names = std::collections::HashSet::new();
+                for path in &projection {
+                    for el in path {
+                        if let extenddb_core::expression::PathElement::Attribute(name) = el {
+                            if let Some(ref_name) = name.strip_prefix('#') {
+                                extra_names.insert(ref_name.to_owned());
+                            }
+                        }
+                    }
                 }
-                (item, _) => item,
-            };
-            Ok(ItemResponse { item })
+                extenddb_core::expression::validate_unused_attributes(
+                    &maps.names, &maps.values, &[], &[],
+                    &extra_names, &std::collections::HashSet::new(),
+                )?;
+                let item = opt.map(|item| apply_projection(&item, &projection, &maps)).transpose()?;
+                Ok(ItemResponse { item })
+            } else {
+                extenddb_core::expression::validate_unused_attributes(
+                    &maps.names, &maps.values, &[], &[],
+                    &std::collections::HashSet::new(), &std::collections::HashSet::new(),
+                )?;
+                Ok(ItemResponse { item: opt })
+            }
         })
         .collect::<Result<Vec<_>, DynamoDbError>>()?;
 

--- a/crates/engine/src/transact_write_items.rs
+++ b/crates/engine/src/transact_write_items.rs
@@ -207,6 +207,13 @@ async fn prepare_write_op<S: TableEngine + DataEngine>(
             put.expression_attribute_values.as_ref(),
         );
         let condition = parse_optional_condition(put.condition_expression.as_deref(), &ctx.limits)?;
+        {
+            let exprs: Vec<&extenddb_core::expression::Expr> = condition.iter().collect();
+            extenddb_core::expression::validate_unused_attributes(
+                &maps.names, &maps.values, &exprs, &[],
+                &HashSet::new(), &HashSet::new(),
+            )?;
+        }
         let stream =
             stream_capture::stream_view_type(&key_info).map(|vt| extenddb_storage::StreamCapture {
                 view_type: vt,
@@ -234,6 +241,13 @@ async fn prepare_write_op<S: TableEngine + DataEngine>(
             del.expression_attribute_values.as_ref(),
         );
         let condition = parse_optional_condition(del.condition_expression.as_deref(), &ctx.limits)?;
+        {
+            let exprs: Vec<&extenddb_core::expression::Expr> = condition.iter().collect();
+            extenddb_core::expression::validate_unused_attributes(
+                &maps.names, &maps.values, &exprs, &[],
+                &HashSet::new(), &HashSet::new(),
+            )?;
+        }
         let stream =
             stream_capture::stream_view_type(&key_info).map(|vt| extenddb_storage::StreamCapture {
                 view_type: vt,
@@ -267,6 +281,14 @@ async fn prepare_write_op<S: TableEngine + DataEngine>(
         let actions = parse_update(&update_tokens)?;
         validate_no_key_updates(&actions, &key_info, &maps)?;
         let condition = parse_optional_condition(upd.condition_expression.as_deref(), &ctx.limits)?;
+        {
+            let exprs: Vec<&extenddb_core::expression::Expr> = condition.iter().collect();
+            extenddb_core::expression::validate_unused_attributes(
+                &maps.names, &maps.values, &exprs,
+                &actions.iter().collect::<Vec<_>>(),
+                &HashSet::new(), &HashSet::new(),
+            )?;
+        }
         let stream =
             stream_capture::stream_view_type(&key_info).map(|vt| extenddb_storage::StreamCapture {
                 view_type: vt,
@@ -302,6 +324,13 @@ async fn prepare_write_op<S: TableEngine + DataEngine>(
             &tokens,
             ctx.limits.max_expression_depth,
         )?;
+        {
+            let exprs: Vec<&extenddb_core::expression::Expr> = vec![&condition];
+            extenddb_core::expression::validate_unused_attributes(
+                &maps.names, &maps.values, &exprs, &[],
+                &HashSet::new(), &HashSet::new(),
+            )?;
+        }
         return Ok(PreparedOp::ConditionCheck {
             key_info,
             key: cc.key.clone(),

--- a/crates/engine/src/update_item.rs
+++ b/crates/engine/src/update_item.rs
@@ -114,6 +114,15 @@ pub async fn handle_update_item<S: TableEngine + DataEngine>(
     let update_tokens = tokenize_with_limit(update_expr, ctx.limits.max_expression_tokens)?;
     let actions = parse_update(&update_tokens)?;
 
+    if input.expected.is_none() || input.expected.as_ref().is_some_and(|m| m.is_empty()) {
+        let exprs: Vec<&extenddb_core::expression::Expr> = condition.iter().collect();
+        extenddb_core::expression::validate_unused_attributes(
+            &maps.names, &maps.values, &exprs,
+            &actions.iter().collect::<Vec<_>>(),
+            &std::collections::HashSet::new(), &std::collections::HashSet::new(),
+        )?;
+    }
+
     // Validate that no update action targets a key attribute (REQ-DATA-003)
     validate_no_key_updates(&actions, &key_info, &maps)?;
 


### PR DESCRIPTION
…lues

DynamoDB rejects requests that provide expression attribute names or values that aren't referenced in any expression. extenddb silently ignored them.
  
### Approach
After all expressions for an operation are parsed, walk the ASTs to collect every `#name` and `:value` reference that was actually used. Compare against the provided maps, if any key wasn't referenced, return `ValidationException`.
  
Uses AST-walking (not runtime tracking) to avoid false positives from parsers that resolve `#name` tokens without going through `ExpressionMaps::resolve_name`.
  
### Covered operations
PutItem, DeleteItem, UpdateItem, Query, Scan, TransactWriteItems (Put/Delete/Update/ConditionCheck), TransactGetItems.
  
### Error messages match DynamoDB
  
  | Scenario | Response |
  |---|---|
  | `ExpressionAttributeNames: {"#a": "pk", "#b": "unused"}` | `ValidationException: Value provided in ExpressionAttributeNames unused in expressions: keys: {#b}` |
  | `ExpressionAttributeValues: {":v": ..., ":unused": ...}` | `ValidationException: Value provided in ExpressionAttributeValues unused in expressions: keys: {:unused}` |
  
### Testing
  - 325 unit tests pass, 0 regressions
  - 281 integration tests pass (same as baseline)
  - Conformance suite: +3 tests, 0 false positives (verified 454/576 = 78.8%)