### PR TITLE
Fix HTTP→HTTPS redirect to preserve client Host header & path

### DIFF
--- a/crates/server/src/console/pages/auth_pages.rs
+++ b/crates/server/src/console/pages/auth_pages.rs
@@ -82,7 +82,7 @@ pub async fn login_submit<
 
     let (token, _csrf) = state.sessions.create(identity).await;
     let cookie = format!(
-        "extenddb_session={token}; Path=/console; HttpOnly; SameSite=Strict; Max-Age=28800"
+        "extenddb_session={token}; Path=/console; HttpOnly; SameSite=Strict; Secure; Max-Age=28800"
     );
 
     (

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -322,8 +322,10 @@ impl<S: Send + 'static> axum_server::accept::Accept<tokio::net::TcpStream, S>
                     Ok((stream, service))
                 }
                 Ok(_) => {
-                    // Plain HTTP — send redirect and reject.
-                    send_https_redirect(&stream, addr);
+                    // Plain HTTP — read enough to extract Host header and path,
+                    // then redirect preserving the client's view of the hostname
+                    // (important for port-forwarding scenarios).
+                    send_https_redirect(&stream, addr).await;
                     Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
                         "plain HTTP redirected to HTTPS",
@@ -335,16 +337,66 @@ impl<S: Send + 'static> axum_server::accept::Accept<tokio::net::TcpStream, S>
     }
 }
 
-/// Write an HTTP 301 redirect response to HTTPS on the raw TCP stream.
-fn send_https_redirect(stream: &tokio::net::TcpStream, addr: std::net::SocketAddr) {
-    let location = format!("https://{addr}/");
+/// Read the plain HTTP request headers from the stream and redirect to HTTPS,
+/// preserving the Host header so port-forwarding setups work correctly.
+async fn send_https_redirect(stream: &tokio::net::TcpStream, addr: std::net::SocketAddr) {
+    // Read enough of the request to find the Host header and request path.
+    // 2 KB is plenty for the request line + headers we care about.
+    let mut buf = [0u8; 2048];
+    let n = match stream.readable().await.and_then(|()| stream.try_read(&mut buf)) {
+        Ok(n) if n > 0 => n,
+        _ => {
+            // Fallback: couldn't read request, use local addr.
+            let _ = stream.try_write(
+                format!(
+                    "HTTP/1.1 301 Moved Permanently\r\n\
+                     Location: https://{addr}/\r\n\
+                     Content-Length: 0\r\n\
+                     Connection: close\r\n\r\n"
+                )
+                .as_bytes(),
+            );
+            return;
+        }
+    };
+
+    let request = String::from_utf8_lossy(&buf[..n]);
+
+    // Extract the request path from the first line (e.g., "GET /console HTTP/1.1").
+    let path = request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or("/");
+
+    // Extract the Host header value.
+    let host = request
+        .lines()
+        .find_map(|line| {
+            let lower = line.to_ascii_lowercase();
+            if lower.starts_with("host:") {
+                Some(line[5..].trim())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| {
+            // No Host header — fall back to local addr (formatted in the buffer below).
+            ""
+        });
+
+    let location = if host.is_empty() {
+        format!("https://{addr}{path}")
+    } else {
+        format!("https://{host}{path}")
+    };
+
     let response = format!(
         "HTTP/1.1 301 Moved Permanently\r\n\
          Location: {location}\r\n\
          Content-Length: 0\r\n\
          Connection: close\r\n\r\n"
     );
-    // Best-effort write — if it fails, the client already got a connection error.
     let _ = stream.try_write(response.as_bytes());
 }
 


### PR DESCRIPTION
The plain-HTTP redirect was using the server's local bind address
(e.g., 10.2.3.4:8000) in the Location header. When accessing via SSH
port forwarding (127.0.0.1:8000 → remote), this broke the redirect by
sending the browser to the remote host's real IP.

Now reads the HTTP request to extract the Host header and request path,
preserving the client's view of the hostname. Falls back to local_addr
only if the Host header is absent.

Also adds the Secure flag to the session cookie (TLS is mandatory).
