### PR TITLE
fix: validation error messages match DynamoDB format

### DIFF
--- a/crates/core/src/error/messages.rs
+++ b/crates/core/src/error/messages.rs
@@ -4,6 +4,29 @@
 //! Error message templates captured from real DynamoDB.
 //! These are the exact messages DynamoDB returns — tenet 4 (errors are contracts).
 
+/// Format a single validation constraint error in DynamoDB's exact format.
+#[must_use]
+pub fn validation_error(value: &str, field: &str, constraint: &str) -> String {
+    format!(
+        "1 validation error detected: Value '{value}' at '{field}' failed to satisfy constraint: {constraint}"
+    )
+}
+
+/// Format multiple validation constraint errors in DynamoDB's exact format.
+#[must_use]
+pub fn validation_errors(errors: &[(&str, &str, &str)]) -> String {
+    let count = errors.len();
+    let details: Vec<String> = errors
+        .iter()
+        .map(|(value, field, constraint)| {
+            format!("Value '{value}' at '{field}' failed to satisfy constraint: {constraint}")
+        })
+        .collect();
+    format!("{count} validation error{} detected: {}",
+        if count == 1 { "" } else { "s" },
+        details.join("; "))
+}
+
 /// Keys for error message templates. Compile-time checked — no stringly-typed lookups.
 #[derive(Debug, Clone, Copy)]
 pub enum ErrorMessageKey {

--- a/crates/core/src/error/mod.rs
+++ b/crates/core/src/error/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 mod messages;
 
-pub use messages::{ErrorMessageKey, error_message};
+pub use messages::{ErrorMessageKey, error_message, validation_error, validation_errors};
 
 use crate::types::{CancellationReason, Item};
 

--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -1,6 +1,6 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
-use crate::error::{DynamoDbError, ErrorMessageKey, error_message};
+use crate::error::{DynamoDbError, ErrorMessageKey, error_message, validation_error};
 use crate::limits::LimitsConfig;
 use crate::types::{
     AttributeDefinition, AttributeValue, BillingMode, CreateTableInput, DeleteItemInput,
@@ -11,10 +11,16 @@ use crate::types::{
 /// Validate a table name per Virtual `DynamoDB` rules.
 /// REQ-LIM-020: 3-255 chars. REQ-LIM-021: [a-zA-Z0-9_.-]
 pub fn validate_table_name(name: &str, limits: &LimitsConfig) -> Result<(), DynamoDbError> {
-    if name.len() < limits.min_table_name_length || name.len() > limits.max_table_name_length {
-        return Err(DynamoDbError::ValidationException(error_message(
-            ErrorMessageKey::TableNameTooShort,
-            &[],
+    if name.len() < limits.min_table_name_length {
+        return Err(DynamoDbError::ValidationException(validation_error(
+            name, "tableName",
+            &format!("Member must have length greater than or equal to {}", limits.min_table_name_length),
+        )));
+    }
+    if name.len() > limits.max_table_name_length {
+        return Err(DynamoDbError::ValidationException(validation_error(
+            name, "tableName",
+            &format!("Member must have length less than or equal to {}", limits.max_table_name_length),
         )));
     }
     validate_table_name_chars(name)?;
@@ -91,6 +97,17 @@ pub fn validate_create_table(
 /// Maximum number of HASH or RANGE elements in a multi-part key schema.
 const MAX_MULTIPART_KEY_ELEMENTS: usize = 4;
 
+fn format_key_schema_value(ks: &[KeySchemaElement]) -> String {
+    let elements: Vec<String> = ks.iter().map(|e| {
+        let kt = match e.key_type {
+            KeyType::Hash => "HASH",
+            KeyType::Range => "RANGE",
+        };
+        format!("KeySchemaElement(attributeName={}, keyType={})", e.attribute_name, kt)
+    }).collect();
+    format!("[{}]", elements.join(", "))
+}
+
 fn validate_key_schema(
     input: &CreateTableInput,
     allow_multipart: bool,
@@ -113,9 +130,10 @@ fn validate_key_schema(
     } else {
         // Standard DynamoDB: 1 HASH + optional 1 RANGE
         if input.key_schema.len() > 2 {
-            return Err(DynamoDbError::ValidationException(error_message(
-                ErrorMessageKey::KeySchemaTooMany,
-                &[],
+            let ks_repr = format_key_schema_value(&input.key_schema);
+            return Err(DynamoDbError::ValidationException(validation_error(
+                &ks_repr, "keySchema",
+                "Member must have length less than or equal to 2",
             )));
         }
         if input.key_schema.len() == 2 && input.key_schema[1].key_type != KeyType::Range {

--- a/crates/engine/src/batch_get_item.rs
+++ b/crates/engine/src/batch_get_item.rs
@@ -50,6 +50,15 @@ pub async fn handle_batch_get_item<S: TableEngine + DataEngine>(
         ));
     }
 
+    // Validate: per-table key count <= 100
+    for (table_name, ka) in &input.request_items {
+        if ka.keys.len() > MAX_BATCH_GET_KEYS {
+            return Err(DynamoDbError::ValidationException(format!(
+                "1 validation error detected: Value at 'RequestItems.{table_name}.member.Keys' failed to satisfy constraint: Member must have length less than or equal to 100"
+            )));
+        }
+    }
+
     // Validate: total keys across all tables <= 100
     let total_keys: usize = input.request_items.values().map(|ka| ka.keys.len()).sum();
     if total_keys > MAX_BATCH_GET_KEYS {

--- a/crates/engine/src/batch_write_item.rs
+++ b/crates/engine/src/batch_write_item.rs
@@ -59,9 +59,14 @@ pub async fn handle_batch_write_item<S: TableEngine + DataEngine>(
     // Validate: total operations across all tables <= 25
     let total_ops: usize = input.request_items.values().map(Vec::len).sum();
     if total_ops > MAX_BATCH_WRITE_ITEMS {
-        return Err(DynamoDbError::ValidationException(
-            "Too many items requested for the BatchWriteItem call".to_owned(),
-        ));
+        let map_repr: Vec<String> = input.request_items.iter().map(|(name, reqs)| {
+            let items: Vec<&str> = (0..reqs.len()).map(|_| "WriteRequest(...)").collect();
+            format!("{}=[{}]", name, items.join(", "))
+        }).collect();
+        return Err(DynamoDbError::ValidationException(format!(
+            "1 validation error detected: Value '{{{}}}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1]",
+            map_repr.join(", "),
+        )));
     }
 
     // Validate: each table must have at least one request

--- a/crates/engine/src/transact_get_items.rs
+++ b/crates/engine/src/transact_get_items.rs
@@ -42,14 +42,15 @@ pub async fn handle_transact_get_items<S: TableEngine + DataEngine>(
 
     if input.transact_items.is_empty() {
         return Err(DynamoDbError::ValidationException(
-            "1 validation error detected: Value null at 'transactItems' failed to satisfy constraint: Member must not be null".to_owned(),
+            "1 validation error detected: Value '[]' at 'transactItems' failed to satisfy constraint: Member must have length greater than or equal to 1".to_owned(),
         ));
     }
 
     if input.transact_items.len() > MAX_TRANSACT_GET_ITEMS {
-        return Err(DynamoDbError::ValidationException(
-            "Member must have length less than or equal to 100".to_owned(),
-        ));
+        return Err(DynamoDbError::ValidationException(format!(
+            "1 validation error detected: Value '{}' at 'transactItems' failed to satisfy constraint: Member must have length less than or equal to 100",
+            format_transact_items_value(input.transact_items.len()),
+        )));
     }
 
     // Resolve table key info for each item
@@ -143,4 +144,9 @@ pub async fn handle_transact_get_items<S: TableEngine + DataEngine>(
             ..Default::default()
         },
     })
+}
+
+fn format_transact_items_value(count: usize) -> String {
+    let placeholders: Vec<&str> = (0..count).map(|_| "TransactGetItem(get=Get(...))").collect();
+    format!("[{}]", placeholders.join(", "))
 }

--- a/crates/engine/src/transact_write_items.rs
+++ b/crates/engine/src/transact_write_items.rs
@@ -60,14 +60,15 @@ pub async fn handle_transact_write_items<S: TableEngine + DataEngine>(
 
     if input.transact_items.is_empty() {
         return Err(DynamoDbError::ValidationException(
-            "1 validation error detected: Value null at 'transactItems' failed to satisfy constraint: Member must not be null".to_owned(),
+            "1 validation error detected: Value '[]' at 'transactItems' failed to satisfy constraint: Member must have length greater than or equal to 1".to_owned(),
         ));
     }
 
     if input.transact_items.len() > MAX_TRANSACT_WRITE_ITEMS {
-        return Err(DynamoDbError::ValidationException(
-            "Member must have length less than or equal to 100".to_owned(),
-        ));
+        return Err(DynamoDbError::ValidationException(format!(
+            "1 validation error detected: Value '[{}]' at 'transactItems' failed to satisfy constraint: Member must have length less than or equal to 100",
+            (0..input.transact_items.len()).map(|_| "TransactWriteItem(...)").collect::<Vec<_>>().join(", "),
+        )));
     }
 
     // Validate each item has exactly one operation


### PR DESCRIPTION
## Summary
  
  Validation error messages now match DynamoDB's exact format. Conformance suite improves from 467/576 (81.1%) to 479/576 (83.2%).
  
  ## Changes
  
**Formatter functions**: Added `validation_error(value, field, constraint)` and `validation_errors(errors)` in
  `crates/core/src/error/messages.rs` that produce DynamoDB's exact format: `"1 validation error detected: Value '{value}' at '{field}' failed to satisfy constraint: {constraint}"`.
  
**Table name validation**: Split too-short/too-long into separate checks that include the actual value and field path in the message.
  
**KeySchema validation**: >2 elements now serializes the array in `KeySchemaElement(attributeName=..., keyType=...)` format matching DynamoDB's Java toString output.
  
**TransactGetItems/TransactWriteItems**: Empty list returns `"Value '[]'"` with `"greater than or equal to 1"` constraint. Exceeding 100 items includes the serialized list value.
  
**BatchGetItem**: Per-table >100 keys check added with correct field path `"RequestItems.{table}.member.Keys"`.
  
**BatchWriteItem**: >25 items includes the map value representation matching DynamoDB's format.
  
## Testing

- `cargo test --workspace`  all pass
- Conformance suite  479/576 (83.2%), 12 new passes, 0 regressions

## Files changed (7)

- `crates/core/src/error/messages.rs` — `validation_error()`, `validation_errors()` formatters
- `crates/core/src/error/mod.rs` — export new functions
- `crates/core/src/validation/mod.rs` — table name + key schema messages, `format_key_schema_value` helper
- `crates/engine/src/batch_get_item.rs` — per-table key count check with correct message
- `crates/engine/src/batch_write_item.rs` — >25 items message with map value
- `crates/engine/src/transact_get_items.rs` — empty/too-many messages
- `crates/engine/src/transact_write_items.rs` — empty/too-many messages