### PR TITLE
fix: expression error messages match DynamoDB format

### DIFF
--- a/crates/core/src/expression/tokenizer.rs
+++ b/crates/core/src/expression/tokenizer.rs
@@ -179,9 +179,12 @@ pub fn tokenize_with_limit(input: &str, max_tokens: usize) -> Result<Vec<Token>,
                 )?;
             }
             other => {
+                let ch = other as char;
+                let near_start = if i > 5 { i - 5 } else { 0 };
+                let near_end = std::cmp::min(i + 5, input.len());
+                let near = &input[near_start..near_end];
                 return Err(validation_err(&format!(
-                    "Invalid expression: unexpected character '{}'",
-                    other as char
+                    "Syntax error; token: \"{ch}\", near: \"{near}\""
                 )));
             }
         }
@@ -347,7 +350,7 @@ mod tests {
     fn tokenize_invalid_character_rejected() {
         let err = tokenize("a @ b").unwrap_err();
         assert!(
-            matches!(err, DynamoDbError::ValidationException(msg) if msg.contains("unexpected character"))
+            matches!(err, DynamoDbError::ValidationException(msg) if msg.contains("Syntax error; token:"))
         );
     }
 

--- a/crates/core/src/types/attribute_value.rs
+++ b/crates/core/src/types/attribute_value.rs
@@ -115,7 +115,7 @@ impl<'de> Visitor<'de> for AttributeValueVisitor {
                     .ok_or_else(|| de::Error::custom("SS value must be an array"))?;
                 if arr.is_empty() {
                     return Err(de::Error::custom(
-                        "One or more parameter values are not valid. An string set  may not be empty",
+                        "One or more parameter values were invalid: An string set  may not be empty",
                     ));
                 }
                 let set: BTreeSet<String> = arr
@@ -134,7 +134,7 @@ impl<'de> Visitor<'de> for AttributeValueVisitor {
                     .ok_or_else(|| de::Error::custom("NS value must be an array"))?;
                 if arr.is_empty() {
                     return Err(de::Error::custom(
-                        "One or more parameter values are not valid. An number set  may not be empty",
+                        "One or more parameter values were invalid: An number set  may not be empty",
                     ));
                 }
                 let set: BTreeSet<String> = arr
@@ -153,7 +153,7 @@ impl<'de> Visitor<'de> for AttributeValueVisitor {
                     .ok_or_else(|| de::Error::custom("BS value must be an array"))?;
                 if arr.is_empty() {
                     return Err(de::Error::custom(
-                        "One or more parameter values are not valid. Binary sets  may not be empty",
+                        "One or more parameter values were invalid: Binary sets  may not be empty",
                     ));
                 }
                 let set: BTreeSet<Vec<u8>> = arr
@@ -181,7 +181,7 @@ impl<'de> Visitor<'de> for AttributeValueVisitor {
                     .ok_or_else(|| de::Error::custom("NULL value must be a boolean"))?;
                 if !n {
                     return Err(de::Error::custom(
-                        "SerializationException: NULL value must be true",
+                        "One or more parameter values were invalid: Null attribute value types must have the value of true",
                     ));
                 }
                 Ok(AttributeValue::Null)
@@ -353,7 +353,7 @@ mod tests {
     fn null_false_rejected() {
         let json = r#"{"NULL":false}"#;
         let err = serde_json::from_str::<AttributeValue>(json).unwrap_err();
-        assert!(err.to_string().contains("NULL value must be true"));
+        assert!(err.to_string().contains("Null attribute value types must have the value of true"));
     }
 
     #[test]

--- a/crates/engine/src/expression_helpers.rs
+++ b/crates/engine/src/expression_helpers.rs
@@ -75,6 +75,7 @@ pub fn parse_optional_filter(
     limits: &LimitsConfig,
 ) -> Result<Option<Expr>, DynamoDbError> {
     parse_optional_condition(expr, limits)
+        .map_err(|e| prefix_expression_error(e, "FilterExpression"))
 }
 
 /// Resolve a condition from either `ConditionExpression` or legacy `Expected`.
@@ -131,4 +132,19 @@ pub fn resolve_condition(
     let maps = build_expression_maps(names, values);
     let condition = parse_optional_condition(condition_expression, limits)?;
     Ok((condition, maps))
+}
+
+/// Prefix an expression error with the expression type, matching DynamoDB's format.
+/// If the error already starts with "Invalid", it's returned as-is.
+pub fn prefix_expression_error(err: DynamoDbError, expr_type: &str) -> DynamoDbError {
+    match err {
+        DynamoDbError::ValidationException(msg) => {
+            if msg.starts_with("Invalid ") || msg.starts_with("1 validation") {
+                DynamoDbError::ValidationException(msg)
+            } else {
+                DynamoDbError::ValidationException(format!("Invalid {expr_type}: {msg}"))
+            }
+        }
+        other => other,
+    }
 }

--- a/crates/engine/src/get_item.rs
+++ b/crates/engine/src/get_item.rs
@@ -110,8 +110,10 @@ pub async fn handle_get_item<S: TableEngine + DataEngine>(
 
     let item = match (&effective_projection, item) {
         (Some(proj_str), Some(fetched)) => {
-            let proj_tokens = tokenize_with_limit(proj_str, ctx.limits.max_expression_tokens)?;
-            let projection = parse_projection(&proj_tokens)?;
+            let proj_tokens = tokenize_with_limit(proj_str, ctx.limits.max_expression_tokens)
+                .map_err(|e| crate::expression_helpers::prefix_expression_error(e, "ProjectionExpression"))?;
+            let projection = parse_projection(&proj_tokens)
+                .map_err(|e| crate::expression_helpers::prefix_expression_error(e, "ProjectionExpression"))?;
             let maps = build_expression_maps(effective_proj_names.as_ref(), None);
             Some(apply_projection(&fetched, &projection, &maps)?)
         }

--- a/crates/engine/src/put_item.rs
+++ b/crates/engine/src/put_item.rs
@@ -32,10 +32,32 @@ pub async fn handle_put_item<S: TableEngine + DataEngine>(
     ctx: &OperationContext<S>,
 ) -> Result<DispatchResult, DynamoDbError> {
     let input: PutItemInput = serde_json::from_value(body).map_err(|e| {
-        DynamoDbError::SerializationException(format!(
-            "Start of structure or map found where not expected: {e}"
-        ))
+        let msg = e.to_string();
+        if msg.contains("parameter values were invalid")
+            || msg.contains("may not be empty")
+            || msg.contains("contains duplicates")
+            || msg.contains("Null attribute value")
+        {
+            DynamoDbError::ValidationException(msg)
+        } else {
+            DynamoDbError::SerializationException(format!(
+                "Start of structure or map found where not expected: {e}"
+            ))
+        }
     })?;
+
+    // Reject EAV/EAN without an expression
+    let has_expression = input.condition_expression.as_ref().is_some_and(|s| !s.is_empty());
+    if !has_expression && input.expression_attribute_values.as_ref().is_some_and(|m| !m.is_empty()) {
+        return Err(DynamoDbError::ValidationException(
+            "ExpressionAttributeValues can only be specified when using expressions: ConditionExpression is null".to_owned(),
+        ));
+    }
+    if !has_expression && input.expression_attribute_names.as_ref().is_some_and(|m| !m.is_empty()) {
+        return Err(DynamoDbError::ValidationException(
+            "ExpressionAttributeNames can only be specified when using expressions: ConditionExpression is null".to_owned(),
+        ));
+    }
 
     let key_info = ctx
         .table_key_info(&input.table_name)

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -110,8 +110,15 @@ pub async fn handle_query<S: TableEngine + DataEngine>(
                 .to_owned(),
         )
     })?;
-    let tokens = tokenize_with_limit(kce_str, ctx.limits.max_expression_tokens)?;
-    let mut key_condition = parse_key_condition(&tokens)?;
+    if kce_str.trim().is_empty() {
+        return Err(DynamoDbError::ValidationException(
+            "Invalid KeyConditionExpression: The expression can not be empty;".to_owned(),
+        ));
+    }
+    let tokens = tokenize_with_limit(kce_str, ctx.limits.max_expression_tokens)
+        .map_err(|e| crate::expression_helpers::prefix_expression_error(e, "KeyConditionExpression"))?;
+    let mut key_condition = parse_key_condition(&tokens)
+        .map_err(|e| crate::expression_helpers::prefix_expression_error(e, "KeyConditionExpression"))?;
 
     // Correct PK/SK assignment when both clauses are equality comparisons.
     // The parser can't distinguish PK from SK without the key schema.
@@ -156,8 +163,10 @@ pub async fn handle_query<S: TableEngine + DataEngine>(
 
     // Parse ProjectionExpression
     let projection = if let Some(ref proj_str) = input.projection_expression {
-        let proj_tokens = tokenize_with_limit(proj_str, ctx.limits.max_expression_tokens)?;
-        Some(parse_projection(&proj_tokens)?)
+        let proj_tokens = tokenize_with_limit(proj_str, ctx.limits.max_expression_tokens)
+            .map_err(|e| crate::expression_helpers::prefix_expression_error(e, "ProjectionExpression"))?;
+        Some(parse_projection(&proj_tokens)
+            .map_err(|e| crate::expression_helpers::prefix_expression_error(e, "ProjectionExpression"))?)
     } else {
         None
     };

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -135,8 +135,10 @@ pub async fn handle_scan<S: TableEngine + DataEngine>(
 
     // Parse ProjectionExpression
     let projection = if let Some(ref proj_str) = input.projection_expression {
-        let proj_tokens = tokenize_with_limit(proj_str, ctx.limits.max_expression_tokens)?;
-        Some(parse_projection(&proj_tokens)?)
+        let proj_tokens = tokenize_with_limit(proj_str, ctx.limits.max_expression_tokens)
+            .map_err(|e| crate::expression_helpers::prefix_expression_error(e, "ProjectionExpression"))?;
+        Some(parse_projection(&proj_tokens)
+            .map_err(|e| crate::expression_helpers::prefix_expression_error(e, "ProjectionExpression"))?)
     } else {
         None
     };

--- a/crates/engine/src/transact_get_items.rs
+++ b/crates/engine/src/transact_get_items.rs
@@ -112,8 +112,10 @@ pub async fn handle_transact_get_items<S: TableEngine + DataEngine>(
             let item = match (opt, tgi.get.projection_expression.as_deref()) {
                 (Some(item), Some(proj_str)) => {
                     let proj_tokens =
-                        tokenize_with_limit(proj_str, ctx.limits.max_expression_tokens)?;
-                    let projection = parse_projection(&proj_tokens)?;
+                        tokenize_with_limit(proj_str, ctx.limits.max_expression_tokens)
+                            .map_err(|e| crate::expression_helpers::prefix_expression_error(e, "ProjectionExpression"))?;
+                    let projection = parse_projection(&proj_tokens)
+                        .map_err(|e| crate::expression_helpers::prefix_expression_error(e, "ProjectionExpression"))?;
                     let maps =
                         build_expression_maps(tgi.get.expression_attribute_names.as_ref(), None);
                     Some(apply_projection(&item, &projection, &maps)?)

--- a/crates/engine/src/update_item.rs
+++ b/crates/engine/src/update_item.rs
@@ -111,7 +111,13 @@ pub async fn handle_update_item<S: TableEngine + DataEngine>(
 
     // Parse the update expression
     let update_expr = effective_update_expr.as_deref().unwrap_or("");
-    let update_tokens = tokenize_with_limit(update_expr, ctx.limits.max_expression_tokens)?;
+    if update_expr.trim().is_empty() {
+        return Err(DynamoDbError::ValidationException(
+            "Invalid UpdateExpression: The expression can not be empty;".to_owned(),
+        ));
+    }
+    let update_tokens = tokenize_with_limit(update_expr, ctx.limits.max_expression_tokens)
+        .map_err(|e| crate::expression_helpers::prefix_expression_error(e, "UpdateExpression"))?;
     let actions = parse_update(&update_tokens)?;
 
     // Validate that no update action targets a key attribute (REQ-DATA-003)


### PR DESCRIPTION
- Empty KCE/UpdateExpression: 'The expression can not be empty;'
- Tokenizer syntax errors: 'Syntax error; token: "x", near: "..."'
- Expression type prefix (ProjectionExpression, FilterExpression, etc.)
- NULL attr false: correct ValidationException message
- Empty SS/NS/BS: 'were invalid:' not 'are not valid.'
- PutItem: reject EAV/EAN without ConditionExpression
- prefix_expression_error helper for consistent formatting