### PR TITLE
fix: reject TransactWriteItems when total item size exceeds 4MB

### DIFF
--- a/crates/engine/src/transact_write_helpers.rs
+++ b/crates/engine/src/transact_write_helpers.rs
@@ -66,6 +66,16 @@ impl PreparedOp {
         }
     }
 
+    /// Approximate item size for transaction size limit enforcement.
+    pub(crate) fn item_size(&self) -> usize {
+        match self {
+            Self::Put { item, .. } => extenddb_core::types::item_size_bytes(item),
+            Self::Delete { key, .. } | Self::Update { key, .. } | Self::ConditionCheck { key, .. } => {
+                extenddb_core::types::item_size_bytes(key)
+            }
+        }
+    }
+
     /// Canonical `"table_name:{json_key}"` string for duplicate-target detection.
     ///
     /// Uses JSON serialization of the extracted key (`BTreeMap` guarantees sorted

--- a/crates/engine/src/transact_write_items.rs
+++ b/crates/engine/src/transact_write_items.rs
@@ -104,6 +104,14 @@ pub async fn handle_transact_write_items<S: TableEngine + DataEngine>(
         prepared.push(op);
     }
 
+    // Validate total transaction size <= 4MB
+    let total_size: usize = prepared.iter().map(|op| op.item_size()).sum();
+    if total_size > 4 * 1024 * 1024 {
+        return Err(DynamoDbError::ValidationException(
+            "Transaction item size has exceeded the 4 MB limit".to_owned(),
+        ));
+    }
+
     // Build storage operations
     let ops: Vec<extenddb_storage::TransactWriteOp<'_>> =
         prepared.iter().map(|p| p.to_storage_op()).collect();


### PR DESCRIPTION
## Summary
  
Rejects TransactWriteItems when total item size across all operations exceeds 4MB, matching DynamoDB behavior.

## Changes

Added aggregate size check after preparing all transaction operations. Sums `item_size_bytes` for Put items and key sizes for
Delete/Update/ConditionCheck operations. Returns `ValidationException` when the total exceeds 4MB.

- `crates/engine/src/transact_write_items.rs`  size check after prepare loop
- `crates/engine/src/transact_write_helpers.rs`  `item_size()` method on `PreparedOp`

## Testing

- `cargo test --workspace`  all pass
- Conformance suite  verified TransactWriteItems 4MB limit test passes