### PR TITLE
fix: support legacy KeyConditions, QueryFilter, ScanFilter, Attribute…

### DIFF
--- a/crates/core/src/types/mod.rs
+++ b/crates/core/src/types/mod.rs
@@ -40,7 +40,7 @@ pub use key_schema::{
     AttributeDefinition, IndexInfo, IndexType, KeySchemaElement, KeyType, ScalarAttributeType,
     TableKeyInfo, hash_key_elements, is_multipart_key_schema, range_key_elements,
 };
-pub use query::{QueryInput, QueryOutput, ScanInput, ScanOutput, Select};
+pub use query::{Condition, QueryInput, QueryOutput, ScanInput, ScanOutput, Select};
 pub use stream::{
     DescribeStreamInput, DescribeStreamOutput, GetRecordsInput, GetRecordsOutput,
     GetShardIteratorInput, GetShardIteratorOutput, ListStreamsInput, ListStreamsOutput,

--- a/crates/core/src/types/query.rs
+++ b/crates/core/src/types/query.rs
@@ -8,7 +8,17 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use super::capacity::{ConsumedCapacity, ReturnConsumedCapacity};
+use super::item::ConditionalOperator;
 use super::{AttributeValue, Item};
+
+/// Legacy condition used in `KeyConditions`, `QueryFilter`, and `ScanFilter`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Condition {
+    #[serde(rename = "ComparisonOperator")]
+    pub comparison_operator: String,
+    #[serde(rename = "AttributeValueList", default)]
+    pub attribute_value_list: Vec<AttributeValue>,
+}
 
 /// `Select` parameter — controls which attributes are returned.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -67,6 +77,18 @@ pub struct QueryInput {
     /// Controls whether consumed capacity information is returned.
     #[serde(rename = "ReturnConsumedCapacity", default)]
     pub return_consumed_capacity: ReturnConsumedCapacity,
+    /// Legacy `KeyConditions` — desugared to `KeyConditionExpression`.
+    #[serde(rename = "KeyConditions")]
+    pub key_conditions: Option<HashMap<String, Condition>>,
+    /// Legacy `QueryFilter` — desugared to `FilterExpression`.
+    #[serde(rename = "QueryFilter")]
+    pub query_filter: Option<HashMap<String, Condition>>,
+    /// Legacy `AttributesToGet` — desugared to `ProjectionExpression`.
+    #[serde(rename = "AttributesToGet")]
+    pub attributes_to_get: Option<Vec<String>>,
+    /// Logical operator for combining multiple legacy filter conditions.
+    #[serde(rename = "ConditionalOperator")]
+    pub conditional_operator: Option<ConditionalOperator>,
 }
 
 fn default_true() -> bool {
@@ -119,6 +141,15 @@ pub struct ScanInput {
     /// Controls whether consumed capacity information is returned.
     #[serde(rename = "ReturnConsumedCapacity", default)]
     pub return_consumed_capacity: ReturnConsumedCapacity,
+    /// Legacy `ScanFilter` — desugared to `FilterExpression`.
+    #[serde(rename = "ScanFilter")]
+    pub scan_filter: Option<HashMap<String, Condition>>,
+    /// Legacy `AttributesToGet` — desugared to `ProjectionExpression`.
+    #[serde(rename = "AttributesToGet")]
+    pub attributes_to_get: Option<Vec<String>>,
+    /// Logical operator for combining multiple legacy filter conditions.
+    #[serde(rename = "ConditionalOperator")]
+    pub conditional_operator: Option<ConditionalOperator>,
 }
 
 /// `Scan` response body.

--- a/crates/engine/src/legacy_filter.rs
+++ b/crates/engine/src/legacy_filter.rs
@@ -1,0 +1,339 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Legacy filter parameter desugaring.
+//!
+//! Converts pre-expression parameters (KeyConditions, QueryFilter, ScanFilter)
+//! into expression-based equivalents.
+
+use std::collections::HashMap;
+
+use extenddb_core::error::DynamoDbError;
+use extenddb_core::expression::{
+    CompareOp, Expr, ExpressionMaps, KeyCondition, PathElement, SortKeyCondition,
+};
+use extenddb_core::types::{AttributeValue, Condition, ConditionalOperator};
+
+/// Desugar legacy `KeyConditions` into a `KeyCondition` struct and expression maps.
+///
+/// The hash key must have ComparisonOperator = "EQ".
+/// The optional range key supports: EQ, LE, LT, GE, GT, BEGINS_WITH, BETWEEN.
+pub fn desugar_key_conditions(
+    conditions: &HashMap<String, Condition>,
+    key_schema: &[(String, bool)], // Vec of (attr_name, is_hash)
+) -> Result<(KeyCondition, ExpressionMaps), DynamoDbError> {
+    // Find the hash key condition
+    let hash_attr = key_schema
+        .iter()
+        .find(|(_, is_hash)| *is_hash)
+        .map(|(name, _)| name.as_str())
+        .ok_or_else(|| {
+            DynamoDbError::ValidationException("No hash key in key schema".to_owned())
+        })?;
+
+    let hash_cond = conditions.get(hash_attr).ok_or_else(|| {
+        DynamoDbError::ValidationException(format!(
+            "Query condition missed key schema element: {hash_attr}"
+        ))
+    })?;
+
+    if hash_cond.comparison_operator != "EQ" {
+        return Err(DynamoDbError::ValidationException(
+            "Query key condition not supported".to_owned(),
+        ));
+    }
+
+    if hash_cond.attribute_value_list.len() != 1 {
+        return Err(DynamoDbError::ValidationException(
+            "Query key condition must have exactly one value for EQ".to_owned(),
+        ));
+    }
+
+    let mut values = HashMap::new();
+    let pk_placeholder = "_kc_pk".to_owned();
+    values.insert(
+        pk_placeholder.clone(),
+        hash_cond.attribute_value_list[0].clone(),
+    );
+
+    let pk_path = vec![PathElement::Attribute(hash_attr.to_owned())];
+    let pk_value = Expr::Placeholder(pk_placeholder.clone());
+
+    // Find optional range key condition
+    let range_attr = key_schema
+        .iter()
+        .find(|(_, is_hash)| !*is_hash)
+        .map(|(name, _)| name.as_str());
+
+    let sk_condition = if let Some(range_name) = range_attr {
+        if let Some(range_cond) = conditions.get(range_name) {
+            Some(desugar_sk_condition(
+                range_cond,
+                range_name,
+                &mut values,
+            )?)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // Check for non-key attributes in KeyConditions (invalid)
+    for attr_name in conditions.keys() {
+        if attr_name != hash_attr && range_attr != Some(attr_name.as_str()) {
+            return Err(DynamoDbError::ValidationException(format!(
+                "Query condition missed key schema element: {hash_attr}"
+            )));
+        }
+    }
+
+    let maps = ExpressionMaps::new(HashMap::new(), values);
+
+    Ok((
+        KeyCondition {
+            pk_path,
+            pk_value,
+            sk_condition,
+            extra_pk_conditions: Vec::new(),
+            extra_sk_conditions: Vec::new(),
+        },
+        maps,
+    ))
+}
+
+fn desugar_sk_condition(
+    cond: &Condition,
+    range_name: &str,
+    values: &mut HashMap<String, AttributeValue>,
+) -> Result<SortKeyCondition, DynamoDbError> {
+    let path = vec![PathElement::Attribute(range_name.to_owned())];
+    match cond.comparison_operator.as_str() {
+        "EQ" | "LE" | "LT" | "GE" | "GT" => {
+            if cond.attribute_value_list.len() != 1 {
+                return Err(DynamoDbError::ValidationException(
+                    "Invalid number of values for comparison".to_owned(),
+                ));
+            }
+            let placeholder = "_kc_sk".to_owned();
+            values.insert(placeholder.clone(), cond.attribute_value_list[0].clone());
+            let op = match cond.comparison_operator.as_str() {
+                "EQ" => CompareOp::Eq,
+                "LE" => CompareOp::Le,
+                "LT" => CompareOp::Lt,
+                "GE" => CompareOp::Ge,
+                "GT" => CompareOp::Gt,
+                _ => unreachable!(),
+            };
+            Ok(SortKeyCondition::Compare {
+                path,
+                op,
+                value: Expr::Placeholder(placeholder),
+            })
+        }
+        "BETWEEN" => {
+            if cond.attribute_value_list.len() != 2 {
+                return Err(DynamoDbError::ValidationException(
+                    "BETWEEN requires exactly 2 values".to_owned(),
+                ));
+            }
+            let lo_placeholder = "_kc_sk_lo".to_owned();
+            let hi_placeholder = "_kc_sk_hi".to_owned();
+            values.insert(lo_placeholder.clone(), cond.attribute_value_list[0].clone());
+            values.insert(hi_placeholder.clone(), cond.attribute_value_list[1].clone());
+            Ok(SortKeyCondition::Between {
+                path,
+                low: Expr::Placeholder(lo_placeholder),
+                high: Expr::Placeholder(hi_placeholder),
+            })
+        }
+        "BEGINS_WITH" => {
+            if cond.attribute_value_list.len() != 1 {
+                return Err(DynamoDbError::ValidationException(
+                    "BEGINS_WITH requires exactly 1 value".to_owned(),
+                ));
+            }
+            let placeholder = "_kc_sk".to_owned();
+            values.insert(placeholder.clone(), cond.attribute_value_list[0].clone());
+            Ok(SortKeyCondition::BeginsWith {
+                path,
+                prefix: Expr::Placeholder(placeholder),
+            })
+        }
+        other => Err(DynamoDbError::ValidationException(format!(
+            "Unsupported KeyCondition operator: {other}"
+        ))),
+    }
+}
+
+/// Desugar legacy `QueryFilter` or `ScanFilter` into a condition expression AST.
+///
+/// Each entry maps an attribute name to a Condition with ComparisonOperator and values.
+/// Multiple entries are combined with the `ConditionalOperator` (default AND).
+pub fn desugar_filter(
+    filter: &HashMap<String, Condition>,
+    conditional_operator: ConditionalOperator,
+) -> Result<(Expr, ExpressionMaps), DynamoDbError> {
+    if filter.is_empty() {
+        return Err(DynamoDbError::ValidationException(
+            "Filter must not be empty".to_owned(),
+        ));
+    }
+
+    let mut conditions = Vec::new();
+    let mut value_map: HashMap<String, AttributeValue> = HashMap::new();
+    let mut counter = 0u32;
+
+    let mut sorted_entries: Vec<_> = filter.iter().collect();
+    sorted_entries.sort_by_key(|(name, _)| *name);
+
+    for (attr_name, cond) in sorted_entries {
+        let path = Expr::Path(vec![PathElement::Attribute(attr_name.clone())]);
+        let expr = desugar_one_filter_condition(&path, cond, &mut value_map, &mut counter)?;
+        conditions.push(expr);
+    }
+
+    let combined = if conditions.len() == 1 {
+        conditions.into_iter().next().unwrap()
+    } else {
+        match conditional_operator {
+            ConditionalOperator::And => conditions
+                .into_iter()
+                .reduce(|acc, c| Expr::And(Box::new(acc), Box::new(c)))
+                .unwrap(),
+            ConditionalOperator::Or => conditions
+                .into_iter()
+                .reduce(|acc, c| Expr::Or(Box::new(acc), Box::new(c)))
+                .unwrap(),
+        }
+    };
+
+    let maps = ExpressionMaps::new(HashMap::new(), value_map);
+    Ok((combined, maps))
+}
+
+fn desugar_one_filter_condition(
+    path: &Expr,
+    cond: &Condition,
+    values: &mut HashMap<String, AttributeValue>,
+    counter: &mut u32,
+) -> Result<Expr, DynamoDbError> {
+    match cond.comparison_operator.as_str() {
+        "EQ" | "NE" | "LE" | "LT" | "GE" | "GT" => {
+            if cond.attribute_value_list.len() != 1 {
+                return Err(DynamoDbError::ValidationException(
+                    "Invalid number of attribute values for comparison".to_owned(),
+                ));
+            }
+            let placeholder = format!("_f{counter}");
+            *counter += 1;
+            values.insert(placeholder.clone(), cond.attribute_value_list[0].clone());
+            let op = match cond.comparison_operator.as_str() {
+                "EQ" => CompareOp::Eq,
+                "NE" => CompareOp::Ne,
+                "LE" => CompareOp::Le,
+                "LT" => CompareOp::Lt,
+                "GE" => CompareOp::Ge,
+                "GT" => CompareOp::Gt,
+                _ => unreachable!(),
+            };
+            Ok(Expr::Compare {
+                op,
+                left: Box::new(path.clone()),
+                right: Box::new(Expr::Placeholder(placeholder)),
+            })
+        }
+        "BETWEEN" => {
+            if cond.attribute_value_list.len() != 2 {
+                return Err(DynamoDbError::ValidationException(
+                    "BETWEEN requires exactly 2 values".to_owned(),
+                ));
+            }
+            let lo = format!("_f{counter}");
+            *counter += 1;
+            let hi = format!("_f{counter}");
+            *counter += 1;
+            values.insert(lo.clone(), cond.attribute_value_list[0].clone());
+            values.insert(hi.clone(), cond.attribute_value_list[1].clone());
+            Ok(Expr::Between {
+                operand: Box::new(path.clone()),
+                low: Box::new(Expr::Placeholder(lo)),
+                high: Box::new(Expr::Placeholder(hi)),
+            })
+        }
+        "BEGINS_WITH" => {
+            if cond.attribute_value_list.len() != 1 {
+                return Err(DynamoDbError::ValidationException(
+                    "BEGINS_WITH requires exactly 1 value".to_owned(),
+                ));
+            }
+            let placeholder = format!("_f{counter}");
+            *counter += 1;
+            values.insert(placeholder.clone(), cond.attribute_value_list[0].clone());
+            Ok(Expr::Function {
+                name: "begins_with".to_owned(),
+                args: vec![path.clone(), Expr::Placeholder(placeholder)],
+            })
+        }
+        "CONTAINS" => {
+            if cond.attribute_value_list.len() != 1 {
+                return Err(DynamoDbError::ValidationException(
+                    "CONTAINS requires exactly 1 value".to_owned(),
+                ));
+            }
+            let placeholder = format!("_f{counter}");
+            *counter += 1;
+            values.insert(placeholder.clone(), cond.attribute_value_list[0].clone());
+            Ok(Expr::Function {
+                name: "contains".to_owned(),
+                args: vec![path.clone(), Expr::Placeholder(placeholder)],
+            })
+        }
+        "NOT_CONTAINS" => {
+            if cond.attribute_value_list.len() != 1 {
+                return Err(DynamoDbError::ValidationException(
+                    "NOT_CONTAINS requires exactly 1 value".to_owned(),
+                ));
+            }
+            let placeholder = format!("_f{counter}");
+            *counter += 1;
+            values.insert(placeholder.clone(), cond.attribute_value_list[0].clone());
+            Ok(Expr::Not(Box::new(Expr::Function {
+                name: "contains".to_owned(),
+                args: vec![path.clone(), Expr::Placeholder(placeholder)],
+            })))
+        }
+        "NULL" => Ok(Expr::Function {
+            name: "attribute_not_exists".to_owned(),
+            args: vec![path.clone()],
+        }),
+        "NOT_NULL" => Ok(Expr::Function {
+            name: "attribute_exists".to_owned(),
+            args: vec![path.clone()],
+        }),
+        "IN" => {
+            if cond.attribute_value_list.is_empty() {
+                return Err(DynamoDbError::ValidationException(
+                    "IN requires at least 1 value".to_owned(),
+                ));
+            }
+            let placeholders: Vec<Expr> = cond
+                .attribute_value_list
+                .iter()
+                .map(|v| {
+                    let placeholder = format!("_f{counter}");
+                    *counter += 1;
+                    values.insert(placeholder.clone(), v.clone());
+                    Expr::Placeholder(placeholder)
+                })
+                .collect();
+            Ok(Expr::In {
+                operand: Box::new(path.clone()),
+                list: placeholders,
+            })
+        }
+        other => Err(DynamoDbError::ValidationException(format!(
+            "Unsupported filter operator: {other}"
+        ))),
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -19,6 +19,7 @@ mod describe_limits;
 mod describe_table;
 mod expected;
 mod expression_helpers;
+mod legacy_filter;
 mod get_item;
 mod import_export;
 mod import_export_io;

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -3,13 +3,17 @@
 
 //! `Query` operation handler.
 
+use std::collections::HashMap;
+
 use serde_json::Value;
 
 use extenddb_core::error::DynamoDbError;
 use extenddb_core::expression::PathElement;
-use extenddb_core::expression::{parse_key_condition, parse_projection, tokenize_with_limit};
+use extenddb_core::expression::{
+    parse_key_condition, parse_projection, tokenize_with_limit, ExpressionMaps,
+};
 use extenddb_core::types::{
-    IndexType, QueryInput, QueryOutput, Select, TableKeyInfo, item_size_bytes,
+    IndexType, KeyType, QueryInput, QueryOutput, Select, TableKeyInfo, item_size_bytes,
 };
 use extenddb_storage::DataEngine;
 use extenddb_storage::TableEngine;
@@ -19,6 +23,7 @@ use crate::capacity_helpers;
 use crate::create_table::storage_err_to_dynamo;
 use crate::expression_helpers::{build_expression_maps, parse_optional_filter};
 use crate::index_helpers::combined_lek_key_schema;
+use crate::legacy_filter::{desugar_filter, desugar_key_conditions};
 use crate::read_helpers::apply_post_read;
 use crate::serialize_output;
 use crate::{DispatchMetrics, DispatchResult};
@@ -98,25 +103,78 @@ pub async fn handle_query<S: TableEngine + DataEngine>(
         key_info.clone()
     };
 
+    // --- Legacy vs expression mutual exclusivity checks ---
+    let has_kce = input.key_condition_expression.is_some();
+    let has_kc = input.key_conditions.as_ref().is_some_and(|m| !m.is_empty());
+
+    if has_kce && has_kc {
+        return Err(DynamoDbError::ValidationException(
+            "Can not use both expression and non-expression parameters in the same request: \
+             Non-expression parameters: {KeyConditions} Expression parameters: {KeyConditionExpression}"
+                .to_owned(),
+        ));
+    }
+
+    let has_fe = input.filter_expression.is_some();
+    let has_qf = input.query_filter.as_ref().is_some_and(|m| !m.is_empty());
+
+    if has_fe && has_qf {
+        return Err(DynamoDbError::ValidationException(
+            "Can not use both expression and non-expression parameters in the same request: \
+             Non-expression parameters: {QueryFilter} Expression parameters: {FilterExpression}"
+                .to_owned(),
+        ));
+    }
+
+    let has_pe = input.projection_expression.is_some();
+    let has_atg = input.attributes_to_get.as_ref().is_some_and(|a| !a.is_empty());
+
+    if has_pe && has_atg {
+        return Err(DynamoDbError::ValidationException(
+            "Can not use both expression and non-expression parameters in the same request: \
+             Non-expression parameters: {AttributesToGet} Expression parameters: {ProjectionExpression}"
+                .to_owned(),
+        ));
+    }
+
+    // Build expression maps from request (used for expression-based parameters)
     let maps = build_expression_maps(
         input.expression_attribute_names.as_ref(),
         input.expression_attribute_values.as_ref(),
     );
 
-    // Parse KeyConditionExpression (required)
-    let kce_str = input.key_condition_expression.as_deref().ok_or_else(|| {
-        DynamoDbError::ValidationException(
+    // Parse KeyConditionExpression or desugar legacy KeyConditions
+    let (mut key_condition, legacy_kc_maps) = if let Some(kce_str) =
+        input.key_condition_expression.as_deref()
+    {
+        let tokens = tokenize_with_limit(kce_str, ctx.limits.max_expression_tokens)?;
+        (parse_key_condition(&tokens)?, None)
+    } else if let Some(ref kc) = input.key_conditions {
+        let key_schema_pairs: Vec<(String, bool)> = query_key_info
+            .key_schema
+            .iter()
+            .map(|ks| (ks.attribute_name.clone(), ks.key_type == KeyType::Hash))
+            .collect();
+        let (kc_parsed, kc_maps) = desugar_key_conditions(kc, &key_schema_pairs)?;
+        (kc_parsed, Some(kc_maps))
+    } else {
+        return Err(DynamoDbError::ValidationException(
             "Either the KeyConditions or KeyConditionExpression parameter must be specified in the request."
                 .to_owned(),
-        )
-    })?;
-    let tokens = tokenize_with_limit(kce_str, ctx.limits.max_expression_tokens)?;
-    let mut key_condition = parse_key_condition(&tokens)?;
+        ));
+    };
+
+    // Use legacy maps for key condition resolution if KeyConditions was used
+    let effective_maps = if let Some(ref kc_maps) = legacy_kc_maps {
+        kc_maps
+    } else {
+        &maps
+    };
 
     // Correct PK/SK assignment when both clauses are equality comparisons.
     // The parser can't distinguish PK from SK without the key schema.
     let pk_attr = &query_key_info.key_schema[0].attribute_name;
-    key_condition.resolve_pk_sk(pk_attr, &maps.names)?;
+    key_condition.resolve_pk_sk(pk_attr, &effective_maps.names)?;
 
     // For multi-part key schemas (GSIs with >1 HASH attribute), reclassify
     // the parsed conditions so all HASH attributes go to pk_path/extra_pk_conditions
@@ -127,7 +185,7 @@ pub async fn handle_query<S: TableEngine + DataEngine>(
             .iter()
             .map(|ks| ks.attribute_name.as_str())
             .collect();
-        key_condition.resolve_multipart(&hash_attrs, &maps.names)?;
+        key_condition.resolve_multipart(&hash_attrs, &effective_maps.names)?;
 
         // Validate all HASH attributes are present in the KeyConditionExpression.
         let provided_count = 1 + key_condition.extra_pk_conditions.len();
@@ -136,12 +194,13 @@ pub async fn handle_query<S: TableEngine + DataEngine>(
             let missing = hash_attrs
                 .iter()
                 .find(|attr| {
-                    let pk_name = resolve_path_attr_name(&key_condition.pk_path, &maps.names);
+                    let pk_name =
+                        resolve_path_attr_name(&key_condition.pk_path, &effective_maps.names);
                     if pk_name.as_deref() == Some(*attr) {
                         return false;
                     }
                     !key_condition.extra_pk_conditions.iter().any(|(path, _)| {
-                        resolve_path_attr_name(path, &maps.names).as_deref() == Some(*attr)
+                        resolve_path_attr_name(path, &effective_maps.names).as_deref() == Some(*attr)
                     })
                 })
                 .unwrap_or(&hash_attrs[0]);
@@ -151,11 +210,39 @@ pub async fn handle_query<S: TableEngine + DataEngine>(
         }
     }
 
-    // Parse FilterExpression
-    let filter = parse_optional_filter(input.filter_expression.as_deref(), &ctx.limits)?;
+    // Parse FilterExpression or desugar legacy QueryFilter
+    let (filter, filter_maps) = if let Some(ref qf) = input.query_filter {
+        if !qf.is_empty() {
+            let cond_op = input.conditional_operator.unwrap_or_default();
+            let (expr, fmaps) = desugar_filter(qf, cond_op)?;
+            (Some(expr), Some(fmaps))
+        } else {
+            (parse_optional_filter(input.filter_expression.as_deref(), &ctx.limits)?, None)
+        }
+    } else {
+        (parse_optional_filter(input.filter_expression.as_deref(), &ctx.limits)?, None)
+    };
 
-    // Parse ProjectionExpression
-    let projection = if let Some(ref proj_str) = input.projection_expression {
+    // Parse ProjectionExpression or desugar legacy AttributesToGet
+    let (effective_projection_str, extra_proj_names) = if input.projection_expression.is_some() {
+        (input.projection_expression.clone(), HashMap::new())
+    } else if let Some(ref attrs) = input.attributes_to_get {
+        let mut names_map = HashMap::new();
+        let placeholders: Vec<String> = attrs
+            .iter()
+            .enumerate()
+            .map(|(i, attr)| {
+                let placeholder = format!("#_ag{i}");
+                names_map.insert(placeholder.clone(), attr.clone());
+                placeholder
+            })
+            .collect();
+        (Some(placeholders.join(", ")), names_map)
+    } else {
+        (None, HashMap::new())
+    };
+
+    let projection = if let Some(ref proj_str) = effective_projection_str {
         let proj_tokens = tokenize_with_limit(proj_str, ctx.limits.max_expression_tokens)?;
         Some(parse_projection(&proj_tokens)?)
     } else {
@@ -171,7 +258,7 @@ pub async fn handle_query<S: TableEngine + DataEngine>(
         }
     }
     if let Some(Select::Count) = input.select {
-        if input.projection_expression.is_some() {
+        if effective_projection_str.is_some() {
             return Err(DynamoDbError::ValidationException(
                 "Cannot specify the ProjectionExpression when Select is COUNT".to_owned(),
             ));
@@ -185,13 +272,34 @@ pub async fn handle_query<S: TableEngine + DataEngine>(
         None
     };
 
+    // Build the combined expression maps used for storage query and post-read evaluation.
+    // Merges the base request maps with any legacy desugared maps and projection name maps.
+    let combined_maps = {
+        let mut names = maps.names.clone();
+        let mut values = maps.values.clone();
+
+        if let Some(ref kc_maps) = legacy_kc_maps {
+            values.extend(kc_maps.values.clone());
+        }
+        if let Some(ref fm) = filter_maps {
+            values.extend(fm.values.clone());
+        }
+        if !extra_proj_names.is_empty() {
+            for (k, v) in &extra_proj_names {
+                let stripped = k.strip_prefix('#').unwrap_or(k);
+                names.insert(stripped.to_owned(), v.clone());
+            }
+        }
+        ExpressionMaps::new(names, values)
+    };
+
     // Query storage
     let (raw_items, storage_last_key) = ctx
         .storage
         .query(
             &query_key_info,
             &key_condition,
-            &maps,
+            &combined_maps,
             input.scan_index_forward,
             input.limit,
             input.exclusive_start_key.as_ref(),
@@ -215,7 +323,7 @@ pub async fn handle_query<S: TableEngine + DataEngine>(
         storage_last_key,
         &filter,
         &projection,
-        &maps,
+        &combined_maps,
         &lek_key_schema,
         input.select.as_ref(),
         index_proj,

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -3,10 +3,12 @@
 
 //! `Scan` operation handler.
 
+use std::collections::HashMap;
+
 use serde_json::Value;
 
 use extenddb_core::error::DynamoDbError;
-use extenddb_core::expression::{parse_projection, tokenize_with_limit};
+use extenddb_core::expression::{parse_projection, tokenize_with_limit, ExpressionMaps};
 use extenddb_core::types::{
     IndexType, ScanInput, ScanOutput, Select, TableKeyInfo, item_size_bytes,
 };
@@ -18,6 +20,7 @@ use crate::capacity_helpers;
 use crate::create_table::storage_err_to_dynamo;
 use crate::expression_helpers::{build_expression_maps, parse_optional_filter};
 use crate::index_helpers::combined_lek_key_schema;
+use crate::legacy_filter::desugar_filter;
 use crate::read_helpers::apply_post_read;
 use crate::serialize_output;
 use crate::{DispatchMetrics, DispatchResult};
@@ -125,16 +128,67 @@ pub async fn handle_scan<S: TableEngine + DataEngine>(
         key_info.clone()
     };
 
+    // --- Legacy vs expression mutual exclusivity checks ---
+    let has_fe = input.filter_expression.is_some();
+    let has_sf = input.scan_filter.as_ref().is_some_and(|m| !m.is_empty());
+
+    if has_fe && has_sf {
+        return Err(DynamoDbError::ValidationException(
+            "Can not use both expression and non-expression parameters in the same request: \
+             Non-expression parameters: {ScanFilter} Expression parameters: {FilterExpression}"
+                .to_owned(),
+        ));
+    }
+
+    let has_pe = input.projection_expression.is_some();
+    let has_atg = input.attributes_to_get.as_ref().is_some_and(|a| !a.is_empty());
+
+    if has_pe && has_atg {
+        return Err(DynamoDbError::ValidationException(
+            "Can not use both expression and non-expression parameters in the same request: \
+             Non-expression parameters: {AttributesToGet} Expression parameters: {ProjectionExpression}"
+                .to_owned(),
+        ));
+    }
+
     let maps = build_expression_maps(
         input.expression_attribute_names.as_ref(),
         input.expression_attribute_values.as_ref(),
     );
 
-    // Parse FilterExpression
-    let filter = parse_optional_filter(input.filter_expression.as_deref(), &ctx.limits)?;
+    // Parse FilterExpression or desugar legacy ScanFilter
+    let (filter, filter_maps) = if let Some(ref sf) = input.scan_filter {
+        if !sf.is_empty() {
+            let cond_op = input.conditional_operator.unwrap_or_default();
+            let (expr, fmaps) = desugar_filter(sf, cond_op)?;
+            (Some(expr), Some(fmaps))
+        } else {
+            (parse_optional_filter(input.filter_expression.as_deref(), &ctx.limits)?, None)
+        }
+    } else {
+        (parse_optional_filter(input.filter_expression.as_deref(), &ctx.limits)?, None)
+    };
 
-    // Parse ProjectionExpression
-    let projection = if let Some(ref proj_str) = input.projection_expression {
+    // Parse ProjectionExpression or desugar legacy AttributesToGet
+    let (effective_projection_str, extra_proj_names) = if input.projection_expression.is_some() {
+        (input.projection_expression.clone(), HashMap::new())
+    } else if let Some(ref attrs) = input.attributes_to_get {
+        let mut names_map = HashMap::new();
+        let placeholders: Vec<String> = attrs
+            .iter()
+            .enumerate()
+            .map(|(i, attr)| {
+                let placeholder = format!("#_ag{i}");
+                names_map.insert(placeholder.clone(), attr.clone());
+                placeholder
+            })
+            .collect();
+        (Some(placeholders.join(", ")), names_map)
+    } else {
+        (None, HashMap::new())
+    };
+
+    let projection = if let Some(ref proj_str) = effective_projection_str {
         let proj_tokens = tokenize_with_limit(proj_str, ctx.limits.max_expression_tokens)?;
         Some(parse_projection(&proj_tokens)?)
     } else {
@@ -150,7 +204,7 @@ pub async fn handle_scan<S: TableEngine + DataEngine>(
         }
     }
     if let Some(Select::Count) = input.select {
-        if input.projection_expression.is_some() {
+        if effective_projection_str.is_some() {
             return Err(DynamoDbError::ValidationException(
                 "Cannot specify the ProjectionExpression when Select is COUNT".to_owned(),
             ));
@@ -161,6 +215,23 @@ pub async fn handle_scan<S: TableEngine + DataEngine>(
         index_info.as_ref()
     } else {
         None
+    };
+
+    // Build the combined expression maps for post-read evaluation.
+    let combined_maps = {
+        let mut names = maps.names.clone();
+        let mut values = maps.values.clone();
+
+        if let Some(ref fm) = filter_maps {
+            values.extend(fm.values.clone());
+        }
+        if !extra_proj_names.is_empty() {
+            for (k, v) in &extra_proj_names {
+                let stripped = k.strip_prefix('#').unwrap_or(k);
+                names.insert(stripped.to_owned(), v.clone());
+            }
+        }
+        ExpressionMaps::new(names, values)
     };
 
     // Scan storage
@@ -191,7 +262,7 @@ pub async fn handle_scan<S: TableEngine + DataEngine>(
         storage_last_key,
         &filter,
         &projection,
-        &maps,
+        &combined_maps,
         &lek_key_schema,
         input.select.as_ref(),
         index_proj,


### PR DESCRIPTION
…sToGet

Older AWS SDKs use pre-expression parameters for Query and Scan. These were previously either silently ignored or rejected. Now they are desugared into their modern expression-based equivalents:

- KeyConditions → KeyCondition struct (EQ, GT, LT, GE, LE, BETWEEN, BEGINS_WITH)
- QueryFilter/ScanFilter → filter Expr AST (all comparison operators including CONTAINS, NOT_CONTAINS, BEGINS_WITH, BETWEEN, IN, NULL, NOT_NULL)
- AttributesToGet → ProjectionExpression (on Query and Scan, matching existing GetItem/BatchGetItem support)

Mutual exclusivity enforced: mixing legacy + expression params returns ValidationException with the standard DynamoDB conflict message.