### PR TITLE
ci: add npm publish workflow with cross-platform binary builds

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,101 @@
+name: Build and Publish to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-14
+            npm-pkg: "@extenddb/darwin-arm64"
+          - target: x86_64-apple-darwin
+            os: macos-13
+            npm-pkg: "@extenddb/darwin-x64"
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            npm-pkg: "@extenddb/linux-x64"
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            npm-pkg: "@extenddb/linux-arm64"
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools (Linux ARM64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+
+      - name: Prepare npm package
+        run: |
+          PKG_DIR="npm/${{ matrix.npm-pkg }}"
+          mkdir -p "$PKG_DIR/bin"
+          cp "target/${{ matrix.target }}/release/extenddb" "$PKG_DIR/bin/extenddb"
+          chmod +x "$PKG_DIR/bin/extenddb"
+
+      - name: Set package version from release tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          PKG_DIR="npm/${{ matrix.npm-pkg }}"
+          jq --arg v "$VERSION" '.version = $v' "$PKG_DIR/package.json" > tmp.json && mv tmp.json "$PKG_DIR/package.json"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: npm/${{ matrix.npm-pkg }}/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts/
+
+      - name: Publish platform packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          for dir in artifacts/*/; do
+            echo "Publishing from $dir"
+            cd "$dir"
+            npm publish --access public
+            cd -
+          done
+
+      - name: Publish main package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          cd npm/extenddb
+          jq --arg v "$VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
+          jq --arg v "$VERSION" '.optionalDependencies["@extenddb/darwin-arm64"] = $v | .optionalDependencies["@extenddb/darwin-x64"] = $v | .optionalDependencies["@extenddb/linux-x64"] = $v | .optionalDependencies["@extenddb/linux-arm64"] = $v' package.json > tmp.json && mv tmp.json package.json
+          npm publish --access public

--- a/npm/@extenddb/darwin-arm64/package.json
+++ b/npm/@extenddb/darwin-arm64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@extenddb/darwin-arm64",
+  "version": "0.0.2",
+  "description": "ExtendDB binary for macOS ARM64 (Apple Silicon)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ExtendDB/extenddb"
+  },
+  "os": ["darwin"],
+  "cpu": ["arm64"],
+  "bin": {
+    "extenddb": "bin/extenddb"
+  }
+}

--- a/npm/@extenddb/darwin-x64/package.json
+++ b/npm/@extenddb/darwin-x64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@extenddb/darwin-x64",
+  "version": "0.0.2",
+  "description": "ExtendDB binary for macOS x64 (Intel)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ExtendDB/extenddb"
+  },
+  "os": ["darwin"],
+  "cpu": ["x64"],
+  "bin": {
+    "extenddb": "bin/extenddb"
+  }
+}

--- a/npm/@extenddb/linux-arm64/package.json
+++ b/npm/@extenddb/linux-arm64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@extenddb/linux-arm64",
+  "version": "0.0.2",
+  "description": "ExtendDB binary for Linux ARM64",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ExtendDB/extenddb"
+  },
+  "os": ["linux"],
+  "cpu": ["arm64"],
+  "bin": {
+    "extenddb": "bin/extenddb"
+  }
+}

--- a/npm/@extenddb/linux-x64/package.json
+++ b/npm/@extenddb/linux-x64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@extenddb/linux-x64",
+  "version": "0.0.2",
+  "description": "ExtendDB binary for Linux x64",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ExtendDB/extenddb"
+  },
+  "os": ["linux"],
+  "cpu": ["x64"],
+  "bin": {
+    "extenddb": "bin/extenddb"
+  }
+}

--- a/npm/extenddb/bin/extenddb
+++ b/npm/extenddb/bin/extenddb
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+const PLATFORMS = {
+  "darwin-arm64": "@extenddb/darwin-arm64",
+  "darwin-x64": "@extenddb/darwin-x64",
+  "linux-x64": "@extenddb/linux-x64",
+  "linux-arm64": "@extenddb/linux-arm64",
+};
+
+const platformKey = `${process.platform}-${process.arch}`;
+const pkg = PLATFORMS[platformKey];
+
+if (!pkg) {
+  console.error(
+    `extenddb: unsupported platform ${process.platform}-${process.arch}`
+  );
+  console.error(`Supported: ${Object.keys(PLATFORMS).join(", ")}`);
+  process.exit(1);
+}
+
+let binPath;
+try {
+  const pkgDir = path.dirname(require.resolve(`${pkg}/package.json`));
+  const pkgJson = require(`${pkg}/package.json`);
+  binPath = path.join(pkgDir, pkgJson.bin.extenddb);
+} catch (e) {
+  console.error(`extenddb: failed to find binary package ${pkg}`);
+  console.error(
+    `Try reinstalling: npm install extenddb`
+  );
+  process.exit(1);
+}
+
+if (!fs.existsSync(binPath)) {
+  console.error(`extenddb: binary not found at ${binPath}`);
+  process.exit(1);
+}
+
+const result = require("child_process").spawnSync(binPath, process.argv.slice(2), {
+  stdio: "inherit",
+});
+
+process.exit(result.status ?? 1);

--- a/npm/extenddb/package.json
+++ b/npm/extenddb/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "extenddb",
+  "version": "0.0.2",
+  "description": "A production-grade DynamoDB-compatible API adapter backed by PostgreSQL",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ExtendDB/extenddb"
+  },
+  "bin": {
+    "extenddb": "bin/extenddb"
+  },
+  "optionalDependencies": {
+    "@extenddb/darwin-arm64": "0.0.2",
+    "@extenddb/darwin-x64": "0.0.2",
+    "@extenddb/linux-x64": "0.0.2",
+    "@extenddb/linux-arm64": "0.0.2"
+  },
+  "keywords": [
+    "dynamodb",
+    "database",
+    "postgresql",
+    "local-development",
+    "aws"
+  ]
+}


### PR DESCRIPTION
## Add npm publish workflow for cross-platform binary distribution

### Summary

Enables users to install and run ExtendDB via npm without needing Rust or building from source:

```bash
npx extenddb init
npx extenddb serve
```

How it works

Uses the same pattern as esbuild, Prisma, and Turbo:

1. Platform packages (@extenddb/darwin-arm64, @extenddb/darwin-x64, @extenddb/linux-x64, @extenddb/linux-arm64) each contain a pre-built binary
2. Main package (extenddb) is a thin wrapper that detects the platform and delegates to the correct binary
3. npm's optionalDependencies ensures only the relevant platform package is downloaded

CI workflow

Triggered by a GitHub Release (from release-please):

1. Cross-compiles for 4 targets in parallel using the GitHub Actions matrix
2. Publishes platform packages first, then the main wrapper
3. Version is derived from the release tag (v0.1.0 → 0.1.0)

Files added

.github/workflows/npm-publish.yml    — CI workflow
npm/extenddb/                         — Main wrapper package
npm/extenddb/bin/extenddb             — Platform-detecting CLI launcher
npm/@extenddb/darwin-arm64/           — macOS Apple Silicon
npm/@extenddb/darwin-x64/             — macOS Intel
npm/@extenddb/linux-x64/              — Linux x64
npm/@extenddb/linux-arm64/            — Linux ARM64

Prerequisites

- npm org @extenddb created on npmjs.com
- NPM_TOKEN secret added to the repo (Automation token from npmjs.com)
- release-please workflow merged (creates the GitHub Releases that trigger this)

Tested locally

Verified the wrapper correctly resolves and executes the platform binary:

$ node node_modules/.bin/extenddb version
extenddb 0.0.2
catalog 0.0.2 (postgres)