### PR TITLE
fix(storage): skip LSIs in enqueue_async_indexes to prevent double-write

### DIFF
--- a/crates/storage-postgres/src/data/index.rs
+++ b/crates/storage-postgres/src/data/index.rs
@@ -198,6 +198,9 @@ pub(crate) async fn enqueue_async_indexes(
         if delay == 0 {
             continue; // Sync — already handled in transaction.
         }
+        if idx.index_type == "LSI" {
+            continue; // LSIs are always synchronous — already handled in transaction.
+        }
         gsi_queue
             .enqueue(
                 pk_hash,


### PR DESCRIPTION
sync_indexes always processes LSIs synchronously (regardless of their
propagation_delay_ms setting). However, enqueue_async_indexes only
skipped indexes with delay == 0, meaning an LSI with a non-zero delay
configured would be written synchronously AND enqueued for async
processing — a double-write.

Add an explicit LSI check in enqueue_async_indexes to skip them, since
they are always handled within the transaction by sync_indexes.
