### PR TITLE
fix: Move UpdateTable no-op detection into storage transaction

### DIFF
--- a/crates/engine/src/create_table.rs
+++ b/crates/engine/src/create_table.rs
@@ -105,6 +105,7 @@ pub(crate) fn storage_err_to_dynamo(e: extenddb_storage::error::StorageError) ->
             }
         }
         StorageError::Validation(msg) => DynamoDbError::ValidationException(msg),
+        StorageError::NoOpUpdate(msg) => DynamoDbError::ValidationException(msg),
         StorageError::IdempotentReplay | StorageError::IdempotentMismatch => {
             // These are handled directly by the transact_write_items caller.
             // If they reach here, it's a programming error.

--- a/crates/engine/src/update_table.rs
+++ b/crates/engine/src/update_table.rs
@@ -4,7 +4,7 @@
 //! `UpdateTable` operation handler.
 
 use extenddb_core::error::DynamoDbError;
-use extenddb_core::types::{BillingMode, DescribeTableInput, UpdateTableInput};
+use extenddb_core::types::{BillingMode, UpdateTableInput};
 use serde_json::Value;
 
 use crate::OperationContext;
@@ -142,49 +142,6 @@ pub async fn handle_update_table(
         }
     }
 
-    // No-op rejection: setting same billing mode to PROVISIONED with same throughput
-    // values is rejected by DynamoDB.
-    if matches!(input.billing_mode, Some(BillingMode::Provisioned)) {
-        if let Some(ref tp) = input.provisioned_throughput {
-            let current = ctx
-                .storage
-                .describe_table(
-                    &ctx.account_id,
-                    DescribeTableInput {
-                        table_name: input.table_name.clone(),
-                    },
-                )
-                .await
-                .map_err(|e| match e {
-                    extenddb_storage::error::StorageError::TableNotFound(_) => {
-                        DynamoDbError::ResourceNotFoundException(
-                            "Requested resource not found".to_owned(),
-                        )
-                    }
-                    other => crate::sanitize_storage_error(other),
-                })?;
-            let current_tp = &current.provisioned_throughput;
-            let is_provisioned = current
-                .billing_mode_summary
-                .as_ref()
-                .map_or(true, |b| b.billing_mode == BillingMode::Provisioned);
-            if current_tp.read_capacity_units == tp.read_capacity_units
-                && current_tp.write_capacity_units == tp.write_capacity_units
-                && is_provisioned
-            {
-                return Err(DynamoDbError::ValidationException(format!(
-                    "The provisioned throughput for the table will not change. The requested value equals the current value. \
-                     Current ReadCapacityUnits provisioned for the table: {}. Requested ReadCapacityUnits: {}. \
-                     Current WriteCapacityUnits provisioned for the table: {}. Requested WriteCapacityUnits: {}.",
-                    current_tp.read_capacity_units,
-                    tp.read_capacity_units,
-                    current_tp.write_capacity_units,
-                    tp.write_capacity_units
-                )));
-            }
-        }
-    }
-
     let desc = ctx
         .storage
         .update_table(&ctx.account_id, input)
@@ -207,6 +164,9 @@ pub async fn handle_update_table(
                 DynamoDbError::ResourceNotFoundException(format!(
                     "One or more parameter values were invalid: Index not found: {name}"
                 ))
+            }
+            extenddb_storage::error::StorageError::NoOpUpdate(msg) => {
+                DynamoDbError::ValidationException(msg)
             }
             other => {
                 tracing::error!(internal_error = %other, "storage internal error");

--- a/crates/storage-postgres/src/update_table.rs
+++ b/crates/storage-postgres/src/update_table.rs
@@ -40,6 +40,57 @@ impl PostgresEngine {
             return Err(StorageError::TableNotActive(input.table_name.clone()));
         }
 
+        // No-op rejection: setting same billing mode to PROVISIONED with same
+        // throughput values is rejected by DynamoDB. This check runs under the
+        // FOR UPDATE lock to eliminate the TOCTOU race that existed when the
+        // check was in the engine layer.
+        if matches!(input.billing_mode, Some(BillingMode::Provisioned)) {
+            if let Some(ref pt) = input.provisioned_throughput {
+                let current_row: Option<(Option<String>, serde_json::Value)> = sqlx::query_as(
+                    "SELECT billing_mode, provisioned_throughput FROM tables \
+                     WHERE account_id = $1 AND table_name = $2",
+                )
+                .bind(account_id)
+                .bind(&input.table_name)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+                if let Some((current_bm, current_pt)) = current_row {
+                    let is_provisioned =
+                        current_bm.as_deref() == Some("PROVISIONED") || current_bm.is_none();
+                    let current_rcu = current_pt
+                        .get("ReadCapacityUnits")
+                        .or_else(|| current_pt.get("read_capacity_units"))
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0);
+                    let current_wcu = current_pt
+                        .get("WriteCapacityUnits")
+                        .or_else(|| current_pt.get("write_capacity_units"))
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0);
+
+                    if is_provisioned
+                        && current_rcu == pt.read_capacity_units
+                        && current_wcu == pt.write_capacity_units
+                    {
+                        return Err(StorageError::NoOpUpdate(format!(
+                            "The provisioned throughput for the table will not change. \
+                             The requested value equals the current value. \
+                             Current ReadCapacityUnits provisioned for the table: {}. \
+                             Requested ReadCapacityUnits: {}. \
+                             Current WriteCapacityUnits provisioned for the table: {}. \
+                             Requested WriteCapacityUnits: {}.",
+                            current_rcu,
+                            pt.read_capacity_units,
+                            current_wcu,
+                            pt.write_capacity_units
+                        )));
+                    }
+                }
+            }
+        }
+
         // Apply billing mode change.
         if let Some(bm) = &input.billing_mode {
             let bm_str = match bm {

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -24,6 +24,8 @@ pub enum StorageError {
     IdempotentReplay,
     #[error("Idempotent parameter mismatch")]
     IdempotentMismatch,
+    #[error("No-op update: {0}")]
+    NoOpUpdate(String),
     #[error("Validation error: {0}")]
     Validation(String),
     #[error(


### PR DESCRIPTION
Move the provisioned throughput no-op check from the engine layer into
the storage-postgres layer, inside the existing FOR UPDATE transaction.
This eliminates the TOCTOU race where a concurrent UpdateTable could
change throughput between the engine's describe_table read and the
storage layer's locked write.

The check now runs after the row lock is acquired, so concurrent
requests are serialized correctly. A new StorageError::NoOpUpdate
variant carries the validation message back to the engine layer for
mapping to ValidationException.
