### PR TITLE
Add community templates and contributor docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,53 @@
+---
+name: Bug report
+about: Report a problem with ExtendDB
+title: '[Bug] '
+labels: 'type/bug, status/needs-triage'
+assignees: ''
+---
+
+## Describe the bug
+
+<!-- A clear and concise description of what the bug is. -->
+
+## To Reproduce
+
+<!-- Steps to reproduce the behavior: -->
+
+1. Start ExtendDB with configuration...
+2. Execute request...
+3. Observe...
+
+## Expected behavior
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Actual behavior
+
+<!-- What happened instead, including any error messages or unexpected output. -->
+
+## Environment
+
+- ExtendDB version:
+- Operating system:
+- Rust version (if building from source):
+- Client SDK/driver and version:
+- Deployment method (binary, container, source):
+
+## Logs / stack trace
+
+<!-- If applicable, paste relevant log output. Use a code block. -->
+
+```
+<paste logs here>
+```
+
+## Additional context
+
+<!-- How has this bug affected you? What are you trying to accomplish? -->
+
+## Checklist
+
+- [ ] I have searched existing issues for duplicates
+- [ ] I have included the ExtendDB version and environment details
+- [ ] I can reproduce this with the latest release

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/extenddb/extenddb/security/advisories/new
+    about: Report security vulnerabilities privately. Do NOT open a public issue.
+  - name: Questions and discussions
+    url: https://github.com/extenddb/extenddb/discussions
+    about: Ask questions, share ideas, and connect with the community.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: Suggest a new capability for ExtendDB
+title: '[Feature] '
+labels: 'type/enhancement, status/needs-triage'
+assignees: ''
+---
+
+## Problem or use case
+
+<!-- What problem does this feature solve? What is the use case? -->
+
+## Proposed solution
+
+<!-- A clear and concise description of how you would like this to work. -->
+
+## Alternatives considered
+
+<!-- What alternative solutions or workarounds have you considered? -->
+
+## DynamoDB API reference
+
+<!-- If this relates to DynamoDB API compatibility, which API operation or behavior is involved? -->
+
+## Additional context
+
+<!-- Any other context, mockups, or references that help explain the request. -->
+
+## Checklist
+
+- [ ] I have searched existing issues and the roadmap for duplicates
+- [ ] I have described the use case, not just the desired implementation

--- a/.github/ISSUE_TEMPLATE/rfc.md
+++ b/.github/ISSUE_TEMPLATE/rfc.md
@@ -1,0 +1,44 @@
+---
+name: RFC (design proposal)
+about: Propose a significant change to ExtendDB (new backend, API addition, breaking change)
+title: "[RFC] "
+labels: rfc
+---
+
+## Summary
+
+One paragraph explaining the proposal.
+
+## Motivation
+
+Why should ExtendDB do this? What use cases does it support? What problems does it solve?
+
+## Proposed design
+
+Describe the design in enough detail that someone familiar with ExtendDB could implement it. Include:
+
+- API surface (new operations, changed behavior, wire format)
+- Storage implications (schema changes, new tables, migration path)
+- Configuration (new `extenddb.toml` sections or flags)
+
+## DynamoDB compatibility
+
+How does this relate to the real DynamoDB API? Is this:
+- [ ] Matching existing DynamoDB behavior
+- [ ] Extending beyond DynamoDB (ExtendDB-specific)
+- [ ] Deliberately diverging from DynamoDB (explain why)
+
+## Alternatives considered
+
+What other approaches did you consider? Why is this one better?
+
+## Breaking changes
+
+Does this break existing behavior? If yes:
+- What breaks?
+- What is the migration path?
+- Can it be feature-gated during transition?
+
+## Open questions
+
+List anything unresolved that needs discussion before implementation.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## What
+
+<!-- Describe what this PR changes. -->
+
+## Why
+
+<!-- Link the issue this addresses. Explain the motivation. -->
+
+Closes #
+
+## Testing done
+
+<!-- How did you verify this change works? Include test commands or output. -->
+
+## Checklist
+
+- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] All tests pass (`cargo test --workspace`)
+- [ ] Code is formatted (`cargo fmt --check`)
+- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
+- [ ] I have added or updated tests for new functionality
+- [ ] I have updated documentation if behavior changed
+- [ ] Breaking changes are noted below (if any)
+
+## Breaking changes
+
+<!-- If this PR introduces breaking changes, describe them here. Otherwise delete this section. -->
+
+---
+
+By submitting this pull request, I confirm that my contribution is made under
+the terms of the Apache License 2.0 and I agree to the Developer Certificate of
+Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 pdfs/
 docs/rendered/
 discussions/
+.DS_Store

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct). For more information, see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact [opensource-codeofconduct@amazon.com](mailto:opensource-codeofconduct@amazon.com) with any additional questions or comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to ExtendDB.
 
 ### Prerequisites
 
-- Rust 1.80+ (stable)
+- Rust 1.85+ (stable)
 - PostgreSQL 14+
 - Python 3.10+ (for integration tests)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,31 @@
+# Roadmap
+
+The ExtendDB public roadmap is hosted as a GitHub Project:
+
+**https://github.com/orgs/extenddb/projects/1**
+
+## Views
+
+| View | Purpose |
+|------|---------|
+| All Items | Every tracked issue under active consideration |
+| Upcoming Releases | Issues grouped by target release |
+| Themes | Issues organized by workstream (API parity, storage engine, compatibility, tooling) |
+
+## What the roadmap represents
+
+The roadmap is a point-in-time snapshot of active work and near-term intentions. Each item links to a GitHub issue where you can follow progress, ask questions, and contribute.
+
+Roadmap items may shift between releases as complexity is discovered or priorities change. We aim for transparency, not guarantees.
+
+## How to follow a specific item
+
+Subscribe to the linked GitHub issue for notifications on development progress and release targeting.
+
+## How to propose a roadmap item
+
+Open a [feature request](https://github.com/extenddb/extenddb/issues/new?template=feature_request.md). Issues with strong community signal (reactions, comments, linked use cases) are evaluated for roadmap inclusion during planning cycles.
+
+## Release cadence
+
+ExtendDB follows semantic versioning. Minor releases target a roughly monthly cadence. Patch releases ship as needed for bug fixes and security updates.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 The ExtendDB public roadmap is hosted as a GitHub Project:
 
-**https://github.com/orgs/extenddb/projects/1**
+**https://github.com/orgs/extenddb/projects/**
 
 ## Views
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,4 @@
 
 ## Reporting a Vulnerability
 
-If you discover a potential security issue in this project, we ask that you notify AWS/Amazon Security via our vulnerability reporting page or directly via email to aws-security@amazon.com. Please do not create a public GitHub issue.
+If you discover a potential security issue in this project, we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](https://aws.amazon.com/security/vulnerability-reporting/) or directly via email to aws-security@amazon.com. Please do not create a public GitHub issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a potential security issue in this project, we ask that you notify AWS/Amazon Security via our vulnerability reporting page or directly via email to aws-security@amazon.com. Please do not create a public GitHub issue.


### PR DESCRIPTION
## Summary
- Issue templates: bug report, feature request, RFC (design proposal)
- PR template with testing checklist and DCO consent
- config.yml: disables blank issues, links security advisories and discussions
- CONTRIBUTING.md: updates Rust minimum to 1.85
- CODE_OF_CONDUCT.md: Amazon Open Source Code of Conduct
- SECURITY.md: vulnerability reporting via aws-security@amazon.com
- ROADMAP.md: points to GitHub Projects board
- .gitignore: adds .DS_Store

## Test plan
- [ ] Issue templates render correctly on GitHub (New Issue page shows three options)
- [ ] PR template auto-populates when opening a new PR
- [ ] Security advisory link in config.yml resolves