### PR TITLE
ci: add GitHub Actions for fmt, clippy, and test checks

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,16 @@
+name: Clippy
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets -- -D warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: "1.85.0"
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -9,9 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.85.0"
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,15 @@
+name: Format
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -9,7 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: "1.85.0"
           components: rustfmt
       - run: cargo fmt --all -- --check

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -9,8 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.85.0"
           components: rustfmt
       - run: cargo fmt --all -- --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: Test
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.85.0"
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.85.0"
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace

--- a/crates/core/src/error/mod.rs
+++ b/crates/core/src/error/mod.rs
@@ -176,8 +176,8 @@ impl DynamoDbError {
     /// - `ValidationException` → `com.amazon.coral.validate#`
     /// - Infrastructure/auth errors → `com.amazon.coral.service#`
     ///   (`SerializationException`, `UnknownOperationException`,
-    ///    `MissingAuthenticationToken`, `IncompleteSignature`,
-    ///    `InvalidSignatureException`)
+    ///   `MissingAuthenticationToken`, `IncompleteSignature`,
+    ///   `InvalidSignatureException`)
     /// - All other `DynamoDB` errors → `com.amazonaws.dynamodb.v20120810#`
     ///
     /// Verified against real DynamoDB 2026-05-04.

--- a/crates/core/src/expression/update_evaluator.rs
+++ b/crates/core/src/expression/update_evaluator.rs
@@ -510,10 +510,8 @@ fn remove_nested(
                 let name = resolve_attr_name(&path[0], maps)?;
                 map.remove(&name);
             }
-            (PathElement::Index(idx), AttributeValue::L(list)) => {
-                if *idx < list.len() {
-                    list.remove(*idx);
-                }
+            (PathElement::Index(idx), AttributeValue::L(list)) if *idx < list.len() => {
+                list.remove(*idx);
             }
             _ => {} // No-op for type mismatch
         }
@@ -527,10 +525,8 @@ fn remove_nested(
                 remove_nested(next, &path[1..], maps)?;
             }
         }
-        (PathElement::Index(idx), AttributeValue::L(list)) => {
-            if *idx < list.len() {
-                remove_nested(&mut list[*idx], &path[1..], maps)?;
-            }
+        (PathElement::Index(idx), AttributeValue::L(list)) if *idx < list.len() => {
+            remove_nested(&mut list[*idx], &path[1..], maps)?;
         }
         _ => {} // No-op
     }


### PR DESCRIPTION
Three separate workflows so each appears as its own status check on PRs:
- Format: cargo fmt --all -- --check
- Clippy: cargo clippy --all-targets -- -D warnings
- Test: cargo test --workspace

Uses rust-cache for faster CI runs on clippy and test.