### PR TITLE
fix(storage-postgres): honor catalog_pool_size config and enforce 10-conn floor

### DIFF
--- a/crates/bin/src/init_helpers.rs
+++ b/crates/bin/src/init_helpers.rs
@@ -119,8 +119,8 @@ key_path = "{tls_key}"
 
 [storage.postgres]
 connection_string = "{catalog_url}"
-# pool_size = 20                 # Max connections for data operations
-# catalog_pool_size =            # Max connections for management/catalog ops (defaults to pool_size)
+# pool_size = 20                 # Max connections for data operations (default 20, min 10)
+# catalog_pool_size =            # Max connections for management/catalog ops (defaults to pool_size, min 10)
 
 [auth]
 # provider = "builtin"           # SigV4 with local credential store (mandatory)

--- a/crates/storage-postgres/src/lib.rs
+++ b/crates/storage-postgres/src/lib.rs
@@ -116,6 +116,13 @@ use sqlx::postgres::PgPoolOptions;
 /// wherever a string representation is needed.
 pub const CATALOG_VERSION: CatalogVersion = CatalogVersion::new(0, 0, 2);
 
+/// Minimum number of connections allowed per pool.
+///
+/// Each DynamoDB request triggers an auth/authz query fanout against the
+/// catalog pool. Pools smaller than this floor starve under concurrent load.
+/// Configured values below the floor are clamped at startup with a warning.
+const MIN_POOL_SIZE: u32 = 10;
+
 /// `PostgreSQL` storage backend configuration.
 pub struct PostgresConfig {
     pub connection_string: String,
@@ -152,10 +159,25 @@ pub struct PostgresEngine {
 
 impl PostgresEngine {
     pub async fn new(config: &PostgresConfig, region: &str) -> Result<Self, StorageError> {
+        // Enforce a minimum of 10 connections per pool. Smaller values starve
+        // the auth/authz query fanout under concurrent load. If the configured
+        // value is below the floor, log a warning and clamp.
+        let pool_size = if config.pool_size < MIN_POOL_SIZE {
+            tracing::warn!(
+                "storage.postgres.pool_size = {} is below the minimum of {}; clamping to {}",
+                config.pool_size,
+                MIN_POOL_SIZE,
+                MIN_POOL_SIZE
+            );
+            MIN_POOL_SIZE
+        } else {
+            config.pool_size
+        };
+
         // P79/P6: Set min_connections to avoid cold-start latency on first requests.
-        let min_conns = config.pool_size.min(2);
+        let min_conns = pool_size.min(2);
         let pool = PgPoolOptions::new()
-            .max_connections(config.pool_size)
+            .max_connections(pool_size)
             .min_connections(min_conns)
             .test_before_acquire(false)
             .max_lifetime(std::time::Duration::from_secs(1800))
@@ -172,7 +194,7 @@ impl PostgresEngine {
         .await
         {
             Ok(Some((data_conn,))) if !data_conn.is_empty() => PgPoolOptions::new()
-                .max_connections(config.pool_size)
+                .max_connections(pool_size)
                 .min_connections(min_conns)
                 .test_before_acquire(false)
                 .max_lifetime(std::time::Duration::from_secs(1800))
@@ -388,6 +410,7 @@ inventory::submit! {
         factory: |config, region| {
             let connection_string = config.connection_config().to_string();
             let max_connections = config.max_connections();
+            let max_catalog_connections = config.max_catalog_connections();
             let region = region.to_string();
             Box::pin(async move {
                 // Build PostgresConfig from extracted values
@@ -440,8 +463,20 @@ inventory::submit! {
                 // Wrap engine in Arc
                 let engine = Arc::new(engine);
 
-                // Create catalog store
-                let catalog_pool_size = max_connections.min(10);
+                // Create catalog store. Honors storage.postgres.catalog_pool_size,
+                // defaulting to pool_size when unset. Clamped to the same minimum
+                // as the engine pool.
+                let catalog_pool_size = if max_catalog_connections < MIN_POOL_SIZE {
+                    tracing::warn!(
+                        "storage.postgres.catalog_pool_size = {} is below the minimum of {}; clamping to {}",
+                        max_catalog_connections,
+                        MIN_POOL_SIZE,
+                        MIN_POOL_SIZE
+                    );
+                    MIN_POOL_SIZE
+                } else {
+                    max_catalog_connections
+                };
                 let catalog_pool = PgPoolOptions::new()
                     .max_connections(catalog_pool_size)
                     .min_connections(catalog_pool_size.min(2))

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1262,9 +1262,9 @@ The `--yes` flag is required to confirm destruction. Without it, the command exi
 
 ### Connection pool size
 
-The `storage.postgres.pool_size` setting (default: 20) controls the maximum number of concurrent PostgreSQL connections used for DynamoDB data operations. Each in-flight request that touches the database holds one connection for the duration of its transaction.
+The `storage.postgres.pool_size` setting (default: 20, minimum: 10) controls the maximum number of concurrent PostgreSQL connections used for DynamoDB data operations. Each in-flight request that touches the database holds one connection for the duration of its transaction. Values below 10 are clamped at startup with a warning.
 
-The `storage.postgres.catalog_pool_size` setting controls the maximum number of concurrent connections for the management/catalog pool (authorization queries, IAM operations, console). Defaults to `pool_size` if not set. With auth enabled (`provider = "builtin"`), each DynamoDB request makes concurrent authorization queries against this pool — size it to match expected concurrency.
+The `storage.postgres.catalog_pool_size` setting controls the maximum number of concurrent connections for the management/catalog pool (authorization queries, IAM operations, console). Defaults to `pool_size` if not set, minimum: 10. With auth enabled (`provider = "builtin"`), each DynamoDB request makes concurrent authorization queries against this pool — size it to match expected concurrency. Values below 10 are clamped at startup with a warning.
 
 **When to increase:** If you see elevated latency under concurrent load, the pool may be saturated. Requests queue at the pool level when all connections are in use. Increase `pool_size` (and `catalog_pool_size` if auth is enabled) to allow more concurrent transactions.
 

--- a/docs/manuals/05-admin-guide.md
+++ b/docs/manuals/05-admin-guide.md
@@ -74,8 +74,8 @@ These settings require a server restart to take effect.
 | Key | Default | Description |
 |-----|---------|-------------|
 | `connection_string` | `postgresql://extenddb:extenddb-local-dev@localhost:5432/extenddb_catalog` | Catalog database connection string |
-| `pool_size` | `20` | Maximum concurrent database connections |
-| `catalog_pool_size` | (= `pool_size`) | Maximum connections for management/authz pool |
+| `pool_size` | `20` | Maximum concurrent database connections (minimum: 10) |
+| `catalog_pool_size` | (= `pool_size`) | Maximum connections for management/authz pool (minimum: 10) |
 
 #### [auth]
 

--- a/extenddb.sample.toml
+++ b/extenddb.sample.toml
@@ -37,17 +37,20 @@
 # Multiple independent catalogs can coexist on one PostgreSQL instance.
 # connection_string = "postgresql://extenddb:extenddb-local-dev@localhost:5432/extenddb_catalog"
 # pool_size = 20               # Maximum concurrent database connections
-                                # for DynamoDB data operations. Total PostgreSQL
+                                # for DynamoDB data operations. Default: 20.
+                                # Minimum: 10 (smaller values are clamped with
+                                # a startup warning). Total PostgreSQL
                                 # connections used: pool_size + catalog_pool_size + 1
                                 # (log-level poller: 1). Increase for
                                 # higher concurrency; ensure PostgreSQL
                                 # max_connections >= pool_size + catalog_pool_size + 1.
 # catalog_pool_size = 20       # Maximum concurrent connections for the
                                 # management/catalog pool (authz, IAM, console).
-                                # Defaults to pool_size if not set. With auth
-                                # enabled, each DynamoDB request makes concurrent
-                                # authz queries — size this to match expected
-                                # concurrency.
+                                # Defaults to pool_size if not set.
+                                # Minimum: 10 (smaller values are clamped with
+                                # a startup warning). With auth enabled, each
+                                # DynamoDB request makes concurrent authz queries
+                                # — size this to match expected concurrency.
 
 [auth]
 # provider = "builtin"          # Auth provider:


### PR DESCRIPTION
## Summary

- Fixes a bug where `storage.postgres.catalog_pool_size` was ignored — the catalog pool was hardcoded to `max_connections.min(10)` regardless of config value.
- Adds a 10-connection minimum floor on both the engine pool (`pool_size`) and the catalog pool (`catalog_pool_size`), with a `tracing::warn!` at startup when configured values are below the floor.
- Updates `extenddb.sample.toml`, `init_helpers.rs`, `getting-started.md`, and `05-admin-guide.md` to document the minimum.

## Why

Each DynamoDB request makes up to 6 catalog queries during auth/authz (1 credential lookup + 5 parallel `AuthorizationStore` fetches via `tokio::try_join!`). With the catalog pool capped at 10 connections, the auth fanout alone caps system throughput in the low thousands of RPS regardless of `pool_size`.

A test workload that plateaued at ~3500 RPS / 8 workers scales past that ceiling once the configured `catalog_pool_size` is honored.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace --lib` (362 tests pass)
- [x] `cargo fmt --check`
- [ ] Manual: re-run the test workload with `pool_size = catalog_pool_size = 1024` and confirm scaling past 8 workers
- [ ] Manual: start with `pool_size = 5` and confirm the warning appears in syslog and the pool is sized to 10