### PR TITLE
docs: removing forward-looking references to support for specific backends

### DIFF
--- a/crates/bin/src/cmd_init.rs
+++ b/crates/bin/src/cmd_init.rs
@@ -16,7 +16,7 @@ use crate::init_helpers::{generate_config, generate_tls_cert_if_needed};
 #[derive(Args)]
 #[allow(clippy::doc_markdown)] // Clap help text, not rustdoc
 pub struct InitArgs {
-    /// Storage backend (postgres, cassandra, etc.) (default: postgres)
+    /// Storage backend (postgres) (default: postgres)
     #[arg(long, default_value = "postgres")]
     backend: Option<String>,
 

--- a/crates/bin/src/config.rs
+++ b/crates/bin/src/config.rs
@@ -298,7 +298,7 @@ pub fn load(config_path: &str) -> anyhow::Result<AppConfig> {
 /// Redact password from a connection string for safe logging (REQ-LOG-002).
 ///
 /// Uses the backend-specific operations engine to handle different connection
-/// string formats (`PostgreSQL`, Cassandra, etc.).
+/// string formats (`PostgreSQL`).
 pub fn redact_password(backend: &str, conn: &str) -> String {
     extenddb_storage::operations::redact_connection_string(backend, conn)
         .unwrap_or_else(|_| conn.to_owned())

--- a/crates/storage/src/bootstrapper.rs
+++ b/crates/storage/src/bootstrapper.rs
@@ -4,9 +4,8 @@
 //! Bootstrapper storage trait for init/destroy/migrate operations.
 //!
 //! These operations are inherently backend-specific (e.g., `CREATE DATABASE`
-//! is PostgreSQL DDL vs `CREATE KEYSPACE` for Cassandra). The trait abstracts
-//! the high-level operations so the CLI commands don't depend on a specific
-//! storage backend.
+//! is PostgreSQL DDL). The trait abstracts the high-level operations so the
+//! CLI commands don't depend on a specific storage backend.
 
 use async_trait::async_trait;
 

--- a/crates/storage/src/config.rs
+++ b/crates/storage/src/config.rs
@@ -12,9 +12,6 @@ pub trait StorageConfig: Send + Sync + std::fmt::Debug {
     /// Backend-specific connection configuration as a string.
     ///
     /// For PostgreSQL: connection string (postgresql://...)
-    /// For Cassandra: contact points (host1:port,host2:port)
-    /// For MongoDB: connection URI (mongodb://...)
-    /// For Redis: endpoint (host:port)
     fn connection_config(&self) -> &str;
 
     /// Maximum concurrent connections for data operations.

--- a/crates/storage/src/server_components.rs
+++ b/crates/storage/src/server_components.rs
@@ -92,7 +92,7 @@ pub type ServerComponentsFactory =
 ///
 /// Backends submit this via inventory::submit! to register themselves.
 pub struct ServerComponentsRegistration {
-    /// Backend name (e.g., "postgres", "cassandra")
+    /// Backend name (e.g., "postgres")
     pub backend: &'static str,
 
     /// Factory function that creates the backend components

--- a/docs/design/11-high-availability.md
+++ b/docs/design/11-high-availability.md
@@ -13,7 +13,7 @@ extenddb currently operates as a single-process server backed by a single Postgr
 ### Goals
 
 1. Multiple extenddb instances sharing the same backing database (horizontal frontend scaling).
-2. Pluggable storage layers (PostgreSQL, Cassandra, MongoDB, future backends) with varying native replication capabilities.
+2. Pluggable storage layers with varying native replication capabilities.
 3. A notion of leadership that enables correct strongly-consistent vs. eventually-consistent read semantics.
 4. Deployment models spanning single-node to multi-region.
 5. Staged delivery — each stage is independently useful and testable.
@@ -31,9 +31,9 @@ extenddb currently operates as a single-process server backed by a single Postgr
 | Term | Definition |
 |------|-----------|
 | **Frontend** | A extenddb process that accepts DynamoDB API requests. Stateless except for in-flight request state. |
-| **Catalog** | The backing database (PostgreSQL, Cassandra, etc.) that stores table metadata, items, streams, and auth data. |
+| **Catalog** | The backing database that stores table metadata, items, streams, and auth data. |
 | **Deployment** | One or more frontends sharing a single logical catalog. All frontends in a deployment serve the same set of accounts and tables. |
-| **Replica set** | Multiple catalog nodes providing data redundancy (e.g., PostgreSQL streaming replication, Cassandra ring, MongoDB replica set). |
+| **Replica set** | Multiple catalog nodes providing data redundancy. |
 | **Leader** | The frontend (or catalog node) that handles writes and strongly-consistent reads for a given scope. |
 | **Follower** | A frontend (or catalog node) that handles eventually-consistent reads. |
 
@@ -160,7 +160,7 @@ The existing "No Caching Rule" is preserved and strengthened. Frontends remain s
 
 The storage adapter (e.g., `storage-postgres`) is responsible for routing reads to the appropriate connection based on the consistency requirement. The engine passes a `ConsistencyLevel` parameter; the storage adapter decides which connection to use.
 
-**Rationale:** Different backends implement replication differently. PostgreSQL uses streaming replication with separate read replicas. Cassandra uses tunable consistency per query. The storage adapter is the right place to abstract this.
+**Rationale:** Different backends implement replication differently. The storage adapter is the right place to abstract this.
 
 ### D3: Leadership Is Per-Catalog, Not Per-Frontend
 
@@ -174,7 +174,7 @@ In deployment models 2 and 3, there is no "leader frontend." All frontends are e
 
 ### D4: Heterogeneous Storage Is Illegal
 
-A single deployment must use a single storage backend type. You cannot mix PostgreSQL and Cassandra nodes in one deployment.
+A single deployment must use a single storage backend type. You cannot mix different backend storage types in one deployment.
 
 **Rationale:** Different backends have different data models, consistency semantics, and transaction capabilities. Mixing them would create an untestable matrix of behaviors. Each deployment is homogeneous.
 
@@ -196,19 +196,6 @@ replicas = [
     "postgresql://replica1:5432/extenddb",
     "postgresql://replica2:5432/extenddb",
 ]
-```
-
-For natively-clustered backends:
-
-```toml
-[storage]
-backend = "cassandra"
-
-[storage.cassandra]
-contact_points = ["node1:9042", "node2:9042", "node3:9042"]
-# Consistency mapping is handled by the storage adapter
-strong_consistency = "QUORUM"
-eventual_consistency = "ONE"
 ```
 
 ### D6: Health Checks and Connection Failover
@@ -235,7 +222,7 @@ The `extenddb.toml` configuration accepts `pool_size` per connection target. The
 - Adds enormous complexity (Raft implementation, membership management, log replication).
 - Unnecessary when the catalog already provides durability and consistency.
 - extenddb frontends are stateless by design — adding state contradicts the architecture.
-- Databases like PostgreSQL, Cassandra, and MongoDB already solve this problem at the storage layer.
+- Many databases already solve this problem at the storage layer.
 
 ### A2: Shared-Nothing Architecture (Each Frontend Owns a Partition)
 
@@ -277,16 +264,14 @@ Add a `ConsistencyLevel` enum to the storage crate. This enum is **internal to t
 #[non_exhaustive]
 pub enum ConsistencyLevel {
     /// Eventually consistent read. May return stale data.
-    /// Maps to: replica connection (PostgreSQL), ONE/LOCAL_ONE (Cassandra).
     #[default]
     Eventually,
     /// Strongly consistent read. Returns the most recent write.
-    /// Maps to: primary connection (PostgreSQL), QUORUM/LOCAL_QUORUM (Cassandra).
     Strong,
 }
 ```
 
-The `#[non_exhaustive]` attribute allows future extension (e.g., `LocalQuorum` for multi-datacenter Cassandra) without a breaking change.
+The `#[non_exhaustive]` attribute allows future extension without a breaking change.
 
 ### 8.2 Consistency Routing via Trait Parameter (Option A)
 
@@ -445,29 +430,6 @@ This avoids adding yet another trait that every storage backend must implement. 
 - Document load balancer configuration (sticky sessions not required since frontends are stateless).
 - Add instance-id to metrics and logs for multi-frontend debugging.
 
-### Stage 4: Cassandra Storage Backend (Future)
-
-**Deliverable:** A `storage-cassandra` crate implementing the storage traits with native consistency mapping.
-
-**Value:** Enables deployment Model 4. Cassandra's native clustering provides HA without external replication setup.
-
-**Scope:**
-- Implement storage traits against Cassandra.
-- Map `ConsistencyLevel::Strong` → `QUORUM`, `ConsistencyLevel::Eventually` → `ONE`.
-- Cassandra's partition key model maps naturally to DynamoDB's.
-- No separate primary/replica config — Cassandra handles it.
-
-### Stage 5: MongoDB Storage Backend (Future)
-
-**Deliverable:** A `storage-mongodb` crate implementing the storage traits with replica set awareness.
-
-**Value:** Enables deployment Model 4 with MongoDB. MongoDB replica sets provide automatic failover.
-
-**Scope:**
-- Implement storage traits against MongoDB.
-- Map `ConsistencyLevel::Strong` → `readPreference: primary`, `ConsistencyLevel::Eventually` → `readPreference: secondaryPreferred`.
-- MongoDB's document model maps naturally to DynamoDB items.
-
 ## 10. Background Worker Coordination
 
 ### Problem
@@ -537,8 +499,6 @@ Each frontend attempts to acquire the lock on its worker tick interval. If it ge
 - No explicit TTL/lease mechanism is needed for PostgreSQL.
 - A crashed frontend's locks are released when PostgreSQL cleans up the dead connection.
 - The instance registry heartbeat (§13) is for **observability only**, not for lock management.
-
-For Cassandra/MongoDB: lightweight transactions (LWT) or findAndModify with TTL-based expiry (since these backends don't have session-scoped locks).
 
 ## 11. Failure Modes and Recovery
 

--- a/docs/manuals/12-extending-extenddb-storage.md
+++ b/docs/manuals/12-extending-extenddb-storage.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-extenddb uses a fully trait-based storage abstraction. The default backend is PostgreSQL, implemented in the `storage-postgres` crate. This document explains the storage architecture, lists every trait a new backend must implement, and provides guidance for adding a new storage backend (e.g., Cassandra, SQLite, FoundationDB).
+extenddb uses a fully trait-based storage abstraction. The default backend is PostgreSQL, implemented in the `storage-postgres` crate. This document explains the storage architecture, lists every trait a new backend must implement, and provides guidance for adding a new storage backend.
 
 As of v0.0.81, the server crate has **no direct PostgreSQL dependencies**. All database access goes through traits defined in the `storage` and `auth` crates. PostgreSQL-specific code lives exclusively in `storage-postgres` and the `bin` crate's wiring layer.
 
@@ -304,9 +304,13 @@ Schema is managed via SQL migration files in `crates/storage-postgres/migrations
 
 ## Adding a New Backend
 
+NOTE: ExtendDB ships with a built-in functional reference backend implementation for PostgreSQL. Future backend
+implementations should be developed and released separately from the ExtendDB project itself, to simplify dependencies
+and maintenance.
+
 ### Step 1: Create a New Crate
 
-Create a new crate (e.g., `storage-cassandra`) in the workspace. It should depend on `extenddb-storage`, `extenddb-auth`, and `extenddb-core`.
+Create a new crate (e.g., `storage-mydbengine`) in your workspace. It should depend on `extenddb-storage`, `extenddb-auth`, and `extenddb-core`.
 
 ### Step 2: Implement the DynamoDB Data Traits
 
@@ -385,33 +389,9 @@ Stream sequence numbers must be monotonically increasing within a shard. Your ba
 
 Account deletion must cascade to all child resources (users, groups, roles, policies, access keys, sessions) atomically. Your backend must provide equivalent cascade logic.
 
-## Hypothetical: Implementing a Cassandra Backend
-
-### What Maps Naturally
-
-- **Item storage** — Cassandra's wide-column model maps well to DynamoDB's key-value items. Partition key → Cassandra partition key, sort key → clustering column, item attributes → a blob/map column.
-- **Query by partition key** — native Cassandra operation.
-- **TTL** — Cassandra has native TTL support per row, though the semantics differ (Cassandra TTL is per-cell, DynamoDB TTL is per-item with a specific attribute).
-- **Horizontal scaling** — Cassandra's distributed nature would provide natural scaling.
-
-### What Requires Design Decisions
-
-- **Condition expressions** — Cassandra has lightweight transactions (LWT) with `IF` clauses, but they are limited compared to DynamoDB's full expression language. You would likely need to read-then-write with application-level locking, or implement condition evaluation in the application layer with Cassandra's compare-and-set.
-- **Transactions** — DynamoDB's `TransactWriteItems` requires ACID across multiple items/tables. Cassandra has no multi-partition transactions. Options: (a) use a transaction coordinator library, (b) implement saga patterns, (c) limit transaction support. This is the hardest problem.
-- **Sort key ordering** — Cassandra clustering columns provide ordering within a partition, which maps well. However, `scan` across all partitions with consistent ordering is not native to Cassandra.
-- **Parallel scan segments** — would need a custom partitioning scheme (e.g., token range splitting).
-- **Stream records** — would need a separate table or Cassandra CDC (Change Data Capture).
-- **Sequence numbers** — monotonically increasing per-shard sequence numbers require coordination. Cassandra counters or a lightweight transaction could work but add latency.
-
-### What Does Not Map
-
-- **Serializable isolation for TransactGetItems** — Cassandra does not provide serializable reads across partitions. You would need to accept weaker consistency or implement a coordination layer.
-- **Atomic multi-table writes** — `TransactWriteItems` can span multiple DynamoDB tables. Cassandra has no cross-table atomicity.
-- **Secondary indexes with consistent propagation** — Cassandra's secondary indexes are local. GSI-like behavior would require materialized views or application-managed denormalization.
-
 ## PostgreSQL-isms in the Default Backend
 
-An honest assessment of where the PostgreSQL implementation makes backend-specific choices. These are implementation details inside `storage-postgres`, not leaks in the trait abstraction:
+The PostgreSQL implementation makes backend-specific choices. These are implementation details inside `storage-postgres`, not leaks in the trait abstraction:
 
 1. **JSONB item storage** — items are stored as JSONB, enabling PostgreSQL-specific query optimizations. The traits pass `Item` = `BTreeMap<String, AttributeValue>` — your backend can use any serialization format.
 


### PR DESCRIPTION
## What

See title.

## Why

Causes confusion about what is currently supported.

## Testing done

pytests, manual

## Checklist

- [Y] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [Y] All tests pass (`cargo test --workspace`)
- [Y] Code is formatted (`cargo fmt --check`)
- [Y] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [N/A] I have added or updated tests for new functionality
- [Y] I have updated documentation if behavior changed
- [N/A] Breaking changes are noted below (if any)

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
