### PR TITLE
fix: validate ExclusiveStartKey and fix index LastEvaluatedKey

### DIFF
--- a/crates/engine/src/index_helpers.rs
+++ b/crates/engine/src/index_helpers.rs
@@ -60,3 +60,26 @@ pub fn apply_index_projection(
         }
     }
 }
+
+/// Validate that an `ExclusiveStartKey` contains the required key elements for Scan.
+///
+/// For base table scans, uses the long DynamoDB error message.
+/// For index scans, uses the short message (matching real DynamoDB behavior).
+pub fn validate_scan_exclusive_start_key(
+    start_key: &Item,
+    key_info: &extenddb_core::types::TableKeyInfo,
+    index_info: Option<&IndexInfo>,
+) -> Result<(), extenddb_core::error::DynamoDbError> {
+    let required = combined_lek_key_schema(&key_info.key_schema, index_info);
+    for ks in &required {
+        if !start_key.contains_key(&ks.attribute_name) {
+            let msg = if index_info.is_some() {
+                "The provided starting key is invalid".to_owned()
+            } else {
+                "The provided starting key is invalid: The provided key element does not match the schema".to_owned()
+            };
+            return Err(extenddb_core::error::DynamoDbError::ValidationException(msg));
+        }
+    }
+    Ok(())
+}

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -13,7 +13,8 @@ use extenddb_core::expression::{
     ExpressionMaps, parse_key_condition, parse_projection, tokenize_for,
 };
 use extenddb_core::types::{
-    IndexType, KeyType, QueryInput, QueryOutput, Select, TableKeyInfo, item_size_bytes,
+    IndexType, KeyType, QueryInput, QueryOutput, Select, TableKeyInfo, extract_key,
+    item_size_bytes,
 };
 
 use crate::OperationContext;
@@ -353,6 +354,18 @@ pub async fn handle_query(
         ExpressionMaps::new(names, values)
     };
 
+    // Validate ExclusiveStartKey matches the key schema
+    if let Some(ref start_key) = input.exclusive_start_key {
+        let required = combined_lek_key_schema(&key_info.key_schema, index_info.as_ref());
+        for ks in &required {
+            if !start_key.contains_key(&ks.attribute_name) {
+                return Err(DynamoDbError::ValidationException(
+                    "The provided starting key is invalid".to_owned(),
+                ));
+            }
+        }
+    }
+
     // Query storage
     let (raw_items, storage_last_key) = ctx
         .storage
@@ -377,10 +390,17 @@ pub async fn handle_query(
     // For index queries, the LEK includes both the index key and the base table key.
     let lek_key_schema = combined_lek_key_schema(&key_info.key_schema, index_info.as_ref());
 
+    // For index queries, enrich the storage LEK with base table key attributes.
+    let enriched_storage_last_key = if storage_last_key.is_some() && index_info.is_some() {
+        raw_items.last().map(|item| extract_key(item, &lek_key_schema))
+    } else {
+        storage_last_key
+    };
+
     // Apply FilterExpression, ProjectionExpression, and 1 MB limit
     let result = apply_post_read(
         &raw_items,
-        storage_last_key,
+        enriched_storage_last_key,
         &filter,
         &projection,
         &combined_maps,

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -10,14 +10,14 @@ use serde_json::Value;
 use extenddb_core::error::DynamoDbError;
 use extenddb_core::expression::{ExpressionMaps, parse_projection, tokenize_with_limit};
 use extenddb_core::types::{
-    IndexType, ScanInput, ScanOutput, Select, TableKeyInfo, item_size_bytes,
+    IndexType, ScanInput, ScanOutput, Select, TableKeyInfo, extract_key, item_size_bytes,
 };
 
 use crate::OperationContext;
 use crate::capacity_helpers;
 use crate::create_table::storage_err_to_dynamo;
 use crate::expression_helpers::{build_expression_maps, parse_optional_filter};
-use crate::index_helpers::combined_lek_key_schema;
+use crate::index_helpers::{combined_lek_key_schema, validate_scan_exclusive_start_key};
 use crate::legacy_filter::desugar_filter;
 use crate::read_helpers::apply_post_read;
 use crate::serialize_output;
@@ -267,6 +267,11 @@ pub async fn handle_scan(
         ExpressionMaps::new(names, values)
     };
 
+    // Validate ExclusiveStartKey matches the key schema
+    if let Some(ref start_key) = input.exclusive_start_key {
+        validate_scan_exclusive_start_key(start_key, &key_info, index_info.as_ref())?;
+    }
+
     // Scan storage
     let (raw_items, storage_last_key) = ctx
         .storage
@@ -289,10 +294,19 @@ pub async fn handle_scan(
     // Determine which key schema to use for LastEvaluatedKey extraction.
     let lek_key_schema = combined_lek_key_schema(&key_info.key_schema, index_info.as_ref());
 
+    // For index scans, the storage layer returns a LEK with only the index key
+    // attributes. Enrich it with the base table key attributes from the last
+    // raw item so the LEK matches DynamoDB's format (all combined keys).
+    let enriched_storage_last_key = if storage_last_key.is_some() && index_info.is_some() {
+        raw_items.last().map(|item| extract_key(item, &lek_key_schema))
+    } else {
+        storage_last_key
+    };
+
     // Apply FilterExpression, ProjectionExpression, and 1 MB limit
     let result = apply_post_read(
         &raw_items,
-        storage_last_key,
+        enriched_storage_last_key,
         &filter,
         &projection,
         &combined_maps,

--- a/crates/storage-postgres/src/data/query_scan.rs
+++ b/crates/storage-postgres/src/data/query_scan.rs
@@ -220,7 +220,9 @@ impl PostgresEngine {
         if let Some(start_key) = exclusive_start_key {
             let pk_name = &key_info.key_schema[0].attribute_name;
             if !start_key.contains_key(pk_name) {
-                return Err(StorageError::Internal("missing pk in start key".to_owned()));
+                return Err(StorageError::Validation(
+                    "The provided starting key is invalid: The provided key element does not match the schema".to_owned(),
+                ));
             }
             // Actual PK/SK binding happens in execute_scan_sql.
 

--- a/tests/python/test_scan_edge_cases.py
+++ b/tests/python/test_scan_edge_cases.py
@@ -165,3 +165,97 @@ class TestScanEdgeCases:
         item = resp["Items"][0]
         assert "a" in item
         assert "b" not in item
+
+    def test_scan_malformed_exclusive_start_key(self, table_factory, dynamodb_client):
+        """Scan with ExclusiveStartKey that doesn't match schema returns ValidationException."""
+        name = table_factory()
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.scan(
+                TableName=name,
+                ExclusiveStartKey={"bad": {"S": "p"}},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert err["Message"] == "The provided starting key is invalid: The provided key element does not match the schema"
+
+    def test_query_malformed_exclusive_start_key(self, table_factory, dynamodb_client):
+        """Query with ExclusiveStartKey that doesn't match schema returns ValidationException."""
+        name = table_factory()
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.query(
+                TableName=name,
+                KeyConditionExpression="pk = :v",
+                ExpressionAttributeValues={":v": {"S": "x"}},
+                ExclusiveStartKey={"bad": {"S": "p"}},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert err["Message"] == "The provided starting key is invalid"
+
+    def test_scan_malformed_exclusive_start_key_on_gsi(self, dynamodb_client):
+        """Scan GSI with ExclusiveStartKey missing index key returns ValidationException."""
+        name = unique_name("gsi-esk")
+        dynamodb_client.create_table(
+            TableName=name,
+            AttributeDefinitions=[
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "gsi_pk", "AttributeType": "S"},
+            ],
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "gsi1",
+                    "KeySchema": [{"AttributeName": "gsi_pk", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        waiter = dynamodb_client.get_waiter("table_exists")
+        waiter.wait(TableName=name, WaiterConfig={"Delay": 1, "MaxAttempts": 30})
+        # Start key has table PK but missing GSI PK
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.scan(
+                TableName=name,
+                IndexName="gsi1",
+                ExclusiveStartKey={"pk": {"S": "x"}},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert err["Message"] == "The provided starting key is invalid"
+        dynamodb_client.delete_table(TableName=name)
+
+    def test_query_malformed_exclusive_start_key_on_gsi(self, dynamodb_client):
+        """Query GSI with ExclusiveStartKey missing index key returns ValidationException."""
+        name = unique_name("gsi-esk-q")
+        dynamodb_client.create_table(
+            TableName=name,
+            AttributeDefinitions=[
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "gsi_pk", "AttributeType": "S"},
+            ],
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "gsi1",
+                    "KeySchema": [{"AttributeName": "gsi_pk", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        waiter = dynamodb_client.get_waiter("table_exists")
+        waiter.wait(TableName=name, WaiterConfig={"Delay": 1, "MaxAttempts": 30})
+        # Start key has table PK but missing GSI PK
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.query(
+                TableName=name,
+                IndexName="gsi1",
+                KeyConditionExpression="gsi_pk = :v",
+                ExpressionAttributeValues={":v": {"S": "x"}},
+                ExclusiveStartKey={"pk": {"S": "x"}},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert err["Message"] == "The provided starting key is invalid"
+        dynamodb_client.delete_table(TableName=name)


### PR DESCRIPTION
## What
  
Validates `ExclusiveStartKey` against the table/index key schema in the engine layer, returning `ValidationException` instead of a 500 Internal Server Error. Also fixes `LastEvaluatedKey` for index scans and queries to include all combined key attributes (base table keys + index keys), matching DynamoDB behavior.

## Why

Closes #59, Closes #63 

A malformed `ExclusiveStartKey` (one that doesn't match the table schema) caused a 500 response. DynamoDB returns a 400 `ValidationException` with a descriptive message.

## Testing done

- Verified error messages against real DynamoDB for base table scan, base table query, GSI scan, and GSI query
- Verified `LastEvaluatedKey` format for LSI scans matches real DynamoDB (`{base_PK, base_SK, index_SK}`)
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` clean


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)

## Breaking changes

`LastEvaluatedKey` for index scans/queries now includes base table key attributes in addition to index key attributes. Previously only index key attributes were returned. This matches DynamoDB behavior but may affect clients that were relying on the previous (incorrect) format.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.