### PR TITLE
fix: size() uses UTF-16 code units for strings

### DIFF
--- a/crates/core/src/expression/evaluator.rs
+++ b/crates/core/src/expression/evaluator.rs
@@ -301,7 +301,7 @@ fn evaluate_size<'a>(
         return Ok(None);
     };
     let sz = match v.as_ref() {
-        AttributeValue::S(s) => s.len(),
+        AttributeValue::S(s) => s.encode_utf16().count(),
         AttributeValue::B(b) => b.len(),
         AttributeValue::N(n) => n.len(), // ASCII digits are 1 byte each, so len() == UTF-8 byte count
         AttributeValue::L(l) => l.len(),

--- a/crates/core/src/expression/evaluator_tests.rs
+++ b/crates/core/src/expression/evaluator_tests.rs
@@ -224,6 +224,16 @@ fn size_function_in_comparison() {
 }
 
 #[test]
+fn size_function_uses_utf16_code_units() {
+    // "é" = 1 UTF-16 code unit, "𝄞" = 2 UTF-16 code units (surrogate pair) → total 3
+    let mut item = BTreeMap::new();
+    item.insert("s".into(), AttributeValue::S("é𝄞".into()));
+    let mut values = HashMap::new();
+    values.insert("n".into(), AttributeValue::N("3".into()));
+    assert!(eval("size(s) = :n", &item, HashMap::new(), values).unwrap());
+}
+
+#[test]
 fn attribute_type_check() {
     let item = simple_item();
     let mut values = HashMap::new();


### PR DESCRIPTION
## What
  
Changes `size()` condition expression function to use UTF-16 code unit count for strings instead of UTF-8 byte length.

## Why

Closes #60

DynamoDB uses UTF-16 code units for `size()` on strings. ExtendDB was using Rust's `str::len()` (UTF-8 bytes), causing condition expressions to evaluate incorrectly for non-ASCII strings. For example, `"é𝄞"` should be size 3 (1 + 2 surrogate pair) but was returning 6.

## Testing done

- Verified against real DynamoDB: `size("é𝄞") = 3` succeeds, `size("é𝄞") = 6` fails
- Verified same behavior on ExtendDB after fix
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` clean

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.