### PR TITLE
fix: reject contains() with duplicate path and operand

### DIFF
--- a/crates/core/src/expression/evaluator.rs
+++ b/crates/core/src/expression/evaluator.rs
@@ -13,7 +13,7 @@ use std::collections::BTreeMap;
 use crate::error::DynamoDbError;
 use crate::types::AttributeValue;
 
-use super::ast::{CompareOp, Expr};
+use super::ast::{CompareOp, Expr, PathElement};
 use super::resolver::{ExpressionMaps, resolve_path};
 
 /// Evaluate a condition expression against an item.
@@ -258,6 +258,21 @@ fn evaluate_function(
                     "Invalid ConditionExpression: contains requires exactly two arguments"
                         .to_owned(),
                 ));
+            }
+            if args[0] == args[1] {
+                let operand_str = match &args[0] {
+                    Expr::Path(p) => {
+                        let parts: Vec<String> = p.iter().map(|e| match e {
+                            PathElement::Attribute(a) => a.clone(),
+                            PathElement::Index(i) => format!("[{i}]"),
+                        }).collect();
+                        format!("[{}]", parts.join("."))
+                    }
+                    _ => String::new(),
+                };
+                return Err(DynamoDbError::ValidationException(format!(
+                    "Invalid ConditionExpression: The first operand must be distinct from the remaining operands for this operator or function; operator: contains, first operand: {operand_str}"
+                )));
             }
             let val = resolve_to_value(&args[0], item, maps)?;
             let operand = resolve_to_value(&args[1], item, maps)?;

--- a/crates/core/src/expression/evaluator_tests.rs
+++ b/crates/core/src/expression/evaluator_tests.rs
@@ -161,6 +161,15 @@ fn contains_string_substring() {
 }
 
 #[test]
+fn contains_duplicate_operand_rejected() {
+    let item = simple_item();
+    let result = eval("contains(name, name)", &item, HashMap::new(), HashMap::new());
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("first operand must be distinct"));
+}
+
+#[test]
 fn between_in_range() {
     let item = simple_item();
     let mut values = HashMap::new();


### PR DESCRIPTION
## What
  
Rejects `contains(path, path)` when both operands are identical, returning a `ValidationException` with the same error message as DynamoDB.

## Why

Closes #61

DynamoDB requires the first operand to be distinct from the second in `contains()`. ExtendDB was accepting it and evaluating it (always true for strings).

## Testing done

- Verified error message against real DynamoDB
- Verified ExtendDB returns identical error after fix
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` clean

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.