### PR TITLE
feat: add Docker-based PostgreSQL setup as an alternative to manual installation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+# extenddb postgres docker-compose configuration
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: extenddb-local-dev
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  pgdata:

--- a/docs/local-postgres-setup.md
+++ b/docs/local-postgres-setup.md
@@ -83,6 +83,57 @@ export EXTENDDB__STORAGE__POSTGRES__CONNECTION_STRING=\
 
 ---
 
+## Docker Setup (Alternative)
+
+A `docker-compose.yml` is provided at the repository root for a quick PostgreSQL setup with no manual installation.
+
+### Prerequisites
+
+- Docker Engine 20.10+ with Compose plugin (`docker compose`)
+
+### Start PostgreSQL
+
+```bash
+docker compose up -d
+```
+
+Wait for the container to be healthy:
+
+```bash
+docker compose ps
+```
+
+### Connection Details
+
+| Setting | Value |
+|---------|-------|
+| Host | `localhost` |
+| Port | `5432` |
+| Admin user | `postgres` |
+| Admin password | `extenddb-local-dev` |
+
+### Initialize ExtendDB
+
+Since the Docker container uses `postgres` as the superuser, pass it explicitly to `init`:
+
+```bash
+./target/release/extenddb init --config extenddb.toml \
+  --pg-user postgres \
+  --pg-pass extenddb-local-dev
+```
+
+### Stop and Clean Up
+
+```bash
+# Stop (preserves data)
+docker compose down
+
+# Stop and delete all data
+docker compose down -v
+```
+
+---
+
 ## License
 
 Copyright 2026 ExtendDB contributors. Licensed under the Apache License, Version 2.0.


### PR DESCRIPTION
## What

Add Docker-based PostgreSQL setup as an alternative to manual installation.
Includes `docker-compose.yml` and documentation in `docs/local-postgres-setup.md`.

## Why

Simplifies local development setup — one command to get PostgreSQL running
instead of manual RPM installation and initdb configuration.

## Testing done

- `docker compose up -d` starts PostgreSQL
- `./target/release/extenddb init --pg-user postgres --pg-pass extenddb-local-dev` succeeds
- `./target/release/extenddb serve` starts and `curl -sk https://127.0.0.1:8000/health` returns healthy
- AWS CLI operations work against the running instance
- `docker compose down`

####  python3 docs/build-docs.py

```sh
Done: 18 HTML, 18 PDF built, 0 skipped/failed.
Output: /home/ackstorm/workspace/extenddb/docs/rendered/
~/workspace/extenddb (main *)$ 
```

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [ N/A ] I have added or updated tests for new functionality
- [ N/A ] I have updated documentation if behavior changed
- [ N/A ] Breaking changes are noted below (if any)

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
