### PR TITLE
fix: begins_with rejects invalid operand types

### DIFF
--- a/crates/core/src/expression/evaluator.rs
+++ b/crates/core/src/expression/evaluator.rs
@@ -242,6 +242,15 @@ fn evaluate_function(
             }
             let val = resolve_to_value(&args[0], item, maps)?;
             let prefix = resolve_to_value(&args[1], item, maps)?;
+            // Reject invalid operand types — only S and B are allowed
+            if let Some(ref p) = prefix.as_deref() {
+                if !matches!(p, AttributeValue::S(_) | AttributeValue::B(_)) {
+                    let type_code = attribute_type_code(p);
+                    return Err(DynamoDbError::ValidationException(format!(
+                        "Invalid ConditionExpression: Incorrect operand type for operator or function; operator or function: begins_with, operand type: {type_code}"
+                    )));
+                }
+            }
             match (val.as_deref(), prefix.as_deref()) {
                 (Some(AttributeValue::S(s)), Some(AttributeValue::S(p))) => {
                     Ok(s.starts_with(p.as_str()))

--- a/crates/core/src/expression/evaluator_tests.rs
+++ b/crates/core/src/expression/evaluator_tests.rs
@@ -153,6 +153,17 @@ fn begins_with_false() {
 }
 
 #[test]
+fn begins_with_rejects_number_operand() {
+    let item = simple_item();
+    let mut values = HashMap::new();
+    values.insert("p".into(), AttributeValue::N("1".into()));
+    let result = eval("begins_with(name, :p)", &item, HashMap::new(), values);
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("operand type: N"));
+}
+
+#[test]
 fn contains_string_substring() {
     let item = simple_item();
     let mut values = HashMap::new();


### PR DESCRIPTION
## What
  
Rejects invalid operand types for `begins_with()`. Only S and B are valid; all other types (N, BOOL, NULL, L, M, SS, NS, BS) return a `ValidationException`.

## Why

Closes #65

`begins_with(s, :prefix)` with a number `:prefix` was silently returning `ConditionalCheckFailedException` instead of rejecting the invalid type upfront. DynamoDB returns `ValidationException` with the operand type in the message.

## Testing done

- Verified all 8 invalid types rejected against real DynamoDB
- Verified ExtendDB matches on all types
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` clean

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.