### PR TITLE
chore: cargo fmt

### DIFF
--- a/crates/core/src/expression/evaluator.rs
+++ b/crates/core/src/expression/evaluator.rs
@@ -271,10 +271,13 @@ fn evaluate_function(
             if args[0] == args[1] {
                 let operand_str = match &args[0] {
                     Expr::Path(p) => {
-                        let parts: Vec<String> = p.iter().map(|e| match e {
-                            PathElement::Attribute(a) => a.clone(),
-                            PathElement::Index(i) => format!("[{i}]"),
-                        }).collect();
+                        let parts: Vec<String> = p
+                            .iter()
+                            .map(|e| match e {
+                                PathElement::Attribute(a) => a.clone(),
+                                PathElement::Index(i) => format!("[{i}]"),
+                            })
+                            .collect();
                         format!("[{}]", parts.join("."))
                     }
                     _ => String::new(),

--- a/crates/core/src/expression/evaluator_tests.rs
+++ b/crates/core/src/expression/evaluator_tests.rs
@@ -174,7 +174,12 @@ fn contains_string_substring() {
 #[test]
 fn contains_duplicate_operand_rejected() {
     let item = simple_item();
-    let result = eval("contains(name, name)", &item, HashMap::new(), HashMap::new());
+    let result = eval(
+        "contains(name, name)",
+        &item,
+        HashMap::new(),
+        HashMap::new(),
+    );
     assert!(result.is_err());
     let msg = result.unwrap_err().to_string();
     assert!(msg.contains("first operand must be distinct"));

--- a/crates/core/src/expression/parser.rs
+++ b/crates/core/src/expression/parser.rs
@@ -493,7 +493,12 @@ mod tests {
 
     #[test]
     fn redundant_parens_rejected() {
-        let cases = ["((a = :v))", "(((a = :v)))", "((a = :v AND b = :v2))", "((NOT (a = :v)))"];
+        let cases = [
+            "((a = :v))",
+            "(((a = :v)))",
+            "((a = :v AND b = :v2))",
+            "((NOT (a = :v)))",
+        ];
         for expr in cases {
             let tokens = tokenize(expr).unwrap();
             let err = parse_condition(&tokens).unwrap_err();
@@ -506,7 +511,12 @@ mod tests {
 
     #[test]
     fn valid_parens_accepted() {
-        let cases = ["(a = :v)", "(a = :v) AND (b = :v2)", "((a = :v) AND (b = :v2))", "(NOT (a = :v))"];
+        let cases = [
+            "(a = :v)",
+            "(a = :v) AND (b = :v2)",
+            "((a = :v) AND (b = :v2))",
+            "(NOT (a = :v))",
+        ];
         for expr in cases {
             let tokens = tokenize(expr).unwrap();
             assert!(

--- a/crates/core/src/expression/update_evaluator.rs
+++ b/crates/core/src/expression/update_evaluator.rs
@@ -510,10 +510,9 @@ fn remove_nested(
                 let name = resolve_attr_name(&path[0], maps)?;
                 map.remove(&name);
             }
-            (PathElement::Index(idx), AttributeValue::L(list))
-                if *idx < list.len() => {
-                    list.remove(*idx);
-                }
+            (PathElement::Index(idx), AttributeValue::L(list)) if *idx < list.len() => {
+                list.remove(*idx);
+            }
             _ => {} // No-op for type mismatch
         }
         return Ok(());
@@ -526,10 +525,9 @@ fn remove_nested(
                 remove_nested(next, &path[1..], maps)?;
             }
         }
-        (PathElement::Index(idx), AttributeValue::L(list))
-            if *idx < list.len() => {
-                remove_nested(&mut list[*idx], &path[1..], maps)?;
-            }
+        (PathElement::Index(idx), AttributeValue::L(list)) if *idx < list.len() => {
+            remove_nested(&mut list[*idx], &path[1..], maps)?;
+        }
         _ => {} // No-op
     }
     Ok(())

--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -910,7 +910,10 @@ mod tests {
 
     #[test]
     fn multipart_table_keys_allowed_when_enabled() {
-        let limits = LimitsConfig { allow_multipart_table_keys: true, ..Default::default() };
+        let limits = LimitsConfig {
+            allow_multipart_table_keys: true,
+            ..Default::default()
+        };
         let input = base_input(
             vec![
                 make_ks("pk1", KeyType::Hash),
@@ -1078,7 +1081,10 @@ mod tests {
 
     #[test]
     fn attribute_name_exceeding_limit_rejected() {
-        let limits = LimitsConfig { max_attribute_name_bytes: 10, ..Default::default() };
+        let limits = LimitsConfig {
+            max_attribute_name_bytes: 10,
+            ..Default::default()
+        };
         let mut item = Item::new();
         item.insert("a".repeat(11), AttributeValue::S("v".to_owned()));
         let err = validate_attribute_name_sizes(&item, &limits).unwrap_err();

--- a/crates/engine/src/index_helpers.rs
+++ b/crates/engine/src/index_helpers.rs
@@ -78,7 +78,9 @@ pub fn validate_scan_exclusive_start_key(
             } else {
                 "The provided starting key is invalid: The provided key element does not match the schema".to_owned()
             };
-            return Err(extenddb_core::error::DynamoDbError::ValidationException(msg));
+            return Err(extenddb_core::error::DynamoDbError::ValidationException(
+                msg,
+            ));
         }
     }
     Ok(())

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -13,8 +13,7 @@ use extenddb_core::expression::{
     ExpressionMaps, parse_key_condition, parse_projection, tokenize_for,
 };
 use extenddb_core::types::{
-    IndexType, KeyType, QueryInput, QueryOutput, Select, TableKeyInfo, extract_key,
-    item_size_bytes,
+    IndexType, KeyType, QueryInput, QueryOutput, Select, TableKeyInfo, extract_key, item_size_bytes,
 };
 
 use crate::OperationContext;
@@ -392,7 +391,9 @@ pub async fn handle_query(
 
     // For index queries, enrich the storage LEK with base table key attributes.
     let enriched_storage_last_key = if storage_last_key.is_some() && index_info.is_some() {
-        raw_items.last().map(|item| extract_key(item, &lek_key_schema))
+        raw_items
+            .last()
+            .map(|item| extract_key(item, &lek_key_schema))
     } else {
         storage_last_key
     };

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -298,7 +298,9 @@ pub async fn handle_scan(
     // attributes. Enrich it with the base table key attributes from the last
     // raw item so the LEK matches DynamoDB's format (all combined keys).
     let enriched_storage_last_key = if storage_last_key.is_some() && index_info.is_some() {
-        raw_items.last().map(|item| extract_key(item, &lek_key_schema))
+        raw_items
+            .last()
+            .map(|item| extract_key(item, &lek_key_schema))
     } else {
         storage_last_key
     };

--- a/crates/engine/src/transact_write_helpers.rs
+++ b/crates/engine/src/transact_write_helpers.rs
@@ -86,8 +86,7 @@ impl PreparedOp {
                 // Use key size + expression attribute values size as a better
                 // approximation of the data involved in the update.
                 let key_size = extenddb_core::types::item_size_bytes(key);
-                let values_size: usize =
-                    maps.values.values().map(attribute_value_size).sum();
+                let values_size: usize = maps.values.values().map(attribute_value_size).sum();
                 key_size + values_size
             }
         }

--- a/crates/server/src/console/pages/auth_pages.rs
+++ b/crates/server/src/console/pages/auth_pages.rs
@@ -87,7 +87,8 @@ pub async fn logout(State(state): State<Arc<ConsoleState>>, headers: HeaderMap) 
     if let Some(token) = extract_session_token(&headers) {
         state.sessions.remove(&token).await;
     }
-    let cookie = "extenddb_session=; Path=/console; HttpOnly; SameSite=Strict; Max-Age=0".to_string();
+    let cookie =
+        "extenddb_session=; Path=/console; HttpOnly; SameSite=Strict; Max-Age=0".to_string();
     (
         StatusCode::SEE_OTHER,
         [("location", "/console/login"), ("set-cookie", &cookie)],

--- a/crates/storage-postgres/src/update_table.rs
+++ b/crates/storage-postgres/src/update_table.rs
@@ -46,18 +46,20 @@ impl PostgresEngine {
         // check was in the engine layer.
         if matches!(input.billing_mode, Some(BillingMode::Provisioned)) {
             if let Some(ref pt) = input.provisioned_throughput {
-                let current_row: Option<(Option<String>, Option<serde_json::Value>)> = sqlx::query_as(
-                    "SELECT billing_mode, provisioned_throughput FROM tables \
+                let current_row: Option<(Option<String>, Option<serde_json::Value>)> =
+                    sqlx::query_as(
+                        "SELECT billing_mode, provisioned_throughput FROM tables \
                      WHERE account_id = $1 AND table_name = $2",
-                )
-                .bind(account_id)
-                .bind(&input.table_name)
-                .fetch_optional(&mut *tx)
-                .await
-                .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    )
+                    .bind(account_id)
+                    .bind(&input.table_name)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
 
                 if let Some((current_bm, current_pt_opt)) = current_row {
-                    let current_pt = current_pt_opt.unwrap_or(serde_json::Value::Object(Default::default()));
+                    let current_pt =
+                        current_pt_opt.unwrap_or(serde_json::Value::Object(Default::default()));
                     let is_provisioned =
                         current_bm.as_deref() == Some("PROVISIONED") || current_bm.is_none();
                     let current_rcu = current_pt

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -356,9 +356,7 @@ pub trait MetadataEngine: Send + Sync {
     ) -> BoxFuture<'_, Result<Vec<(String, String)>, StorageError>>;
 
     /// List all tables with TTL enabled across all accounts: `(account_id, table_name, ttl_attribute)`.
-    fn all_tables_with_ttl(
-        &self,
-    ) -> BoxFuture<'_, Result<Vec<TtlTableInfo>, StorageError>>;
+    fn all_tables_with_ttl(&self) -> BoxFuture<'_, Result<Vec<TtlTableInfo>, StorageError>>;
 
     /// List all tables with TTL enabled AND index ready: `(account_id, table_name, ttl_attribute)`.
     fn all_tables_with_ttl_index_ready(

--- a/crates/storage/src/management_store/mod.rs
+++ b/crates/storage/src/management_store/mod.rs
@@ -37,7 +37,13 @@ pub type UserListEntry = (String, String, String, bool, time::OffsetDateTime);
 /// Group info: `(account_id, group_name, group_arn, created_at)`.
 pub type GroupListEntry = (String, String, String, time::OffsetDateTime);
 /// Role info: `(account_id, role_name, role_arn, assume_role_policy, created_at)`.
-pub type RoleListEntry = (String, String, String, serde_json::Value, time::OffsetDateTime);
+pub type RoleListEntry = (
+    String,
+    String,
+    String,
+    serde_json::Value,
+    time::OffsetDateTime,
+);
 
 // ── Settings store ─────────────────────────────────────────────────────
 
@@ -180,10 +186,7 @@ pub trait ManagementStore: Send + Sync {
     fn delete_user(&self, account_id: &str, user_name: &str) -> BoxFuture<'_, OpResult<()>>;
 
     /// List users in an account as `(account_id, user_name, user_arn, has_password, created_at)`.
-    fn list_users(
-        &self,
-        account_id: &str,
-    ) -> BoxFuture<'_, OpResult<Vec<UserListEntry>>>;
+    fn list_users(&self, account_id: &str) -> BoxFuture<'_, OpResult<Vec<UserListEntry>>>;
 
     fn get_user_detail(
         &self,
@@ -239,10 +242,7 @@ pub trait ManagementStore: Send + Sync {
     fn delete_group(&self, account_id: &str, group_name: &str) -> BoxFuture<'_, OpResult<()>>;
 
     /// List groups in an account as `(account_id, group_name, group_arn, created_at)`.
-    fn list_groups(
-        &self,
-        account_id: &str,
-    ) -> BoxFuture<'_, OpResult<Vec<GroupListEntry>>>;
+    fn list_groups(&self, account_id: &str) -> BoxFuture<'_, OpResult<Vec<GroupListEntry>>>;
 
     fn get_group_detail(
         &self,
@@ -276,10 +276,7 @@ pub trait ManagementStore: Send + Sync {
     fn delete_role(&self, account_id: &str, role_name: &str) -> BoxFuture<'_, OpResult<()>>;
 
     /// List roles in an account as `(account_id, role_name, role_arn, trust_policy, created_at)`.
-    fn list_roles(
-        &self,
-        account_id: &str,
-    ) -> BoxFuture<'_, OpResult<Vec<RoleListEntry>>>;
+    fn list_roles(&self, account_id: &str) -> BoxFuture<'_, OpResult<Vec<RoleListEntry>>>;
 
     fn get_role_detail(
         &self,


### PR DESCRIPTION
## What
  
Runs `cargo fmt --all` across the workspace to fix formatting inconsistencies introduced by recent PRs.

## Why

Formatting had drifted. This brings the codebase back in line so `cargo fmt --check` passes cleanly in CI.

## Testing done

- `cargo fmt --all -- --check` passes
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [ ] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
