### PR TITLE
fix: omit Item from transact_get response when projection is empty

### DIFF
--- a/crates/engine/src/transact_get_items.rs
+++ b/crates/engine/src/transact_get_items.rs
@@ -153,7 +153,8 @@ pub async fn handle_transact_get_items(
                 )?;
                 let item = opt
                     .map(|item| apply_projection(&item, &projection, &maps))
-                    .transpose()?;
+                    .transpose()?
+                    .filter(|i| !i.is_empty());
                 Ok(ItemResponse { item })
             } else {
                 extenddb_core::expression::validate_unused_attributes(


### PR DESCRIPTION
## What

Omits the `Item` field from `TransactGetItems` responses when a projection expression matches no attributes. Returns `{}` instead of `{"Item": {}}`.

## Why

Closes #74

DynamoDB omits `Item` entirely when projection selects no attributes. ExtendDB was returning an empty `Item` object, which can cause deserialization issues for clients.

## Testing done

- Verified against real DynamoDB: `[{}]` for absent projection, `[{"Item": {...}}]` for matching projection
- Verified ExtendDB returns identical responses after fix
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [ ] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.