### PR TITLE
fix: transact get capacity

### DIFF
--- a/crates/engine/src/transact_get_items.rs
+++ b/crates/engine/src/transact_get_items.rs
@@ -153,7 +153,8 @@ pub async fn handle_transact_get_items(
                 )?;
                 let item = opt
                     .map(|item| apply_projection(&item, &projection, &maps))
-                    .transpose()?;
+                    .transpose()?
+                    .filter(|i| !i.is_empty());
                 Ok(ItemResponse { item })
             } else {
                 extenddb_core::expression::validate_unused_attributes(

--- a/crates/engine/src/transact_get_items.rs
+++ b/crates/engine/src/transact_get_items.rs
@@ -100,17 +100,21 @@ pub async fn handle_transact_get_items(
         .map_err(storage_err_to_dynamo)?;
 
     // Capacity metering: RCU rounded per item, then summed (M-1).
-    // TransactGetItems is always strongly consistent.
+    // Capacity metering: TransactGetItems costs 2 RCU per item (transactions
+    // double the read cost). Missing items still cost 2 RCU.
     let mut per_table_rcu: std::collections::HashMap<String, f64> =
         std::collections::HashMap::new();
     let rcu: f64 = items
         .iter()
         .zip(input.transact_items.iter())
-        .filter_map(|(opt, tgi)| opt.as_ref().map(|item| (item, &tgi.get.table_name)))
-        .map(|(item, table_name)| {
-            let item_rcu = capacity_helpers::read_capacity_units(item_size_bytes(item), true);
-            *per_table_rcu.entry(table_name.clone()).or_default() += item_rcu;
-            item_rcu
+        .map(|(opt, tgi)| {
+            let base_rcu = match opt {
+                Some(item) => capacity_helpers::read_capacity_units(item_size_bytes(item), true),
+                None => 1.0, // minimum 1 RCU for missing item
+            };
+            let txn_rcu = base_rcu * 2.0; // transactions cost 2x
+            *per_table_rcu.entry(tgi.get.table_name.clone()).or_default() += txn_rcu;
+            txn_rcu
         })
         .sum();
     let total_pre_proj_bytes: usize = items

--- a/tests/python/test_transactions.py
+++ b/tests/python/test_transactions.py
@@ -262,3 +262,21 @@ class TestTransactGetItems:
         """Empty TransactItems is rejected (by boto3 or server)."""
         with pytest.raises((ClientError, ParamValidationError)):
             dynamodb_client.transact_get_items(TransactItems=[])
+
+    def test_transact_get_consumed_capacity(self, table_factory, dynamodb_client):
+        """TransactGetItems costs 2 RCU per item, including missing items."""
+        name = table_factory()
+        dynamodb_client.put_item(
+            TableName=name,
+            Item={"pk": {"S": "exists"}},
+        )
+        resp = dynamodb_client.transact_get_items(
+            ReturnConsumedCapacity="TOTAL",
+            TransactItems=[
+                {"Get": {"TableName": name, "Key": {"pk": {"S": "exists"}}}},
+                {"Get": {"TableName": name, "Key": {"pk": {"S": "missing"}}}},
+            ],
+        )
+        cap = resp["ConsumedCapacity"][0]
+        assert cap["CapacityUnits"] == 4.0
+        assert cap["ReadCapacityUnits"] == 4.0


### PR DESCRIPTION
## What

Fixes TransactGetItems consumed capacity to charge 2 RCU per item (transaction cost) and account for missing items.

## Why

Closes #76

TransactGetItems was reporting 1 RCU for a 2-item request. DynamoDB charges 2 RCU per item in transactions (2x strongly consistent read cost), including missing items.

## Testing done

- Verified against real DynamoDB: 1 existing + 1 missing item = 4.0 RCU
- Verified ExtendDB returns 4.0 after fix
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.