### PR TITLE
Multiple changes to speed up the pytest suite

### DIFF
--- a/devtools/run-tests
+++ b/devtools/run-tests
@@ -30,6 +30,7 @@
 # Options:
 #   --release         use release build for Rust tests
 #   --filter PATTERN  pass to cargo test / pytest -k
+#   --parallel[=N]    run pytest in parallel (default: 1/3 of CPU cores)
 #   --config PATH     config file path (default: extenddb.toml in repo root)
 #
 # REQ-TEST-001, D-1, D-2, D-3, D-4, D-5
@@ -65,6 +66,7 @@ RUN_CATALOG_CHECK=false
 RELEASE=false
 FILTER=""
 CONFIG_PATH=""
+PARALLEL=""
 
 usage() {
     cat <<'EOF'
@@ -86,6 +88,7 @@ Suites (at least one required):
 Options:
   --release         release build for Rust tests
   --filter PATTERN  filter for cargo test / pytest -k
+  --parallel[=N]    run pytest in parallel (default: 1/3 of CPU cores)
   --config PATH     config file path
 EOF
     exit 1
@@ -109,6 +112,13 @@ while [[ $# -gt 0 ]]; do
         --filter)         FILTER="$2"; shift 2 ;;
         --catalog-check)  RUN_CATALOG_CHECK=true; shift ;;
         --config)         CONFIG_PATH="$2"; shift 2 ;;
+        --parallel)
+            # --parallel (no argument) or --parallel=N
+            PARALLEL="auto"; shift
+            ;;
+        --parallel=*)
+            PARALLEL="${1#--parallel=}"; shift
+            ;;
         -h|--help)        usage ;;
         *)                echo "error: unknown option: $1"; usage ;;
     esac
@@ -414,6 +424,16 @@ if $RUN_PYTEST; then
     echo "  AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}"
     # CLI lifecycle tests manage their own server; exclude from main suite
     PYTEST_ARGS=(python3 -m pytest tests/ -v --ignore=tests/python --ignore=tests/test_cli_lifecycle.py)
+    # Parallel execution (--parallel): distribute by file so module/class-scoped
+    # fixtures stay within a single worker.
+    if [[ -n "$PARALLEL" ]] && python3 -c "import xdist" 2>/dev/null; then
+        if [[ "$PARALLEL" == "auto" ]]; then
+            XDIST_WORKERS=$(python3 -c "import os; print(max(2, os.cpu_count() // 3))")
+        else
+            XDIST_WORKERS="$PARALLEL"
+        fi
+        PYTEST_ARGS+=(-n "$XDIST_WORKERS" --dist loadfile)
+    fi
     if [[ -n "$FILTER" ]]; then
         PYTEST_ARGS+=(-k "$FILTER")
     fi

--- a/docs/manuals/06-developer-test-guide.md
+++ b/docs/manuals/06-developer-test-guide.md
@@ -188,11 +188,23 @@ The primary test suite is in Python, testing extenddb through the same AWS SDK i
 # Via run-tests script (recommended)
 devtools/run-tests --extenddb --pytest
 
+# Run in parallel (uses 1/3 of CPU cores by default)
+devtools/run-tests --extenddb --pytest --parallel
+
+# Run in parallel with a specific worker count
+devtools/run-tests --extenddb --pytest --parallel=4
+
 # Direct execution (for quick iteration during development)
 python3 -m pytest tests/ -v
 python3 -m pytest tests/test_put_item.py -v
 python3 -m pytest tests/test_put_item.py::test_put_item_basic -v
 ```
+
+The `--parallel` flag enables pytest-xdist with `--dist loadfile`, which
+distributes entire test files across workers. This keeps module/class-scoped
+fixtures on a single worker while running independent files concurrently. The
+default worker count (1/3 of CPU cores, minimum 2) leaves headroom for the
+extenddb server and its Postgres backend.
 
 ### Comprehensive Tests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@
 boto3==1.33.13
 pytest==7.4.4
 pytest-cov==4.1.0
+pytest-xdist==3.5.0
 requests==2.31.0
 
 # Documentation (PDF build via docs/build-docs.py)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,3 +110,47 @@ def wait_for_deleted(client, table_name: str, timeout: float = 60.0) -> None:
             return
         time.sleep(0.02)
     raise TimeoutError(f"Table {table_name} was not deleted within {timeout}s")
+
+
+from contextlib import contextmanager
+from typing import Generator
+
+
+@contextmanager
+def scoped_table(
+    client,
+    attribute_definitions: list[dict] | None = None,
+    key_schema: list[dict] | None = None,
+    **extra_kwargs,
+) -> Generator[str, None, None]:
+    """Create a uniquely-named table, yield its name, delete on exit.
+
+    Use this in class/module-scoped fixtures to avoid repeating
+    create/wait/delete boilerplate:
+
+        @pytest.fixture(scope="class")
+        def my_table(dynamodb_client):
+            with scoped_table(dynamodb_client) as name:
+                yield name
+    """
+    name = f"extenddb-test-{uuid.uuid4().hex[:12]}"
+    create_kwargs: dict = {
+        "TableName": name,
+        "AttributeDefinitions": attribute_definitions or [
+            {"AttributeName": "pk", "AttributeType": "S"},
+        ],
+        "KeySchema": key_schema or [
+            {"AttributeName": "pk", "KeyType": "HASH"},
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+    }
+    create_kwargs.update(extra_kwargs)
+    client.create_table(**create_kwargs)
+    wait_for_active(client, name)
+    try:
+        yield name
+    finally:
+        try:
+            client.delete_table(TableName=name)
+        except client.exceptions.ResourceNotFoundException:
+            pass  # Already deleted by the test itself.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def wait_for_active(client, table_name: str, timeout: float = 60.0) -> None:
         resp = client.describe_table(TableName=table_name)
         if resp["Table"]["TableStatus"] == "ACTIVE":
             return
-        time.sleep(0.2)
+        time.sleep(0.02)
     raise TimeoutError(f"Table {table_name} did not become ACTIVE within {timeout}s")
 @pytest.fixture()
 def create_and_cleanup_table(dynamodb_client, unique_table_name):
@@ -108,5 +108,5 @@ def wait_for_deleted(client, table_name: str, timeout: float = 60.0) -> None:
             client.describe_table(TableName=table_name)
         except client.exceptions.ResourceNotFoundException:
             return
-        time.sleep(0.2)
+        time.sleep(0.02)
     raise TimeoutError(f"Table {table_name} was not deleted within {timeout}s")

--- a/tests/test_batch_operations.py
+++ b/tests/test_batch_operations.py
@@ -9,50 +9,43 @@ REQ-TEST-001, REQ-TEST-002, REQ-TEST-003
 
 from __future__ import annotations
 
-import uuid
-
 import pytest
 from botocore.exceptions import ClientError
 
-from conftest import wait_for_active
-@pytest.fixture()
-def hash_table(dynamodb_client, create_and_cleanup_table, unique_table_name):
-    """Create a hash-only table and wait for ACTIVE."""
-    create_and_cleanup_table(unique_table_name)
-    wait_for_active(dynamodb_client, unique_table_name)
-    return unique_table_name
-@pytest.fixture()
-def hash_range_table(dynamodb_client, create_and_cleanup_table):
-    """Create a hash+range (S,S) table and wait for ACTIVE."""
-    name = f"extenddb-test-{uuid.uuid4().hex[:12]}"
-    create_and_cleanup_table(
-        name,
-        AttributeDefinitions=[
+from conftest import wait_for_active, scoped_table
+@pytest.fixture(scope="class")
+def hash_table(dynamodb_client):
+    """Create a hash-only table for the class, delete on teardown."""
+    with scoped_table(dynamodb_client) as name:
+        yield name
+@pytest.fixture(scope="class")
+def hash_range_table(dynamodb_client):
+    """Create a hash+range (S,S) table for the class, delete on teardown."""
+    with scoped_table(
+        dynamodb_client,
+        attribute_definitions=[
             {"AttributeName": "pk", "AttributeType": "S"},
             {"AttributeName": "sk", "AttributeType": "S"},
         ],
-        KeySchema=[
+        key_schema=[
             {"AttributeName": "pk", "KeyType": "HASH"},
             {"AttributeName": "sk", "KeyType": "RANGE"},
         ],
-    )
-    wait_for_active(dynamodb_client, name)
-    return name
-@pytest.fixture()
-def second_table(dynamodb_client, create_and_cleanup_table):
+    ) as name:
+        yield name
+@pytest.fixture(scope="class")
+def second_table(dynamodb_client):
     """Create a second hash-only table for cross-table batch tests."""
-    name = f"extenddb-test-{uuid.uuid4().hex[:12]}"
-    create_and_cleanup_table(
-        name,
-        AttributeDefinitions=[
+    with scoped_table(
+        dynamodb_client,
+        attribute_definitions=[
             {"AttributeName": "id", "AttributeType": "S"},
         ],
-        KeySchema=[
+        key_schema=[
             {"AttributeName": "id", "KeyType": "HASH"},
         ],
-    )
-    wait_for_active(dynamodb_client, name)
-    return name
+    ) as name:
+        yield name
 # ── BatchGetItem ──────────────────────────────────────────────────────
 class TestBatchGetItem:
     """Tests for the BatchGetItem operation."""

--- a/tests/test_item_operations.py
+++ b/tests/test_item_operations.py
@@ -9,52 +9,45 @@ REQ-TEST-001, REQ-TEST-002, REQ-TEST-003, REQ-TEST-004
 
 from __future__ import annotations
 
-import uuid
-
 import pytest
 from botocore.exceptions import ClientError
 
-from conftest import wait_for_active
-@pytest.fixture()
-def hash_table(dynamodb_client, create_and_cleanup_table, unique_table_name):
-    """Create a hash-only table and wait for ACTIVE."""
-    create_and_cleanup_table(unique_table_name)
-    wait_for_active(dynamodb_client, unique_table_name)
-    return unique_table_name
-@pytest.fixture()
-def hash_range_table(dynamodb_client, create_and_cleanup_table):
-    """Create a hash+range (S,S) table and wait for ACTIVE."""
-    name = f"extenddb-test-{uuid.uuid4().hex[:12]}"
-    create_and_cleanup_table(
-        name,
-        AttributeDefinitions=[
+from conftest import wait_for_active, scoped_table
+@pytest.fixture(scope="class")
+def hash_table(dynamodb_client):
+    """Create a hash-only table for the class, delete on teardown."""
+    with scoped_table(dynamodb_client) as name:
+        yield name
+@pytest.fixture(scope="class")
+def hash_range_table(dynamodb_client):
+    """Create a hash+range (S,S) table for the class, delete on teardown."""
+    with scoped_table(
+        dynamodb_client,
+        attribute_definitions=[
             {"AttributeName": "pk", "AttributeType": "S"},
             {"AttributeName": "sk", "AttributeType": "S"},
         ],
-        KeySchema=[
+        key_schema=[
             {"AttributeName": "pk", "KeyType": "HASH"},
             {"AttributeName": "sk", "KeyType": "RANGE"},
         ],
-    )
-    wait_for_active(dynamodb_client, name)
-    return name
-@pytest.fixture()
-def hash_numeric_range_table(dynamodb_client, create_and_cleanup_table):
-    """Create a hash+range (S,N) table and wait for ACTIVE."""
-    name = f"extenddb-test-{uuid.uuid4().hex[:12]}"
-    create_and_cleanup_table(
-        name,
-        AttributeDefinitions=[
+    ) as name:
+        yield name
+@pytest.fixture(scope="class")
+def hash_numeric_range_table(dynamodb_client):
+    """Create a hash+range (S,N) table for the class, delete on teardown."""
+    with scoped_table(
+        dynamodb_client,
+        attribute_definitions=[
             {"AttributeName": "pk", "AttributeType": "S"},
             {"AttributeName": "sk", "AttributeType": "N"},
         ],
-        KeySchema=[
+        key_schema=[
             {"AttributeName": "pk", "KeyType": "HASH"},
             {"AttributeName": "sk", "KeyType": "RANGE"},
         ],
-    )
-    wait_for_active(dynamodb_client, name)
-    return name
+    ) as name:
+        yield name
 class TestPutItem:
     """PutItem operation tests."""
 

--- a/tests/test_query_scan.py
+++ b/tests/test_query_scan.py
@@ -11,87 +11,79 @@ REQ-TEST-001, REQ-TEST-002, REQ-TEST-003
 
 from __future__ import annotations
 
-import uuid
-
 import pytest
 from botocore.exceptions import ClientError
 
-from conftest import wait_for_active
-@pytest.fixture()
-def query_table(dynamodb_client, create_and_cleanup_table):
+from conftest import wait_for_active, scoped_table
+@pytest.fixture(scope="class")
+def query_table(dynamodb_client):
     """Create a hash+range (S,N) table with 10 items for query tests."""
-    name = f"extenddb-test-{uuid.uuid4().hex[:12]}"
-    create_and_cleanup_table(
-        name,
-        AttributeDefinitions=[
+    with scoped_table(
+        dynamodb_client,
+        attribute_definitions=[
             {"AttributeName": "pk", "AttributeType": "S"},
             {"AttributeName": "sk", "AttributeType": "N"},
         ],
-        KeySchema=[
+        key_schema=[
             {"AttributeName": "pk", "KeyType": "HASH"},
             {"AttributeName": "sk", "KeyType": "RANGE"},
         ],
-    )
-    wait_for_active(dynamodb_client, name)
-    for i in range(1, 11):
-        dynamodb_client.put_item(
-            TableName=name,
-            Item={
-                "pk": {"S": "user-1"},
-                "sk": {"N": str(i)},
-                "name": {"S": f"item-{i}"},
-                "age": {"N": str(20 + i)},
-            },
-        )
-    return name
-@pytest.fixture()
-def string_sk_table(dynamodb_client, create_and_cleanup_table):
+    ) as name:
+        for i in range(1, 11):
+            dynamodb_client.put_item(
+                TableName=name,
+                Item={
+                    "pk": {"S": "user-1"},
+                    "sk": {"N": str(i)},
+                    "name": {"S": f"item-{i}"},
+                    "age": {"N": str(20 + i)},
+                },
+            )
+        yield name
+@pytest.fixture(scope="class")
+def string_sk_table(dynamodb_client):
     """Create a hash+range (S,S) table with items for begins_with tests."""
-    name = f"extenddb-test-{uuid.uuid4().hex[:12]}"
-    create_and_cleanup_table(
-        name,
-        AttributeDefinitions=[
+    with scoped_table(
+        dynamodb_client,
+        attribute_definitions=[
             {"AttributeName": "pk", "AttributeType": "S"},
             {"AttributeName": "sk", "AttributeType": "S"},
         ],
-        KeySchema=[
+        key_schema=[
             {"AttributeName": "pk", "KeyType": "HASH"},
             {"AttributeName": "sk", "KeyType": "RANGE"},
         ],
-    )
-    wait_for_active(dynamodb_client, name)
-    items = ["alpha-1", "alpha-2", "beta-1", "gamma-1"]
-    for prefix in items:
-        dynamodb_client.put_item(
+    ) as name:
+        items = ["alpha-1", "alpha-2", "beta-1", "gamma-1"]
+        for prefix in items:
+            dynamodb_client.put_item(
+                TableName=name,
+                Item={"pk": {"S": "user-1"}, "sk": {"S": prefix}, "data": {"S": "v"}},
+            )
+        # Verify all items are visible before yielding to tests.
+        resp = dynamodb_client.query(
             TableName=name,
-            Item={"pk": {"S": "user-1"}, "sk": {"S": prefix}, "data": {"S": "v"}},
+            KeyConditionExpression="pk = :pk",
+            ExpressionAttributeValues={":pk": {"S": "user-1"}},
+            ConsistentRead=True,
         )
-    # Verify all items are visible before yielding to tests.
-    resp = dynamodb_client.query(
-        TableName=name,
-        KeyConditionExpression="pk = :pk",
-        ExpressionAttributeValues={":pk": {"S": "user-1"}},
-        ConsistentRead=True,
-    )
-    assert resp["Count"] == len(items), (
-        f"string_sk_table fixture: expected {len(items)} items, got {resp['Count']}"
-    )
-    return name
-@pytest.fixture()
-def scan_table(dynamodb_client, create_and_cleanup_table):
+        assert resp["Count"] == len(items), (
+            f"string_sk_table fixture: expected {len(items)} items, got {resp['Count']}"
+        )
+        yield name
+@pytest.fixture(scope="class")
+def scan_table(dynamodb_client):
     """Create a hash-only table with 13 items for scan tests."""
-    name = f"extenddb-test-{uuid.uuid4().hex[:12]}"
-    create_and_cleanup_table(name)
-    wait_for_active(dynamodb_client, name)
-    for i in range(1, 14):
-        dynamodb_client.put_item(
-            TableName=name,
-            Item={
-                "pk": {"S": f"item-{i:03d}"},
-                "category": {"S": "a" if i <= 3 else "b"},
-            },
-        )
-    return name
+    with scoped_table(dynamodb_client) as name:
+        for i in range(1, 14):
+            dynamodb_client.put_item(
+                TableName=name,
+                Item={
+                    "pk": {"S": f"item-{i:03d}"},
+                    "category": {"S": "a" if i <= 3 else "b"},
+                },
+            )
+        yield name
 class TestQuery:
     """Query operation tests."""
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -100,6 +100,36 @@ def _drain_all_shards(
             if not resp.get("Records"):
                 break
     return all_records
+
+
+def _wait_for_stream_records(
+    streams_client, stream_arn: str, min_count: int,
+    prefix: str | None = None, timeout: float = 5.0,
+    iterator_type: str = "TRIM_HORIZON",
+    sequence_number: str | None = None,
+) -> list[dict]:
+    """Poll stream until at least min_count records are available.
+
+    If prefix is given, only count records whose pk starts with that prefix.
+    Returns all records found (not just the filtered ones).
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        records = _drain_all_shards(
+            streams_client, stream_arn, iterator_type,
+            sequence_number=sequence_number,
+        )
+        if prefix:
+            matching = [
+                r for r in records
+                if r["dynamodb"]["Keys"]["pk"]["S"].startswith(prefix)
+            ]
+        else:
+            matching = records
+        if len(matching) >= min_count:
+            return records
+        time.sleep(0.02)
+    return records
 class TestListStreams:
     """ListStreams operation tests."""
 
@@ -153,9 +183,8 @@ class TestIteratorAdvancement:
                 TableName=table_name,
                 Item={"pk": {"S": f"adv-{i}"}, "val": {"N": str(i)}},
             )
-        time.sleep(0.5)
 
-        # First pass: drain all records.
+        # First pass: drain all records, polling until we have them.
         desc = streams_client.describe_stream(StreamArn=stream_arn)
         shards = desc["StreamDescription"]["Shards"]
         shard_iters: dict[str, str | None] = {}
@@ -170,7 +199,8 @@ class TestIteratorAdvancement:
             shard_iters[shard["ShardId"]] = it["ShardIterator"]
 
         # Read until we get all records.
-        for _ in range(10):
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
             for sid in list(shard_iters):
                 it = shard_iters[sid]
                 if not it:
@@ -180,7 +210,7 @@ class TestIteratorAdvancement:
                 shard_iters[sid] = resp.get("NextShardIterator")
             if len(first_pass_records) >= n:
                 break
-            time.sleep(0.3)
+            time.sleep(0.02)
 
         assert len(first_pass_records) >= n
 
@@ -226,7 +256,7 @@ class TestIteratorAdvancement:
                 shard_iters[sid] = resp.get("NextShardIterator")
             if not any_records:
                 break
-            time.sleep(0.2)
+            time.sleep(0.02)
 
         # Empty poll — should return 0 records and a valid NextShardIterator.
         for sid, it in shard_iters.items():
@@ -242,15 +272,20 @@ class TestIteratorAdvancement:
             TableName=table_name,
             Item={"pk": {"S": "empty-poll-test"}, "data": {"S": "hello"}},
         )
-        time.sleep(0.5)
 
-        # Poll again — should get exactly the new record.
+        # Poll again until we get the new record.
         new_records: list[dict] = []
-        for sid, it in shard_iters.items():
-            if not it:
-                continue
-            resp = streams_client.get_records(ShardIterator=it, Limit=100)
-            new_records.extend(resp.get("Records", []))
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            for sid, it in shard_iters.items():
+                if not it:
+                    continue
+                resp = streams_client.get_records(ShardIterator=it, Limit=100)
+                new_records.extend(resp.get("Records", []))
+                shard_iters[sid] = resp.get("NextShardIterator")
+            if new_records:
+                break
+            time.sleep(0.02)
 
         assert len(new_records) == 1
         assert new_records[0]["dynamodb"]["Keys"]["pk"]["S"] == "empty-poll-test"
@@ -269,9 +304,10 @@ class TestExactlyOnceDelivery:
                 TableName=table_name,
                 Item={"pk": {"S": pk}, "seq": {"N": str(i)}},
             )
-        time.sleep(1)
 
-        records = _drain_all_shards(streams_client, stream_arn)
+        records = _wait_for_stream_records(
+            streams_client, stream_arn, min_count=n, prefix="exact-"
+        )
         # Filter to only our records (table may have records from other tests).
         our_records = [
             r for r in records
@@ -302,7 +338,11 @@ class TestExactlyOnceDelivery:
                 TableName=table_name,
                 Item={"pk": {"S": pk}, "seq": {"N": str(i)}},
             )
-        time.sleep(1)
+
+        # Wait for records to be available before doing incremental polling.
+        _wait_for_stream_records(
+            streams_client, stream_arn, min_count=n, prefix="incr-"
+        )
 
         desc = streams_client.describe_stream(StreamArn=stream_arn)
         shards = desc["StreamDescription"]["Shards"]
@@ -355,7 +395,11 @@ class TestInOrderDelivery:
                 TableName=table_name,
                 Item={"pk": {"S": f"order-{i}"}, "val": {"N": str(i)}},
             )
-        time.sleep(0.5)
+
+        # Wait for records to be available.
+        _wait_for_stream_records(
+            streams_client, stream_arn, min_count=5, prefix="order-"
+        )
 
         desc = streams_client.describe_stream(StreamArn=stream_arn)
         for shard in desc["StreamDescription"]["Shards"]:
@@ -392,8 +436,9 @@ class TestIteratorTypes:
             TableName=table_name,
             Item={"pk": {"S": "horizon-1"}, "v": {"S": "a"}},
         )
-        time.sleep(0.5)
-        records = _drain_all_shards(streams_client, stream_arn, "TRIM_HORIZON")
+        records = _wait_for_stream_records(
+            streams_client, stream_arn, min_count=1, prefix="horizon-"
+        )
         pks = [r["dynamodb"]["Keys"]["pk"]["S"] for r in records]
         assert "horizon-1" in pks
 
@@ -406,7 +451,10 @@ class TestIteratorTypes:
             TableName=table_name,
             Item={"pk": {"S": "latest-before"}, "v": {"S": "old"}},
         )
-        time.sleep(0.5)
+        # Wait for it to appear in the stream.
+        _wait_for_stream_records(
+            streams_client, stream_arn, min_count=1, prefix="latest-before"
+        )
 
         # Get LATEST iterators.
         desc = streams_client.describe_stream(StreamArn=stream_arn)
@@ -424,13 +472,19 @@ class TestIteratorTypes:
             TableName=table_name,
             Item={"pk": {"S": "latest-after"}, "v": {"S": "new"}},
         )
-        time.sleep(0.5)
 
-        # Read with LATEST iterators — should see "after" but not "before".
+        # Poll with LATEST iterators until we see the "after" item.
         records: list[dict] = []
-        for sid, it in shard_iters.items():
-            resp = streams_client.get_records(ShardIterator=it, Limit=100)
-            records.extend(resp.get("Records", []))
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            for sid, it in shard_iters.items():
+                resp = streams_client.get_records(ShardIterator=it, Limit=100)
+                records.extend(resp.get("Records", []))
+                shard_iters[sid] = resp.get("NextShardIterator", it)
+            pks = [r["dynamodb"]["Keys"]["pk"]["S"] for r in records]
+            if "latest-after" in pks:
+                break
+            time.sleep(0.02)
 
         pks = [r["dynamodb"]["Keys"]["pk"]["S"] for r in records]
         assert "latest-after" in pks
@@ -443,10 +497,11 @@ class TestIteratorTypes:
             TableName=table_name,
             Item={"pk": {"S": "at-seq-test"}, "v": {"S": "x"}},
         )
-        time.sleep(0.5)
 
-        # Find the record's sequence number.
-        records = _drain_all_shards(streams_client, stream_arn, "TRIM_HORIZON")
+        # Wait for the record to appear, then find its sequence number.
+        records = _wait_for_stream_records(
+            streams_client, stream_arn, min_count=1, prefix="at-seq-test"
+        )
         target = [
             r for r in records
             if r["dynamodb"]["Keys"]["pk"]["S"] == "at-seq-test"
@@ -484,12 +539,18 @@ class TestIteratorTypes:
             TableName=table_name,
             Item={"pk": {"S": "after-seq-1"}, "v": {"S": "first"}},
         )
-        time.sleep(0.3)
+        # Wait for first to appear before writing second.
+        _wait_for_stream_records(
+            streams_client, stream_arn, min_count=1, prefix="after-seq-1"
+        )
         dynamodb_client.put_item(
             TableName=table_name,
             Item={"pk": {"S": "after-seq-2"}, "v": {"S": "second"}},
         )
-        time.sleep(0.5)
+        # Wait for both to appear.
+        _wait_for_stream_records(
+            streams_client, stream_arn, min_count=1, prefix="after-seq-2"
+        )
 
         # Get all records to find the first item's sequence number.
         all_records = _drain_all_shards(streams_client, stream_arn, "TRIM_HORIZON")
@@ -534,13 +595,19 @@ class TestMixedWorkload:
             TableName=table_name,
             Key={"pk": {"S": pk}},
         )
-        time.sleep(1)
 
-        records = _drain_all_shards(streams_client, stream_arn, "TRIM_HORIZON")
-        our_records = [
-            r for r in records
-            if r["dynamodb"]["Keys"]["pk"]["S"] == pk
-        ]
+        # Poll until we have all 3 events for this pk.
+        deadline = time.monotonic() + 5.0
+        our_records: list[dict] = []
+        while time.monotonic() < deadline:
+            records = _drain_all_shards(streams_client, stream_arn, "TRIM_HORIZON")
+            our_records = [
+                r for r in records
+                if r["dynamodb"]["Keys"]["pk"]["S"] == pk
+            ]
+            if len(our_records) >= 3:
+                break
+            time.sleep(0.02)
 
         events = [r["eventName"] for r in our_records]
         assert events == ["INSERT", "MODIFY", "REMOVE"], (

--- a/tests/test_transaction_operations.py
+++ b/tests/test_transaction_operations.py
@@ -11,13 +11,12 @@ from __future__ import annotations
 import pytest
 from botocore.exceptions import ClientError
 
-from conftest import wait_for_active
-@pytest.fixture()
-def hash_table(dynamodb_client, create_and_cleanup_table, unique_table_name):
-    """Create a hash-only table and wait for ACTIVE."""
-    create_and_cleanup_table(unique_table_name)
-    wait_for_active(dynamodb_client, unique_table_name)
-    return unique_table_name
+from conftest import wait_for_active, scoped_table
+@pytest.fixture(scope="module")
+def hash_table(dynamodb_client):
+    """Create a hash-only table for the module, delete on teardown."""
+    with scoped_table(dynamodb_client) as name:
+        yield name
 # ---------------------------------------------------------------------------
 # TransactWriteItems — happy paths
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- **perf(test): Add pytest-xdist for parallel test execution**
- **perf(test): Reduce wait_for_active/wait_for_deleted polling interval**
- **perf(test): Promote table fixtures to class/module scope**

## What

Speeds up some tests by polling more frequently and adopting pytest-xdist.

## Why

Slow tests are annoying and slow down development.

## Testing done

`devtools/run-tests --extenddb --pytest --parallel`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have updated documentation if behavior changed
- [none] Breaking changes are noted below (if any)

These do not apply because there are no Rust changes:
- [ ] All tests pass (`cargo test --workspace`)
- [ ] Code is formatted (`cargo fmt --check`)
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)

This does not apply because I'm changing the way the tests run (and nothing else):
- [ ] I have added or updated tests for new functionality

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
