### PR TITLE
fix: reject SET into path with missing parent attribute

### DIFF
--- a/crates/core/src/expression/update_evaluator.rs
+++ b/crates/core/src/expression/update_evaluator.rs
@@ -411,10 +411,12 @@ fn set_path(
         return Ok(());
     }
 
-    // Navigate to the parent, then set the final element
-    let current = item
-        .entry(first_name)
-        .or_insert_with(|| AttributeValue::M(BTreeMap::new()));
+    // DynamoDB rejects SET into a path where the parent doesn't exist
+    let Some(current) = item.get_mut(&first_name) else {
+        return Err(DynamoDbError::ValidationException(
+            "The document path provided in the update expression is invalid for update".to_owned(),
+        ));
+    };
 
     set_nested(current, &path[1..], value, maps)
 }
@@ -510,10 +512,9 @@ fn remove_nested(
                 let name = resolve_attr_name(&path[0], maps)?;
                 map.remove(&name);
             }
-            (PathElement::Index(idx), AttributeValue::L(list))
-                if *idx < list.len() => {
-                    list.remove(*idx);
-                }
+            (PathElement::Index(idx), AttributeValue::L(list)) if *idx < list.len() => {
+                list.remove(*idx);
+            }
             _ => {} // No-op for type mismatch
         }
         return Ok(());
@@ -526,10 +527,9 @@ fn remove_nested(
                 remove_nested(next, &path[1..], maps)?;
             }
         }
-        (PathElement::Index(idx), AttributeValue::L(list))
-            if *idx < list.len() => {
-                remove_nested(&mut list[*idx], &path[1..], maps)?;
-            }
+        (PathElement::Index(idx), AttributeValue::L(list)) if *idx < list.len() => {
+            remove_nested(&mut list[*idx], &path[1..], maps)?;
+        }
         _ => {} // No-op
     }
     Ok(())


### PR DESCRIPTION
## What

Rejects `SET absent_parent.child = :v` when the parent attribute doesn't exist on the item, instead of creating it as an empty map.

## Why

Closes #78

DynamoDB returns `ValidationException: The document path provided in the update expression is invalid for update` when a SET path references a parent attribute that doesn't exist. ExtendDB was creating the parent map implicitly.

## Testing done

- Verified against real DynamoDB: absent parent rejects, existing parent succeeds
- Verified ExtendDB matches after fix
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [ ] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.