### PR TITLE
fix: validate ExpressionAttributeNames/Values key syntax

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod error;
 pub mod expression;
 pub mod limits;
 pub mod metrics;
+pub mod serde_helpers;
 pub mod throttle;
 pub mod types;
 pub mod validation;

--- a/crates/core/src/serde_helpers.rs
+++ b/crates/core/src/serde_helpers.rs
@@ -1,0 +1,204 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Custom serde deserializers for DynamoDB input validation.
+
+use std::collections::HashMap;
+use std::fmt;
+
+use serde::de::{self, Deserializer, MapAccess, Visitor};
+
+use crate::types::AttributeValue;
+
+/// Deserialize `ExpressionAttributeNames` with key prefix validation.
+/// Keys must start with `#` and the map must not be empty.
+pub fn deserialize_expression_names<'de, D>(
+    deserializer: D,
+) -> Result<Option<HashMap<String, String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct NamesVisitor;
+
+    impl<'de> Visitor<'de> for NamesVisitor {
+        type Value = Option<HashMap<String, String>>;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("a map of expression attribute names")
+        }
+
+        fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_some<D: Deserializer<'de>>(self, d: D) -> Result<Self::Value, D::Error> {
+            let map: HashMap<String, String> = de::Deserialize::deserialize(d)?;
+            if map.is_empty() {
+                return Err(de::Error::custom(
+                    "ExpressionAttributeNames must not be empty",
+                ));
+            }
+            for key in map.keys() {
+                if !key.starts_with('#') {
+                    return Err(de::Error::custom(format!(
+                        "ExpressionAttributeNames contains invalid key: Syntax error; key: \"{key}\""
+                    )));
+                }
+            }
+            Ok(Some(map))
+        }
+
+        fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
+            let m: HashMap<String, String> =
+                de::Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))?;
+            if m.is_empty() {
+                return Err(de::Error::custom(
+                    "ExpressionAttributeNames must not be empty",
+                ));
+            }
+            for key in m.keys() {
+                if !key.starts_with('#') {
+                    return Err(de::Error::custom(format!(
+                        "ExpressionAttributeNames contains invalid key: Syntax error; key: \"{key}\""
+                    )));
+                }
+            }
+            Ok(Some(m))
+        }
+    }
+
+    deserializer.deserialize_option(NamesVisitor)
+}
+
+/// Deserialize `ExpressionAttributeValues` with key prefix validation.
+/// Keys must start with `:` and the map must not be empty.
+pub fn deserialize_expression_values<'de, D>(
+    deserializer: D,
+) -> Result<Option<HashMap<String, AttributeValue>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct ValuesVisitor;
+
+    impl<'de> Visitor<'de> for ValuesVisitor {
+        type Value = Option<HashMap<String, AttributeValue>>;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("a map of expression attribute values")
+        }
+
+        fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_some<D: Deserializer<'de>>(self, d: D) -> Result<Self::Value, D::Error> {
+            let map: HashMap<String, AttributeValue> = de::Deserialize::deserialize(d)?;
+            if map.is_empty() {
+                return Err(de::Error::custom(
+                    "ExpressionAttributeValues must not be empty",
+                ));
+            }
+            for key in map.keys() {
+                if !key.starts_with(':') {
+                    return Err(de::Error::custom(format!(
+                        "ExpressionAttributeValues contains invalid key: Syntax error; key: \"{key}\""
+                    )));
+                }
+            }
+            Ok(Some(map))
+        }
+
+        fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
+            let m: HashMap<String, AttributeValue> =
+                de::Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))?;
+            if m.is_empty() {
+                return Err(de::Error::custom(
+                    "ExpressionAttributeValues must not be empty",
+                ));
+            }
+            for key in m.keys() {
+                if !key.starts_with(':') {
+                    return Err(de::Error::custom(format!(
+                        "ExpressionAttributeValues contains invalid key: Syntax error; key: \"{key}\""
+                    )));
+                }
+            }
+            Ok(Some(m))
+        }
+    }
+
+    deserializer.deserialize_option(ValuesVisitor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use std::collections::HashMap;
+
+    #[derive(Debug, Deserialize)]
+    struct TestNames {
+        #[serde(default, deserialize_with = "deserialize_expression_names")]
+        names: Option<HashMap<String, String>>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct TestValues {
+        #[serde(default, deserialize_with = "deserialize_expression_values")]
+        values: Option<HashMap<String, AttributeValue>>,
+    }
+
+    #[test]
+    fn names_missing_hash_rejected() {
+        let json = r#"{"names":{"a":"real"}}"#;
+        let result: Result<TestNames, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Syntax error; key")
+        );
+    }
+
+    #[test]
+    fn names_with_hash_accepted() {
+        let json = "{\"names\":{\"#a\":\"real\"}}";
+        let result: Result<TestNames, _> = serde_json::from_str(json);
+        assert!(result.is_ok());
+        assert!(result.unwrap().names.unwrap().contains_key("#a"));
+    }
+
+    #[test]
+    fn names_empty_rejected() {
+        let json = r#"{"names":{}}"#;
+        let result: Result<TestNames, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("must not be empty")
+        );
+    }
+
+    #[test]
+    fn values_missing_colon_rejected() {
+        let json = r#"{"values":{"v":{"S":"x"}}}"#;
+        let result: Result<TestValues, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Syntax error; key")
+        );
+    }
+
+    #[test]
+    fn values_with_colon_accepted() {
+        let json = r#"{"values":{":v":{"S":"x"}}}"#;
+        let result: Result<TestValues, _> = serde_json::from_str(json);
+        assert!(result.is_ok());
+    }
+}

--- a/crates/core/src/types/batch.rs
+++ b/crates/core/src/types/batch.rs
@@ -21,7 +21,11 @@ pub struct KeysAndAttributes {
     pub consistent_read: Option<bool>,
     #[serde(rename = "ProjectionExpression")]
     pub projection_expression: Option<String>,
-    #[serde(rename = "ExpressionAttributeNames")]
+    #[serde(
+        rename = "ExpressionAttributeNames",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_names"
+    )]
     pub expression_attribute_names: Option<HashMap<String, String>>,
     /// Legacy projection API. Superseded by `ProjectionExpression`.
     /// Cannot be used together with `ProjectionExpression`.

--- a/crates/core/src/types/item.rs
+++ b/crates/core/src/types/item.rs
@@ -121,9 +121,17 @@ pub struct PutItemInput {
     pub return_values: ReturnValues,
     #[serde(rename = "ConditionExpression")]
     pub condition_expression: Option<String>,
-    #[serde(rename = "ExpressionAttributeNames")]
+    #[serde(
+        rename = "ExpressionAttributeNames",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_names"
+    )]
     pub expression_attribute_names: Option<HashMap<String, String>>,
-    #[serde(rename = "ExpressionAttributeValues")]
+    #[serde(
+        rename = "ExpressionAttributeValues",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_values"
+    )]
     pub expression_attribute_values: Option<HashMap<String, super::AttributeValue>>,
     #[serde(rename = "Expected")]
     pub expected: Option<HashMap<String, ExpectedAttributeValue>>,
@@ -171,7 +179,11 @@ pub struct GetItemInput {
     pub consistent_read: Option<bool>,
     #[serde(rename = "ProjectionExpression")]
     pub projection_expression: Option<String>,
-    #[serde(rename = "ExpressionAttributeNames")]
+    #[serde(
+        rename = "ExpressionAttributeNames",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_names"
+    )]
     pub expression_attribute_names: Option<HashMap<String, String>>,
     /// Legacy `AttributesToGet` — desugared to `ProjectionExpression`.
     #[serde(rename = "AttributesToGet")]
@@ -204,9 +216,17 @@ pub struct DeleteItemInput {
     pub return_values: ReturnValues,
     #[serde(rename = "ConditionExpression")]
     pub condition_expression: Option<String>,
-    #[serde(rename = "ExpressionAttributeNames")]
+    #[serde(
+        rename = "ExpressionAttributeNames",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_names"
+    )]
     pub expression_attribute_names: Option<HashMap<String, String>>,
-    #[serde(rename = "ExpressionAttributeValues")]
+    #[serde(
+        rename = "ExpressionAttributeValues",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_values"
+    )]
     pub expression_attribute_values: Option<HashMap<String, super::AttributeValue>>,
     #[serde(rename = "Expected")]
     pub expected: Option<HashMap<String, ExpectedAttributeValue>>,
@@ -253,9 +273,17 @@ pub struct UpdateItemInput {
     pub update_expression: Option<String>,
     #[serde(rename = "ConditionExpression")]
     pub condition_expression: Option<String>,
-    #[serde(rename = "ExpressionAttributeNames")]
+    #[serde(
+        rename = "ExpressionAttributeNames",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_names"
+    )]
     pub expression_attribute_names: Option<HashMap<String, String>>,
-    #[serde(rename = "ExpressionAttributeValues")]
+    #[serde(
+        rename = "ExpressionAttributeValues",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_values"
+    )]
     pub expression_attribute_values: Option<HashMap<String, super::AttributeValue>>,
     #[serde(rename = "ReturnValues", default)]
     pub return_values: ReturnValues,

--- a/crates/core/src/types/query.rs
+++ b/crates/core/src/types/query.rs
@@ -60,9 +60,17 @@ pub struct QueryInput {
     pub filter_expression: Option<String>,
     #[serde(rename = "ProjectionExpression")]
     pub projection_expression: Option<String>,
-    #[serde(rename = "ExpressionAttributeNames")]
+    #[serde(
+        rename = "ExpressionAttributeNames",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_names"
+    )]
     pub expression_attribute_names: Option<HashMap<String, String>>,
-    #[serde(rename = "ExpressionAttributeValues")]
+    #[serde(
+        rename = "ExpressionAttributeValues",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_values"
+    )]
     pub expression_attribute_values: Option<HashMap<String, AttributeValue>>,
     #[serde(rename = "ScanIndexForward", default = "default_true")]
     pub scan_index_forward: bool,
@@ -122,9 +130,17 @@ pub struct ScanInput {
     pub filter_expression: Option<String>,
     #[serde(rename = "ProjectionExpression")]
     pub projection_expression: Option<String>,
-    #[serde(rename = "ExpressionAttributeNames")]
+    #[serde(
+        rename = "ExpressionAttributeNames",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_names"
+    )]
     pub expression_attribute_names: Option<HashMap<String, String>>,
-    #[serde(rename = "ExpressionAttributeValues")]
+    #[serde(
+        rename = "ExpressionAttributeValues",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_values"
+    )]
     pub expression_attribute_values: Option<HashMap<String, AttributeValue>>,
     #[serde(rename = "Limit")]
     pub limit: Option<i64>,

--- a/crates/core/src/types/transaction.rs
+++ b/crates/core/src/types/transaction.rs
@@ -46,7 +46,11 @@ pub struct TransactGet {
     pub table_name: String,
     #[serde(rename = "ProjectionExpression")]
     pub projection_expression: Option<String>,
-    #[serde(rename = "ExpressionAttributeNames")]
+    #[serde(
+        rename = "ExpressionAttributeNames",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_names"
+    )]
     pub expression_attribute_names: Option<HashMap<String, String>>,
 }
 
@@ -123,10 +127,18 @@ pub struct TransactConditionCheck {
     #[serde(rename = "ConditionExpression")]
     pub condition_expression: String,
     /// Attribute name substitutions.
-    #[serde(rename = "ExpressionAttributeNames")]
+    #[serde(
+        rename = "ExpressionAttributeNames",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_names"
+    )]
     pub expression_attribute_names: Option<HashMap<String, String>>,
     /// Attribute value substitutions.
-    #[serde(rename = "ExpressionAttributeValues")]
+    #[serde(
+        rename = "ExpressionAttributeValues",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_values"
+    )]
     pub expression_attribute_values: Option<HashMap<String, AttributeValue>>,
     /// Controls whether the existing item is returned in the cancellation reason.
     #[serde(rename = "ReturnValuesOnConditionCheckFailure", default)]
@@ -147,10 +159,18 @@ pub struct TransactPut {
     #[serde(rename = "ConditionExpression")]
     pub condition_expression: Option<String>,
     /// Attribute name substitutions.
-    #[serde(rename = "ExpressionAttributeNames")]
+    #[serde(
+        rename = "ExpressionAttributeNames",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_names"
+    )]
     pub expression_attribute_names: Option<HashMap<String, String>>,
     /// Attribute value substitutions.
-    #[serde(rename = "ExpressionAttributeValues")]
+    #[serde(
+        rename = "ExpressionAttributeValues",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_values"
+    )]
     pub expression_attribute_values: Option<HashMap<String, AttributeValue>>,
     /// Controls whether the existing item is returned in the cancellation reason.
     #[serde(rename = "ReturnValuesOnConditionCheckFailure", default)]
@@ -171,10 +191,18 @@ pub struct TransactDelete {
     #[serde(rename = "ConditionExpression")]
     pub condition_expression: Option<String>,
     /// Attribute name substitutions.
-    #[serde(rename = "ExpressionAttributeNames")]
+    #[serde(
+        rename = "ExpressionAttributeNames",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_names"
+    )]
     pub expression_attribute_names: Option<HashMap<String, String>>,
     /// Attribute value substitutions.
-    #[serde(rename = "ExpressionAttributeValues")]
+    #[serde(
+        rename = "ExpressionAttributeValues",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_values"
+    )]
     pub expression_attribute_values: Option<HashMap<String, AttributeValue>>,
     /// Controls whether the existing item is returned in the cancellation reason.
     #[serde(rename = "ReturnValuesOnConditionCheckFailure", default)]
@@ -198,10 +226,18 @@ pub struct TransactUpdate {
     #[serde(rename = "ConditionExpression")]
     pub condition_expression: Option<String>,
     /// Attribute name substitutions.
-    #[serde(rename = "ExpressionAttributeNames")]
+    #[serde(
+        rename = "ExpressionAttributeNames",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_names"
+    )]
     pub expression_attribute_names: Option<HashMap<String, String>>,
     /// Attribute value substitutions.
-    #[serde(rename = "ExpressionAttributeValues")]
+    #[serde(
+        rename = "ExpressionAttributeValues",
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_expression_values"
+    )]
     pub expression_attribute_values: Option<HashMap<String, AttributeValue>>,
     /// Controls whether the existing item is returned in the cancellation reason.
     #[serde(rename = "ReturnValuesOnConditionCheckFailure", default)]

--- a/crates/engine/src/create_table.rs
+++ b/crates/engine/src/create_table.rs
@@ -26,6 +26,8 @@ pub async fn handle_create_table(
         let msg = e.to_string();
         if msg.contains("validation error detected")
             || msg.contains("parameter values were invalid")
+            || msg.contains("must not be empty")
+            || msg.contains("Syntax error; key")
         {
             DynamoDbError::ValidationException(msg)
         } else if msg.contains("missing field") && msg.contains("TableName") {

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -151,6 +151,9 @@ pub(crate) fn deserialize_error(e: serde_json::Error) -> DynamoDbError {
     if msg.contains("validation error detected")
         || msg.contains("may not be empty")
         || msg.contains("contains duplicates")
+        || msg.contains("must not be empty")
+        || msg.contains("contains invalid key")
+        || msg.contains("Syntax error; key")
     {
         DynamoDbError::ValidationException(msg)
     } else {

--- a/crates/engine/src/put_item.rs
+++ b/crates/engine/src/put_item.rs
@@ -66,6 +66,8 @@ pub async fn handle_put_item(
             || msg.contains("contains duplicates")
             || msg.contains("Null attribute value")
             || msg.contains("validation error detected")
+            || msg.contains("must not be empty")
+            || msg.contains("Syntax error; key")
         {
             DynamoDbError::ValidationException(msg)
         } else {


### PR DESCRIPTION
## What
  
Validates `ExpressionAttributeNames` and `ExpressionAttributeValues` key syntax at deserialization time. Names keys must start with `#`, values keys must start with `:`, and neither map can be empty if specified.

## Why

Closes #79

ExtendDB was accepting invalid keys (missing `#` or `:` prefix) and either silently ignoring them or producing misleading errors like `ConditionalCheckFailed` instead of `ValidationException`.

## Testing done

- Verified all three cases against real DynamoDB (names no `#`, values no `:`, empty names)
- Verified ExtendDB returns identical `ValidationException` messages after fix
- `cargo test --workspace` passes (5 new unit tests for the deserializers)
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.