### PR TITLE
fix: Reject empty string/binary values in key positions

### DIFF
--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -631,6 +631,7 @@ pub fn validate_key_only(
             ))
         })?;
         validate_key_attribute_type(&ks.attribute_name, value, attr_defs)?;
+        validate_no_empty_key_value(&ks.attribute_name, value)?;
     }
     Ok(())
 }
@@ -718,6 +719,34 @@ fn validate_key_attribute_type(
     Ok(())
 }
 
+/// Validate that a key attribute value is not empty.
+///
+/// `DynamoDB` rejects empty-string and empty-binary values in key positions,
+/// returning a `ValidationException` with a type-specific error message.
+///
+/// # Errors
+///
+/// Returns `DynamoDbError::ValidationException` if `value` is an empty string
+/// (`S("")`) or empty binary (`B(<empty>)`).
+fn validate_no_empty_key_value(
+    attr_name: &str,
+    value: &AttributeValue,
+) -> Result<(), DynamoDbError> {
+    let kind = match value {
+        AttributeValue::S(s) if s.is_empty() => Some("string"),
+        AttributeValue::B(b) if b.is_empty() => Some("binary"),
+        _ => None,
+    };
+    if let Some(kind) = kind {
+        return Err(DynamoDbError::ValidationException(format!(
+            "One or more parameter values are not valid. \
+             The AttributeValue for a key attribute cannot contain an empty {kind} value. \
+             Key: {attr_name}"
+        )));
+    }
+    Ok(())
+}
+
 /// Validate partition key and sort key sizes against limits.
 ///
 /// # Errors
@@ -730,12 +759,7 @@ pub fn validate_key_sizes(
 ) -> Result<(), DynamoDbError> {
     for ks in key_schema {
         if let Some(value) = item.get(&ks.attribute_name) {
-            if matches!(value, AttributeValue::S(s) if s.is_empty()) {
-                return Err(DynamoDbError::ValidationException(format!(
-                    "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: {}",
-                    ks.attribute_name
-                )));
-            }
+            validate_no_empty_key_value(&ks.attribute_name, value)?;
             let size = key_value_byte_size(value);
             let (max_size, key_label) = match ks.key_type {
                 KeyType::Hash => (limits.max_partition_key_size_bytes, "partition key"),
@@ -1090,6 +1114,80 @@ mod tests {
         assert!(
             err.to_string().contains("Size of attribute name"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_key_sizes_rejects_empty_binary_partition_key() {
+        let limits = LimitsConfig::default();
+        let mut item = Item::new();
+        item.insert("pk".to_owned(), AttributeValue::B(Vec::new()));
+        let err = validate_key_sizes(&item, &[make_ks("pk", KeyType::Hash)], &limits).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("empty binary value"), "got: {msg}");
+        assert!(msg.contains("Key: pk"), "got: {msg}");
+    }
+
+    #[test]
+    fn validate_key_sizes_still_rejects_empty_string_partition_key() {
+        let limits = LimitsConfig::default();
+        let mut item = Item::new();
+        item.insert("pk".to_owned(), AttributeValue::S(String::new()));
+        let err = validate_key_sizes(&item, &[make_ks("pk", KeyType::Hash)], &limits).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("empty string value"), "got: {msg}");
+        assert!(msg.contains("Key: pk"), "got: {msg}");
+    }
+
+    #[test]
+    fn validate_key_sizes_accepts_non_empty_binary_partition_key() {
+        let limits = LimitsConfig::default();
+        let mut item = Item::new();
+        item.insert("pk".to_owned(), AttributeValue::B(vec![0x00]));
+        assert!(validate_key_sizes(&item, &[make_ks("pk", KeyType::Hash)], &limits).is_ok());
+    }
+
+    #[test]
+    fn validate_key_only_rejects_empty_binary_key() {
+        let mut key = Item::new();
+        key.insert("pk".to_owned(), AttributeValue::B(Vec::new()));
+        let err = validate_key_only(
+            &key,
+            &[make_ks("pk", KeyType::Hash)],
+            &[make_ad("pk", ScalarAttributeType::B)],
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("empty binary value"), "got: {msg}");
+        assert!(msg.contains("Key: pk"), "got: {msg}");
+    }
+
+    #[test]
+    fn validate_key_only_rejects_empty_string_key() {
+        let mut key = Item::new();
+        key.insert("pk".to_owned(), AttributeValue::S(String::new()));
+        let err = validate_key_only(
+            &key,
+            &[make_ks("pk", KeyType::Hash)],
+            &[make_ad("pk", ScalarAttributeType::S)],
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("empty string value"), "got: {msg}");
+        assert!(msg.contains("Key: pk"), "got: {msg}");
+    }
+
+    #[test]
+    fn validate_key_only_accepts_non_empty_binary_key() {
+        let mut key = Item::new();
+        key.insert("pk".to_owned(), AttributeValue::B(vec![0xff]));
+        assert!(
+            validate_key_only(
+                &key,
+                &[make_ks("pk", KeyType::Hash)],
+                &[make_ad("pk", ScalarAttributeType::B)],
+            )
+            .is_ok()
         );
     }
 }

--- a/tests/python/test_items.py
+++ b/tests/python/test_items.py
@@ -210,6 +210,17 @@ class TestPutItem:
             )
         assert exc_info.value.response["Error"]["Code"] == "ValidationException"
 
+    def test_put_item_rejects_empty_binary_key(self, table_factory, dynamodb_client):
+        """PutItem rejects empty binary values in key positions"""
+
+        name = table_factory(hash_type="B")
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.put_item(TableName=name, Item={"pk": {"B": b""}})
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException", err
+        assert "empty binary value" in err["Message"], err["Message"]
+        assert "Key: pk" in err["Message"], err["Message"]
+
 
 class TestGetItem:
     """GetItem API tests."""

--- a/tests/test_batch_operations.py
+++ b/tests/test_batch_operations.py
@@ -375,6 +375,89 @@ class TestBatchWriteItem:
                 }
             )
         assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_batch_write_rejects_empty_key_values(
+        self, dynamodb_client, create_and_cleanup_table
+    ):
+        """BatchWriteItem rejects empty key attribute values for both binary
+        and string types in both PutRequest and DeleteRequest"""
+
+        # Set up a binary-keyed table and a string-keyed table.
+        binary_table = f"extenddb-test-{uuid.uuid4().hex[:12]}"
+        create_and_cleanup_table(
+            binary_table,
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "B"}],
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        )
+        wait_for_active(dynamodb_client, binary_table)
+
+        string_table = f"extenddb-test-{uuid.uuid4().hex[:12]}"
+        create_and_cleanup_table(
+            string_table,
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        )
+        wait_for_active(dynamodb_client, string_table)
+
+        # Empty binary in PutRequest — exercises validate_key_sizes.
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.batch_write_item(
+                RequestItems={
+                    binary_table: [
+                        {"PutRequest": {"Item": {"pk": {"B": b""}}}},
+                    ]
+                }
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException", err
+        assert "empty binary value" in err["Message"], err["Message"]
+        assert "Key: pk" in err["Message"], err["Message"]
+
+        # Empty binary in DeleteRequest — exercises validate_key_only via
+        # the validate_batch_key_only wrapper.
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.batch_write_item(
+                RequestItems={
+                    binary_table: [
+                        {"DeleteRequest": {"Key": {"pk": {"B": b""}}}},
+                    ]
+                }
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException", err
+        assert "empty binary value" in err["Message"], err["Message"]
+        assert "Key: pk" in err["Message"], err["Message"]
+
+        # Empty string in PutRequest — same validate_key_sizes path with the
+        # string-typed message variant.
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.batch_write_item(
+                RequestItems={
+                    string_table: [
+                        {"PutRequest": {"Item": {"pk": {"S": ""}}}},
+                    ]
+                }
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException", err
+        assert "empty string value" in err["Message"], err["Message"]
+        assert "Key: pk" in err["Message"], err["Message"]
+
+        # Empty string in DeleteRequest — exercises validate_key_only with the
+        # string-typed message variant. This is a NEW behavior the CR adds:
+        # validate_key_only previously had no empty-key check at all.
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.batch_write_item(
+                RequestItems={
+                    string_table: [
+                        {"DeleteRequest": {"Key": {"pk": {"S": ""}}}},
+                    ]
+                }
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException", err
+        assert "empty string value" in err["Message"], err["Message"]
+        assert "Key: pk" in err["Message"], err["Message"]
 # ── BatchGetItem key validation ───────────────────────────────────────
 class TestBatchGetItemKeyValidation:
     """Tests for BatchGetItem per-key validation (M2 fix)."""


### PR DESCRIPTION
## What

Expanded the empty key attribute value validation logic to cover empty binary keys, and centralized the check in a single helper to be used across all validation paths to close existing gaps

## Why

Closes #88

DynamoDB requires every key attribute value to be non-empty, returning ValidationException with type-specific messages. Empty string keys were already rejected in certain validation paths, but not in others like those used for DeleteItem/UpdateItem. Empty binary keys were also uncaught in all validation paths

## Testing done

- cargo test --workspace passes (with newly added unit tests)
- cargo clippy --all-targets -- -D warnings clean
- cargo fmt --all -- --check clean
- Manual verification that behavior and exception messaging matches real DynamoDB for empty string/binary key cases across all relevant APIs

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
