### PR TITLE
fix: reject duplicate values in NS and BS sets

### DIFF
--- a/crates/core/src/types/attribute_value.rs
+++ b/crates/core/src/types/attribute_value.rs
@@ -161,6 +161,13 @@ impl<'de> Visitor<'de> for AttributeValueVisitor {
                             .unwrap_or_else(|_| s.to_owned()))
                     })
                     .collect::<Result<_, _>>()?;
+                if set.len() != arr.len() {
+                    let values: Vec<&str> = arr.iter().filter_map(|v| v.as_str()).collect();
+                    let repr = values.join(", ");
+                    return Err(de::Error::custom(format!(
+                        "One or more parameter values were invalid: Input collection [{repr}] contains duplicates."
+                    )));
+                }
                 Ok(AttributeValue::NS(set))
             }
             "BS" => {
@@ -183,6 +190,13 @@ impl<'de> Visitor<'de> for AttributeValueVisitor {
                             .map_err(|e| de::Error::custom(format!("invalid base64: {e}")))
                     })
                     .collect::<Result<_, _>>()?;
+                if set.len() != arr.len() {
+                    let values: Vec<&str> = arr.iter().filter_map(|v| v.as_str()).collect();
+                    let repr = values.join(", ");
+                    return Err(de::Error::custom(format!(
+                        "One or more parameter values were invalid: Input collection [{repr}] contains duplicates."
+                    )));
+                }
                 Ok(AttributeValue::BS(set))
             }
             "BOOL" => {


### PR DESCRIPTION
## What
  
Rejects PutItem (and any write) with duplicate values in Number Sets (NS) and Binary Sets (BS) at deserialization time.

## Why

Closes #100

DynamoDB returns `ValidationException: Input collection [...] contains duplicates` for NS and BS with duplicate values. ExtendDB was silently deduplicating them via `BTreeSet`. String Sets (SS) already had this validation.

## Testing done

- Verified ExtendDB now rejects NS and BS duplicates with correct error message
- Verified valid sets (no duplicates) still succeed
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [ ] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.