### PR TITLE
fix: update item wcu

### DIFF
--- a/crates/engine/src/update_item.rs
+++ b/crates/engine/src/update_item.rs
@@ -152,10 +152,6 @@ pub async fn handle_update_item(
         input.return_values,
         ReturnValues::AllOld | ReturnValues::UpdatedOld
     );
-    let return_new = matches!(
-        input.return_values,
-        ReturnValues::AllNew | ReturnValues::UpdatedNew
-    );
 
     let view_type = stream_capture::stream_view_type(&key_info);
     let stream = view_type.map(|vt| extenddb_storage::StreamCapture {
@@ -164,7 +160,6 @@ pub async fn handle_update_item(
         region: ctx.region.clone(),
     });
     let need_old_for_stream = stream.is_some();
-    let need_new_for_stream = stream.is_some();
 
     let (old_item, new_item) = ctx
         .storage
@@ -173,7 +168,7 @@ pub async fn handle_update_item(
             &input.key,
             &actions,
             return_old || need_old_for_stream,
-            return_new || need_new_for_stream,
+            true, // always fetch new item for WCU calculation
             condition.as_ref(),
             &maps,
             stream.as_ref(),


### PR DESCRIPTION
## What
  
Always fetches the new item from storage in `update_item` so WCU is calculated from the actual item size, regardless of `ReturnValues`.

## Why

Closes #95

WCU was calculated from `new_item` which was only populated when `ReturnValues` included the new image. Without it, WCU always reported 1 regardless of actual item size.

## Testing done

- Verified against real DynamoDB: 4KB update reports 5 WCU with and without ReturnValues
- Verified ExtendDB matches (5.0 WCU no return, 9.0 WCU with return for 8KB item)
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [ ] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.