### PR TITLE
fix: reject arithmetic overflow in update expressions

### DIFF
--- a/crates/core/src/expression/update_evaluator.rs
+++ b/crates/core/src/expression/update_evaluator.rs
@@ -108,7 +108,15 @@ fn evaluate_arithmetic(
         ArithOp::Sub => ld - rd,
     };
 
-    Ok(AttributeValue::N(result.to_string()))
+    let result_str = result.to_string();
+    // Validate the result is within DynamoDB's number range
+    crate::validation::number::validate_and_normalize_number(&result_str).map_err(|_| {
+        DynamoDbError::ValidationException(
+            "Number overflow. Attempting to store a number with magnitude larger than supported range".to_owned(),
+        )
+    })?;
+
+    Ok(AttributeValue::N(result_str))
 }
 
 /// Evaluate SET functions: `if_not_exists(path, value)`.
@@ -198,7 +206,15 @@ fn apply_add(
             let ad: bigdecimal::BigDecimal = add_n.parse().map_err(|_| {
                 DynamoDbError::ValidationException("Invalid numeric value in expression".to_owned())
             })?;
-            AttributeValue::N((ed + ad).to_string())
+            let result_str = (ed + ad).to_string();
+            crate::validation::number::validate_and_normalize_number(&result_str).map_err(
+                |_| {
+                    DynamoDbError::ValidationException(
+                        "Number overflow. Attempting to store a number with magnitude larger than supported range".to_owned(),
+                    )
+                },
+            )?;
+            AttributeValue::N(result_str)
         }
         // Set: union with existing
         (Some(AttributeValue::SS(existing_set)), AttributeValue::SS(add_set)) => {


### PR DESCRIPTION
## What

Validates arithmetic results (SET `n = n + :v` and ADD) against DynamoDB's number range. Rejects with `ValidationException` when the result exceeds 9.99...E+125.

## Why

Closes #94

DynamoDB rejects arithmetic that produces numbers outside its supported range. ExtendDB was allowing overflow, producing numbers with hundreds of digits.

## Testing done

- Verified against real DynamoDB: overflow rejected, valid arithmetic works
- Verified ExtendDB matches after fix
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [ ] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.