### PR TITLE
fix: number size uses DynamoDB sizing (1 byte per 2 digits + 1)

### DIFF
--- a/crates/core/src/types/item.rs
+++ b/crates/core/src/types/item.rs
@@ -335,7 +335,7 @@ pub fn item_size_bytes(item: &Item) -> usize {
 pub fn attribute_value_size(value: &AttributeValue) -> usize {
     match value {
         AttributeValue::S(s) => s.len(),
-        AttributeValue::N(n) => n.len(),
+        AttributeValue::N(n) => dynamodb_number_size(n),
         AttributeValue::B(b) => b.len(),
         AttributeValue::Bool(_) | AttributeValue::Null => 1,
         AttributeValue::L(list) => 3 + list.iter().map(attribute_value_size).sum::<usize>(),
@@ -346,7 +346,41 @@ pub fn attribute_value_size(value: &AttributeValue) -> usize {
                 .sum::<usize>()
         }
         AttributeValue::SS(set) => set.iter().map(String::len).sum(),
-        AttributeValue::NS(set) => set.iter().map(String::len).sum(),
+        AttributeValue::NS(set) => set.iter().map(|n| dynamodb_number_size(n)).sum(),
         AttributeValue::BS(set) => set.iter().map(Vec::len).sum(),
     }
+}
+
+/// Calculate the DynamoDB size of a number in bytes.
+///
+/// DynamoDB number sizing: approximately 1 byte per 2 significant digits + 1 byte.
+/// Zero is 1 byte. Negative numbers add 1 byte. Max 21 bytes.
+fn dynamodb_number_size(n: &str) -> usize {
+    let s = n.trim_start_matches('-');
+    let is_zero = s.chars().all(|c| c == '0' || c == '.');
+    if is_zero {
+        return 1;
+    }
+
+    let significant = if let Some(dot_pos) = s.find('.') {
+        let (int_part, frac_part) = s.split_at(dot_pos);
+        let frac = &frac_part[1..];
+        let int_trimmed = int_part.trim_start_matches('0');
+        let frac_trimmed = frac.trim_end_matches('0');
+        if int_trimmed.is_empty() {
+            let frac_sig = frac.trim_start_matches('0');
+            frac_sig.trim_end_matches('0').len()
+        } else {
+            format!("{int_trimmed}{frac_trimmed}").len()
+        }
+    } else {
+        let trimmed = s.trim_start_matches('0').trim_end_matches('0');
+        if trimmed.is_empty() { 1 } else { trimmed.len() }
+    };
+
+    let mut size = significant.div_ceil(2) + 1;
+    if n.starts_with('-') {
+        size += 1;
+    }
+    size.min(21)
 }

--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -462,10 +462,9 @@ pub fn validate_put_item(
 
     let size = item_size_bytes(&input.item);
     if size > limits.max_item_size_bytes {
-        return Err(DynamoDbError::ValidationException(format!(
-            "Item size has exceeded the maximum allowed size of {}",
-            limits.max_item_size_bytes
-        )));
+        return Err(DynamoDbError::ValidationException(
+            "Item size has exceeded the maximum allowed size".to_owned(),
+        ));
     }
 
     validate_key_sizes(&input.item, key_schema, limits)?;
@@ -774,9 +773,9 @@ fn key_value_byte_size(value: &AttributeValue) -> usize {
 pub fn validate_item_size(item: &Item, max_bytes: usize) -> Result<(), DynamoDbError> {
     let size = item_size_bytes(item);
     if size > max_bytes {
-        return Err(DynamoDbError::ValidationException(format!(
-            "Item size has exceeded the maximum allowed size of {max_bytes}"
-        )));
+        return Err(DynamoDbError::ValidationException(
+            "Item size has exceeded the maximum allowed size".to_owned(),
+        ));
     }
     Ok(())
 }


### PR DESCRIPTION
## What

Fixes number size calculation to match DynamoDB's sizing: ~1 byte per 2 significant digits + 1 byte (max 21 bytes). Also fixes the item size error message to not include the specific byte limit.

## Why

Closes #90, Closes #91

ExtendDB was using string length for number sizing (38 bytes for a 38-digit number). DynamoDB uses ~20 bytes. This caused valid items with large number sets to be rejected as over the 400KB limit.

## Testing done

- Verified against real DynamoDB: 100x 38-digit numbers in NS reports 2 WCU (confirming ~20 bytes per number)
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [ ] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
