### PR TITLE
fix: accept both ParamValidationError and ClientError in name_too_sho…

### DIFF
--- a/tests/test_table_operations.py
+++ b/tests/test_table_operations.py
@@ -60,11 +60,9 @@ class TestCreateTable:
         assert exc_info.value.response["Error"]["Code"] == "ResourceInUseException"
 
     def test_create_table_name_too_short(self, dynamodb_client):
-        # botocore validates table name min length (3) client-side, raising
-        # ParamValidationError before the request reaches the server.
-        from botocore.exceptions import ParamValidationError
+        from botocore.exceptions import ClientError, ParamValidationError
 
-        with pytest.raises(ParamValidationError):
+        with pytest.raises((ParamValidationError, ClientError)):
             dynamodb_client.create_table(
                 TableName="ab",
                 AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],


### PR DESCRIPTION
## What
  
Accepts both `ParamValidationError` and `ClientError` in the `test_create_table_name_too_short` test.

## Why

Closes #83

Boto3 client-side validation behavior varies by version and config. The test should pass whether the rejection comes from boto3 or the server.

## Testing done

- Matches the pattern already used in `test_transactions.py` and `test_data_types.py`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.