### PR TITLE
fix(pytest): add missing import uuid

### DIFF
--- a/tests/test_batch_operations.py
+++ b/tests/test_batch_operations.py
@@ -9,6 +9,8 @@ REQ-TEST-001, REQ-TEST-002, REQ-TEST-003
 
 from __future__ import annotations
 
+import uuid
+
 import pytest
 from botocore.exceptions import ClientError
 


### PR DESCRIPTION
## What

fixes a test missing an import, that I probably broke in a prior PR on accident

## Why

our tests should work

## Testing done

ran pytests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- Clippy is clean (`cargo clippy -- -W clippy::pedantic`) -- things clippy flags are unrelated
- I have added or updated tests for new functionality -- this is a test change
- I have updated documentation if behavior changed -- no behavior change
- Breaking changes are noted below -- no breaking change

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
