### PR TITLE
test: add pytest coverage for fixes from 6b98234 to c20b2d6; fix a few older tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,17 +67,28 @@ def dynamodb_client_no_validation(endpoint_url: str | None):
 def unique_table_name() -> str:
     """Generate a unique table name for test isolation."""
     return f"extenddb-test-{uuid.uuid4().hex[:12]}"
-def wait_for_active(client, table_name: str, timeout: float = 60.0) -> None:
+def _is_real_dynamodb() -> bool:
+    """Return True when tests target real DynamoDB (no EXTENDDB_TEST_ENDPOINT)."""
+    return not os.environ.get("EXTENDDB_TEST_ENDPOINT", "").strip()
+
+
+def _poll_interval() -> float:
+    """Return polling interval: 200ms for real DynamoDB, 20ms for ExtendDB."""
+    return 0.2 if _is_real_dynamodb() else 0.02
+
+
+def wait_for_active(client, table_name: str, timeout: float = 120.0) -> None:
     """Poll DescribeTable until status is ACTIVE.
 
     Shared helper — import from conftest instead of duplicating per-module.
     """
+    interval = _poll_interval()
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         resp = client.describe_table(TableName=table_name)
         if resp["Table"]["TableStatus"] == "ACTIVE":
             return
-        time.sleep(0.02)
+        time.sleep(interval)
     raise TimeoutError(f"Table {table_name} did not become ACTIVE within {timeout}s")
 @pytest.fixture()
 def create_and_cleanup_table(dynamodb_client, unique_table_name):
@@ -113,20 +124,25 @@ def create_and_cleanup_table(dynamodb_client, unique_table_name):
         except dynamodb_client.exceptions.ResourceNotFoundException:
             continue
         except dynamodb_client.exceptions.ResourceInUseException:
-            # Table is already being deleted (e.g., test called delete_table directly).
-            # Fall through to wait_for_deleted below.
-            pass
+            # Table may be UPDATING (e.g., billing mode switch). Wait for
+            # ACTIVE then retry the delete.
+            wait_for_active(dynamodb_client, name)
+            try:
+                dynamodb_client.delete_table(TableName=name)
+            except dynamodb_client.exceptions.ResourceNotFoundException:
+                continue
         # Wait for the table to be fully removed.
         wait_for_deleted(dynamodb_client, name)
-def wait_for_deleted(client, table_name: str, timeout: float = 60.0) -> None:
+def wait_for_deleted(client, table_name: str, timeout: float = 300.0) -> None:
     """Poll DescribeTable until the table no longer exists."""
+    interval = _poll_interval()
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         try:
             client.describe_table(TableName=table_name)
         except client.exceptions.ResourceNotFoundException:
             return
-        time.sleep(0.02)
+        time.sleep(interval)
     raise TimeoutError(f"Table {table_name} was not deleted within {timeout}s")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ import uuid
 import boto3
 import pytest
 import urllib3
+from botocore.config import Config
 
 # D4: Suppress InsecureRequestWarning for self-signed TLS certs from ``extenddb init``.
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -42,6 +43,23 @@ def dynamodb_client(endpoint_url: str | None):
     if endpoint_url:
         kwargs["endpoint_url"] = endpoint_url
         # D4: Self-signed certs from `extenddb init` — disable SSL verification.
+        if endpoint_url.startswith("https://"):
+            kwargs["verify"] = False
+    return boto3.client(**kwargs)
+@pytest.fixture(scope="session")
+def dynamodb_client_no_validation(endpoint_url: str | None):
+    """DynamoDB client with parameter validation disabled.
+
+    Use this when testing that the *service* rejects invalid parameters,
+    bypassing botocore's client-side validation.
+    """
+    kwargs: dict = {
+        "service_name": "dynamodb",
+        "region_name": os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
+        "config": Config(parameter_validation=False),
+    }
+    if endpoint_url:
+        kwargs["endpoint_url"] = endpoint_url
         if endpoint_url.startswith("https://"):
             kwargs["verify"] = False
     return boto3.client(**kwargs)

--- a/tests/test_item_operations.py
+++ b/tests/test_item_operations.py
@@ -264,3 +264,243 @@ class TestDataTypes:
         dynamodb_client.put_item(TableName=hash_table, Item=item)
         resp = dynamodb_client.get_item(TableName=hash_table, Key={"pk": {"S": "big-num"}})
         assert resp["Item"]["val"]["N"] == big_num
+
+
+# ---------------------------------------------------------------------------
+# PutItem validation additions (covers commits since 6b98234dcf)
+# ---------------------------------------------------------------------------
+
+
+class TestPutItemValidation:
+    """PutItem validation edge cases from recent fixes."""
+
+    @pytest.fixture(scope="class")
+    def val_table(self, dynamodb_client):
+        with scoped_table(dynamodb_client) as name:
+            yield name
+
+    def test_put_item_invalid_number_nan(self, dynamodb_client, val_table):
+        """PutItem with NaN number returns ValidationException (not SerializationException)."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.put_item(
+                TableName=val_table,
+                Item={"pk": {"S": "x"}, "n": {"N": "NaN"}},
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_put_item_invalid_number_infinity(self, dynamodb_client, val_table):
+        """PutItem with Infinity number returns ValidationException."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.put_item(
+                TableName=val_table,
+                Item={"pk": {"S": "x"}, "n": {"N": "Infinity"}},
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_put_item_number_exceeds_precision(self, dynamodb_client, val_table):
+        """PutItem with >38 significant digits returns ValidationException."""
+        # 39 significant digits — exceeds DynamoDB's limit.
+        big = "1" * 39
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.put_item(
+                TableName=val_table,
+                Item={"pk": {"S": "x"}, "n": {"N": big}},
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_put_item_unused_expression_attribute_names(self, dynamodb_client, val_table):
+        """Extra ExpressionAttributeNames with ConditionExpression are rejected."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.put_item(
+                TableName=val_table,
+                Item={"pk": {"S": "x"}},
+                ConditionExpression="attribute_not_exists(pk)",
+                ExpressionAttributeNames={"#unused": "something"},
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+
+# ---------------------------------------------------------------------------
+# UpdateItem tests (covers commits since 6b98234dcf)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateItem:
+    """UpdateItem operation and validation tests."""
+
+    @pytest.fixture(scope="class")
+    def upd_table(self, dynamodb_client):
+        with scoped_table(dynamodb_client) as name:
+            yield name
+
+    def test_update_item_set_list_index_beyond_bounds(self, dynamodb_client, upd_table):
+        """SET mylist[99] = :v appends to the list when index is beyond bounds."""
+        dynamodb_client.put_item(
+            TableName=upd_table,
+            Item={"pk": {"S": "list-append"}, "mylist": {"L": [{"S": "a"}, {"S": "b"}]}},
+        )
+        dynamodb_client.update_item(
+            TableName=upd_table,
+            Key={"pk": {"S": "list-append"}},
+            UpdateExpression="SET mylist[99] = :v",
+            ExpressionAttributeValues={":v": {"S": "c"}},
+        )
+        resp = dynamodb_client.get_item(TableName=upd_table, Key={"pk": {"S": "list-append"}})
+        items = resp["Item"]["mylist"]["L"]
+        assert items[-1] == {"S": "c"}
+        assert len(items) == 3
+
+    def test_update_item_missing_intermediate_map_path(self, dynamodb_client, upd_table):
+        """SET a.b.c = :v where a.b doesn't exist is rejected."""
+        dynamodb_client.put_item(
+            TableName=upd_table,
+            Item={"pk": {"S": "no-intermediate"}},
+        )
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.update_item(
+                TableName=upd_table,
+                Key={"pk": {"S": "no-intermediate"}},
+                UpdateExpression="SET #a.#b.#c = :v",
+                ExpressionAttributeNames={"#a": "a", "#b": "b", "#c": "c"},
+                ExpressionAttributeValues={":v": {"S": "x"}},
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_update_item_reserved_keyword_without_alias(self, dynamodb_client, upd_table):
+        """Using reserved keyword 'status' without #alias is rejected."""
+        dynamodb_client.put_item(
+            TableName=upd_table,
+            Item={"pk": {"S": "reserved-kw"}},
+        )
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.update_item(
+                TableName=upd_table,
+                Key={"pk": {"S": "reserved-kw"}},
+                UpdateExpression="SET status = :v",
+                ExpressionAttributeValues={":v": {"S": "active"}},
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_update_item_empty_update_expression(self, dynamodb_client, upd_table):
+        """Empty UpdateExpression string is rejected."""
+        dynamodb_client.put_item(
+            TableName=upd_table,
+            Item={"pk": {"S": "empty-expr"}},
+        )
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.update_item(
+                TableName=upd_table,
+                Key={"pk": {"S": "empty-expr"}},
+                UpdateExpression="",
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_update_item_condition_on_nonexistent_item(self, dynamodb_client, upd_table):
+        """attribute_not_exists on a missing item succeeds (creates the item)."""
+        dynamodb_client.update_item(
+            TableName=upd_table,
+            Key={"pk": {"S": "cond-new-item"}},
+            UpdateExpression="SET #d = :v",
+            ConditionExpression="attribute_not_exists(pk)",
+            ExpressionAttributeNames={"#d": "data"},
+            ExpressionAttributeValues={":v": {"S": "created"}},
+        )
+        resp = dynamodb_client.get_item(TableName=upd_table, Key={"pk": {"S": "cond-new-item"}})
+        assert resp["Item"]["data"]["S"] == "created"
+
+    def test_update_item_ne_comparison_missing_attribute(self, dynamodb_client, upd_table):
+        """ConditionExpression 'attr <> :val' passes when attr is absent."""
+        dynamodb_client.put_item(
+            TableName=upd_table,
+            Item={"pk": {"S": "ne-missing"}},
+        )
+        # attr doesn't exist on the item — <> should evaluate to true.
+        dynamodb_client.update_item(
+            TableName=upd_table,
+            Key={"pk": {"S": "ne-missing"}},
+            UpdateExpression="SET #d = :v",
+            ConditionExpression="#a <> :cmp",
+            ExpressionAttributeNames={"#d": "data", "#a": "nonexistent_attr"},
+            ExpressionAttributeValues={":v": {"S": "ok"}, ":cmp": {"S": "anything"}},
+        )
+        resp = dynamodb_client.get_item(TableName=upd_table, Key={"pk": {"S": "ne-missing"}})
+        assert resp["Item"]["data"]["S"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# DeleteItem tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteItem:
+    """DeleteItem operation tests."""
+
+    @pytest.fixture(scope="class")
+    def del_table(self, dynamodb_client):
+        with scoped_table(dynamodb_client) as name:
+            yield name
+
+    def test_delete_item_nonexistent_table(self, dynamodb_client):
+        """DeleteItem on nonexistent table returns ResourceNotFoundException."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.delete_item(
+                TableName="nonexistent-table-xyz-999",
+                Key={"pk": {"S": "x"}},
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+    def test_delete_item_condition_on_nonexistent_item(self, dynamodb_client, del_table):
+        """DeleteItem with attribute_not_exists on missing item succeeds (no-op)."""
+        # Item doesn't exist — condition passes, delete is a no-op.
+        dynamodb_client.delete_item(
+            TableName=del_table,
+            Key={"pk": {"S": "ghost-delete"}},
+            ConditionExpression="attribute_not_exists(pk)",
+        )
+        # Verify no item was created.
+        resp = dynamodb_client.get_item(TableName=del_table, Key={"pk": {"S": "ghost-delete"}})
+        assert "Item" not in resp
+
+
+# ---------------------------------------------------------------------------
+# Projection tests
+# ---------------------------------------------------------------------------
+
+
+class TestProjection:
+    """ProjectionExpression edge cases."""
+
+    @pytest.fixture(scope="class")
+    def proj_table(self, dynamodb_client):
+        with scoped_table(dynamodb_client) as name:
+            dynamodb_client.put_item(
+                TableName=name,
+                Item={
+                    "pk": {"S": "proj-1"},
+                    "mylist": {"L": [{"S": "zero"}, {"S": "one"}, {"S": "two"}]},
+                    "nested": {"M": {"inner": {"S": "deep"}}},
+                },
+            )
+            yield name
+
+    def test_projection_list_index(self, dynamodb_client, proj_table):
+        """ProjectionExpression with list index returns element wrapped in a list."""
+        resp = dynamodb_client.get_item(
+            TableName=proj_table,
+            Key={"pk": {"S": "proj-1"}},
+            ProjectionExpression="mylist[1]",
+        )
+        item = resp["Item"]
+        # DynamoDB returns the projected element inside a single-element list.
+        assert "mylist" in item
+        assert item["mylist"]["L"] == [{"S": "one"}]
+
+    def test_projection_list_index_out_of_bounds(self, dynamodb_client, proj_table):
+        """ProjectionExpression with out-of-bounds list index returns empty item."""
+        resp = dynamodb_client.get_item(
+            TableName=proj_table,
+            Key={"pk": {"S": "proj-1"}},
+            ProjectionExpression="mylist[99]",
+        )
+        # Out-of-bounds index — attribute not included in response.
+        assert "mylist" not in resp.get("Item", {})

--- a/tests/test_query_scan.py
+++ b/tests/test_query_scan.py
@@ -304,3 +304,404 @@ class TestScan:
         with pytest.raises(ClientError) as exc_info:
             dynamodb_client.scan(TableName=scan_table, TotalSegments=3)
         assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+
+# ---------------------------------------------------------------------------
+# Query validation additions (covers commits since 6b98234dcf)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="class")
+def binary_sk_table(dynamodb_client):
+    """Create a hash+range (S,B) table for binary sort key tests."""
+    with scoped_table(
+        dynamodb_client,
+        attribute_definitions=[
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "sk", "AttributeType": "B"},
+        ],
+        key_schema=[
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"},
+        ],
+    ) as name:
+        # Insert items with binary sort keys sharing a common prefix.
+        dynamodb_client.put_item(
+            TableName=name,
+            Item={"pk": {"S": "bin"}, "sk": {"B": b"\x01\x02\x03"}, "v": {"S": "a"}},
+        )
+        dynamodb_client.put_item(
+            TableName=name,
+            Item={"pk": {"S": "bin"}, "sk": {"B": b"\x01\x02\x04"}, "v": {"S": "b"}},
+        )
+        dynamodb_client.put_item(
+            TableName=name,
+            Item={"pk": {"S": "bin"}, "sk": {"B": b"\x02\x00\x00"}, "v": {"S": "c"}},
+        )
+        yield name
+
+
+@pytest.fixture(scope="class")
+def lsi_table(dynamodb_client):
+    """Create a table with an LSI for synchronous write verification."""
+    with scoped_table(
+        dynamodb_client,
+        attribute_definitions=[
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "sk", "AttributeType": "S"},
+            {"AttributeName": "lsi_sk", "AttributeType": "N"},
+        ],
+        key_schema=[
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"},
+        ],
+        LocalSecondaryIndexes=[
+            {
+                "IndexName": "lsi-index",
+                "KeySchema": [
+                    {"AttributeName": "pk", "KeyType": "HASH"},
+                    {"AttributeName": "lsi_sk", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+    ) as name:
+        yield name
+
+
+class TestQueryValidation:
+    """Query validation edge cases from recent fixes."""
+
+    def test_query_kce_with_parentheses(self, dynamodb_client, query_table):
+        """KeyConditionExpression with parentheses is accepted."""
+        resp = dynamodb_client.query(
+            TableName=query_table,
+            KeyConditionExpression="(pk = :pk) AND (sk > :sk)",
+            ExpressionAttributeValues={":pk": {"S": "user-1"}, ":sk": {"N": "8"}},
+        )
+        assert resp["Count"] == 2
+
+    def test_query_kce_must_reference_partition_key(self, dynamodb_client, query_table):
+        """KCE that doesn't reference the partition key is rejected."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.query(
+                TableName=query_table,
+                KeyConditionExpression="sk > :sk",
+                ExpressionAttributeValues={":sk": {"N": "5"}},
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_query_undefined_name_in_filter_expression(self, dynamodb_client, query_table):
+        """FilterExpression referencing undefined #name fails before execution."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.query(
+                TableName=query_table,
+                KeyConditionExpression="pk = :pk",
+                FilterExpression="#undefined > :v",
+                ExpressionAttributeValues={":pk": {"S": "user-1"}, ":v": {"N": "1"}},
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_query_unused_expression_attribute_names(self, dynamodb_client, query_table):
+        """Extra ExpressionAttributeNames not referenced in any expression are rejected."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.query(
+                TableName=query_table,
+                KeyConditionExpression="pk = :pk",
+                ExpressionAttributeValues={":pk": {"S": "user-1"}},
+                ExpressionAttributeNames={"#unused": "some_attr"},
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_query_unused_expression_attribute_values(self, dynamodb_client, query_table):
+        """Extra ExpressionAttributeValues not referenced in any expression are rejected."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.query(
+                TableName=query_table,
+                KeyConditionExpression="pk = :pk",
+                ExpressionAttributeValues={":pk": {"S": "user-1"}, ":unused": {"N": "99"}},
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_query_filter_size_on_missing_attribute(self, dynamodb_client, query_table):
+        """size() on a missing attribute does not match (returns None, not 0)."""
+        resp = dynamodb_client.query(
+            TableName=query_table,
+            KeyConditionExpression="pk = :pk",
+            FilterExpression="size(nonexistent_attr) = :zero",
+            ExpressionAttributeValues={":pk": {"S": "user-1"}, ":zero": {"N": "0"}},
+        )
+        # No items should match — size(missing) is not 0.
+        assert resp["Count"] == 0
+
+    def test_query_begins_with_binary_sort_key(self, dynamodb_client, binary_sk_table):
+        """begins_with on binary sort key returns correct results (not ISE)."""
+        resp = dynamodb_client.query(
+            TableName=binary_sk_table,
+            KeyConditionExpression="pk = :pk AND begins_with(sk, :prefix)",
+            ExpressionAttributeValues={
+                ":pk": {"S": "bin"},
+                ":prefix": {"B": b"\x01\x02"},
+            },
+        )
+        # Should match the two items with prefix \x01\x02.
+        assert resp["Count"] == 2
+        values = sorted(item["v"]["S"] for item in resp["Items"])
+        assert values == ["a", "b"]
+
+    def test_query_reserved_keyword_without_alias(self, dynamodb_client, query_table):
+        """Using a reserved keyword without #alias in FilterExpression is rejected."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.query(
+                TableName=query_table,
+                KeyConditionExpression="pk = :pk",
+                FilterExpression="name > :v",
+                ExpressionAttributeValues={":pk": {"S": "user-1"}, ":v": {"S": "a"}},
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+
+class TestScanValidation:
+    """Scan validation edge cases from recent fixes."""
+
+    def test_scan_negative_segment(self, dynamodb_client, scan_table):
+        """Negative Segment value is rejected."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.scan(
+                TableName=scan_table,
+                Segment=-1,
+                TotalSegments=3,
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_scan_unused_expression_attribute_names(self, dynamodb_client, scan_table):
+        """Extra ExpressionAttributeNames not referenced in any expression are rejected."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.scan(
+                TableName=scan_table,
+                FilterExpression="category = :cat",
+                ExpressionAttributeValues={":cat": {"S": "a"}},
+                ExpressionAttributeNames={"#unused": "something"},
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_scan_unused_expression_attribute_values(self, dynamodb_client, scan_table):
+        """Extra ExpressionAttributeValues not referenced in any expression are rejected."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.scan(
+                TableName=scan_table,
+                FilterExpression="category = :cat",
+                ExpressionAttributeValues={":cat": {"S": "a"}, ":extra": {"N": "1"}},
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+
+# ---------------------------------------------------------------------------
+# Legacy API tests (pre-expression parameters)
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyQuery:
+    """Tests for legacy Query parameters (KeyConditions, QueryFilter, AttributesToGet)."""
+
+    def test_query_key_conditions_eq(self, dynamodb_client, query_table):
+        """KeyConditions with EQ operator returns correct results."""
+        resp = dynamodb_client.query(
+            TableName=query_table,
+            KeyConditions={
+                "pk": {
+                    "AttributeValueList": [{"S": "user-1"}],
+                    "ComparisonOperator": "EQ",
+                },
+                "sk": {
+                    "AttributeValueList": [{"N": "5"}],
+                    "ComparisonOperator": "EQ",
+                },
+            },
+        )
+        assert resp["Count"] == 1
+        assert resp["Items"][0]["name"] == {"S": "item-5"}
+
+    def test_query_key_conditions_between(self, dynamodb_client, query_table):
+        """KeyConditions with BETWEEN operator."""
+        resp = dynamodb_client.query(
+            TableName=query_table,
+            KeyConditions={
+                "pk": {
+                    "AttributeValueList": [{"S": "user-1"}],
+                    "ComparisonOperator": "EQ",
+                },
+                "sk": {
+                    "AttributeValueList": [{"N": "3"}, {"N": "7"}],
+                    "ComparisonOperator": "BETWEEN",
+                },
+            },
+        )
+        assert resp["Count"] == 5
+
+    def test_query_key_conditions_begins_with(self, dynamodb_client, string_sk_table):
+        """KeyConditions with BEGINS_WITH operator."""
+        resp = dynamodb_client.query(
+            TableName=string_sk_table,
+            KeyConditions={
+                "pk": {
+                    "AttributeValueList": [{"S": "user-1"}],
+                    "ComparisonOperator": "EQ",
+                },
+                "sk": {
+                    "AttributeValueList": [{"S": "alpha"}],
+                    "ComparisonOperator": "BEGINS_WITH",
+                },
+            },
+        )
+        assert resp["Count"] == 2
+
+    def test_query_filter_legacy(self, dynamodb_client, query_table):
+        """QueryFilter parameter filters results."""
+        resp = dynamodb_client.query(
+            TableName=query_table,
+            KeyConditions={
+                "pk": {
+                    "AttributeValueList": [{"S": "user-1"}],
+                    "ComparisonOperator": "EQ",
+                },
+            },
+            QueryFilter={
+                "age": {
+                    "AttributeValueList": [{"N": "25"}],
+                    "ComparisonOperator": "GT",
+                },
+            },
+        )
+        assert resp["Count"] == 5
+        assert resp["ScannedCount"] == 10
+
+    def test_query_attributes_to_get(self, dynamodb_client, query_table):
+        """AttributesToGet returns only specified attributes."""
+        resp = dynamodb_client.query(
+            TableName=query_table,
+            KeyConditions={
+                "pk": {
+                    "AttributeValueList": [{"S": "user-1"}],
+                    "ComparisonOperator": "EQ",
+                },
+                "sk": {
+                    "AttributeValueList": [{"N": "1"}],
+                    "ComparisonOperator": "EQ",
+                },
+            },
+            AttributesToGet=["name"],
+        )
+        item = resp["Items"][0]
+        assert "name" in item
+        assert "age" not in item
+
+    def test_query_key_conditions_with_kce_rejected(self, dynamodb_client, query_table):
+        """Mixing KeyConditions with KeyConditionExpression is rejected."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.query(
+                TableName=query_table,
+                KeyConditions={
+                    "pk": {
+                        "AttributeValueList": [{"S": "user-1"}],
+                        "ComparisonOperator": "EQ",
+                    },
+                },
+                KeyConditionExpression="pk = :pk",
+                ExpressionAttributeValues={":pk": {"S": "user-1"}},
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_query_filter_with_filter_expression_rejected(self, dynamodb_client, query_table):
+        """Mixing QueryFilter with FilterExpression is rejected."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.query(
+                TableName=query_table,
+                KeyConditionExpression="pk = :pk",
+                ExpressionAttributeValues={":pk": {"S": "user-1"}, ":v": {"N": "25"}},
+                FilterExpression="age > :v",
+                QueryFilter={
+                    "age": {
+                        "AttributeValueList": [{"N": "25"}],
+                        "ComparisonOperator": "GT",
+                    },
+                },
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+
+class TestLegacyScan:
+    """Tests for legacy Scan parameters (ScanFilter, AttributesToGet)."""
+
+    def test_scan_filter_legacy(self, dynamodb_client, scan_table):
+        """ScanFilter parameter filters results."""
+        resp = dynamodb_client.scan(
+            TableName=scan_table,
+            ScanFilter={
+                "category": {
+                    "AttributeValueList": [{"S": "a"}],
+                    "ComparisonOperator": "EQ",
+                },
+            },
+        )
+        assert resp["Count"] == 3
+
+    def test_scan_attributes_to_get(self, dynamodb_client, scan_table):
+        """AttributesToGet returns only specified attributes."""
+        resp = dynamodb_client.scan(
+            TableName=scan_table,
+            AttributesToGet=["pk"],
+            Limit=1,
+        )
+        item = resp["Items"][0]
+        assert "pk" in item
+        assert "category" not in item
+
+    def test_scan_filter_with_filter_expression_rejected(self, dynamodb_client, scan_table):
+        """Mixing ScanFilter with FilterExpression is rejected."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.scan(
+                TableName=scan_table,
+                FilterExpression="category = :cat",
+                ExpressionAttributeValues={":cat": {"S": "a"}},
+                ScanFilter={
+                    "category": {
+                        "AttributeValueList": [{"S": "a"}],
+                        "ComparisonOperator": "EQ",
+                    },
+                },
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+
+# ---------------------------------------------------------------------------
+# LSI synchronous write verification
+# ---------------------------------------------------------------------------
+
+
+class TestQueryLSI:
+    """LSI queries return data immediately (synchronous write)."""
+
+    def test_lsi_query_immediately_consistent(self, dynamodb_client, lsi_table):
+        """Write to a table with LSI, immediately query LSI — item is visible."""
+        dynamodb_client.put_item(
+            TableName=lsi_table,
+            Item={
+                "pk": {"S": "lsi-user"},
+                "sk": {"S": "profile"},
+                "lsi_sk": {"N": "100"},
+                "data": {"S": "hello"},
+            },
+        )
+        # Single query — no polling. LSI writes are synchronous.
+        resp = dynamodb_client.query(
+            TableName=lsi_table,
+            IndexName="lsi-index",
+            KeyConditionExpression="pk = :pk AND lsi_sk = :sk",
+            ExpressionAttributeValues={
+                ":pk": {"S": "lsi-user"},
+                ":sk": {"N": "100"},
+            },
+        )
+        assert resp["Count"] == 1
+        assert resp["Items"][0]["data"]["S"] == "hello"

--- a/tests/test_query_scan.py
+++ b/tests/test_query_scan.py
@@ -464,10 +464,10 @@ class TestQueryValidation:
 class TestScanValidation:
     """Scan validation edge cases from recent fixes."""
 
-    def test_scan_negative_segment(self, dynamodb_client, scan_table):
-        """Negative Segment value is rejected."""
+    def test_scan_negative_segment(self, dynamodb_client_no_validation, scan_table):
+        """Negative Segment value is rejected by the service."""
         with pytest.raises(ClientError) as exc_info:
-            dynamodb_client.scan(
+            dynamodb_client_no_validation.scan(
                 TableName=scan_table,
                 Segment=-1,
                 TotalSegments=3,

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -21,7 +21,7 @@ import uuid
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from conftest import wait_for_active, wait_for_deleted
+from conftest import _poll_interval, wait_for_active, wait_for_deleted
 # EXTENDDB_TEST_ENDPOINT is required — devtools/run-tests validates this.
 # Tests will fail with KeyError if the env var is missing.
 @pytest.fixture(scope="module")
@@ -128,7 +128,7 @@ def _wait_for_stream_records(
             matching = records
         if len(matching) >= min_count:
             return records
-        time.sleep(0.02)
+        time.sleep(_poll_interval())
     return records
 class TestListStreams:
     """ListStreams operation tests."""
@@ -210,7 +210,7 @@ class TestIteratorAdvancement:
                 shard_iters[sid] = resp.get("NextShardIterator")
             if len(first_pass_records) >= n:
                 break
-            time.sleep(0.02)
+            time.sleep(_poll_interval())
 
         assert len(first_pass_records) >= n
 
@@ -256,7 +256,7 @@ class TestIteratorAdvancement:
                 shard_iters[sid] = resp.get("NextShardIterator")
             if not any_records:
                 break
-            time.sleep(0.02)
+            time.sleep(_poll_interval())
 
         # Empty poll — should return 0 records and a valid NextShardIterator.
         for sid, it in shard_iters.items():
@@ -285,7 +285,7 @@ class TestIteratorAdvancement:
                 shard_iters[sid] = resp.get("NextShardIterator")
             if new_records:
                 break
-            time.sleep(0.02)
+            time.sleep(_poll_interval())
 
         assert len(new_records) == 1
         assert new_records[0]["dynamodb"]["Keys"]["pk"]["S"] == "empty-poll-test"
@@ -484,7 +484,7 @@ class TestIteratorTypes:
             pks = [r["dynamodb"]["Keys"]["pk"]["S"] for r in records]
             if "latest-after" in pks:
                 break
-            time.sleep(0.02)
+            time.sleep(_poll_interval())
 
         pks = [r["dynamodb"]["Keys"]["pk"]["S"] for r in records]
         assert "latest-after" in pks
@@ -607,7 +607,7 @@ class TestMixedWorkload:
             ]
             if len(our_records) >= 3:
                 break
-            time.sleep(0.02)
+            time.sleep(_poll_interval())
 
         events = [r["eventName"] for r in our_records]
         assert events == ["INSERT", "MODIFY", "REMOVE"], (

--- a/tests/test_table_operations.py
+++ b/tests/test_table_operations.py
@@ -176,3 +176,188 @@ class TestDeleteTable:
             TableName=unique_table_name,
             DeletionProtectionEnabled=False,
         )
+
+
+# ---------------------------------------------------------------------------
+# CreateTable validation additions (covers commits since 6b98234dcf)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTableValidation:
+    """CreateTable validation edge cases from recent fixes."""
+
+    def test_create_table_duplicate_key_schema(self, dynamodb_client):
+        """CreateTable with duplicate attribute in KeySchema is rejected."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.create_table(
+                TableName=f"extenddb-test-{__import__('uuid').uuid4().hex[:8]}",
+                AttributeDefinitions=[
+                    {"AttributeName": "pk", "AttributeType": "S"},
+                ],
+                KeySchema=[
+                    {"AttributeName": "pk", "KeyType": "HASH"},
+                    {"AttributeName": "pk", "KeyType": "RANGE"},
+                ],
+                BillingMode="PAY_PER_REQUEST",
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_create_table_three_key_schema_elements(self, dynamodb_client):
+        """CreateTable with >2 KeySchema elements is rejected."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.create_table(
+                TableName=f"extenddb-test-{__import__('uuid').uuid4().hex[:8]}",
+                AttributeDefinitions=[
+                    {"AttributeName": "pk", "AttributeType": "S"},
+                    {"AttributeName": "sk", "AttributeType": "S"},
+                    {"AttributeName": "extra", "AttributeType": "S"},
+                ],
+                KeySchema=[
+                    {"AttributeName": "pk", "KeyType": "HASH"},
+                    {"AttributeName": "sk", "KeyType": "RANGE"},
+                    {"AttributeName": "extra", "KeyType": "RANGE"},
+                ],
+                BillingMode="PAY_PER_REQUEST",
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_create_table_lsi_without_range_key(self, dynamodb_client):
+        """CreateTable with LSI on a hash-only table is rejected."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.create_table(
+                TableName=f"extenddb-test-{__import__('uuid').uuid4().hex[:8]}",
+                AttributeDefinitions=[
+                    {"AttributeName": "pk", "AttributeType": "S"},
+                    {"AttributeName": "lsi_sk", "AttributeType": "N"},
+                ],
+                KeySchema=[
+                    {"AttributeName": "pk", "KeyType": "HASH"},
+                ],
+                LocalSecondaryIndexes=[
+                    {
+                        "IndexName": "bad-lsi",
+                        "KeySchema": [
+                            {"AttributeName": "pk", "KeyType": "HASH"},
+                            {"AttributeName": "lsi_sk", "KeyType": "RANGE"},
+                        ],
+                        "Projection": {"ProjectionType": "ALL"},
+                    },
+                ],
+                BillingMode="PAY_PER_REQUEST",
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_create_table_invalid_billing_mode(self, dynamodb_client):
+        """CreateTable with invalid BillingMode string is rejected."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.create_table(
+                TableName=f"extenddb-test-{__import__('uuid').uuid4().hex[:8]}",
+                AttributeDefinitions=[
+                    {"AttributeName": "pk", "AttributeType": "S"},
+                ],
+                KeySchema=[
+                    {"AttributeName": "pk", "KeyType": "HASH"},
+                ],
+                BillingMode="INVALID_MODE",
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+
+# ---------------------------------------------------------------------------
+# ListTables sort order
+# ---------------------------------------------------------------------------
+
+
+class TestListTablesOrder:
+    """ListTables returns tables in alphabetical order."""
+
+    def test_list_tables_alphabetical_order(self, create_and_cleanup_table, dynamodb_client):
+        """Tables are returned in alphabetical (lexicographic) order."""
+        # Create tables with names that sort in a known order.
+        prefix = f"extenddb-order-{uuid.uuid4().hex[:4]}"
+        names = [f"{prefix}-charlie", f"{prefix}-alpha", f"{prefix}-bravo"]
+        for name in names:
+            create_and_cleanup_table(name)
+
+        # Collect all tables.
+        collected: list[str] = []
+        kwargs: dict = {}
+        while True:
+            result = dynamodb_client.list_tables(**kwargs)
+            collected.extend(result["TableNames"])
+            if "LastEvaluatedTableName" not in result:
+                break
+            kwargs["ExclusiveStartTableName"] = result["LastEvaluatedTableName"]
+
+        # Filter to just our test tables.
+        our_tables = [t for t in collected if t.startswith(prefix)]
+        assert our_tables == sorted(our_tables)
+
+
+# ---------------------------------------------------------------------------
+# UpdateTable validation
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateTable:
+    """UpdateTable validation edge cases from recent fixes."""
+
+    def test_update_table_pay_per_request_with_throughput(
+        self, create_and_cleanup_table, dynamodb_client, unique_table_name
+    ):
+        """UpdateTable with PAY_PER_REQUEST + ProvisionedThroughput is rejected."""
+        create_and_cleanup_table(unique_table_name)
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.update_table(
+                TableName=unique_table_name,
+                BillingMode="PAY_PER_REQUEST",
+                ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_update_table_zero_throughput(
+        self, create_and_cleanup_table, dynamodb_client, unique_table_name
+    ):
+        """UpdateTable with throughput=0 is rejected."""
+        create_and_cleanup_table(
+            unique_table_name,
+            BillingMode="PROVISIONED",
+            ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+        )
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.update_table(
+                TableName=unique_table_name,
+                ProvisionedThroughput={"ReadCapacityUnits": 0, "WriteCapacityUnits": 5},
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_update_table_remove_nonexistent_gsi(
+        self, create_and_cleanup_table, dynamodb_client, unique_table_name
+    ):
+        """UpdateTable trying to delete a GSI that doesn't exist is rejected."""
+        create_and_cleanup_table(unique_table_name)
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.update_table(
+                TableName=unique_table_name,
+                GlobalSecondaryIndexUpdates=[
+                    {"Delete": {"IndexName": "nonexistent-gsi"}},
+                ],
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException" or err["Code"] == "ResourceNotFoundException"
+
+    def test_update_table_billing_mode_switch(
+        self, create_and_cleanup_table, dynamodb_client, unique_table_name
+    ):
+        """Switch from PROVISIONED to PAY_PER_REQUEST succeeds."""
+        create_and_cleanup_table(
+            unique_table_name,
+            BillingMode="PROVISIONED",
+            ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+        )
+        resp = dynamodb_client.update_table(
+            TableName=unique_table_name,
+            BillingMode="PAY_PER_REQUEST",
+        )
+        # Should succeed — the table transitions billing mode.
+        assert resp["TableDescription"]["TableName"] == unique_table_name

--- a/tests/test_table_operations.py
+++ b/tests/test_table_operations.py
@@ -59,18 +59,16 @@ class TestCreateTable:
             create_and_cleanup_table(unique_table_name)
         assert exc_info.value.response["Error"]["Code"] == "ResourceInUseException"
 
-    def test_create_table_name_too_short(self, dynamodb_client):
-        # botocore validates table name min length (3) client-side, raising
-        # ParamValidationError before the request reaches the server.
-        from botocore.exceptions import ParamValidationError
-
-        with pytest.raises(ParamValidationError):
-            dynamodb_client.create_table(
+    def test_create_table_name_too_short(self, dynamodb_client_no_validation):
+        """Table name shorter than 3 chars is rejected by the service."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client_no_validation.create_table(
                 TableName="ab",
                 AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
                 KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
                 BillingMode="PAY_PER_REQUEST",
             )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
 
     def test_create_table_invalid_characters(self, dynamodb_client):
         with pytest.raises(ClientError) as exc_info:
@@ -316,16 +314,16 @@ class TestUpdateTable:
         assert exc_info.value.response["Error"]["Code"] == "ValidationException"
 
     def test_update_table_zero_throughput(
-        self, create_and_cleanup_table, dynamodb_client, unique_table_name
+        self, create_and_cleanup_table, dynamodb_client_no_validation, unique_table_name
     ):
-        """UpdateTable with throughput=0 is rejected."""
+        """UpdateTable with throughput=0 is rejected by the service."""
         create_and_cleanup_table(
             unique_table_name,
             BillingMode="PROVISIONED",
             ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
         )
         with pytest.raises(ClientError) as exc_info:
-            dynamodb_client.update_table(
+            dynamodb_client_no_validation.update_table(
                 TableName=unique_table_name,
                 ProvisionedThroughput={"ReadCapacityUnits": 0, "WriteCapacityUnits": 5},
             )

--- a/tests/test_transaction_operations.py
+++ b/tests/test_transaction_operations.py
@@ -325,3 +325,50 @@ def test_transact_write_conditional_put_fail(dynamodb_client, hash_table):
     # Original item unchanged
     resp = dynamodb_client.get_item(TableName=hash_table, Key={"pk": {"S": "cp-2"}})
     assert resp["Item"]["v"]["S"] == "old"
+
+
+# ---------------------------------------------------------------------------
+# TransactWriteItems — size limit and condition edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_transact_write_total_size_exceeds_4mb(dynamodb_client, hash_table):
+    """TransactWriteItems with total item size > 4MB is rejected."""
+    # Each item is ~400KB, 11 items = ~4.4MB > 4MB limit.
+    items = []
+    for i in range(11):
+        items.append({
+            "Put": {
+                "TableName": hash_table,
+                "Item": {
+                    "pk": {"S": f"big-{i}"},
+                    "data": {"S": "x" * (390 * 1024)},
+                },
+            }
+        })
+    with pytest.raises(ClientError) as exc_info:
+        dynamodb_client.transact_write_items(TransactItems=items)
+    assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+
+def test_transact_write_condition_on_nonexistent_item(dynamodb_client, hash_table):
+    """ConditionCheck with attribute_not_exists on missing item passes."""
+    dynamodb_client.transact_write_items(
+        TransactItems=[
+            {
+                "ConditionCheck": {
+                    "TableName": hash_table,
+                    "Key": {"pk": {"S": "tw-ghost-check"}},
+                    "ConditionExpression": "attribute_not_exists(pk)",
+                }
+            },
+            {
+                "Put": {
+                    "TableName": hash_table,
+                    "Item": {"pk": {"S": "tw-after-ghost"}, "v": {"S": "ok"}},
+                }
+            },
+        ]
+    )
+    resp = dynamodb_client.get_item(TableName=hash_table, Key={"pk": {"S": "tw-after-ghost"}})
+    assert resp["Item"]["v"]["S"] == "ok"


### PR DESCRIPTION
- **test: add pytest coverage for fixes from 6b98234 to c20b2d6 inclusive.**
- **fix(tests): Bypass botocore client-side validation in service-level tests**
- **fix(tests): Use appropriate polling intervals for real DynamoDB**

## What

Better test coverage for fixes we landed recently

## Why

This helps confirm that our fixes were correct

## Testing done

ran new & changed pytests against DynamoDB

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] I have added or updated tests for new functionality
- Clippy is clean (`cargo clippy -- -W clippy::pedantic`) - no new clippy issues
- I have updated documentation if behavior changed - unchanged
- [Breaking changes are noted below (if any) - unchanged

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
