### PR TITLE
fix: accept reversed KeyConditionExpression comparisons

### DIFF
--- a/crates/core/src/expression/key_condition.rs
+++ b/crates/core/src/expression/key_condition.rs
@@ -777,6 +777,18 @@ mod tests {
     }
 
     #[test]
+    fn reverse_comparator_maps_each_operator_and_is_involutive() {
+        use CompareOp::{Eq, Ge, Gt, Le, Lt, Ne};
+
+        let cases = [(Eq, Eq), (Ne, Ne), (Lt, Gt), (Le, Ge), (Gt, Lt), (Ge, Le)];
+
+        for (op, reversed) in cases {
+            assert_eq!(reverse_comparator(op), reversed);
+            assert_eq!(reverse_comparator(reverse_comparator(op)), op);
+        }
+    }
+
+    #[test]
     fn resolve_multipart_reclassifies() {
         let tokens = tokenize("pk1 = :v1 AND pk2 = :v2 AND sk1 = :v3").unwrap();
         let mut kc = parse_key_condition(&tokens).unwrap();

--- a/crates/core/src/expression/key_condition.rs
+++ b/crates/core/src/expression/key_condition.rs
@@ -8,7 +8,7 @@
 //! `ConditionExpression`:
 //!
 //! - Partition key: `pk = :val` (equality only, required)
-//! - Sort key (optional): `sk op :val`, `sk BETWEEN :lo AND :hi`,
+//! - Sort key (optional): `sk op :val`, `:val op sk`, `sk BETWEEN :lo AND :hi`,
 //!   `begins_with(sk, :prefix)`
 //! - Only AND is allowed to combine PK and SK conditions
 //! - No OR, NOT, nested conditions, or other functions
@@ -305,6 +305,11 @@ enum RawClause {
     BeginsWith(Vec<PathElement>, Expr),
 }
 
+enum KeyOperand {
+    Path(Vec<PathElement>),
+    Value(Expr),
+}
+
 fn classify_single(clause: RawClause) -> Result<KeyCondition, DynamoDbError> {
     match clause {
         RawClause::Eq(path, value) => Ok(KeyCondition {
@@ -468,14 +473,42 @@ fn parse_key_clause_inner(tokens: &[Token], pos: &mut usize) -> Result<RawClause
         }
     }
 
-    // path op value | path BETWEEN lo AND hi
-    let path = parse_key_operand_path(tokens, pos)?;
+    // path op :value | :value op path | path BETWEEN :lo AND :hi
+    let left = parse_key_operand(tokens, pos)?;
 
     if *pos >= tokens.len() {
         return Err(validation_err(
-            "Invalid KeyConditionExpression: expected operator after attribute path",
+            "Invalid KeyConditionExpression: expected operator after operand",
         ));
     }
+
+    let path = match left {
+        KeyOperand::Path(path) => path,
+        KeyOperand::Value(value) => {
+            let op = try_comparator(&tokens[*pos]).ok_or_else(|| {
+                validation_err("Invalid KeyConditionExpression: expected comparison operator")
+            })?;
+            // DynamoDB rejects <> in KeyConditionExpression — only =, <, <=, >, >=
+            // are valid key condition operators.
+            if op == CompareOp::Ne {
+                return Err(validation_err(
+                    "Invalid KeyConditionExpression: Unsupported operator on KeyCondition: NE",
+                ));
+            }
+            *pos += 1;
+
+            let path = parse_key_operand_path(tokens, pos)?;
+            // Key conditions are stored path-first, so reverse the operator when
+            // the source expression puts the value placeholder on the left.
+            let op = reverse_comparator(op);
+
+            return if op == CompareOp::Eq {
+                Ok(RawClause::Eq(path, value))
+            } else {
+                Ok(RawClause::Compare(path, op, value))
+            };
+        }
+    };
 
     // BETWEEN
     if tokens[*pos] == Token::Between {
@@ -508,10 +541,38 @@ fn parse_key_clause_inner(tokens: &[Token], pos: &mut usize) -> Result<RawClause
     }
 }
 
+fn parse_key_operand(tokens: &[Token], pos: &mut usize) -> Result<KeyOperand, DynamoDbError> {
+    if *pos >= tokens.len() {
+        return Err(validation_err(
+            "Invalid KeyConditionExpression: unexpected end of expression",
+        ));
+    }
+
+    match &tokens[*pos] {
+        Token::Ident(_) | Token::NameRef(_) => {
+            let path = parser_common::parse_path(tokens, pos)?;
+            Ok(KeyOperand::Path(path))
+        }
+        Token::Placeholder(_) => {
+            let value = parse_key_value(tokens, pos)?;
+            Ok(KeyOperand::Value(value))
+        }
+        _ => Err(validation_err(
+            "Invalid KeyConditionExpression: expected attribute path or value placeholder",
+        )),
+    }
+}
+
 fn parse_key_operand_path(
     tokens: &[Token],
     pos: &mut usize,
 ) -> Result<Vec<PathElement>, DynamoDbError> {
+    if *pos >= tokens.len() {
+        return Err(validation_err(
+            "Invalid KeyConditionExpression: expected attribute path",
+        ));
+    }
+
     match &tokens[*pos] {
         Token::Ident(_) | Token::NameRef(_) => parser_common::parse_path(tokens, pos),
         _ => Err(validation_err(
@@ -535,6 +596,17 @@ fn parse_key_value(tokens: &[Token], pos: &mut usize) -> Result<Expr, DynamoDbEr
         _ => Err(validation_err(
             "Invalid KeyConditionExpression: key condition values must be expression attribute value placeholders",
         )),
+    }
+}
+
+fn reverse_comparator(op: CompareOp) -> CompareOp {
+    match op {
+        CompareOp::Eq => CompareOp::Eq,
+        CompareOp::Ne => CompareOp::Ne,
+        CompareOp::Lt => CompareOp::Gt,
+        CompareOp::Le => CompareOp::Ge,
+        CompareOp::Gt => CompareOp::Lt,
+        CompareOp::Ge => CompareOp::Le,
     }
 }
 
@@ -674,6 +746,34 @@ mod tests {
             }) => {}
             other => panic!("expected Gt SK condition, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_reversed_sort_key_comparison() {
+        let tokens = tokenize("pk = :pk AND :lo <= sk").unwrap();
+        let kc = parse_key_condition(&tokens).unwrap();
+
+        assert_eq!(kc.pk_path, vec![PathElement::Attribute("pk".to_owned())]);
+        match &kc.sk_condition {
+            Some(SortKeyCondition::Compare {
+                path,
+                op: CompareOp::Ge,
+                value: Expr::Placeholder(name),
+            }) => {
+                assert_eq!(path, &vec![PathElement::Attribute("sk".to_owned())]);
+                assert_eq!(name, "lo");
+            }
+            other => panic!("expected reversed Ge SK condition, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_reversed_partition_key_equality() {
+        let tokens = tokenize(":pk = pk").unwrap();
+        let kc = parse_key_condition(&tokens).unwrap();
+
+        assert_eq!(kc.pk_path, vec![PathElement::Attribute("pk".to_owned())]);
+        assert_eq!(kc.pk_value, Expr::Placeholder("pk".to_owned()));
     }
 
     #[test]

--- a/tests/python/test_query_scan.py
+++ b/tests/python/test_query_scan.py
@@ -99,6 +99,20 @@ class TestQuery:
         sks = [item["sk"]["S"] for item in resp["Items"]]
         assert sks == ["sort-001", "sort-002", "sort-003"]
 
+    def test_query_key_condition_reversed_sort_key_comparison(self):
+        """Query accepts a value placeholder on the left side of a sort-key comparison."""
+        resp = self.client.query(
+            TableName=self.table,
+            KeyConditionExpression="pk = :pk AND :lo <= sk",
+            ExpressionAttributeValues={
+                ":pk": {"S": "partition-0"},
+                ":lo": {"S": "sort-002"},
+            },
+        )
+        assert resp["Count"] == 3
+        sks = [item["sk"]["S"] for item in resp["Items"]]
+        assert sks == ["sort-002", "sort-003", "sort-004"]
+
     def test_query_scan_index_forward_false(self):
         """Query with ScanIndexForward=False returns items in reverse order."""
         resp = self.client.query(

--- a/tests/test_query_scan.py
+++ b/tests/test_query_scan.py
@@ -113,6 +113,17 @@ class TestQuery:
         )
         assert resp["Count"] == 3
 
+    def test_query_reversed_sk_comparison(self, dynamodb_client, query_table):
+        resp = dynamodb_client.query(
+            TableName=query_table,
+            KeyConditionExpression="pk = :pk AND :lo <= sk",
+            ExpressionAttributeValues={
+                ":pk": {"S": "user-1"},
+                ":lo": {"N": "3"},
+            },
+        )
+        assert resp["Count"] == 8
+
     def test_query_sk_between(self, dynamodb_client, query_table):
         resp = dynamodb_client.query(
             TableName=query_table,


### PR DESCRIPTION
## What

Accept value-placeholder-first comparisons in `KeyConditionExpression`, such as:

```text
pk = :pk AND :lo <= sk
```

The key condition parser now normalizes reversed comparisons by swapping the key path and value placeholder, then reversing the comparison operator. For example, `:lo <= sk` is parsed as `sk >= :lo`.

## Why

Closes #111

DynamoDB accepts this expression form, but ExtendDB returned a validation error before query execution:

```text
Invalid KeyConditionExpression: expected attribute path
```

## Testing done

- Added parser unit tests for reversed sort-key comparison and reversed partition-key equality
- Added Query regression coverage for `pk = :pk AND :lo <= sk` in both Python query suites
- `cargo fmt --check` passes
- `cargo test --workspace` passes
- `cargo clippy -- -W clippy::pedantic -W clippy::unwrap_used -W clippy::expect_used` completes successfully with exit code 0; existing workspace pedantic warnings remain unrelated to this change
- `pytest tests/test_query_scan.py::TestQuery::test_query_reversed_sk_comparison -v --tb=short` passes against local ExtendDB
- `pytest tests/python/test_query_scan.py::TestQuery::test_query_key_condition_reversed_sort_key_comparison -v --tb=short` passes against local ExtendDB

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy command completes successfully -- existing workspace pedantic warnings are unrelated to this change
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed -- no documentation change needed; this matches DynamoDB-compatible query syntax and is covered by tests
- [x] Breaking changes are noted below -- no breaking change

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.