### PR TITLE
fix: UpdateItem with no directives is a no-op upsert

### DIFF
--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -535,23 +535,6 @@ pub fn validate_update_item(
 ) -> Result<(), DynamoDbError> {
     validate_table_name(&input.table_name, limits)?;
     validate_key_only(&input.key, key_schema, attr_defs)?;
-
-    // Either UpdateExpression or AttributeUpdates must be provided.
-    // Note: an empty string UpdateExpression is "provided" but will fail later
-    // with the correct "The expression can not be empty;" message from tokenize_for.
-    let has_update_expr = input.update_expression.is_some();
-    let has_attr_updates = input
-        .attribute_updates
-        .as_ref()
-        .is_some_and(|u| !u.is_empty());
-
-    if !has_update_expr && !has_attr_updates {
-        return Err(DynamoDbError::ValidationException(
-            "One or more parameter values were invalid: An UpdateExpression must be provided"
-                .to_owned(),
-        ));
-    }
-
     Ok(())
 }
 
@@ -1189,5 +1172,62 @@ mod tests {
             )
             .is_ok()
         );
+    }
+
+    fn update_input_no_directives() -> UpdateItemInput {
+        UpdateItemInput {
+            table_name: "TestTable".to_owned(),
+            key: {
+                let mut k = Item::new();
+                k.insert("pk".to_owned(), AttributeValue::S("p".to_owned()));
+                k
+            },
+            update_expression: None,
+            condition_expression: None,
+            expression_attribute_names: None,
+            expression_attribute_values: None,
+            return_values: ReturnValues::None,
+            expected: None,
+            conditional_operator: None,
+            attribute_updates: None,
+            return_values_on_condition_check_failure: Default::default(),
+            return_consumed_capacity: Default::default(),
+            return_item_collection_metrics: Default::default(),
+        }
+    }
+
+    #[test]
+    fn update_item_no_update_expression_or_attribute_updates_accepted() {
+        // DynamoDB treats UpdateItem with only TableName + Key as a no-op
+        // upsert. Validation must not reject it.
+        let limits = LimitsConfig::default();
+        let key_schema = vec![make_ks("pk", KeyType::Hash)];
+        let attr_defs = vec![make_ad("pk", ScalarAttributeType::S)];
+        let input = update_input_no_directives();
+        assert!(validate_update_item(&input, &limits, &key_schema, &attr_defs).is_ok());
+    }
+
+    #[test]
+    fn update_item_empty_attribute_updates_map_accepted() {
+        // An empty AttributeUpdates map is equivalent to no directives.
+        let limits = LimitsConfig::default();
+        let key_schema = vec![make_ks("pk", KeyType::Hash)];
+        let attr_defs = vec![make_ad("pk", ScalarAttributeType::S)];
+        let mut input = update_input_no_directives();
+        input.attribute_updates = Some(std::collections::HashMap::new());
+        assert!(validate_update_item(&input, &limits, &key_schema, &attr_defs).is_ok());
+    }
+
+    #[test]
+    fn update_item_empty_string_update_expression_passes_validation() {
+        // Validation must let Some("") through so the engine's tokenize_for
+        // produces the DynamoDB-compatible "The expression can not be empty;"
+        // message. PR #24 (ef8b94f) protects this routing; we keep it.
+        let limits = LimitsConfig::default();
+        let key_schema = vec![make_ks("pk", KeyType::Hash)];
+        let attr_defs = vec![make_ad("pk", ScalarAttributeType::S)];
+        let mut input = update_input_no_directives();
+        input.update_expression = Some(String::new());
+        assert!(validate_update_item(&input, &limits, &key_schema, &attr_defs).is_ok());
     }
 }

--- a/crates/engine/src/update_item.rs
+++ b/crates/engine/src/update_item.rs
@@ -121,17 +121,21 @@ pub async fn handle_update_item(
         &ctx.limits,
     )?;
 
-    // Parse the update expression
-    let update_expr = effective_update_expr.as_deref().unwrap_or("");
-    let update_tokens = tokenize_for(
-        update_expr,
-        ctx.limits.max_expression_tokens,
-        "UpdateExpression",
-    )?;
-    if ctx.limits.enforce_reserved_keywords {
-        validate_no_reserved_words(&update_tokens)?;
-    }
-    let actions = parse_update_from(&update_tokens, update_expr)?;
+    // No UpdateExpression and no AttributeUpdates: no-op upsert.
+    // Some("") still errors via tokenize_for.
+    let actions = if let Some(update_expr) = effective_update_expr.as_deref() {
+        let update_tokens = tokenize_for(
+            update_expr,
+            ctx.limits.max_expression_tokens,
+            "UpdateExpression",
+        )?;
+        if ctx.limits.enforce_reserved_keywords {
+            validate_no_reserved_words(&update_tokens)?;
+        }
+        parse_update_from(&update_tokens, update_expr)?
+    } else {
+        Vec::new()
+    };
 
     if input.expected.is_none() || input.expected.as_ref().is_some_and(|m| m.is_empty()) {
         let exprs: Vec<&extenddb_core::expression::Expr> = condition.iter().collect();

--- a/tests/test_item_operations.py
+++ b/tests/test_item_operations.py
@@ -395,6 +395,34 @@ class TestUpdateItem:
             )
         assert exc_info.value.response["Error"]["Code"] == "ValidationException"
 
+    def test_update_item_no_directives_upserts_key_only(self, dynamodb_client, upd_table):
+        """UpdateItem with only TableName + Key on a missing item upserts a key-only item."""
+        dynamodb_client.update_item(
+            TableName=upd_table,
+            Key={"pk": {"S": "noop-missing"}},
+        )
+        resp = dynamodb_client.get_item(
+            TableName=upd_table,
+            Key={"pk": {"S": "noop-missing"}},
+            ConsistentRead=True,
+        )
+        assert resp["Item"] == {"pk": {"S": "noop-missing"}}
+
+    def test_update_item_no_directives_noop_on_existing(self, dynamodb_client, upd_table):
+        """UpdateItem with only TableName + Key on an existing item is a no-op."""
+        original = {"pk": {"S": "noop-existing"}, "x": {"N": "42"}}
+        dynamodb_client.put_item(TableName=upd_table, Item=original)
+        dynamodb_client.update_item(
+            TableName=upd_table,
+            Key={"pk": {"S": "noop-existing"}},
+        )
+        resp = dynamodb_client.get_item(
+            TableName=upd_table,
+            Key={"pk": {"S": "noop-existing"}},
+            ConsistentRead=True,
+        )
+        assert resp["Item"] == original
+
     def test_update_item_condition_on_nonexistent_item(self, dynamodb_client, upd_table):
         """attribute_not_exists on a missing item succeeds (creates the item)."""
         dynamodb_client.update_item(


### PR DESCRIPTION
## What

`UpdateItem` with only `TableName` and `Key` (no `UpdateExpression`, no `AttributeUpdates`) now matches DynamoDB:

- Missing item: HTTP 200, key-only item upserted.
- Existing item: HTTP 200, no-op.

Empty `UpdateExpression` (`""`) still rejected via `tokenize_for` (preserves PR #24, commit `ef8b94f`).

## Why

Closes #118 

## Testing done

Tested against real DynamoDB to confirm the expected behavior, then verified the fix against ExtendDB end-to-end. New tests:

- 3 unit tests on `validate_update_item` covering `None`, `Some({})`, and `Some("")`.
- 2 pytest tests in `TestUpdateItem` covering the missing-item upsert and existing-item no-op.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy --all-targets --workspace -- -D warnings`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any)

## Breaking changes

None.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
