### PR TITLE
fix: omit empty Attributes on UpdateItem UPDATED_NEW/UPDATED_OLD

### DIFF
--- a/crates/engine/src/update_item.rs
+++ b/crates/engine/src/update_item.rs
@@ -196,12 +196,12 @@ pub async fn handle_update_item(
         ReturnValues::None => None,
         ReturnValues::AllOld => old_item,
         ReturnValues::AllNew => new_item,
-        ReturnValues::UpdatedOld => {
-            old_item.map(|item| filter_to_updated_attrs(&item, &actions, &maps))
-        }
-        ReturnValues::UpdatedNew => {
-            new_item.map(|item| filter_to_updated_attrs(&item, &actions, &maps))
-        }
+        ReturnValues::UpdatedOld => old_item
+            .map(|item| filter_to_updated_attrs(&item, &actions, &maps))
+            .filter(|item| !item.is_empty()),
+        ReturnValues::UpdatedNew => new_item
+            .map(|item| filter_to_updated_attrs(&item, &actions, &maps))
+            .filter(|item| !item.is_empty()),
     };
 
     let output = UpdateItemOutput {

--- a/tests/test_item_operations.py
+++ b/tests/test_item_operations.py
@@ -454,6 +454,53 @@ class TestUpdateItem:
         resp = dynamodb_client.get_item(TableName=upd_table, Key={"pk": {"S": "ne-missing"}})
         assert resp["Item"]["data"]["S"] == "ok"
 
+    def test_update_item_remove_with_updated_new_omits_attributes(self, dynamodb_client, upd_table):
+        """REMOVE leaves nothing in UPDATED_NEW: Attributes field must be omitted, not returned as {}."""
+        dynamodb_client.put_item(
+            TableName=upd_table,
+            Item={"pk": {"S": "remove-empty"}, "map_attr": {"M": {"child": {"S": "old"}}}},
+        )
+        resp = dynamodb_client.update_item(
+            TableName=upd_table,
+            Key={"pk": {"S": "remove-empty"}},
+            UpdateExpression="REMOVE map_attr",
+            ReturnValues="UPDATED_NEW",
+        )
+        assert "Attributes" not in resp, f"expected Attributes omitted, got {resp.get('Attributes')!r}"
+
+    def test_update_item_set_new_attribute_with_updated_old_omits_attributes(
+        self, dynamodb_client, upd_table
+    ):
+        """SET on a brand-new attribute has no prior value: UPDATED_OLD must omit Attributes."""
+        dynamodb_client.put_item(
+            TableName=upd_table,
+            Item={"pk": {"S": "set-new-old"}},
+        )
+        resp = dynamodb_client.update_item(
+            TableName=upd_table,
+            Key={"pk": {"S": "set-new-old"}},
+            UpdateExpression="SET fresh_attr = :v",
+            ExpressionAttributeValues={":v": {"S": "new"}},
+            ReturnValues="UPDATED_OLD",
+        )
+        assert "Attributes" not in resp, f"expected Attributes omitted, got {resp.get('Attributes')!r}"
+
+    def test_update_item_legacy_delete_with_updated_new_omits_attributes(
+        self, dynamodb_client, upd_table
+    ):
+        """Legacy AttributeUpdates DELETE on a Map mirrors REMOVE: UPDATED_NEW must omit Attributes."""
+        dynamodb_client.put_item(
+            TableName=upd_table,
+            Item={"pk": {"S": "legacy-delete"}, "map_attr": {"M": {"child": {"S": "old"}}}},
+        )
+        resp = dynamodb_client.update_item(
+            TableName=upd_table,
+            Key={"pk": {"S": "legacy-delete"}},
+            AttributeUpdates={"map_attr": {"Action": "DELETE"}},
+            ReturnValues="UPDATED_NEW",
+        )
+        assert "Attributes" not in resp, f"expected Attributes omitted, got {resp.get('Attributes')!r}"
+
 
 # ---------------------------------------------------------------------------
 # DeleteItem tests


### PR DESCRIPTION
## What

`UpdateItem` with `ReturnValues=UPDATED_NEW` or `UPDATED_OLD` now matches DynamoDB when no targeted attribute is present in the chosen snapshot:

- `REMOVE` / legacy `DELETE` on a `Map` attribute with `UPDATED_NEW`: response omits `Attributes` (was `{"Attributes": {}}`).
- `SET` on a brand-new attribute with `UPDATED_OLD`: response omits `Attributes` (was `{"Attributes": {}}`).

## Why

Closes #120 

## Testing done

Tested against real DynamoDB to confirm the expected behavior, then verified the fix against ExtendDB end-to-end. New tests:

- 3 pytest tests in `TestUpdateItem` covering `REMOVE + UPDATED_NEW`, `SET` of a brand-new attribute + `UPDATED_OLD`, and legacy `AttributeUpdates DELETE` + `UPDATED_NEW`.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy --all-targets --workspace -- -D warnings`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)

## Breaking changes

None.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
