### PR TITLE
feat(auth-cache): SWR cache for credentials, IAM policies, and table-key info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +640,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +849,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "extenddb"
 version = "0.1.0"
 dependencies = [
@@ -831,6 +870,7 @@ dependencies = [
  "config",
  "daemonize",
  "extenddb-auth",
+ "extenddb-cache",
  "extenddb-core",
  "extenddb-engine",
  "extenddb-server",
@@ -858,7 +898,9 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
+ "extenddb-cache",
  "extenddb-core",
+ "futures",
  "hex",
  "hmac",
  "serde_json",
@@ -868,6 +910,17 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "extenddb-cache"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "moka",
+ "serde",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -889,6 +942,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "crc32fast",
+ "extenddb-auth",
  "extenddb-core",
  "extenddb-storage",
  "hex",
@@ -914,9 +968,11 @@ dependencies = [
  "bcrypt",
  "crc32fast",
  "extenddb-auth",
+ "extenddb-cache",
  "extenddb-core",
  "extenddb-engine",
  "extenddb-storage",
+ "futures",
  "hyper",
  "metrics",
  "rand 0.9.4",
@@ -1706,6 +1762,26 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -2753,6 +2829,12 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@
 resolver = "2"
 members = [
     "crates/core",
+    "crates/cache",
     "crates/engine",
     "crates/storage",
     "crates/storage-postgres",
@@ -21,6 +22,7 @@ license = "Apache-2.0"
 [workspace.dependencies]
 # Internal crates
 extenddb-core = { path = "crates/core" }
+extenddb-cache = { path = "crates/cache" }
 extenddb-engine = { path = "crates/engine" }
 extenddb-storage = { path = "crates/storage" }
 extenddb-storage-postgres = { path = "crates/storage-postgres" }
@@ -49,6 +51,9 @@ hyper = { version = "1" }
 
 # Database plugin registry
 inventory = "0.3"
+
+# Caching
+moka = { version = "0.12", features = ["future"] }
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "json", "time", "uuid", "bigdecimal"] }

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -9,7 +9,9 @@ license.workspace = true
 
 [dependencies]
 extenddb-core = { workspace = true }
+extenddb-cache = { workspace = true }
 async-trait = { workspace = true }
+futures = { workspace = true }
 thiserror = { workspace = true }
 axum = { workspace = true }
 hmac = "0.12"
@@ -21,4 +23,5 @@ tracing = { workspace = true }
 zeroize = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true }
+extenddb-cache = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }

--- a/crates/auth/src/cache_registry.rs
+++ b/crates/auth/src/cache_registry.rs
@@ -1,0 +1,294 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Centralized handle for the auth/authz cache instances.
+//!
+//! `AuthCacheRegistry` is constructed during server bootstrap and threaded
+//! through `ServerComponents` and `AppState` so management API handlers can
+//! invalidate cache entries on IAM mutations (write-through invalidation).
+//!
+//! All cache instances are `Clone` and share their underlying state via
+//! `Arc`. Cloning the registry is cheap.
+//!
+//! See `docs/design/12-auth-authz-cache.md`.
+
+use std::sync::Arc;
+
+use futures::future::BoxFuture;
+
+use crate::CachedCredentialStore;
+
+/// Invalidation hooks for the `TableKeyInfo` cache.
+///
+/// Implemented by `extenddb-server`'s `CachedTableKeyInfoStore` and held in
+/// the registry as `Arc<dyn TableKeyInfoCacheInvalidator>` to avoid a
+/// circular crate dependency.
+pub trait TableKeyInfoCacheInvalidator: Send + Sync {
+    fn invalidate<'a>(
+        &'a self,
+        account_id: &'a str,
+        table_name: &'a str,
+    ) -> futures::future::BoxFuture<'a, ()>;
+}
+
+/// Invalidation hooks for the authorization cache.
+///
+/// Implemented by `extenddb-server`'s `CachedAuthzStore` (which can't be
+/// referenced directly here without creating a circular dependency).
+/// Implementations should be fast — they typically forward to `moka`'s
+/// `invalidate` or `invalidate_entries_if`, which is fire-and-forget.
+pub trait AuthzCacheInvalidator: Send + Sync {
+    fn invalidate_user_policies<'a>(
+        &'a self,
+        account_id: &'a str,
+        user_name: &'a str,
+    ) -> BoxFuture<'a, ()>;
+
+    fn invalidate_user_group_policies<'a>(
+        &'a self,
+        account_id: &'a str,
+        user_name: &'a str,
+    ) -> BoxFuture<'a, ()>;
+
+    fn invalidate_users<'a>(
+        &'a self,
+        account_id: &'a str,
+        user_names: &'a [String],
+    ) -> BoxFuture<'a, ()>;
+
+    fn invalidate_user_boundary<'a>(
+        &'a self,
+        account_id: &'a str,
+        user_name: &'a str,
+    ) -> BoxFuture<'a, ()>;
+
+    fn invalidate_user_tags<'a>(
+        &'a self,
+        account_id: &'a str,
+        user_name: &'a str,
+    ) -> BoxFuture<'a, ()>;
+
+    fn invalidate_role_policies<'a>(
+        &'a self,
+        account_id: &'a str,
+        role_name: &'a str,
+    ) -> BoxFuture<'a, ()>;
+
+    fn invalidate_role_boundary<'a>(
+        &'a self,
+        account_id: &'a str,
+        role_name: &'a str,
+    ) -> BoxFuture<'a, ()>;
+
+    fn invalidate_role_tags<'a>(
+        &'a self,
+        account_id: &'a str,
+        role_name: &'a str,
+    ) -> BoxFuture<'a, ()>;
+
+    fn invalidate_session<'a>(
+        &'a self,
+        account_id: &'a str,
+        role_name: &'a str,
+        session_name: &'a str,
+    ) -> BoxFuture<'a, ()>;
+
+    fn invalidate_resource_tags<'a>(&'a self, arn: &'a str) -> BoxFuture<'a, ()>;
+
+    /// Invalidate every cached session-data entry for a given role.
+    ///
+    /// Used when a role is deleted so cached session policies and tags for
+    /// any active session of that role are dropped immediately. Implemented
+    /// via `invalidate_if` over the `(account, role, session)` cache key.
+    fn invalidate_role_sessions<'a>(
+        &'a self,
+        account_id: &'a str,
+        role_name: &'a str,
+    ) -> BoxFuture<'a, ()>;
+
+    /// Invalidate every cached entry belonging to `account_id` across every
+    /// authz subcache (policies, group policies, boundary, tags, sessions,
+    /// resource tags). Used by `delete_account` to ensure cached state for
+    /// the deleted account is dropped.
+    fn invalidate_account<'a>(&'a self, account_id: &'a str) -> BoxFuture<'a, ()>;
+}
+
+/// Holds shared handles to every auth/authz cache instance.
+///
+/// Used by the management API to issue write-through invalidations after
+/// admin mutations.
+///
+/// Construction note: the registry is built during server bootstrap. The
+/// storage backend factory creates the credential cache (which lives in
+/// this crate); the server crate creates the authorization cache (which
+/// lives there) and registers it through `with_authz_invalidator`. This
+/// lets the registry sit in `extenddb-auth` without requiring a circular
+/// dependency on `extenddb-server`.
+#[derive(Clone, Default)]
+pub struct AuthCacheRegistry {
+    pub credential: Option<Arc<CachedCredentialStore>>,
+    pub authz: Option<Arc<dyn AuthzCacheInvalidator>>,
+    pub table_key_info: Option<Arc<dyn TableKeyInfoCacheInvalidator>>,
+}
+
+impl AuthCacheRegistry {
+    /// Construct an empty registry. All `invalidate_*` methods are no-ops in
+    /// this state. Used for unit tests and for `enabled = false` mode.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Set the credential cache handle.
+    #[must_use]
+    pub fn with_credential(mut self, store: Arc<CachedCredentialStore>) -> Self {
+        self.credential = Some(store);
+        self
+    }
+
+    /// Set the authorization cache handle (typed-erased through
+    /// [`AuthzCacheInvalidator`] to avoid a circular crate dependency).
+    #[must_use]
+    pub fn with_authz_invalidator(mut self, invalidator: Arc<dyn AuthzCacheInvalidator>) -> Self {
+        self.authz = Some(invalidator);
+        self
+    }
+
+    /// Set the table-key-info cache handle.
+    #[must_use]
+    pub fn with_table_key_info_invalidator(
+        mut self,
+        invalidator: Arc<dyn TableKeyInfoCacheInvalidator>,
+    ) -> Self {
+        self.table_key_info = Some(invalidator);
+        self
+    }
+
+    /// Invalidate the cached `TableKeyInfo` for `(account_id, table_name)`.
+    /// Called by control-plane handlers (`CreateTable`, `UpdateTable`,
+    /// `DeleteTable`, etc.) after the catalog mutation succeeds.
+    pub async fn invalidate_table_key_info(&self, account_id: &str, table_name: &str) {
+        if let Some(c) = &self.table_key_info {
+            c.invalidate(account_id, table_name).await;
+        }
+    }
+
+    /// Invalidate the cached credential for `access_key_id`.
+    ///
+    /// Called by management endpoints after `CreateAccessKey`,
+    /// `DeleteAccessKey`, `ImportAccessKey`, or any operation that changes the
+    /// active state of the key. Safe to call when the cache is disabled
+    /// (no-op).
+    pub async fn invalidate_credential(&self, access_key_id: &str) {
+        if let Some(c) = &self.credential {
+            c.invalidate(access_key_id).await;
+        }
+    }
+
+    pub async fn invalidate_user_policies(&self, account_id: &str, user_name: &str) {
+        if let Some(c) = &self.authz {
+            c.invalidate_user_policies(account_id, user_name).await;
+        }
+    }
+
+    pub async fn invalidate_user_group_policies(&self, account_id: &str, user_name: &str) {
+        if let Some(c) = &self.authz {
+            c.invalidate_user_group_policies(account_id, user_name)
+                .await;
+        }
+    }
+
+    pub async fn invalidate_users(&self, account_id: &str, user_names: &[String]) {
+        if let Some(c) = &self.authz {
+            c.invalidate_users(account_id, user_names).await;
+        }
+    }
+
+    pub async fn invalidate_user_boundary(&self, account_id: &str, user_name: &str) {
+        if let Some(c) = &self.authz {
+            c.invalidate_user_boundary(account_id, user_name).await;
+        }
+    }
+
+    pub async fn invalidate_user_tags(&self, account_id: &str, user_name: &str) {
+        if let Some(c) = &self.authz {
+            c.invalidate_user_tags(account_id, user_name).await;
+        }
+    }
+
+    pub async fn invalidate_role_policies(&self, account_id: &str, role_name: &str) {
+        if let Some(c) = &self.authz {
+            c.invalidate_role_policies(account_id, role_name).await;
+        }
+    }
+
+    pub async fn invalidate_role_boundary(&self, account_id: &str, role_name: &str) {
+        if let Some(c) = &self.authz {
+            c.invalidate_role_boundary(account_id, role_name).await;
+        }
+    }
+
+    pub async fn invalidate_role_tags(&self, account_id: &str, role_name: &str) {
+        if let Some(c) = &self.authz {
+            c.invalidate_role_tags(account_id, role_name).await;
+        }
+    }
+
+    pub async fn invalidate_session(&self, account_id: &str, role_name: &str, session_name: &str) {
+        if let Some(c) = &self.authz {
+            c.invalidate_session(account_id, role_name, session_name)
+                .await;
+        }
+    }
+
+    pub async fn invalidate_resource_tags(&self, arn: &str) {
+        if let Some(c) = &self.authz {
+            c.invalidate_resource_tags(arn).await;
+        }
+    }
+
+    /// Invalidate every cached session-data entry for `role_name`. Called
+    /// when a role is deleted. No-op when the cache is disabled.
+    pub async fn invalidate_role_sessions(&self, account_id: &str, role_name: &str) {
+        if let Some(c) = &self.authz {
+            c.invalidate_role_sessions(account_id, role_name).await;
+        }
+    }
+
+    /// Invalidate every cached entry — across every authz subcache and the
+    /// credential cache — that belongs to `account_id`. Called by
+    /// `delete_account`. No-op when caches are disabled.
+    pub async fn invalidate_account(&self, account_id: &str) {
+        if let Some(c) = &self.authz {
+            c.invalidate_account(account_id).await;
+        }
+        // Best-effort credential fanout; failures are logged-but-not-fatal
+        // because the credential cache's negative TTL bounds the worst-case
+        // exposure window if invalidation fails.
+        if let Some(c) = &self.credential {
+            if let Err(e) = c.invalidate_account(account_id) {
+                tracing::warn!(
+                    account_id = account_id,
+                    error = ?e,
+                    "credential cache invalidate_account failed; relying on TTL"
+                );
+            }
+        }
+    }
+
+    /// Invalidate every cached credential for `principal_name` in
+    /// `account_id`. Called when a user or role is deleted. No-op when
+    /// caches are disabled.
+    pub async fn invalidate_principal_credentials(&self, account_id: &str, principal_name: &str) {
+        if let Some(c) = &self.credential {
+            if let Err(e) = c.invalidate_principal(account_id, principal_name) {
+                tracing::warn!(
+                    account_id = account_id,
+                    principal = principal_name,
+                    error = ?e,
+                    "credential cache invalidate_principal failed; relying on TTL"
+                );
+            }
+        }
+    }
+}

--- a/crates/auth/src/cache_registry.rs
+++ b/crates/auth/src/cache_registry.rs
@@ -50,7 +50,7 @@ pub trait AuthzCacheInvalidator: Send + Sync {
         user_name: &'a str,
     ) -> BoxFuture<'a, ()>;
 
-    fn invalidate_users<'a>(
+    fn invalidate_users_group_policies<'a>(
         &'a self,
         account_id: &'a str,
         user_names: &'a [String],
@@ -198,9 +198,13 @@ impl AuthCacheRegistry {
         }
     }
 
-    pub async fn invalidate_users(&self, account_id: &str, user_names: &[String]) {
+    /// Fan out a group-membership-affecting event to the cached
+    /// `user_group_policies` entry for each member. See
+    /// [`AuthzCacheInvalidator::invalidate_users_group_policies`].
+    pub async fn invalidate_users_group_policies(&self, account_id: &str, user_names: &[String]) {
         if let Some(c) = &self.authz {
-            c.invalidate_users(account_id, user_names).await;
+            c.invalidate_users_group_policies(account_id, user_names)
+                .await;
         }
     }
 

--- a/crates/auth/src/cache_registry.rs
+++ b/crates/auth/src/cache_registry.rs
@@ -29,6 +29,10 @@ pub trait TableKeyInfoCacheInvalidator: Send + Sync {
         account_id: &'a str,
         table_name: &'a str,
     ) -> futures::future::BoxFuture<'a, ()>;
+
+    /// Drop every cached entry. Used by the manual `cache invalidate
+    /// all` admin endpoint.
+    fn invalidate_all(&self);
 }
 
 /// Invalidation hooks for the authorization cache.
@@ -111,6 +115,10 @@ pub trait AuthzCacheInvalidator: Send + Sync {
     /// resource tags). Used by `delete_account` to ensure cached state for
     /// the deleted account is dropped.
     fn invalidate_account<'a>(&'a self, account_id: &'a str) -> BoxFuture<'a, ()>;
+
+    /// Drop every cached entry across every authz subcache. Used by the
+    /// manual `cache invalidate all` admin endpoint.
+    fn invalidate_all(&self);
 }
 
 /// Holds shared handles to every auth/authz cache instance.
@@ -277,6 +285,24 @@ impl AuthCacheRegistry {
                     "credential cache invalidate_account failed; relying on TTL"
                 );
             }
+        }
+    }
+
+    /// Drop every cached entry across every cache (authz subcaches,
+    /// credentials, table-key-info). Used by the manual `cache
+    /// invalidate all` admin endpoint. No-op for any cache that is
+    /// disabled. Callers MUST gate this on explicit confirmation; it
+    /// causes a reload storm against the catalog as the next requests
+    /// re-populate from cold.
+    pub fn invalidate_all_caches(&self) {
+        if let Some(c) = &self.authz {
+            c.invalidate_all();
+        }
+        if let Some(c) = &self.table_key_info {
+            c.invalidate_all();
+        }
+        if let Some(c) = &self.credential {
+            c.invalidate_all();
         }
     }
 

--- a/crates/auth/src/credential_cache.rs
+++ b/crates/auth/src/credential_cache.rs
@@ -1,0 +1,493 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `CachedCredentialStore` — wraps any [`CredentialStore`] with a stale-while-
+//! revalidate cache.
+//!
+//! Each `lookup_credential(access_key_id)` call first consults the in-memory
+//! cache. Fresh entries (younger than `soft_ttl`) are returned immediately.
+//! Stale-but-usable entries (between `soft_ttl` and `ttl`) are returned
+//! immediately while a background task refreshes them. Misses block on the
+//! upstream store. Negative results (`Ok(None)`) are cached for the shorter
+//! `negative_ttl`. Errors are never cached.
+//!
+//! Write-through invalidation is exposed via [`CachedCredentialStore::invalidate`]:
+//! the management API calls it whenever an access key is created, deleted, or
+//! has its active status changed, so self-induced changes propagate instantly
+//! within the local instance.
+//!
+//! See `docs/design/12-auth-authz-cache.md` for the full design.
+
+use std::sync::Arc;
+
+use extenddb_cache::{Loader, SwrCache, SwrCacheConfig};
+use extenddb_core::error::DynamoDbError;
+use futures::FutureExt;
+use futures::future::BoxFuture;
+
+use crate::{CredentialStore, StoredCredential};
+
+/// A `CredentialStore` that wraps another store and caches results.
+///
+/// The cache uses stale-while-revalidate semantics — see the module-level
+/// docs and `docs/design/12-auth-authz-cache.md`.
+///
+/// Cloning is cheap; clones share the underlying cache and inner store.
+#[derive(Clone)]
+pub struct CachedCredentialStore {
+    cache: SwrCache<String, StoredCredential, DynamoDbError>,
+}
+
+impl CachedCredentialStore {
+    /// Wrap `inner` with a cache configured by `config`.
+    ///
+    /// The `inner` store is moved into an `Arc` so the cache's loader closure
+    /// can outlive the constructor call. The wrapper itself is `Clone` and
+    /// safe to share across tasks.
+    #[must_use]
+    pub fn new<T>(inner: T, config: SwrCacheConfig) -> Self
+    where
+        T: CredentialStore + 'static,
+    {
+        let inner: Arc<dyn CredentialStore> = Arc::new(inner);
+        Self::with_arc(inner, config)
+    }
+
+    /// Wrap an already-`Arc`-wrapped `CredentialStore`.
+    ///
+    /// Use this when the caller already holds an `Arc<dyn CredentialStore>`
+    /// (e.g. when sharing the same backing store across multiple wrappers).
+    #[must_use]
+    pub fn with_arc(inner: Arc<dyn CredentialStore>, config: SwrCacheConfig) -> Self {
+        Self {
+            cache: SwrCache::new(Self::build_loader(inner), config),
+        }
+    }
+
+    /// Construct a pass-through wrapper that bypasses the cache on every
+    /// lookup. Used when `auth.cache.enabled = false`.
+    #[must_use]
+    pub fn pass_through<T>(inner: T, config: SwrCacheConfig) -> Self
+    where
+        T: CredentialStore + 'static,
+    {
+        let inner: Arc<dyn CredentialStore> = Arc::new(inner);
+        Self::pass_through_arc(inner, config)
+    }
+
+    /// Like [`Self::pass_through`] but accepts an `Arc<dyn CredentialStore>`.
+    #[must_use]
+    pub fn pass_through_arc(inner: Arc<dyn CredentialStore>, config: SwrCacheConfig) -> Self {
+        Self {
+            cache: SwrCache::pass_through(Self::build_loader(inner), config),
+        }
+    }
+
+    fn build_loader(
+        inner: Arc<dyn CredentialStore>,
+    ) -> Loader<String, StoredCredential, DynamoDbError> {
+        Arc::new(move |access_key_id: String|
+            -> BoxFuture<'static, Result<Option<StoredCredential>, DynamoDbError>> {
+            let inner = inner.clone();
+            async move { inner.lookup_credential(&access_key_id).await }.boxed()
+        })
+    }
+
+    /// Drop the cached entry for `access_key_id`. The next lookup will
+    /// re-fetch from the inner store. Used by management endpoints (e.g.
+    /// `CreateAccessKey`, `DeleteAccessKey`, `UpdateAccessKey` status change)
+    /// to make local mutations visible immediately.
+    pub async fn invalidate(&self, access_key_id: &str) {
+        self.cache.invalidate(&access_key_id.to_owned()).await;
+    }
+
+    /// Drop every cached entry. Intended for administrative use (e.g. global
+    /// cache flush via a future control endpoint).
+    pub fn invalidate_all(&self) {
+        self.cache.invalidate_all();
+    }
+
+    /// Drop every cached credential whose `account_id` matches.
+    ///
+    /// Called by `delete_account` to ensure no cached credential for the
+    /// deleted account remains usable. Negative entries are kept (they
+    /// expire at `negative_ttl` anyway).
+    ///
+    /// # Errors
+    /// Returns the underlying moka error if predicate registration fails (in
+    /// practice, only at shutdown).
+    pub fn invalidate_account(
+        &self,
+        account_id: &str,
+    ) -> Result<(), extenddb_cache::PredicateError> {
+        let acct = account_id.to_owned();
+        self.cache
+            .invalidate_if_value(move |v| v.map(|cred| cred.account_id == acct).unwrap_or(false))
+    }
+
+    /// Drop every cached credential for `principal_name` in `account_id`.
+    ///
+    /// Called when deleting a user (matches AKIA*) or role (matches the
+    /// associated ASIA* session credentials).
+    ///
+    /// # Errors
+    /// Returns the underlying moka error if predicate registration fails.
+    pub fn invalidate_principal(
+        &self,
+        account_id: &str,
+        principal_name: &str,
+    ) -> Result<(), extenddb_cache::PredicateError> {
+        let acct = account_id.to_owned();
+        let principal = principal_name.to_owned();
+        self.cache.invalidate_if_value(move |v| {
+            v.map(|cred| cred.account_id == acct && cred.principal_name == principal)
+                .unwrap_or(false)
+        })
+    }
+
+    /// Snapshot the cache's internal counters for export to `/metrics`.
+    #[must_use]
+    pub fn metrics(&self) -> Arc<extenddb_cache::SwrMetrics> {
+        self.cache.metrics()
+    }
+
+    /// Returns the current entry count (best-effort).
+    #[must_use]
+    pub fn entry_count(&self) -> u64 {
+        self.cache.entry_count()
+    }
+
+    /// Returns `true` when this wrapper was constructed in pass-through mode
+    /// (`auth.cache.enabled = false`). Surfaced by the metrics endpoint so
+    /// operators can tell "cache disabled" from "cache cold".
+    #[must_use]
+    pub fn is_pass_through(&self) -> bool {
+        self.cache.is_pass_through()
+    }
+}
+
+#[async_trait::async_trait]
+impl CredentialStore for CachedCredentialStore {
+    async fn lookup_credential(
+        &self,
+        access_key_id: &str,
+    ) -> Result<Option<StoredCredential>, DynamoDbError> {
+        let result = self.cache.get(access_key_id.to_owned()).await?;
+        // CB-12 (cache-hit path): the storage layer enforces session expiry on
+        // load, but a cached session credential survives until `ttl_seconds`
+        // even if its `expires_at` has passed. Re-validate on every hit so
+        // the cache cannot extend a session past its issued lifetime.
+        // Mirror the storage-layer error so the cache is transparent to the
+        // auth provider.
+        if let Some(ref cred) = result {
+            if cred.is_session {
+                if let Some(expires_at) = cred.expires_at {
+                    if expires_at < time::OffsetDateTime::now_utc() {
+                        // Drop the stale entry so the next lookup goes
+                        // straight to the storage layer (which will raise
+                        // ExpiredTokenException itself, or return the
+                        // post-rotation credential if one exists).
+                        self.cache.invalidate(&access_key_id.to_owned()).await;
+                        return Err(DynamoDbError::ExpiredTokenException(
+                            "The security token included in the request is expired".to_owned(),
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use super::*;
+
+    /// In-process credential store backed by a Mutex-protected map. Counts
+    /// `lookup_credential` invocations so tests can assert cache behavior.
+    struct CountingCredStore {
+        creds: Mutex<std::collections::HashMap<String, StoredCredential>>,
+        calls: AtomicUsize,
+    }
+
+    impl CountingCredStore {
+        fn new() -> Self {
+            Self {
+                creds: Mutex::new(std::collections::HashMap::new()),
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn insert(&self, key: &str, cred: StoredCredential) {
+            self.creds.lock().unwrap().insert(key.to_owned(), cred);
+        }
+
+        fn remove(&self, key: &str) {
+            self.creds.lock().unwrap().remove(key);
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CredentialStore for CountingCredStore {
+        async fn lookup_credential(
+            &self,
+            access_key_id: &str,
+        ) -> Result<Option<StoredCredential>, DynamoDbError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.creds.lock().unwrap().get(access_key_id).cloned())
+        }
+    }
+
+    fn make_cred(secret: &str, principal: &str) -> StoredCredential {
+        StoredCredential {
+            secret_key: secret.to_owned(),
+            account_id: "123456789012".to_owned(),
+            principal_name: principal.to_owned(),
+            session_name: None,
+            is_session: false,
+            session_token: None,
+            is_active: true,
+            expires_at: None,
+        }
+    }
+
+    fn fast_config() -> SwrCacheConfig {
+        SwrCacheConfig {
+            ttl: Duration::from_millis(200),
+            soft_ttl: Duration::from_millis(50),
+            negative_ttl: Duration::from_millis(50),
+            max_entries: 100,
+            name: "test-cred",
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn invalidate_principal_drops_all_keys_for_user() {
+        let inner = Arc::new(CountingCredStore::new());
+        inner.insert("AKIAALICE1", make_cred("s1", "alice"));
+        inner.insert("AKIAALICE2", make_cred("s2", "alice"));
+        inner.insert("AKIABOB", make_cred("s3", "bob"));
+        let store = CachedCredentialStore::with_arc(inner.clone(), fast_config());
+
+        // Prime all three.
+        let _ = store.lookup_credential("AKIAALICE1").await.unwrap();
+        let _ = store.lookup_credential("AKIAALICE2").await.unwrap();
+        let _ = store.lookup_credential("AKIABOB").await.unwrap();
+        assert_eq!(inner.calls(), 3);
+
+        store.invalidate_principal("123456789012", "alice").unwrap();
+        store.cache.run_pending_tasks().await;
+
+        // Re-fetch each.
+        let _ = store.lookup_credential("AKIAALICE1").await.unwrap();
+        let _ = store.lookup_credential("AKIAALICE2").await.unwrap();
+        let _ = store.lookup_credential("AKIABOB").await.unwrap();
+        assert_eq!(
+            inner.calls(),
+            5,
+            "alice's two keys re-fetched (2); bob still cached (0). Initial=3, total=5."
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn invalidate_account_drops_all_creds_for_account() {
+        let inner = Arc::new(CountingCredStore::new());
+        let mut a1 = make_cred("s1", "alice");
+        a1.account_id = "a1".to_owned();
+        let mut a2 = make_cred("s2", "alice");
+        a2.account_id = "a2".to_owned();
+        inner.insert("AKIAA1", a1);
+        inner.insert("AKIAA2", a2);
+        let store = CachedCredentialStore::with_arc(inner.clone(), fast_config());
+
+        let _ = store.lookup_credential("AKIAA1").await.unwrap();
+        let _ = store.lookup_credential("AKIAA2").await.unwrap();
+        assert_eq!(inner.calls(), 2);
+
+        store.invalidate_account("a1").unwrap();
+        store.cache.run_pending_tasks().await;
+
+        let _ = store.lookup_credential("AKIAA1").await.unwrap();
+        let _ = store.lookup_credential("AKIAA2").await.unwrap();
+        assert_eq!(
+            inner.calls(),
+            3,
+            "AKIAA1 (account a1) re-fetched; AKIAA2 (account a2) still cached"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn pass_through_skips_cache_on_every_lookup() {
+        let inner = Arc::new(CountingCredStore::new());
+        inner.insert("AKIATEST", make_cred("s", "alice"));
+        let store = CachedCredentialStore::pass_through_arc(inner.clone(), fast_config());
+
+        for _ in 0..5 {
+            let r = store.lookup_credential("AKIATEST").await.unwrap().unwrap();
+            assert_eq!(r.principal_name, "alice");
+        }
+        assert_eq!(
+            inner.calls(),
+            5,
+            "pass-through must invoke inner store on every call"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn second_lookup_hits_cache() {
+        let inner = Arc::new(CountingCredStore::new());
+        inner.insert("AKIATEST", make_cred("s", "alice"));
+        let store = CachedCredentialStore::with_arc(inner.clone(), fast_config());
+
+        let r1 = store.lookup_credential("AKIATEST").await.unwrap().unwrap();
+        let r2 = store.lookup_credential("AKIATEST").await.unwrap().unwrap();
+
+        assert_eq!(r1.principal_name, "alice");
+        assert_eq!(r2.principal_name, "alice");
+        assert_eq!(inner.calls(), 1, "second lookup must hit cache");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn invalidate_forces_refetch() {
+        let inner = Arc::new(CountingCredStore::new());
+        inner.insert("AKIATEST", make_cred("s", "alice"));
+        let store = CachedCredentialStore::with_arc(inner.clone(), fast_config());
+
+        let _ = store.lookup_credential("AKIATEST").await.unwrap();
+        store.invalidate("AKIATEST").await;
+        let _ = store.lookup_credential("AKIATEST").await.unwrap();
+
+        assert_eq!(
+            inner.calls(),
+            2,
+            "invalidation must force a re-fetch from the inner store"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn negative_lookup_is_cached_then_picks_up_new_key_after_negative_ttl() {
+        let inner = Arc::new(CountingCredStore::new());
+        let store = CachedCredentialStore::with_arc(inner.clone(), fast_config());
+
+        // Initially missing.
+        let r1 = store.lookup_credential("AKIANEW").await.unwrap();
+        assert!(r1.is_none());
+
+        // Within negative_ttl, second call hits cache.
+        let r2 = store.lookup_credential("AKIANEW").await.unwrap();
+        assert!(r2.is_none());
+        assert_eq!(inner.calls(), 1);
+
+        // Operator inserts the key.
+        inner.insert("AKIANEW", make_cred("s", "bob"));
+
+        // Wait past negative_ttl (50ms).
+        tokio::time::sleep(Duration::from_millis(80)).await;
+
+        // Lookup now sees it.
+        let r3 = store.lookup_credential("AKIANEW").await.unwrap().unwrap();
+        assert_eq!(r3.principal_name, "bob");
+    }
+
+    /// CB-12 (cache-hit path): a cached session credential whose `expires_at`
+    /// has passed must NOT authenticate, even when the cache TTL hasn't
+    /// elapsed yet. Without the cache-hit expiry check, a session could
+    /// keep working for up to `auth.cache.ttl_seconds` past its expiry.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn cached_session_past_expires_at_returns_expired_token() {
+        let inner = Arc::new(CountingCredStore::new());
+        // A session that "expires" 10 seconds in the past. The CountingCredStore
+        // mock returns the credential unconditionally; the wrapper layer is
+        // what we're testing here.
+        let mut cred = make_cred("s", "alice");
+        cred.is_session = true;
+        cred.session_token = Some("tok".to_owned());
+        cred.expires_at = Some(time::OffsetDateTime::now_utc() - time::Duration::seconds(10));
+        inner.insert("ASIATEST00000000", cred);
+
+        let store = CachedCredentialStore::with_arc(inner.clone(), fast_config());
+
+        let r1 = store.lookup_credential("ASIATEST00000000").await;
+        match r1 {
+            Err(DynamoDbError::ExpiredTokenException(_)) => {}
+            Err(other) => {
+                panic!("expected ExpiredTokenException from cache-hit expiry check, got {other:?}")
+            }
+            Ok(_) => panic!("expected ExpiredTokenException, got Ok"),
+        }
+        // The cached entry was dropped on the expiry check. A second call
+        // re-hits the inner store rather than serving the cached expired cred.
+        let calls_after_first = inner.calls();
+        let r2 = store.lookup_credential("ASIATEST00000000").await;
+        match r2 {
+            Err(DynamoDbError::ExpiredTokenException(_)) => {}
+            Err(other) => {
+                panic!("expected ExpiredTokenException on re-fetch, got {other:?}")
+            }
+            Ok(_) => panic!("expected ExpiredTokenException on re-fetch, got Ok"),
+        }
+        assert!(
+            inner.calls() > calls_after_first,
+            "expired-session cache hit must drop the entry, forcing a re-fetch on the next call \
+             (calls_after_first={calls_after_first}, after_second={})",
+            inner.calls()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn invalidation_after_delete_returns_none() {
+        let inner = Arc::new(CountingCredStore::new());
+        inner.insert("AKIATEST", make_cred("s", "alice"));
+        let store = CachedCredentialStore::with_arc(inner.clone(), fast_config());
+
+        // Prime cache.
+        let r1 = store.lookup_credential("AKIATEST").await.unwrap().unwrap();
+        assert_eq!(r1.principal_name, "alice");
+
+        // Simulate admin deletion: remove from inner, invalidate cache.
+        inner.remove("AKIATEST");
+        store.invalidate("AKIATEST").await;
+
+        // Next lookup reflects the deletion.
+        let r2 = store.lookup_credential("AKIATEST").await.unwrap();
+        assert!(r2.is_none(), "post-invalidation lookup must see deletion");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn many_concurrent_lookups_for_same_key_collapse_to_few_loads() {
+        let inner = Arc::new(CountingCredStore::new());
+        inner.insert("AKIATEST", make_cred("s", "alice"));
+        let store = CachedCredentialStore::with_arc(inner.clone(), fast_config());
+
+        let mut handles = Vec::new();
+        for _ in 0..64 {
+            let store = store.clone();
+            handles.push(tokio::spawn(async move {
+                store.lookup_credential("AKIATEST").await.unwrap().unwrap()
+            }));
+        }
+        for h in handles {
+            let _ = h.await.unwrap();
+        }
+
+        // The cache deduplicates *post-warmup*; cold-start may incur a few
+        // duplicate inserts on the way to the first cached entry. Verify the
+        // deduplication is meaningful (≤ caller count, and warmup is cheap).
+        let n = inner.calls();
+        assert!(
+            n <= 64,
+            "loader call count must not exceed concurrent caller count, got {n}"
+        );
+        // Once warm, no further lookups.
+        let _ = store.lookup_credential("AKIATEST").await.unwrap();
+        assert_eq!(inner.calls(), n, "warm lookup must hit cache");
+    }
+}

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -6,8 +6,13 @@
 //! Defines the `AuthProvider` trait for pluggable auth backends. Ships with
 //! `BuiltinAuthProvider` (full SigV4 verification with local credential store).
 
+pub mod cache_registry;
+pub mod credential_cache;
 pub mod policy;
 pub mod sigv4;
+
+pub use cache_registry::{AuthCacheRegistry, AuthzCacheInvalidator, TableKeyInfoCacheInvalidator};
+pub use credential_cache::CachedCredentialStore;
 
 use axum::http::HeaderMap;
 use extenddb_core::error::DynamoDbError;
@@ -69,6 +74,12 @@ pub struct StoredCredential {
     /// storage so the auth layer can produce the correct error response.
     #[zeroize(skip)]
     pub is_active: bool,
+    /// For session credentials: the absolute expiry time. Long-lived AKIA*
+    /// credentials set this to `None`. Auth checks this on every cache hit
+    /// so cached sessions don't outlive their `expires_at` window — the
+    /// storage layer's expiry check only fires on the cache-miss path.
+    #[zeroize(skip)]
+    pub expires_at: Option<time::OffsetDateTime>,
 }
 
 /// Trait for looking up credentials from storage.
@@ -149,7 +160,10 @@ impl<C: CredentialStore + 'static> AuthProvider for BuiltinAuthProvider<C> {
 
         // For session credentials, verify X-Amz-Security-Token matches the stored token.
         // CB-12: Session expiration is enforced at the credential store layer (fail-closed).
-        // Expired sessions are never returned — the store returns ExpiredTokenException directly.
+        // Expired sessions are never returned — the storage layer returns
+        // ExpiredTokenException on the cache-miss path, and CachedCredentialStore
+        // re-validates `expires_at` on every cache hit before returning so cached
+        // entries cannot survive past their issued lifetime.
         if credential.is_session {
             let token = headers
                 .get("x-amz-security-token")

--- a/crates/auth/src/policy/evaluator.rs
+++ b/crates/auth/src/policy/evaluator.rs
@@ -45,9 +45,52 @@ pub fn evaluate_policies(
     resource_arn: &str,
     context: &impl ConditionContext,
 ) -> AuthzDecision {
-    // Collect all policies for the explicit deny scan
+    evaluate_with(
+        identity_policies.iter(),
+        permissions_boundary,
+        session_policy,
+        action,
+        resource_arn,
+        context,
+    )
+}
+
+/// Variant of [`evaluate_policies`] accepting `Arc<PolicyDocument>` slices.
+///
+/// Used by the request hot path with the parsed-document cache to avoid
+/// cloning policies out of `Arc` on every authorization decision.
+pub fn evaluate_policies_arc(
+    identity_policies: &[std::sync::Arc<PolicyDocument>],
+    permissions_boundary: Option<&PolicyDocument>,
+    session_policy: Option<&PolicyDocument>,
+    action: &str,
+    resource_arn: &str,
+    context: &impl ConditionContext,
+) -> AuthzDecision {
+    evaluate_with(
+        identity_policies.iter().map(std::sync::Arc::as_ref),
+        permissions_boundary,
+        session_policy,
+        action,
+        resource_arn,
+        context,
+    )
+}
+
+fn evaluate_with<'a, I>(
+    identity_policies: I,
+    permissions_boundary: Option<&'a PolicyDocument>,
+    session_policy: Option<&'a PolicyDocument>,
+    action: &str,
+    resource_arn: &str,
+    context: &impl ConditionContext,
+) -> AuthzDecision
+where
+    I: Iterator<Item = &'a PolicyDocument> + Clone,
+{
+    // Collect all policies for the explicit deny scan.
     let all_policies: Vec<&PolicyDocument> = identity_policies
-        .iter()
+        .clone()
         .chain(permissions_boundary)
         .chain(session_policy)
         .collect();

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -16,6 +16,7 @@ default = ["postgres"]
 postgres = ["extenddb-storage-postgres"]
 
 [dependencies]
+extenddb-cache = { workspace = true }
 extenddb-core = { workspace = true }
 extenddb-engine = { workspace = true }
 extenddb-storage = { workspace = true }

--- a/crates/bin/src/cmd_serve.rs
+++ b/crates/bin/src/cmd_serve.rs
@@ -252,8 +252,96 @@ async fn serve_inner(
 
     let storage = components.engine;
     let catalog_store = components.catalog_store;
-    let auth = components.auth_provider;
+    let cred_store = components.credential_store;
     let runtime_hooks = components.runtime_hooks;
+
+    // Build SwrCacheConfig values from the [auth.cache] TOML section.
+    let cache_cfg = &app_config.auth.cache;
+    let cache_enabled = cache_cfg.enabled;
+    let make_cache_cfg = |name: &'static str| -> extenddb_cache::SwrCacheConfig {
+        extenddb_cache::SwrCacheConfig {
+            ttl: std::time::Duration::from_secs(cache_cfg.ttl_seconds),
+            soft_ttl: std::time::Duration::from_secs(cache_cfg.soft_ttl_seconds),
+            negative_ttl: std::time::Duration::from_secs(cache_cfg.negative_ttl_seconds),
+            max_entries: cache_cfg.max_entries,
+            name,
+        }
+    };
+    // Validate config eagerly so misconfiguration fails fast at startup.
+    // Today every named subcache shares the same TTL/max_entries shape (only
+    // `name` differs), so a single `validate()` check suffices. If per-cache
+    // tuning is ever added, validate every constructed config here.
+    if let Err(e) = make_cache_cfg("__validate__").validate() {
+        anyhow::bail!(
+            "Invalid [auth.cache] configuration: {e}. Check ttl_seconds, \
+             soft_ttl_seconds, negative_ttl_seconds, max_entries."
+        );
+    }
+    if !cache_enabled {
+        tracing::warn!(
+            "auth.cache.enabled = false — auth/authz caches are in pass-through mode \
+             (every lookup hits the catalog directly)"
+        );
+    }
+
+    // Phase 2: Wrap the raw credential store. In pass-through mode the
+    // wrapper bypasses the cache and forwards every lookup to the inner
+    // store; otherwise it caches per the TOML config.
+    let cached_cred_store = Arc::new(if cache_enabled {
+        extenddb_auth::CachedCredentialStore::with_arc(cred_store, make_cache_cfg("credential"))
+    } else {
+        extenddb_auth::CachedCredentialStore::pass_through_arc(
+            cred_store,
+            make_cache_cfg("credential"),
+        )
+    });
+    let auth: Arc<dyn extenddb_auth::AuthProvider> = Arc::new(
+        extenddb_auth::BuiltinAuthProvider::new((*cached_cred_store).clone()),
+    );
+
+    // Phase 3: Build the authorization cache.
+    let authz_cache: Arc<extenddb_server::CachedAuthzStore> = {
+        let store: Arc<dyn extenddb_storage::authorization_store::AuthorizationStore> =
+            catalog_store.clone();
+        let cfg = extenddb_server::AuthzCacheConfig {
+            identity_policies: make_cache_cfg("identity_policies"),
+            group_policies: make_cache_cfg("group_policies"),
+            boundary: make_cache_cfg("boundary"),
+            principal_tags: make_cache_cfg("principal_tags"),
+            resource_tags: make_cache_cfg("resource_tags"),
+            session_data: make_cache_cfg("session_data"),
+        };
+        Arc::new(if cache_enabled {
+            extenddb_server::CachedAuthzStore::new(store, cfg)
+        } else {
+            extenddb_server::CachedAuthzStore::pass_through(store, cfg)
+        })
+    };
+
+    // Phase 4: Build the TableKeyInfo cache.
+    let table_key_info_cache: Arc<extenddb_server::CachedTableKeyInfoStore> =
+        Arc::new(if cache_enabled {
+            extenddb_server::CachedTableKeyInfoStore::new(
+                storage.clone(),
+                make_cache_cfg("table_key_info"),
+            )
+        } else {
+            extenddb_server::CachedTableKeyInfoStore::pass_through(
+                storage.clone(),
+                make_cache_cfg("table_key_info"),
+            )
+        });
+
+    // Assemble the cache registry threaded into AppState for write-through
+    // invalidations from the management API.
+    let auth_cache =
+        extenddb_auth::AuthCacheRegistry::empty()
+            .with_credential(cached_cred_store)
+            .with_authz_invalidator(
+                authz_cache.clone() as Arc<dyn extenddb_auth::AuthzCacheInvalidator>
+            )
+            .with_table_key_info_invalidator(table_key_info_cache.clone()
+                as Arc<dyn extenddb_auth::TableKeyInfoCacheInvalidator>);
 
     let data_db_info = runtime_hooks
         .as_ref()
@@ -405,6 +493,9 @@ async fn serve_inner(
         import_paths,
         export_paths,
         throttle: throttle.clone(),
+        auth_cache,
+        authz_cache,
+        table_key_info_cache,
         config_entries,
         docs_store,
     };

--- a/crates/bin/src/config.rs
+++ b/crates/bin/src/config.rs
@@ -197,14 +197,77 @@ pub struct AuthConfig {
     /// authentication enabled.
     #[serde(default = "default_provider")]
     pub provider: String,
+    /// Configuration for the in-memory auth/authz caches. Optional; defaults
+    /// apply when absent.
+    #[serde(default)]
+    pub cache: AuthCacheConfigToml,
 }
 
 impl Default for AuthConfig {
     fn default() -> Self {
         Self {
             provider: default_provider(),
+            cache: AuthCacheConfigToml::default(),
         }
     }
+}
+
+/// Configuration for the in-memory auth/authz caches (`[auth.cache]` section).
+///
+/// Each `*_seconds` field has a sensible default; operators only need to
+/// override values when they want to deviate from the docs. The configuration
+/// is static — values are read once at startup.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthCacheConfigToml {
+    /// Master switch. When `false`, all caches operate in pass-through mode
+    /// (fall through to the underlying store on every request) — useful as a
+    /// kill switch during incident response.
+    #[serde(default = "default_cache_enabled")]
+    pub enabled: bool,
+    /// Hard TTL: cached values older than this trigger a fresh load.
+    #[serde(default = "default_cache_ttl_seconds")]
+    pub ttl_seconds: u64,
+    /// Soft TTL: cached values older than this trigger a background refresh
+    /// while still returning the cached value to the caller.
+    #[serde(default = "default_cache_soft_ttl_seconds")]
+    pub soft_ttl_seconds: u64,
+    /// TTL applied to negative results (`Ok(None)` from the loader). Typically
+    /// shorter than `ttl_seconds` so newly-created entities become visible
+    /// quickly.
+    #[serde(default = "default_cache_negative_ttl_seconds")]
+    pub negative_ttl_seconds: u64,
+    /// Maximum entries per cache. When exceeded, LRU eviction kicks in.
+    #[serde(default = "default_cache_max_entries")]
+    pub max_entries: u64,
+}
+
+impl Default for AuthCacheConfigToml {
+    fn default() -> Self {
+        Self {
+            enabled: default_cache_enabled(),
+            ttl_seconds: default_cache_ttl_seconds(),
+            soft_ttl_seconds: default_cache_soft_ttl_seconds(),
+            negative_ttl_seconds: default_cache_negative_ttl_seconds(),
+            max_entries: default_cache_max_entries(),
+        }
+    }
+}
+
+fn default_cache_enabled() -> bool {
+    true
+}
+fn default_cache_ttl_seconds() -> u64 {
+    60
+}
+fn default_cache_soft_ttl_seconds() -> u64 {
+    30
+}
+fn default_cache_negative_ttl_seconds() -> u64 {
+    5
+}
+fn default_cache_max_entries() -> u64 {
+    10_000
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/bin/src/init_helpers.rs
+++ b/crates/bin/src/init_helpers.rs
@@ -125,6 +125,16 @@ connection_string = "{catalog_url}"
 [auth]
 # provider = "builtin"           # SigV4 with local credential store (mandatory)
 
+[auth.cache]
+# In-memory caches eliminate per-request catalog queries for IAM data.
+# Defaults: ttl 60s, soft_ttl 30s, negative_ttl 5s, max 10000 entries/cache.
+# Set enabled = false to disable all caches (for incident response).
+# enabled = true
+# ttl_seconds = 60
+# soft_ttl_seconds = 30
+# negative_ttl_seconds = 5
+# max_entries = 10000
+
 [logging]
 # level = "info"                 # trace, debug, info, warn, error
 # format = "pretty"              # "pretty" (human) or "json" (structured)

--- a/crates/bin/src/manage_http.rs
+++ b/crates/bin/src/manage_http.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use base64::Engine;
 
 use crate::config;
-use crate::manage_types::ManageCommand;
+use crate::manage_types::{CacheAction, CacheInvalidateScope, ManageCommand};
 
 /// Resolve the management API endpoint from CLI args or config file.
 ///
@@ -419,5 +419,79 @@ pub fn dispatch(
             c.req("GET", &format!("/management/accounts/{account_id}/roles/{role_name}/permissions-boundary"), None),
         M::DeleteRoleBoundary { account_id, role_name } =>
             c.req("DELETE", &format!("/management/accounts/{account_id}/roles/{role_name}/permissions-boundary"), None),
+        M::Cache { action } => dispatch_cache(&c, action),
     }
+}
+
+fn dispatch_cache(c: &Ctx<'_>, action: CacheAction) -> anyhow::Result<(u16, String)> {
+    let CacheAction::Invalidate { scope } = action;
+    // Build the body matching the management API's `InvalidateRequest`
+    // shape. The CLI exposes only the subset of selector fields that
+    // each scope actually uses, so unused fields stay omitted.
+    let body = match scope {
+        CacheInvalidateScope::All { yes } => {
+            if !yes {
+                anyhow::bail!(
+                    "cache invalidate all requires --yes. This drops every cached \
+                     entry on the local instance and will cause a reload storm."
+                );
+            }
+            serde_json::json!({ "scope": "all", "selectors": { "confirm": true } })
+        }
+        CacheInvalidateScope::Account { account_id } => serde_json::json!({
+            "scope": "account",
+            "selectors": { "account_id": account_id },
+        }),
+        CacheInvalidateScope::Credential { access_key_id } => serde_json::json!({
+            "scope": "credential",
+            "selectors": { "access_key_id": access_key_id },
+        }),
+        CacheInvalidateScope::User {
+            account_id,
+            user_name,
+        } => serde_json::json!({
+            "scope": "user",
+            "selectors": { "account_id": account_id, "user_name": user_name },
+        }),
+        CacheInvalidateScope::Role {
+            account_id,
+            role_name,
+        } => serde_json::json!({
+            "scope": "role",
+            "selectors": { "account_id": account_id, "role_name": role_name },
+        }),
+        CacheInvalidateScope::GroupMembers {
+            account_id,
+            user_names,
+        } => {
+            // Comma-separated → Vec<String>. Leading/trailing whitespace
+            // and empty entries are filtered so users can paste lists
+            // freely.
+            let names: Vec<String> = user_names
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(ToOwned::to_owned)
+                .collect();
+            if names.is_empty() {
+                anyhow::bail!("--user-names must contain at least one non-empty name");
+            }
+            serde_json::json!({
+                "scope": "group_members",
+                "selectors": { "account_id": account_id, "user_names": names },
+            })
+        }
+        CacheInvalidateScope::TableKeyInfo {
+            account_id,
+            table_name,
+        } => serde_json::json!({
+            "scope": "table_key_info",
+            "selectors": { "account_id": account_id, "table_name": table_name },
+        }),
+        CacheInvalidateScope::ResourceTags { arn } => serde_json::json!({
+            "scope": "resource_tags",
+            "selectors": { "arn": arn },
+        }),
+    };
+    c.req("POST", "/management/cache/invalidate", Some(&body))
 }

--- a/crates/bin/src/manage_types.rs
+++ b/crates/bin/src/manage_types.rs
@@ -402,4 +402,76 @@ pub enum ManageCommand {
         #[arg(long)]
         role_name: String,
     },
+    /// Cache management (admin-only break-glass invalidation)
+    Cache {
+        #[command(subcommand)]
+        action: CacheAction,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum CacheAction {
+    /// Invalidate cache entries. See `cache invalidate --help` for scopes.
+    Invalidate {
+        #[command(subcommand)]
+        scope: CacheInvalidateScope,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum CacheInvalidateScope {
+    /// Invalidate every cached entry across every cache (requires --yes).
+    All {
+        /// Confirm the global flush. Refuses to run without it.
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
+    /// Invalidate every cached entry for a specific account.
+    Account {
+        #[arg(long)]
+        account_id: String,
+    },
+    /// Invalidate a single cached credential by access key.
+    Credential {
+        #[arg(long)]
+        access_key_id: String,
+    },
+    /// Invalidate everything cached about an IAM user (policies, group
+    /// policies, boundary, tags, credentials).
+    User {
+        #[arg(long)]
+        account_id: String,
+        #[arg(long)]
+        user_name: String,
+    },
+    /// Invalidate everything cached about an IAM role (policies, boundary,
+    /// tags, sessions, credentials).
+    Role {
+        #[arg(long)]
+        account_id: String,
+        #[arg(long)]
+        role_name: String,
+    },
+    /// Invalidate the cached group_policies for a list of users (used
+    /// after a group-membership change that the write-through hooks
+    /// missed).
+    GroupMembers {
+        #[arg(long)]
+        account_id: String,
+        /// Comma-separated user names.
+        #[arg(long)]
+        user_names: String,
+    },
+    /// Invalidate the TableKeyInfo cache for a single table.
+    TableKeyInfo {
+        #[arg(long)]
+        account_id: String,
+        #[arg(long)]
+        table_name: String,
+    },
+    /// Invalidate the resource_tags cache for a resource ARN.
+    ResourceTags {
+        #[arg(long)]
+        arn: String,
+    },
 }

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+[package]
+name = "extenddb-cache"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "In-memory stale-while-revalidate cache primitive used by the auth and storage layers."
+
+[features]
+# `test-util` exposes test-only helpers like `SwrCache::run_pending_tasks`
+# to consumers outside this crate. Production code never enables this.
+test-util = []
+
+[dependencies]
+moka = { workspace = true }
+serde = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+futures = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }

--- a/crates/cache/src/entry.rs
+++ b/crates/cache/src/entry.rs
@@ -1,0 +1,34 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cache entry payload.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::time::Instant;
+
+/// Internal cache entry. Stored as `Arc<Entry<V>>` inside the `moka` cache so
+/// the value can be cheaply cloned out of the cache on hit and so the
+/// `refresh_in_flight` flag can be CAS'd without removing the entry.
+///
+/// `value` is `Option<V>` to support negative caching: `None` means the
+/// upstream loader returned `Ok(None)` (e.g. "key not found"). The two TTLs
+/// (positive and negative) are applied at lookup time by `SwrCache`, not
+/// stored on the entry.
+pub(crate) struct Entry<V> {
+    pub(crate) value: Option<V>,
+    pub(crate) fetched_at: Instant,
+    /// True when a background refresh task is currently running for this key.
+    /// Used to single-flight refresh-ahead loads.
+    pub(crate) refresh_in_flight: AtomicBool,
+}
+
+impl<V> Entry<V> {
+    pub(crate) fn new(value: Option<V>) -> Arc<Self> {
+        Arc::new(Self {
+            value,
+            fetched_at: Instant::now(),
+            refresh_in_flight: AtomicBool::new(false),
+        })
+    }
+}

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -1,0 +1,57 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Stale-while-revalidate (SWR) cache primitive used by the auth and storage layers.
+//!
+//! See `docs/design/12-auth-authz-cache.md` for the full design rationale.
+//!
+//! # Behavior
+//!
+//! Each cache entry has two timestamps relative to its insertion time:
+//!
+//! ```text
+//! fetched_at ──── soft_ttl ──── hard_ttl ──── ∞
+//!               fresh        stale-but-usable   miss
+//! ```
+//!
+//! - `now − fetched_at < soft_ttl` → return cached value, no work.
+//! - `soft_ttl ≤ now − fetched_at < hard_ttl` → return cached value AND spawn a
+//!   tokio task to refetch and replace.
+//! - `now − fetched_at ≥ hard_ttl` → cache miss. Caller awaits the load.
+//!   Concurrent misses for the same key share one in-flight load (single-flight).
+//!
+//! Negative results (`Ok(None)` from the loader) are cached for `negative_ttl`,
+//! which is typically much shorter than `hard_ttl`. Errors are never cached.
+//!
+//! # Thread / runtime safety
+//!
+//! `SwrCache` is `Clone + Send + Sync` and may be shared across tasks via direct
+//! cloning (the underlying `moka` cache is internally `Arc`-shared). All
+//! operations are async and contention-free under typical loads.
+//!
+//! # Shutdown
+//!
+//! Background refresh tasks are spawned via `tokio::spawn` without retaining
+//! the `JoinHandle`. At runtime shutdown, tokio cancels in-flight tasks; an
+//! in-progress loader query may produce a "connection closed" warning in
+//! the logs from the database layer but cannot leak resources. Callers that
+//! need deterministic shutdown should call `invalidate_all` and wait briefly
+//! before dropping the cache; an explicit cancellation token is a future
+//! enhancement.
+
+#![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
+
+mod entry;
+mod swr;
+
+#[cfg(test)]
+mod tests;
+
+pub use swr::{ConfigError, Loader, SwrCache, SwrCacheConfig, SwrMetrics, SwrMetricsSnapshot};
+
+/// Re-export of moka's `PredicateError`, returned by `invalidate_if` and
+/// `invalidate_if_value`. Re-exported so callers don't need a direct moka
+/// dependency.
+pub use moka::PredicateError;

--- a/crates/cache/src/swr.rs
+++ b/crates/cache/src/swr.rs
@@ -1,0 +1,637 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Stale-while-revalidate cache implementation.
+//!
+//! See `lib.rs` for the API surface and `docs/design/12-auth-authz-cache.md`
+//! for the design rationale.
+
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use futures::future::BoxFuture;
+use moka::future::Cache as MokaCache;
+
+use crate::entry::Entry;
+
+/// Configuration for an `SwrCache`.
+#[derive(Debug, Clone)]
+pub struct SwrCacheConfig {
+    /// Hard TTL — entries older than this are full misses.
+    pub ttl: Duration,
+    /// Soft TTL — entries older than this trigger background refresh on access.
+    /// Must be `<= ttl`.
+    pub soft_ttl: Duration,
+    /// TTL applied to negative entries (`Ok(None)` from the loader).
+    /// Must be `<= ttl`.
+    pub negative_ttl: Duration,
+    /// Maximum number of entries before LRU eviction kicks in. Must be `> 0`.
+    pub max_entries: u64,
+    /// Optional name used in logs and metrics. Defaults to "swr-cache".
+    pub name: &'static str,
+}
+
+impl Default for SwrCacheConfig {
+    fn default() -> Self {
+        Self {
+            ttl: Duration::from_secs(60),
+            soft_ttl: Duration::from_secs(30),
+            negative_ttl: Duration::from_secs(5),
+            max_entries: 10_000,
+            name: "swr-cache",
+        }
+    }
+}
+
+/// Reasons a [`SwrCacheConfig`] may fail validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigError {
+    ZeroTtl,
+    ZeroMaxEntries,
+    SoftTtlExceedsTtl,
+    NegativeTtlExceedsTtl,
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = match self {
+            Self::ZeroTtl => "ttl must be > 0",
+            Self::ZeroMaxEntries => "max_entries must be > 0",
+            Self::SoftTtlExceedsTtl => "soft_ttl must be <= ttl",
+            Self::NegativeTtlExceedsTtl => "negative_ttl must be <= ttl",
+        };
+        f.write_str(msg)
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+impl SwrCacheConfig {
+    /// Validate config invariants. Operators that accept untrusted config
+    /// (e.g. TOML) MUST call this at startup; bad values silently produce a
+    /// thrash cache otherwise.
+    ///
+    /// # Errors
+    /// Returns `ConfigError` describing the first invariant violation found.
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if self.ttl.is_zero() {
+            return Err(ConfigError::ZeroTtl);
+        }
+        if self.max_entries == 0 {
+            return Err(ConfigError::ZeroMaxEntries);
+        }
+        if self.soft_ttl > self.ttl {
+            return Err(ConfigError::SoftTtlExceedsTtl);
+        }
+        if self.negative_ttl > self.ttl {
+            return Err(ConfigError::NegativeTtlExceedsTtl);
+        }
+        Ok(())
+    }
+}
+
+/// Type alias for a boxed loader future.
+///
+/// Loaders are stored as `Arc<dyn Fn(K) -> BoxFuture<...>>` so the cache can
+/// invoke them from both the request path and spawned refresh tasks.
+///
+/// # Concurrency contract
+///
+/// Loaders may be invoked concurrently across **different keys**. Within a
+/// single key, the cache deduplicates concurrent invocations on hard miss
+/// via moka's single-flight semantics; only one loader future runs and all
+/// racing callers share its outcome. Background refreshes are deduped via
+/// the per-entry `refresh_in_flight` flag.
+///
+/// Loaders MUST be effect-free with respect to the cache's externally-
+/// observable state. Capturing shared `Arc<dyn ...Store>` handles is fine;
+/// capturing a `Mutex` or `mpsc::Sender` is a mistake.
+pub type Loader<K, V, E> = Arc<dyn Fn(K) -> BoxFuture<'static, Result<Option<V>, E>> + Send + Sync>;
+
+/// Atomic counters exposed for observability. Cheap to read; cheap to
+/// `clone` (it returns an `Arc`-shared handle).
+#[derive(Debug, Default)]
+pub struct SwrMetrics {
+    pub hits: AtomicU64,
+    pub stale_hits: AtomicU64,
+    pub misses: AtomicU64,
+    pub negative_hits: AtomicU64,
+    pub refresh_success: AtomicU64,
+    pub refresh_failure: AtomicU64,
+    pub refresh_skipped_inflight: AtomicU64,
+    /// Refreshes whose result was discarded because the cache's epoch
+    /// advanced (i.e. an explicit invalidation happened during the refresh).
+    /// High counts mean the cache is doing wasted refresh work; low counts
+    /// are the typical case.
+    pub refresh_dropped_epoch: AtomicU64,
+    pub invalidations: AtomicU64,
+}
+
+impl SwrMetrics {
+    fn incr(counter: &AtomicU64) {
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Snapshot all counters for export (e.g. to Prometheus).
+    #[must_use]
+    pub fn snapshot(&self) -> SwrMetricsSnapshot {
+        SwrMetricsSnapshot {
+            hits: self.hits.load(Ordering::Relaxed),
+            stale_hits: self.stale_hits.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+            negative_hits: self.negative_hits.load(Ordering::Relaxed),
+            refresh_success: self.refresh_success.load(Ordering::Relaxed),
+            refresh_failure: self.refresh_failure.load(Ordering::Relaxed),
+            refresh_skipped_inflight: self.refresh_skipped_inflight.load(Ordering::Relaxed),
+            refresh_dropped_epoch: self.refresh_dropped_epoch.load(Ordering::Relaxed),
+            invalidations: self.invalidations.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Plain-old-data view of `SwrMetrics`. Useful for tests and metric exports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SwrMetricsSnapshot {
+    pub hits: u64,
+    pub stale_hits: u64,
+    pub misses: u64,
+    pub negative_hits: u64,
+    pub refresh_success: u64,
+    pub refresh_failure: u64,
+    pub refresh_skipped_inflight: u64,
+    #[serde(default)]
+    pub refresh_dropped_epoch: u64,
+    pub invalidations: u64,
+}
+
+/// Stale-while-revalidate cache.
+///
+/// `K` is the key type. `V` is the value type. `E` is the loader's error type.
+///
+/// Cloning is cheap — clones share the underlying `moka` cache, loader,
+/// configuration, and metrics. All operations are async-safe and may be
+/// invoked concurrently from any number of tasks.
+///
+/// # Single-flight on hard miss
+///
+/// Concurrent callers requesting the same missing key share one loader
+/// invocation via `moka::future::Cache::try_get_with`. moka requires the
+/// error type be `Clone + Send + Sync + 'static` so it can hand each racing
+/// caller their own copy of the same error.
+pub struct SwrCache<K, V, E>
+where
+    K: Hash + Eq + Send + Sync + Clone + 'static,
+    V: Clone + Send + Sync + 'static,
+    E: Clone + Send + Sync + 'static,
+{
+    /// The underlying moka cache. `None` in pass-through mode so the kill
+    /// switch costs zero memory beyond a tag bit, and `get` provably
+    /// cannot accidentally read or write moka state.
+    inner: Option<MokaCache<K, Arc<Entry<V>>>>,
+    loader: Loader<K, V, E>,
+    config: Arc<SwrCacheConfig>,
+    metrics: Arc<SwrMetrics>,
+    /// Monotonic counter incremented on every explicit invalidation
+    /// (`invalidate`, `invalidate_if`, `invalidate_all`). The hard-miss and
+    /// background-refresh paths capture the epoch BEFORE running the loader
+    /// and only `insert` if the epoch hasn't moved. Closes the
+    /// refresh-races-invalidation race.
+    epoch: Arc<AtomicU64>,
+}
+
+impl<K, V, E> Clone for SwrCache<K, V, E>
+where
+    K: Hash + Eq + Send + Sync + Clone + 'static,
+    V: Clone + Send + Sync + 'static,
+    E: Clone + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            loader: self.loader.clone(),
+            config: self.config.clone(),
+            metrics: self.metrics.clone(),
+            epoch: self.epoch.clone(),
+        }
+    }
+}
+
+impl<K, V, E> SwrCache<K, V, E>
+where
+    K: Hash + Eq + Send + Sync + Clone + Debug + 'static,
+    V: Clone + Send + Sync + 'static,
+    E: Clone + Send + Sync + Debug + 'static,
+{
+    /// Construct a new cache with the given loader and configuration.
+    ///
+    /// The loader is invoked on a hard miss (request blocks) and from a
+    /// spawned task on stale-hit refresh (request does not block).
+    ///
+    /// # Errors
+    /// Returns `ConfigError` if `config` fails [`SwrCacheConfig::validate`].
+    pub fn try_new(loader: Loader<K, V, E>, config: SwrCacheConfig) -> Result<Self, ConfigError> {
+        config.validate()?;
+        let inner = MokaCache::builder()
+            .max_capacity(config.max_entries)
+            // moka's TTL caps how long an entry lives in the underlying map.
+            // `validate()` guarantees `negative_ttl <= ttl`, so the hard
+            // TTL is sufficient — we enforce the per-entry semantic TTL
+            // (positive vs negative) at lookup time.
+            .time_to_live(config.ttl)
+            // Opt in to `invalidate_entries_if` (used for fanout
+            // invalidations like `invalidate_role_sessions`).
+            .support_invalidation_closures()
+            .build();
+        Ok(Self {
+            inner: Some(inner),
+            loader,
+            config: Arc::new(config),
+            metrics: Arc::new(SwrMetrics::default()),
+            epoch: Arc::new(AtomicU64::new(0)),
+        })
+    }
+
+    /// Construct a pass-through cache: every `get` invokes the loader
+    /// directly without consulting the underlying map; every `invalidate*`
+    /// is a no-op.
+    ///
+    /// Used when the operator sets `auth.cache.enabled = false`. The cache
+    /// wrappers stay in place so the call-graph is unchanged, but the cache
+    /// itself adds zero overhead beyond a single `if` branch.
+    ///
+    /// `config` is still validated (the `name` is used for metric labels);
+    /// TTL fields are ignored at runtime since nothing is cached.
+    ///
+    /// # Errors
+    /// Returns `ConfigError` if `config` fails [`SwrCacheConfig::validate`].
+    pub fn try_pass_through(
+        loader: Loader<K, V, E>,
+        config: SwrCacheConfig,
+    ) -> Result<Self, ConfigError> {
+        config.validate()?;
+        // Pass-through carries no moka instance: every `get` short-circuits
+        // before consulting `inner`, so the underlying allocator + LRU
+        // bookkeeping would be pure overhead. The `Option::None` here also
+        // makes it impossible for a future refactor to accidentally read
+        // or write a stale entry while in pass-through mode.
+        Ok(Self {
+            inner: None,
+            loader,
+            config: Arc::new(config),
+            metrics: Arc::new(SwrMetrics::default()),
+            epoch: Arc::new(AtomicU64::new(0)),
+        })
+    }
+
+    /// Construct a pass-through cache, panicking on invalid configuration.
+    ///
+    /// # Panics
+    /// Panics if `config` fails [`SwrCacheConfig::validate`].
+    #[must_use]
+    pub fn pass_through(loader: Loader<K, V, E>, config: SwrCacheConfig) -> Self {
+        Self::try_pass_through(loader, config).expect("invalid SwrCacheConfig")
+    }
+
+    /// Construct a new cache, panicking on invalid configuration.
+    ///
+    /// Prefer [`Self::try_new`] in production code paths that accept user
+    /// config; reserve `new` for tests and statically-valid configurations.
+    ///
+    /// # Panics
+    /// Panics if `config` fails [`SwrCacheConfig::validate`].
+    #[must_use]
+    pub fn new(loader: Loader<K, V, E>, config: SwrCacheConfig) -> Self {
+        Self::try_new(loader, config).expect("invalid SwrCacheConfig")
+    }
+
+    /// Returns a shared handle to the metrics. Cheap to clone.
+    #[must_use]
+    pub fn metrics(&self) -> Arc<SwrMetrics> {
+        self.metrics.clone()
+    }
+
+    /// Returns the configured cache name (for logging / metric labelling).
+    #[must_use]
+    pub fn name(&self) -> &'static str {
+        self.config.name
+    }
+
+    /// Returns the current number of entries (best-effort, may lag eviction).
+    /// Always 0 in pass-through mode (no underlying storage).
+    #[must_use]
+    pub fn entry_count(&self) -> u64 {
+        match &self.inner {
+            Some(c) => c.entry_count(),
+            None => 0,
+        }
+    }
+
+    /// Returns `true` when this cache was constructed via `pass_through` /
+    /// `try_pass_through` and forwards every `get` directly to the loader.
+    #[must_use]
+    pub fn is_pass_through(&self) -> bool {
+        self.inner.is_none()
+    }
+
+    /// Look up a key, fetching from the loader on miss and serving stale on
+    /// soft expiry while refreshing in the background.
+    ///
+    /// Returns `Ok(None)` if the loader returned `Ok(None)` (negative hit).
+    /// Returns `Err(_)` if the loader failed and no cached value was usable.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the loader on a hard miss. Concurrent hard-
+    /// miss callers share one loader invocation (single-flight); all racing
+    /// callers see the same error value (cloned). Errors during background
+    /// refresh are logged and counted, but the cached (stale) value
+    /// continues to be served until `ttl` elapses.
+    pub async fn get(&self, key: K) -> Result<Option<V>, E> {
+        let Some(inner) = self.inner.as_ref() else {
+            // Kill-switch mode: bypass the cache entirely. Counted as a miss
+            // for observability so operators can confirm bypass behavior.
+            SwrMetrics::incr(&self.metrics.misses);
+            return (self.loader)(key).await;
+        };
+
+        let now = Instant::now();
+
+        // Fast path: check for an existing entry without touching the loader.
+        if let Some(entry) = inner.get(&key).await {
+            let age = now.saturating_duration_since(entry.fetched_at);
+            let entry_ttl = if entry.value.is_some() {
+                self.config.ttl
+            } else {
+                self.config.negative_ttl
+            };
+
+            if age < entry_ttl {
+                if entry.value.is_none() {
+                    SwrMetrics::incr(&self.metrics.negative_hits);
+                } else if age < self.config.soft_ttl {
+                    SwrMetrics::incr(&self.metrics.hits);
+                } else {
+                    SwrMetrics::incr(&self.metrics.stale_hits);
+                    self.maybe_spawn_refresh(inner, &key, &entry);
+                }
+                return Ok(entry.value.clone());
+            }
+            // Otherwise: fall through to a hard miss / load.
+        }
+
+        // Hard miss — go through moka's single-flight path so concurrent
+        // callers for the same key share one loader invocation.
+        SwrMetrics::incr(&self.metrics.misses);
+        self.load_single_flight(inner, key).await
+    }
+
+    /// Drive a hard-miss load through moka's `try_get_with` so concurrent
+    /// callers share one loader future.
+    ///
+    /// We invalidate the existing entry first so `try_get_with`'s
+    /// "I have an existing value" fast path doesn't return our just-expired
+    /// entry; the invalidate is necessary because moka's per-entry TTL is
+    /// one global hard expiry while our `ttl`/`negative_ttl` distinction is
+    /// per-entry-state.
+    async fn load_single_flight(
+        &self,
+        inner: &MokaCache<K, Arc<Entry<V>>>,
+        key: K,
+    ) -> Result<Option<V>, E> {
+        // Drop the current entry (if any) so try_get_with's first invocation
+        // executes the loader. The invalidate is a fast in-memory mark; even
+        // if a concurrent caller's try_get_with collides with ours, moka
+        // dedupes the actual loader invocation.
+        inner.invalidate(&key).await;
+
+        let loader = self.loader.clone();
+        let epoch_before = self.epoch.load(Ordering::Acquire);
+        let key_for_init = key.clone();
+
+        let inserted: Result<Arc<Entry<V>>, Arc<E>> = inner
+            .try_get_with(key.clone(), async move {
+                (loader)(key_for_init).await.map(Entry::new)
+            })
+            .await;
+
+        match inserted {
+            Ok(entry) => {
+                // Epoch guard — if invalidate fired while the loader was
+                // running, the cached entry is now potentially stale relative
+                // to the new state. Drop it so the next caller takes the
+                // fresh path. We still return THIS load's value to the
+                // current caller — it reflects the loader's view of the
+                // world at fetch time, which is the contract we promise.
+                if self.epoch.load(Ordering::Acquire) != epoch_before {
+                    inner.invalidate(&key).await;
+                    SwrMetrics::incr(&self.metrics.refresh_dropped_epoch);
+                }
+                Ok(entry.value.clone())
+            }
+            Err(shared_err) => {
+                // moka shared one Arc<E> across every racing caller. Clone
+                // the inner E so each caller gets an owned value. Errors are
+                // not cached; the next call will re-attempt.
+                Err((*shared_err).clone())
+            }
+        }
+    }
+
+    /// Spawn a background refresh task for `key` if one is not already in
+    /// flight.
+    ///
+    /// Single-flight is enforced by an atomic CAS on the entry's
+    /// `refresh_in_flight` flag. The flag is cleared on task completion via
+    /// an RAII guard, so a panicking loader cannot leave the flag stuck
+    /// (panic safety).
+    ///
+    /// The refresh task captures the cache's `epoch` BEFORE running the
+    /// loader and only inserts on success if the epoch hasn't moved.
+    /// Otherwise the result is discarded (closes the refresh-races-
+    /// invalidate / refresh-races-fresh-write data hazards).
+    fn maybe_spawn_refresh(
+        &self,
+        inner: &MokaCache<K, Arc<Entry<V>>>,
+        key: &K,
+        entry: &Arc<Entry<V>>,
+    ) {
+        // CAS: only one task wins the right to spawn a refresh.
+        if entry
+            .refresh_in_flight
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            SwrMetrics::incr(&self.metrics.refresh_skipped_inflight);
+            return;
+        }
+
+        let cache = inner.clone();
+        let loader = self.loader.clone();
+        let metrics = self.metrics.clone();
+        let epoch = self.epoch.clone();
+        let key = key.clone();
+        let entry_for_clear = entry.clone();
+        let name = self.config.name;
+        let epoch_before = epoch.load(Ordering::Acquire);
+
+        tokio::spawn(async move {
+            // Panic-safe: clear `refresh_in_flight` on any exit, including
+            // panic. Tokio swallows task panics into a JoinHandle which we
+            // drop, but without this guard the flag leaks `true` and
+            // suppresses all future refreshes for this entry until hard TTL
+            // evicts it.
+            let _guard = ClearRefreshFlag(entry_for_clear.clone());
+            let result = (loader)(key.clone()).await;
+            match result {
+                Ok(value) => {
+                    // Epoch guard — if invalidate fired during the load, the
+                    // value we just fetched is potentially stale relative to
+                    // the post-invalidate state. Drop it; next caller takes
+                    // the fresh path. Same logic as `load_single_flight`.
+                    if epoch.load(Ordering::Acquire) != epoch_before {
+                        SwrMetrics::incr(&metrics.refresh_dropped_epoch);
+                        return;
+                    }
+                    // Identity guard — even if no explicit invalidate fired,
+                    // a concurrent hard miss (e.g. hard TTL elapsed during
+                    // this slow refresh) may have replaced the cache slot
+                    // with a freshly-loaded entry. Inserting our result
+                    // would clobber that fresher value. Compare the current
+                    // slot's Arc identity with the entry we started from;
+                    // only write back if they still match.
+                    let still_ours = cache
+                        .get(&key)
+                        .await
+                        .is_some_and(|cur| Arc::ptr_eq(&cur, &entry_for_clear));
+                    if !still_ours {
+                        SwrMetrics::incr(&metrics.refresh_dropped_epoch);
+                        return;
+                    }
+                    let new_entry = Entry::new(value);
+                    cache.insert(key, new_entry).await;
+                    SwrMetrics::incr(&metrics.refresh_success);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        cache = name,
+                        error = ?e,
+                        "background cache refresh failed; continuing to serve stale entry"
+                    );
+                    SwrMetrics::incr(&metrics.refresh_failure);
+                }
+            }
+        });
+    }
+
+    /// Forget the cached value for `key`. The next call will re-fetch.
+    ///
+    /// Used for write-through invalidation when the underlying data changes.
+    /// In pass-through mode this is a no-op since nothing is cached.
+    pub async fn invalidate(&self, key: &K) {
+        let Some(inner) = self.inner.as_ref() else {
+            return;
+        };
+        // Bump epoch BEFORE invalidating so any in-flight refresh that
+        // captured the prior epoch will discard its result on completion.
+        self.epoch.fetch_add(1, Ordering::AcqRel);
+        inner.invalidate(key).await;
+        SwrMetrics::incr(&self.metrics.invalidations);
+    }
+
+    /// Forget every entry whose key matches `predicate`.
+    ///
+    /// `moka`'s `invalidate_entries_if` is asynchronous — entries become
+    /// inaccessible immediately but are evicted from the underlying map by a
+    /// background task.
+    ///
+    /// # Errors
+    /// Returns the underlying moka error if predicate registration fails (in
+    /// practice, only at shutdown).
+    pub fn invalidate_if<F>(&self, key_predicate: F) -> Result<(), moka::PredicateError>
+    where
+        F: Fn(&K) -> bool + Send + Sync + 'static,
+    {
+        let Some(inner) = self.inner.as_ref() else {
+            return Ok(());
+        };
+        self.epoch.fetch_add(1, Ordering::AcqRel);
+        SwrMetrics::incr(&self.metrics.invalidations);
+        inner
+            .invalidate_entries_if(move |k, _v| key_predicate(k))
+            .map(|_| ())
+    }
+
+    /// Forget every entry whose value matches `predicate`.
+    ///
+    /// Used by callers (e.g. credential cache fanout on role deletion) that
+    /// need to invalidate by a value field rather than by key. The
+    /// predicate receives the cached value if positive (`Some(&V)`), or
+    /// `None` for negative entries; predicates that only care about the
+    /// positive case can short-circuit on `None`.
+    ///
+    /// # Errors
+    /// Returns the underlying moka error if predicate registration fails (in
+    /// practice, only at shutdown).
+    pub fn invalidate_if_value<F>(&self, value_predicate: F) -> Result<(), moka::PredicateError>
+    where
+        F: Fn(Option<&V>) -> bool + Send + Sync + 'static,
+    {
+        let Some(inner) = self.inner.as_ref() else {
+            return Ok(());
+        };
+        self.epoch.fetch_add(1, Ordering::AcqRel);
+        SwrMetrics::incr(&self.metrics.invalidations);
+        inner
+            .invalidate_entries_if(move |_k, v| value_predicate(v.value.as_ref()))
+            .map(|_| ())
+    }
+
+    /// Forget every cached value. No-op in pass-through mode.
+    pub fn invalidate_all(&self) {
+        let Some(inner) = self.inner.as_ref() else {
+            return;
+        };
+        self.epoch.fetch_add(1, Ordering::AcqRel);
+        inner.invalidate_all();
+        SwrMetrics::incr(&self.metrics.invalidations);
+    }
+
+    /// Returns the current epoch counter. Tests assert correct epoch
+    /// behavior; not part of the public production API contract.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn epoch(&self) -> u64 {
+        self.epoch.load(Ordering::Acquire)
+    }
+
+    /// Run any pending eviction / expiry housekeeping.
+    ///
+    /// Used by tests to make `entry_count()` deterministic without waiting
+    /// on moka's internal timers. Production code does not need to call
+    /// this; moka schedules its own background work. No-op in pass-through
+    /// mode (no underlying cache to drain).
+    ///
+    /// Available only with the `test-util` feature, or to other tests
+    /// inside this crate.
+    #[cfg(any(test, feature = "test-util"))]
+    pub async fn run_pending_tasks(&self) {
+        if let Some(inner) = self.inner.as_ref() {
+            inner.run_pending_tasks().await;
+        }
+    }
+}
+
+/// RAII guard that clears the `refresh_in_flight` flag on the original entry
+/// when the spawned refresh task exits — including via panic. Without this
+/// guard, a panicking loader leaks `true` on the flag and suppresses all
+/// future refreshes for that entry until hard TTL eviction.
+struct ClearRefreshFlag<V>(Arc<Entry<V>>);
+
+impl<V> Drop for ClearRefreshFlag<V> {
+    fn drop(&mut self) {
+        self.0.refresh_in_flight.store(false, Ordering::Release);
+    }
+}

--- a/crates/cache/src/tests.rs
+++ b/crates/cache/src/tests.rs
@@ -1,0 +1,835 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for the stale-while-revalidate cache primitive.
+//!
+//! These tests use a counting loader to assert that the cache invokes the
+//! upstream the expected number of times. Where the test asserts behavior
+//! around timing, we use `tokio::time::sleep` with a short real-world delay —
+//! we do not depend on `tokio::time::pause` because `moka`'s internal expiry
+//! uses `std::time::Instant` directly, which is unaffected by pause/advance.
+
+#![allow(clippy::unwrap_used)] // tests
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use futures::FutureExt;
+
+use crate::swr::{Loader, SwrCache, SwrCacheConfig};
+
+/// Wraps a `Fn` so we can build an `Arc<dyn Fn>` loader inline. The closure
+/// signature `(K) -> impl Future` is wrapped in `boxed()` to satisfy the
+/// `BoxFuture<'static, ...>` return type the cache expects.
+fn make_loader<K, V, E, F, Fut>(f: F) -> Loader<K, V, E>
+where
+    K: Send + Sync + 'static,
+    V: Send + Sync + 'static,
+    E: Send + Sync + 'static,
+    F: Fn(K) -> Fut + Send + Sync + 'static,
+    Fut: std::future::Future<Output = Result<Option<V>, E>> + Send + 'static,
+{
+    Arc::new(move |k| f(k).boxed())
+}
+
+/// A loader that counts how many times it has been invoked, per-key.
+/// Returns `Ok(Some(format!("v={key}, n={count}")))` so tests can also
+/// distinguish *which* call returned the cached value.
+struct CountingLoader {
+    calls: Arc<AtomicUsize>,
+    /// If set, the loader sleeps before returning. Useful for racing tests.
+    delay: Duration,
+}
+
+impl CountingLoader {
+    fn new() -> (Self, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        (
+            Self {
+                calls: calls.clone(),
+                delay: Duration::ZERO,
+            },
+            calls,
+        )
+    }
+
+    fn with_delay(delay: Duration) -> (Self, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        (
+            Self {
+                calls: calls.clone(),
+                delay,
+            },
+            calls,
+        )
+    }
+
+    fn into_loader(self) -> Loader<String, String, &'static str> {
+        let calls = self.calls;
+        let delay = self.delay;
+        make_loader(move |k: String| {
+            let calls = calls.clone();
+            async move {
+                let n = calls.fetch_add(1, Ordering::SeqCst) + 1;
+                if !delay.is_zero() {
+                    tokio::time::sleep(delay).await;
+                }
+                Ok::<_, &'static str>(Some(format!("v={k}, n={n}")))
+            }
+        })
+    }
+}
+
+fn fast_config() -> SwrCacheConfig {
+    SwrCacheConfig {
+        ttl: Duration::from_millis(200),
+        soft_ttl: Duration::from_millis(50),
+        negative_ttl: Duration::from_millis(50),
+        max_entries: 100,
+        name: "test",
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn second_call_returns_cached_value_without_loading() {
+    let (loader, calls) = CountingLoader::new();
+    let cache = SwrCache::new(loader.into_loader(), fast_config());
+
+    let v1 = cache.get("k".into()).await.unwrap().unwrap();
+    let v2 = cache.get("k".into()).await.unwrap().unwrap();
+
+    assert_eq!(v1, v2, "cached value should be identical to first load");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "loader should be called once"
+    );
+
+    let m = cache.metrics().snapshot();
+    assert_eq!(m.misses, 1);
+    assert_eq!(m.hits, 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn entry_expires_at_hard_ttl() {
+    let (loader, calls) = CountingLoader::new();
+    let cache = SwrCache::new(loader.into_loader(), fast_config());
+
+    cache.get("k".into()).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    cache.get("k".into()).await.unwrap();
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "loader should be invoked twice (initial + post-TTL)"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stale_hit_serves_cached_and_spawns_refresh() {
+    let (loader, calls) = CountingLoader::new();
+    let cache = SwrCache::new(loader.into_loader(), fast_config());
+
+    // First load: miss + insert. n=1.
+    let v1 = cache.get("k".into()).await.unwrap().unwrap();
+    assert!(v1.contains("n=1"), "first value: {v1}");
+
+    // Wait past soft_ttl (50ms) but well before hard_ttl (200ms).
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // Stale hit: should return cached n=1 immediately and spawn a refresh.
+    let v2 = cache.get("k".into()).await.unwrap().unwrap();
+    assert!(
+        v2.contains("n=1"),
+        "stale hit must return cached n=1, got {v2}"
+    );
+
+    // The refresh task is spawned but hasn't yielded yet. Yield so it runs,
+    // and give moka's `insert` time to apply. We use a short sleep that's
+    // well below soft_ttl (50ms) so the next read is within the fresh
+    // window of the refreshed entry.
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "refresh task should have invoked the loader once more"
+    );
+
+    // The next access should now see the refreshed value (n=2). The refresh
+    // reset fetched_at, so this is a *fresh* hit (not another stale hit).
+    let v3 = cache.get("k".into()).await.unwrap().unwrap();
+    assert!(v3.contains("n=2"), "after refresh, expect n=2, got {v3}");
+
+    let m = cache.metrics().snapshot();
+    assert_eq!(m.misses, 1, "exactly one hard miss");
+    assert_eq!(m.stale_hits, 1, "exactly one stale hit");
+    assert_eq!(m.hits, 1, "v3 is a fresh hit on the refreshed entry");
+    assert_eq!(m.refresh_success, 1);
+    assert_eq!(m.refresh_failure, 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_stale_hits_spawn_only_one_refresh() {
+    let (loader, calls) = CountingLoader::with_delay(Duration::from_millis(50));
+    let cache = SwrCache::new(loader.into_loader(), fast_config());
+
+    // Prime the cache.
+    cache.get("k".into()).await.unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    // Wait past soft_ttl. The entry is now stale-but-usable.
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // Fire many concurrent stale-hits.
+    let mut handles = Vec::new();
+    for _ in 0..16 {
+        let cache = cache.clone();
+        handles.push(tokio::spawn(
+            async move { cache.get("k".into()).await.unwrap() },
+        ));
+    }
+    for h in handles {
+        let _ = h.await;
+    }
+
+    // Give the refresh task time to complete.
+    tokio::time::sleep(Duration::from_millis(120)).await;
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "16 concurrent stale-hits must trigger exactly one refresh"
+    );
+
+    let m = cache.metrics().snapshot();
+    assert_eq!(m.refresh_success, 1, "exactly one refresh succeeded");
+    assert!(
+        m.refresh_skipped_inflight >= 14,
+        "most concurrent triggers should be skipped (got {})",
+        m.refresh_skipped_inflight
+    );
+}
+
+// `concurrent_misses_collapse_to_one_load` was removed: its loose
+// (`<= 32`) upper bound is fully subsumed by the strict
+// `concurrent_hard_miss_invokes_loader_exactly_once` test added in PR1,
+// and the post-warmup hit check is covered by
+// `second_call_returns_cached_value_without_loading`.
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn negative_result_is_cached_for_negative_ttl_only() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_loader = calls.clone();
+    let loader: Loader<String, String, &'static str> = make_loader(move |_k: String| {
+        let calls = calls_for_loader.clone();
+        async move {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok::<_, &'static str>(None)
+        }
+    });
+    // Configure: hard TTL 1s, negative TTL 50ms.
+    let config = SwrCacheConfig {
+        ttl: Duration::from_secs(1),
+        soft_ttl: Duration::from_millis(500),
+        negative_ttl: Duration::from_millis(50),
+        max_entries: 100,
+        name: "test",
+    };
+    let cache = SwrCache::new(loader, config);
+
+    // First call loads None.
+    let v1 = cache.get("k".into()).await.unwrap();
+    assert!(v1.is_none());
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    // Within the negative TTL, second call hits cache.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    let v2 = cache.get("k".into()).await.unwrap();
+    assert!(v2.is_none());
+    assert_eq!(calls.load(Ordering::SeqCst), 1, "negative cache hit");
+
+    // Past the negative TTL, third call re-fetches.
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    let v3 = cache.get("k".into()).await.unwrap();
+    assert!(v3.is_none());
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "negative cache should expire at negative_ttl, not at ttl"
+    );
+
+    let m = cache.metrics().snapshot();
+    assert_eq!(m.negative_hits, 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn errors_are_not_cached() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_loader = calls.clone();
+    // Loader fails the first call, succeeds the second.
+    let loader: Loader<String, String, &'static str> = make_loader(move |_k: String| {
+        let calls = calls_for_loader.clone();
+        async move {
+            let n = calls.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                Err::<Option<String>, _>("boom")
+            } else {
+                Ok(Some("ok".to_owned()))
+            }
+        }
+    });
+    let cache = SwrCache::new(loader, fast_config());
+
+    // First call: error propagates.
+    let r1 = cache.get("k".into()).await;
+    assert_eq!(r1, Err("boom"));
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    // Second call: loader is invoked again (error not cached).
+    let r2 = cache.get("k".into()).await.unwrap().unwrap();
+    assert_eq!(r2, "ok");
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+    // Third call: cached.
+    let r3 = cache.get("k".into()).await.unwrap().unwrap();
+    assert_eq!(r3, "ok");
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn invalidate_forces_next_call_to_load() {
+    let (loader, calls) = CountingLoader::new();
+    let cache = SwrCache::new(loader.into_loader(), fast_config());
+
+    cache.get("k".into()).await.unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    cache.invalidate(&"k".to_owned()).await;
+
+    cache.get("k".into()).await.unwrap();
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "invalidation should force a re-fetch"
+    );
+
+    let m = cache.metrics().snapshot();
+    assert_eq!(m.invalidations, 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn refresh_failure_does_not_evict_stale_entry() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_loader = calls.clone();
+    let loader: Loader<String, String, &'static str> = make_loader(move |_k: String| {
+        let calls = calls_for_loader.clone();
+        async move {
+            let n = calls.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                // First call: succeeds and primes the cache.
+                Ok::<_, &'static str>(Some("v1".to_owned()))
+            } else {
+                // Subsequent calls (refresh): fail.
+                Err("refresh boom")
+            }
+        }
+    });
+    let cache = SwrCache::new(loader, fast_config());
+
+    let v1 = cache.get("k".into()).await.unwrap().unwrap();
+    assert_eq!(v1, "v1");
+
+    // Cross the soft TTL.
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // Stale-hit triggers a refresh, which fails. We still see v1.
+    let v2 = cache.get("k".into()).await.unwrap().unwrap();
+    assert_eq!(v2, "v1", "stale-but-usable value still served");
+
+    // Give the refresh task time to complete.
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    let m = cache.metrics().snapshot();
+    assert_eq!(m.refresh_failure, 1);
+    assert_eq!(m.refresh_success, 0);
+
+    // Another call before hard TTL still serves the stale value (the failed
+    // refresh did not evict it). However, since the refresh_in_flight flag was
+    // cleared, the next stale-hit will spawn another refresh attempt.
+    let v3 = cache.get("k".into()).await.unwrap().unwrap();
+    assert_eq!(v3, "v1");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn lru_eviction_caps_size_at_max_entries() {
+    let (loader, _) = CountingLoader::new();
+    let config = SwrCacheConfig {
+        ttl: Duration::from_secs(60),
+        soft_ttl: Duration::from_secs(30),
+        negative_ttl: Duration::from_secs(5),
+        max_entries: 4,
+        name: "test",
+    };
+    let cache = SwrCache::new(loader.into_loader(), config);
+
+    for i in 0..16 {
+        cache.get(format!("k{i}")).await.unwrap();
+    }
+    // moka eviction is asynchronous; allow it to settle.
+    cache.run_pending_tasks().await;
+
+    let n = cache.entry_count();
+    assert!(n <= 4, "entry count must be ≤ max_entries=4, got {n}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn invalidate_all_clears_every_entry() {
+    let (loader, _) = CountingLoader::new();
+    let cache = SwrCache::new(loader.into_loader(), fast_config());
+
+    for i in 0..5 {
+        cache.get(format!("k{i}")).await.unwrap();
+    }
+    cache.run_pending_tasks().await;
+    assert!(cache.entry_count() > 0);
+
+    cache.invalidate_all();
+    cache.run_pending_tasks().await;
+    assert_eq!(cache.entry_count(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn config_default_has_expected_values() {
+    let cfg = SwrCacheConfig::default();
+    assert_eq!(cfg.ttl, Duration::from_secs(60));
+    assert_eq!(cfg.soft_ttl, Duration::from_secs(30));
+    assert_eq!(cfg.negative_ttl, Duration::from_secs(5));
+    assert_eq!(cfg.max_entries, 10_000);
+    assert_eq!(cfg.name, "swr-cache");
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// PR1 tests — single-flight, race epochs, panic safety, config validation
+// ─────────────────────────────────────────────────────────────────────
+
+use crate::swr::ConfigError;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn config_validate_rejects_zero_ttl() {
+    let cfg = SwrCacheConfig {
+        ttl: Duration::ZERO,
+        ..fast_config()
+    };
+    assert_eq!(cfg.validate(), Err(ConfigError::ZeroTtl));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn config_validate_rejects_zero_max_entries() {
+    let cfg = SwrCacheConfig {
+        max_entries: 0,
+        ..fast_config()
+    };
+    assert_eq!(cfg.validate(), Err(ConfigError::ZeroMaxEntries));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn config_validate_rejects_soft_ttl_above_ttl() {
+    let cfg = SwrCacheConfig {
+        ttl: Duration::from_secs(10),
+        soft_ttl: Duration::from_secs(20),
+        negative_ttl: Duration::from_secs(5),
+        max_entries: 10,
+        name: "test",
+    };
+    assert_eq!(cfg.validate(), Err(ConfigError::SoftTtlExceedsTtl));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn config_validate_rejects_negative_ttl_above_ttl() {
+    let cfg = SwrCacheConfig {
+        ttl: Duration::from_secs(10),
+        soft_ttl: Duration::from_secs(5),
+        negative_ttl: Duration::from_secs(20),
+        max_entries: 10,
+        name: "test",
+    };
+    assert_eq!(cfg.validate(), Err(ConfigError::NegativeTtlExceedsTtl));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn try_new_returns_error_for_invalid_config() {
+    let (loader, _) = CountingLoader::new();
+    let bad = SwrCacheConfig {
+        ttl: Duration::ZERO,
+        ..fast_config()
+    };
+    let result = SwrCache::try_new(loader.into_loader(), bad);
+    assert!(matches!(result, Err(ConfigError::ZeroTtl)));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn config_validate_passes_default() {
+    SwrCacheConfig::default().validate().unwrap();
+}
+
+/// PR1 C1: with proper single-flight, N concurrent hard-miss callers must
+/// invoke the loader **exactly once**. Pre-PR1 this assertion was loose
+/// (`<= 32`) because the implementation didn't actually dedup.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_hard_miss_invokes_loader_exactly_once() {
+    let (loader, calls) = CountingLoader::with_delay(Duration::from_millis(50));
+    let cache = SwrCache::new(loader.into_loader(), fast_config());
+
+    let mut handles = Vec::new();
+    for _ in 0..32 {
+        let cache = cache.clone();
+        handles.push(tokio::spawn(
+            async move { cache.get("k".into()).await.unwrap() },
+        ));
+    }
+    for h in handles {
+        let _ = h.await.unwrap();
+    }
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "32 concurrent hard misses must collapse to exactly one loader call"
+    );
+}
+
+/// PR1 C2/C3: a refresh that completes after an explicit `invalidate` must
+/// NOT clobber the (now-empty) cache slot with stale loader output.
+///
+/// Sequence:
+/// 1. Prime cache. n=1.
+/// 2. Sleep past `soft_ttl`. Stale-hit triggers refresh; loader sleeps inside.
+/// 3. Issue invalidate concurrently with the refresh in flight.
+/// 4. Refresh returns n=2; epoch guard discards the value.
+/// 5. Next access hard-misses, gets n=3 (the actually-current value).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn refresh_dropped_when_invalidate_races() {
+    let (loader, calls) = CountingLoader::with_delay(Duration::from_millis(80));
+    let cache = SwrCache::new(loader.into_loader(), fast_config());
+
+    // First load (n=1) — fast path returns "v=k, n=1".
+    let v1 = cache.get("k".into()).await.unwrap().unwrap();
+    assert!(v1.contains("n=1"));
+
+    // Cross soft_ttl so next access spawns a refresh.
+    tokio::time::sleep(Duration::from_millis(60)).await;
+
+    // Stale-hit: spawns a refresh whose loader will sleep 80ms.
+    let v2 = cache.get("k".into()).await.unwrap().unwrap();
+    assert!(v2.contains("n=1"), "stale-hit returns cached, got {v2}");
+
+    // Race: invalidate while the refresh is still in-flight (~50ms in).
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    cache.invalidate(&"k".to_owned()).await;
+
+    // Wait for the refresh to complete. Its result must be discarded.
+    tokio::time::sleep(Duration::from_millis(120)).await;
+    let m = cache.metrics().snapshot();
+    assert_eq!(
+        m.refresh_dropped_epoch, 1,
+        "refresh that raced invalidate must drop its result"
+    );
+    assert_eq!(
+        m.refresh_success, 0,
+        "the refresh did not write to the cache"
+    );
+
+    // Next call hard-misses since the entry was invalidated. The loader
+    // counter records: 1 (initial) + 1 (refresh, dropped) + 1 (this miss) = 3.
+    let v3 = cache.get("k".into()).await.unwrap().unwrap();
+    let total = calls.load(Ordering::SeqCst);
+    assert_eq!(total, 3, "loader called 3 times: initial, refresh, miss");
+    assert!(
+        v3.contains("n=3"),
+        "post-invalidate read sees the most recent loader call: got {v3}"
+    );
+}
+
+/// PR-review S1: a slow refresh whose loader started before a concurrent
+/// hard miss must NOT clobber the freshly-loaded value.
+///
+/// Sequence:
+/// 1. Prime cache (n=1).
+/// 2. Sleep past `soft_ttl`. Stale-hit triggers refresh; loader sleeps inside.
+/// 3. Sleep past `hard_ttl` (without firing invalidate). The cached entry is
+///    now hard-expired. A fresh request hard-misses → loads n=3 (n=2 is the
+///    refresh's loader call). Cache slot now holds n=3.
+/// 4. The original refresh's loader returns its n=2 value.
+/// 5. The identity guard sees the cache slot's Arc no longer matches the
+///    Arc the refresh started from → drops the refresh result.
+/// 6. Subsequent reads continue to see n=3, not n=2.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn refresh_dropped_when_hard_miss_races() {
+    // Timing budget chosen so the post-hard-miss entry stays alive in the
+    // cache for the duration of the test:
+    //   soft_ttl  = 50ms, hard_ttl = 200ms, slow refresh = 300ms.
+    // Sequence (approximate elapsed):
+    //   t=0    prime n=1 (Entry-A)
+    //   t=80   stale-hit → refresh #2 starts (sleeps 300ms, finishes ~t=380)
+    //   t=250  Entry-A past hard_ttl → hard miss loads n=3 (Entry-B)
+    //   t=380  refresh #2 finishes; identity guard sees the slot now holds
+    //          Entry-B (Arc::ptr_eq != entry_for_clear) → drop the result
+    //   t=400  read v4: Entry-B still fresh, returns "n=3"
+    let cfg = SwrCacheConfig {
+        ttl: Duration::from_millis(200),
+        soft_ttl: Duration::from_millis(50),
+        negative_ttl: Duration::from_millis(50),
+        max_entries: 100,
+        name: "test",
+    };
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_loader = calls.clone();
+    let loader: Loader<String, String, &'static str> = make_loader(move |_k: String| {
+        let calls = calls_for_loader.clone();
+        async move {
+            let n = calls.fetch_add(1, Ordering::SeqCst) + 1;
+            // The refresh that runs AFTER the initial load is the one we
+            // want slow — that's call #2. Initial and post-hard-miss loads
+            // return promptly so the test stays fast.
+            if n == 2 {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+            }
+            Ok::<_, &'static str>(Some(format!("n={n}")))
+        }
+    });
+    let cache = SwrCache::new(loader, cfg);
+
+    // 1. Prime cache. n=1.
+    let v1 = cache.get("k".into()).await.unwrap().unwrap();
+    assert_eq!(v1, "n=1");
+
+    // 2. Cross soft_ttl, trigger refresh. The refresh loader sleeps 300ms.
+    tokio::time::sleep(Duration::from_millis(80)).await;
+    let v2 = cache.get("k".into()).await.unwrap().unwrap();
+    assert_eq!(v2, "n=1", "stale-hit returns cached value");
+
+    // 3. Cross hard_ttl (no invalidate). Next read is a hard miss → n=3.
+    // (Total elapsed ~250ms, past the 200ms hard TTL.)
+    tokio::time::sleep(Duration::from_millis(170)).await;
+    let v3 = cache.get("k".into()).await.unwrap().unwrap();
+    assert_eq!(v3, "n=3", "hard-miss path loads fresh value");
+
+    // 4–5. Wait for the slow refresh (n=2) to finish. Its result must be
+    // discarded by the identity guard, NOT inserted on top of n=3.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // 6. Subsequent reads still see n=3. The post-hard-miss entry is ~150ms
+    // old now (well within the 200ms hard TTL). If the refresh had clobbered,
+    // we'd see n=2 here.
+    let v4 = cache.get("k".into()).await.unwrap().unwrap();
+    assert_eq!(
+        v4, "n=3",
+        "stale refresh must not overwrite the post-hard-miss value"
+    );
+
+    let m = cache.metrics().snapshot();
+    assert_eq!(
+        m.refresh_success, 0,
+        "the slow refresh must NOT have written back; got {m:?}"
+    );
+    assert!(
+        m.refresh_dropped_epoch >= 1,
+        "the slow refresh must be counted as dropped; got {m:?}"
+    );
+}
+
+/// PR1 H4: a panicking loader must NOT leak `refresh_in_flight = true`.
+/// Without the RAII guard, future refreshes would be permanently
+/// suppressed for that entry.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn panicking_refresh_does_not_leak_inflight_flag() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_loader = calls.clone();
+    let loader: Loader<String, String, &'static str> = make_loader(move |_k: String| {
+        let calls = calls_for_loader.clone();
+        async move {
+            let n = calls.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                // First call (initial load) — succeeds.
+                Ok::<_, &'static str>(Some("v1".to_owned()))
+            } else if n == 1 {
+                // Second call (first refresh) — panics inside the spawned task.
+                panic!("simulated refresh panic");
+            } else {
+                // Subsequent calls (subsequent refreshes) — succeed.
+                Ok::<_, &'static str>(Some("v2".to_owned()))
+            }
+        }
+    });
+    let cache = SwrCache::new(loader, fast_config());
+
+    // Prime cache.
+    let v1 = cache.get("k".into()).await.unwrap().unwrap();
+    assert_eq!(v1, "v1");
+
+    // Cross soft_ttl. Stale-hit spawns refresh #1, which panics.
+    tokio::time::sleep(Duration::from_millis(80)).await;
+    cache.get("k".into()).await.unwrap();
+
+    // Give the panicking refresh time to land. Tokio swallows the panic,
+    // but the RAII guard must have cleared `refresh_in_flight`.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Without the guard, this stale-hit would increment
+    // `refresh_skipped_inflight` because the flag would still be `true`. With
+    // the guard, the next stale-hit successfully spawns refresh #2.
+    cache.get("k".into()).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let m = cache.metrics().snapshot();
+    assert!(
+        m.refresh_success >= 1,
+        "second refresh must succeed after first one panicked; got {m:?}"
+    );
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        3,
+        "loader called: initial + panicking refresh + recovered refresh"
+    );
+}
+
+/// PR1: epoch counter increments on every invalidation form.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn epoch_increments_on_each_invalidation() {
+    let (loader, _) = CountingLoader::new();
+    let cache = SwrCache::new(loader.into_loader(), fast_config());
+
+    let e0 = cache.epoch();
+    cache.invalidate(&"k".to_owned()).await;
+    let e1 = cache.epoch();
+    assert!(e1 > e0);
+    cache.invalidate_all();
+    let e2 = cache.epoch();
+    assert!(e2 > e1);
+    cache.invalidate_if(|_k: &String| true).unwrap();
+    let e3 = cache.epoch();
+    assert!(e3 > e2);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// PR2 tests — pass-through (kill switch) mode
+// ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pass_through_invokes_loader_on_every_call() {
+    let (loader, calls) = CountingLoader::new();
+    let cache = SwrCache::pass_through(loader.into_loader(), fast_config());
+
+    assert!(cache.is_pass_through());
+    cache.get("k".into()).await.unwrap();
+    cache.get("k".into()).await.unwrap();
+    cache.get("k".into()).await.unwrap();
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        3,
+        "pass-through must call loader on every get; nothing is cached"
+    );
+    assert_eq!(cache.entry_count(), 0, "no entries are stored");
+
+    // Misses are still counted for observability.
+    let m = cache.metrics().snapshot();
+    assert_eq!(m.misses, 3);
+    assert_eq!(m.hits, 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pass_through_invalidate_is_noop() {
+    let (loader, calls) = CountingLoader::new();
+    let cache = SwrCache::pass_through(loader.into_loader(), fast_config());
+
+    cache.get("k".into()).await.unwrap();
+    cache.invalidate(&"k".to_owned()).await;
+    cache.invalidate_all();
+    cache.invalidate_if(|_: &String| true).unwrap();
+
+    assert_eq!(calls.load(Ordering::SeqCst), 1, "1 get call");
+    let m = cache.metrics().snapshot();
+    // No invalidation counters bumped in pass-through mode (the calls were no-ops).
+    assert_eq!(m.invalidations, 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pass_through_propagates_loader_errors() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_loader = calls.clone();
+    let loader: Loader<String, String, &'static str> = make_loader(move |_k: String| {
+        let calls = calls_for_loader.clone();
+        async move {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Err::<Option<String>, _>("oops")
+        }
+    });
+    let cache = SwrCache::pass_through(loader, fast_config());
+
+    let r1 = cache.get("k".into()).await;
+    let r2 = cache.get("k".into()).await;
+    assert_eq!(r1, Err("oops"));
+    assert_eq!(r2, Err("oops"));
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "pass-through doesn't cache errors (or anything); both calls hit the loader"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn try_pass_through_validates_config() {
+    let (loader, _) = CountingLoader::new();
+    let bad = SwrCacheConfig {
+        ttl: Duration::ZERO,
+        ..fast_config()
+    };
+    let result = SwrCache::try_pass_through(loader.into_loader(), bad);
+    assert!(matches!(result, Err(crate::swr::ConfigError::ZeroTtl)));
+}
+
+/// PR1: hard-miss followers receive a *cloned* error value (via Clone bound),
+/// not a panic. moka's `try_get_with` returns `Arc<E>` for racing callers; we
+/// surface each follower's own owned `E`. With single-flight, all 8 racing
+/// callers share one loader invocation.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_hard_miss_errors_are_returned_to_each_caller() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_loader = calls.clone();
+    let loader: Loader<String, String, &'static str> = make_loader(move |_k: String| {
+        let calls = calls_for_loader.clone();
+        async move {
+            calls.fetch_add(1, Ordering::SeqCst);
+            // Sleep so concurrent callers race on the single-flight entry.
+            tokio::time::sleep(Duration::from_millis(30)).await;
+            Err::<Option<String>, _>("loader-fail")
+        }
+    });
+    let cache = SwrCache::new(loader, fast_config());
+
+    // 8 concurrent callers. With single-flight, the loader runs once and
+    // every caller sees the same error value (cloned).
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let cache = cache.clone();
+        handles.push(tokio::spawn(async move { cache.get("k".into()).await }));
+    }
+    let mut err_count = 0;
+    for h in handles {
+        let r = h.await.unwrap();
+        assert_eq!(r, Err("loader-fail"));
+        err_count += 1;
+    }
+    assert_eq!(err_count, 8, "every caller gets the error");
+    // moka's try_get_with deduplicates the single-flight call: exactly one
+    // loader invocation serves all 8 racing callers. Errors are NOT cached
+    // afterward (confirmed by `errors_are_not_cached`), so a subsequent
+    // get() would re-attempt.
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "8 concurrent hard-miss callers must collapse to exactly one loader call"
+    );
+}

--- a/crates/core/src/error/mod.rs
+++ b/crates/core/src/error/mod.rs
@@ -10,7 +10,7 @@ use crate::types::{CancellationReason, Item};
 ///
 /// REQ-ERR-001 through REQ-ERR-004: error JSON format, status codes, and SDK retry behavior.
 /// SP-ERR-002: HTTP status codes match the real DynamoDB error catalog exactly.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 #[non_exhaustive]
 pub enum DynamoDbError {
     #[error("{0}")]

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+extenddb-auth = { workspace = true }
 extenddb-core = { workspace = true }
 extenddb-storage = { workspace = true }
 serde = { workspace = true }

--- a/crates/engine/src/backup.rs
+++ b/crates/engine/src/backup.rs
@@ -141,6 +141,14 @@ pub(crate) async fn handle_restore_table_from_backup(
         .await
         .map_err(storage_err_to_dynamo)?;
 
+    // Drop any cached negative TableKeyInfo from a prior probe so subsequent
+    // requests against the restored table see it without TTL lag. Tags are
+    // not propagated through restore today; if that ever changes, also
+    // invalidate resource_tags for the new ARN — see handle_create_table.
+    ctx.auth_cache
+        .invalidate_table_key_info(&ctx.account_id, target_table_name)
+        .await;
+
     serialize_output(&json!({ "TableDescription": desc }))
 }
 

--- a/crates/engine/src/create_table.rs
+++ b/crates/engine/src/create_table.rs
@@ -44,11 +44,29 @@ pub async fn handle_create_table(
 
     validate_create_table(&input, &ctx.limits)?;
 
+    let table_name = input.table_name.clone();
     let table_desc = ctx
         .storage
         .create_table(&ctx.account_id, input)
         .await
         .map_err(storage_err_to_dynamo)?;
+
+    // Drop any cached TableKeyInfo (typically a negative-cached "not found"
+    // from a prior describe attempt) so requests against the new table see
+    // it immediately.
+    ctx.auth_cache
+        .invalidate_table_key_info(&ctx.account_id, &table_name)
+        .await;
+
+    // The CreateTable request itself ran through authorize_request, which
+    // populates resource_tags for this ARN. At that point the tags row didn't
+    // exist yet, so the cache holds an empty TagMap. Drop it so subsequent
+    // ABAC evaluations see the tags supplied via CreateTable.Tags.
+    let arn = format!(
+        "arn:aws:dynamodb:{}:{}:table/{}",
+        ctx.region, ctx.account_id, table_name
+    );
+    ctx.auth_cache.invalidate_resource_tags(&arn).await;
 
     let output = CreateTableOutput {
         table_description: table_desc,

--- a/crates/engine/src/delete_table.rs
+++ b/crates/engine/src/delete_table.rs
@@ -18,11 +18,26 @@ pub async fn handle_delete_table(
 
     validate_table_name(&input.table_name, &ctx.limits)?;
 
+    let table_name = input.table_name.clone();
     let table_desc = ctx
         .storage
         .delete_table(&ctx.account_id, input)
         .await
         .map_err(storage_err_to_dynamo)?;
+
+    // Drop the cached TableKeyInfo so subsequent requests see the deletion
+    // (or get a fresh negative-cache entry) immediately.
+    ctx.auth_cache
+        .invalidate_table_key_info(&ctx.account_id, &table_name)
+        .await;
+
+    // The deleted table's tags rows are gone; if a table with the same name
+    // is recreated, ABAC must not see the prior tag map.
+    let arn = format!(
+        "arn:aws:dynamodb:{}:{}:table/{}",
+        ctx.region, ctx.account_id, table_name
+    );
+    ctx.auth_cache.invalidate_resource_tags(&arn).await;
 
     let output = DeleteTableOutput {
         table_description: table_desc,

--- a/crates/engine/src/import_export.rs
+++ b/crates/engine/src/import_export.rs
@@ -60,6 +60,14 @@ pub async fn handle_import_table(
     let table_arn = table_desc.table_arn.clone();
     let table_id = table_desc.table_id.clone();
 
+    // Drop any cached negative TableKeyInfo from a prior probe so subsequent
+    // requests against the new table see it without TTL lag. (Tags aren't
+    // propagated through ImportTable today, so resource_tags doesn't need
+    // invalidation here — see create_table_input_from_params.)
+    ctx.auth_cache
+        .invalidate_table_key_info(&ctx.account_id, &tcp.table_name)
+        .await;
+
     wait_for_table_active(ctx, &tcp.table_name).await?;
 
     let key_info = ctx

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -265,6 +265,15 @@ pub struct OperationContext {
     /// Populated for single-table item-level operations; `None` for table-level
     /// and batch/transact operations.
     pub pre_fetched_key_info: Option<extenddb_core::types::TableKeyInfo>,
+    /// Auth/authz cache handles. Used by control-plane and tagging operations
+    /// to issue write-through cache invalidations after the underlying state
+    /// changes (e.g. `TagResource` invalidates the resource-tags cache).
+    pub auth_cache: extenddb_auth::AuthCacheRegistry,
+    /// Optional cached `TableKeyInfo` lookup. When set, batch / transact /
+    /// multi-table engine handlers route through this instead of calling
+    /// `storage.table_key_info` directly. When unset (e.g. unit tests), the
+    /// engine falls back to direct storage lookups.
+    pub table_key_info_lookup: Option<Arc<dyn extenddb_storage::TableKeyInfoLookup>>,
 }
 
 impl OperationContext {
@@ -279,6 +288,9 @@ impl OperationContext {
             if ki.table_name == table_name && *ki.account_id == *self.account_id {
                 return Ok(ki.clone());
             }
+        }
+        if let Some(ref lookup) = self.table_key_info_lookup {
+            return lookup.lookup(&self.account_id, table_name).await;
         }
         self.storage
             .table_key_info(&self.account_id, table_name)

--- a/crates/engine/src/tagging.rs
+++ b/crates/engine/src/tagging.rs
@@ -90,6 +90,12 @@ pub async fn handle_tag_resource(
         .await
         .map_err(sanitize_storage_error)?;
 
+    // Drop any cached resource-tag entry so the new tags are visible to
+    // ABAC policy evaluation immediately.
+    ctx.auth_cache
+        .invalidate_resource_tags(&input.resource_arn)
+        .await;
+
     // TagResource returns an empty body on success.
     Ok(Value::Object(serde_json::Map::new()))
 }
@@ -120,6 +126,10 @@ pub async fn handle_untag_resource(
         .untag_resource(&input.resource_arn, &input.tag_keys)
         .await
         .map_err(sanitize_storage_error)?;
+
+    ctx.auth_cache
+        .invalidate_resource_tags(&input.resource_arn)
+        .await;
 
     // UntagResource returns an empty body on success.
     Ok(Value::Object(serde_json::Map::new()))

--- a/crates/engine/src/update_table.rs
+++ b/crates/engine/src/update_table.rs
@@ -142,6 +142,7 @@ pub async fn handle_update_table(
         }
     }
 
+    let table_name = input.table_name.clone();
     let desc = ctx
         .storage
         .update_table(&ctx.account_id, input)
@@ -173,6 +174,18 @@ pub async fn handle_update_table(
                 DynamoDbError::InternalServerError("Internal server error".to_owned())
             }
         })?;
+
+    // Drop the cached TableKeyInfo: index changes, stream-spec changes, and
+    // throughput changes all alter what the cached value contains.
+    //
+    // NOTE: UpdateTable does NOT currently accept Tags. If that ever
+    // changes, also invalidate `resource_tags` for the table ARN here —
+    // the request itself populates resource_tags during authorize_request,
+    // so a stale empty entry would otherwise hide the new tags. See
+    // handle_create_table for the same pattern.
+    ctx.auth_cache
+        .invalidate_table_key_info(&ctx.account_id, &table_name)
+        .await;
 
     let output = extenddb_core::types::UpdateTableOutput {
         table_description: desc,

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -8,10 +8,12 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+extenddb-cache = { workspace = true }
 extenddb-core = { workspace = true }
 extenddb-engine = { workspace = true }
 extenddb-storage = { workspace = true }
 extenddb-auth = { workspace = true }
+futures = { workspace = true }
 axum = { workspace = true }
 async-trait = { workspace = true }
 tower = { workspace = true }
@@ -32,3 +34,6 @@ aes-gcm = { workspace = true }
 rand = { workspace = true }
 axum-server = { workspace = true }
 rustls = { workspace = true }
+
+[dev-dependencies]
+extenddb-cache = { workspace = true, features = ["test-util"] }

--- a/crates/server/src/authorization.rs
+++ b/crates/server/src/authorization.rs
@@ -4,18 +4,25 @@
 //! Authorization layer for DynamoDB requests.
 //!
 //! After authentication resolves an `AuthIdentity`, this module fetches the
-//! applicable IAM policies, permissions boundary, and session policy via the
-//! [`AuthorizationStore`] trait, builds a `RequestContext`, and evaluates
-//! authorization using the policy engine from `extenddb-auth`.
+//! applicable IAM policies, permissions boundary, and session policy via
+//! [`CachedAuthzStore`] (which sits on top of the storage [`AuthorizationStore`]
+//! trait), builds a `RequestContext`, and evaluates authorization using the
+//! policy engine from `extenddb-auth`.
+//!
+//! All policy documents are pre-parsed by the cache, so this layer never
+//! invokes `PolicyDocument::from_json` on the request hot path.
+//!
+//! See `docs/design/12-auth-authz-cache.md`.
 
 use std::collections::HashMap;
 
 use extenddb_auth::AuthIdentity;
 use extenddb_auth::policy::context::{RequestContext, RequestParams};
-use extenddb_auth::policy::document::PolicyDocument;
-use extenddb_auth::policy::evaluator::{AuthzDecision, evaluate_policies};
+use extenddb_auth::policy::evaluator::{AuthzDecision, evaluate_policies_arc};
 use extenddb_core::error::DynamoDbError;
-use extenddb_storage::authorization_store::AuthorizationStore;
+use extenddb_storage::management_store::OpError;
+
+use crate::authz_cache::{CachedAuthzStore, PolicyList, TagMap};
 
 /// Evaluate whether the authenticated identity is authorized for the given
 /// DynamoDB operation on the given resource.
@@ -24,7 +31,7 @@ use extenddb_storage::authorization_store::AuthorizationStore;
 /// evaluation algorithm runs: explicit deny → permissions boundary → session
 /// policy → identity allow → implicit deny.
 pub async fn check_authorization(
-    store: &dyn AuthorizationStore,
+    cache: &CachedAuthzStore,
     identity: &AuthIdentity,
     operation: &str,
     resource_arn: &str,
@@ -37,7 +44,7 @@ pub async fn check_authorization(
             user_name,
         } => {
             check_user_authorization(
-                store,
+                cache,
                 account_id,
                 user_name,
                 operation,
@@ -53,7 +60,7 @@ pub async fn check_authorization(
             session_name,
         } => {
             check_role_authorization(
-                store,
+                cache,
                 account_id,
                 role_name,
                 session_name,
@@ -68,7 +75,7 @@ pub async fn check_authorization(
 }
 
 async fn check_user_authorization(
-    store: &dyn AuthorizationStore,
+    cache: &CachedAuthzStore,
     account_id: &str,
     user_name: &str,
     operation: &str,
@@ -78,25 +85,39 @@ async fn check_user_authorization(
 ) -> Result<(), DynamoDbError> {
     let action = format!("dynamodb:{operation}");
 
-    // Fetch all 5 authz inputs concurrently — they are independent queries.
+    // Fetch all 5 authz inputs concurrently — they are independent cache
+    // lookups (or DB queries, on cold start). All come back pre-parsed.
     let (user_policies, group_policies, boundary, principal_tags, resource_tags) = tokio::try_join!(
-        fetch_policies(store.fetch_user_policies(account_id, user_name)),
-        fetch_policies(store.fetch_user_group_policies(account_id, user_name)),
-        fetch_boundary(store.fetch_user_boundary(account_id, user_name)),
-        fetch_tags(store.fetch_user_tags(account_id, user_name)),
-        fetch_resource_tags(store, resource_arn),
+        wrap_policies(cache.fetch_user_policies(account_id, user_name)),
+        wrap_policies(cache.fetch_user_group_policies(account_id, user_name)),
+        wrap_boundary(cache.fetch_user_boundary(account_id, user_name)),
+        wrap_tags(cache.fetch_user_tags(account_id, user_name)),
+        wrap_tags(cache.fetch_resource_tags(resource_arn)),
     )?;
 
-    // Combine identity policies.
-    let mut identity_policies = user_policies;
-    identity_policies.extend(group_policies);
+    // Combine identity policies. Each side is an `Arc<Vec<Arc<PolicyDocument>>>`;
+    // we build a single Vec<Arc<...>> for the evaluator. The per-element
+    // clones are atomic-only (Arc inner ref counts).
+    let mut identity_policies: Vec<
+        std::sync::Arc<extenddb_auth::policy::document::PolicyDocument>,
+    > = Vec::with_capacity(user_policies.len() + group_policies.len());
+    identity_policies.extend(user_policies.iter().cloned());
+    identity_policies.extend(group_policies.iter().cloned());
 
-    // Build request context.
-    let context = RequestContext::build(principal_tags, resource_tags, is_scan, params);
+    // Build request context. RequestContext::build expects owned HashMaps,
+    // so we deref through the Arc and clone once. This is the only place
+    // where the tag map allocation is unavoidable; future iterations could
+    // change RequestContext to hold Arc<HashMap<...>> for true zero-copy.
+    let context = RequestContext::build(
+        (*principal_tags).clone(),
+        (*resource_tags).clone(),
+        is_scan,
+        params,
+    );
 
-    let decision = evaluate_policies(
+    let decision = evaluate_policies_arc(
         &identity_policies,
-        boundary.as_ref(),
+        boundary.as_deref(),
         None,
         &action,
         resource_arn,
@@ -121,7 +142,7 @@ async fn check_user_authorization(
 
 #[allow(clippy::too_many_arguments)]
 async fn check_role_authorization(
-    store: &dyn AuthorizationStore,
+    cache: &CachedAuthzStore,
     account_id: &str,
     role_name: &str,
     session_name: &str,
@@ -132,21 +153,24 @@ async fn check_role_authorization(
 ) -> Result<(), DynamoDbError> {
     let action = format!("dynamodb:{operation}");
 
-    // Fetch all 4 authz inputs concurrently — they are independent queries.
     let (identity_policies, boundary, (session_policy, principal_tags), resource_tags) = tokio::try_join!(
-        fetch_policies(store.fetch_role_policies(account_id, role_name)),
-        fetch_boundary(store.fetch_role_boundary(account_id, role_name)),
-        fetch_session_data_and_tags(store, account_id, role_name, session_name),
-        fetch_resource_tags(store, resource_arn),
+        wrap_policies(cache.fetch_role_policies(account_id, role_name)),
+        wrap_boundary(cache.fetch_role_boundary(account_id, role_name)),
+        fetch_session_data_and_tags(cache, account_id, role_name, session_name),
+        wrap_tags(cache.fetch_resource_tags(resource_arn)),
     )?;
 
-    // Build request context.
-    let context = RequestContext::build(principal_tags, resource_tags, is_scan, params);
+    let context = RequestContext::build(principal_tags, (*resource_tags).clone(), is_scan, params);
 
-    let decision = evaluate_policies(
-        &identity_policies,
-        boundary.as_ref(),
-        session_policy.as_ref(),
+    // Convert the Arc<Vec<...>> to a slice for the evaluator. We materialize
+    // a fresh Vec to allow appending session_policy in the future without
+    // altering the cached value. For now the slice is read-only.
+    let identity_slice: Vec<std::sync::Arc<extenddb_auth::policy::document::PolicyDocument>> =
+        identity_policies.iter().cloned().collect();
+    let decision = evaluate_policies_arc(
+        &identity_slice,
+        boundary.as_deref(),
+        session_policy.as_deref(),
         &action,
         resource_arn,
         &context,
@@ -170,141 +194,87 @@ async fn check_role_authorization(
 }
 
 // ---------------------------------------------------------------------------
-// Helpers — convert store results to authorization types
+// Helpers — translate cache results to authorization-layer types
 // ---------------------------------------------------------------------------
 
-/// Parse policy JSON strings into `PolicyDocument`s. Fail closed on parse errors.
-async fn fetch_policies(
-    fut: impl std::future::Future<
-        Output = Result<Vec<String>, extenddb_storage::management_store::OpError>,
-    >,
-) -> Result<Vec<PolicyDocument>, DynamoDbError> {
-    let jsons = fut.await.map_err(|e| {
-        tracing::error!("Authorization: fetch policies failed: {e:?}");
-        DynamoDbError::InternalServerError("Internal error during authorization".to_owned())
-    })?;
-
-    let mut docs = Vec::with_capacity(jsons.len());
-    for json_str in &jsons {
-        match PolicyDocument::from_json(json_str) {
-            Ok(doc) => docs.push(doc),
-            Err(e) => {
-                // Fail closed: an unparseable stored policy denies access rather
-                // than being silently skipped.
-                tracing::error!("Authorization: unparseable policy: {e}");
-                return Err(DynamoDbError::AccessDeniedException(
-                    "Not authorized to perform this action (policy evaluation error)".to_owned(),
-                ));
-            }
+/// Translate an `OpResult` from the cache into a `DynamoDbError`.
+///
+/// Parse failures are reported by the cache as `OpError::Internal("policy
+/// parse failed: ...")`; those map to `AccessDeniedException` (fail-closed).
+/// Other internal errors map to `InternalServerError`.
+fn op_err_to_dynamo(e: OpError) -> DynamoDbError {
+    match &e {
+        OpError::Internal(msg) if msg.starts_with("policy parse failed") => {
+            tracing::error!("Authorization: {msg}");
+            DynamoDbError::AccessDeniedException(
+                "Not authorized to perform this action (policy evaluation error)".to_owned(),
+            )
+        }
+        _ => {
+            tracing::error!("Authorization: cache load failed: {e:?}");
+            DynamoDbError::InternalServerError("Internal error during authorization".to_owned())
         }
     }
-    Ok(docs)
 }
 
-/// Parse a boundary policy JSON string into a `PolicyDocument`. Fail closed on parse errors.
-async fn fetch_boundary(
+async fn wrap_policies(
+    fut: impl std::future::Future<Output = extenddb_storage::management_store::OpResult<PolicyList>>,
+) -> Result<PolicyList, DynamoDbError> {
+    fut.await.map_err(op_err_to_dynamo)
+}
+
+async fn wrap_boundary(
     fut: impl std::future::Future<
-        Output = Result<Option<String>, extenddb_storage::management_store::OpError>,
+        Output = extenddb_storage::management_store::OpResult<
+            Option<std::sync::Arc<extenddb_auth::policy::document::PolicyDocument>>,
+        >,
     >,
-) -> Result<Option<PolicyDocument>, DynamoDbError> {
-    let json = fut.await.map_err(|e| {
-        tracing::error!("Authorization: fetch boundary failed: {e:?}");
-        DynamoDbError::InternalServerError("Internal error during authorization".to_owned())
-    })?;
-
-    match json {
-        Some(json_str) => match PolicyDocument::from_json(&json_str) {
-            Ok(doc) => Ok(Some(doc)),
-            Err(e) => {
-                tracing::error!("Authorization: unparseable permissions boundary: {e}");
-                Err(DynamoDbError::AccessDeniedException(
-                    "Not authorized to perform this action (policy evaluation error)".to_owned(),
-                ))
-            }
-        },
-        None => Ok(None),
-    }
+) -> Result<Option<std::sync::Arc<extenddb_auth::policy::document::PolicyDocument>>, DynamoDbError>
+{
+    fut.await.map_err(op_err_to_dynamo)
 }
 
-/// Convert tag tuples to a `HashMap`.
-async fn fetch_tags(
-    fut: impl std::future::Future<
-        Output = Result<Vec<(String, String)>, extenddb_storage::management_store::OpError>,
-    >,
-) -> Result<HashMap<String, String>, DynamoDbError> {
-    let tags = fut.await.map_err(|e| {
-        tracing::error!("Authorization: fetch tags failed: {e:?}");
-        DynamoDbError::InternalServerError("Internal error during authorization".to_owned())
-    })?;
-    Ok(tags.into_iter().collect())
+async fn wrap_tags(
+    fut: impl std::future::Future<Output = extenddb_storage::management_store::OpResult<TagMap>>,
+) -> Result<TagMap, DynamoDbError> {
+    fut.await.map_err(op_err_to_dynamo)
 }
 
-/// Fetch resource tags, returning empty map for wildcard ARNs.
-async fn fetch_resource_tags(
-    store: &dyn AuthorizationStore,
-    resource_arn: &str,
-) -> Result<HashMap<String, String>, DynamoDbError> {
-    // Wildcard ARNs (e.g. table/*) have no specific resource to tag.
-    if resource_arn.ends_with("/*") {
-        return Ok(HashMap::new());
-    }
-    fetch_tags(store.fetch_resource_tags(resource_arn)).await
-}
-
-/// Fetch session data and merge role tags with session tags (session wins on conflict).
 async fn fetch_session_data_and_tags(
-    store: &dyn AuthorizationStore,
+    cache: &CachedAuthzStore,
     account_id: &str,
     role_name: &str,
     session_name: &str,
-) -> Result<(Option<PolicyDocument>, HashMap<String, String>), DynamoDbError> {
-    // Fetch role tags and session data concurrently (independent queries).
+) -> Result<
+    (
+        Option<std::sync::Arc<extenddb_auth::policy::document::PolicyDocument>>,
+        HashMap<String, String>,
+    ),
+    DynamoDbError,
+> {
+    // Fetch role tags and session data concurrently.
     let (role_tags, session_data) = tokio::try_join!(
+        wrap_tags(cache.fetch_role_tags(account_id, role_name)),
         async {
-            store
-                .fetch_role_tags(account_id, role_name)
-                .await
-                .map_err(|e| {
-                    tracing::error!("Authorization: fetch role tags failed: {e:?}");
-                    DynamoDbError::InternalServerError(
-                        "Internal error during authorization".to_owned(),
-                    )
-                })
-        },
-        async {
-            store
+            cache
                 .fetch_session_data(account_id, role_name, session_name)
                 .await
-                .map_err(|e| {
-                    tracing::error!("Authorization: fetch session data failed: {e:?}");
-                    DynamoDbError::InternalServerError(
-                        "Internal error during authorization".to_owned(),
-                    )
-                })
+                .map_err(op_err_to_dynamo)
         },
     )?;
-    let mut tags: HashMap<String, String> = role_tags.into_iter().collect();
 
+    // Merge: start from a clone of role tags (we need to mutate-and-overlay
+    // session tags). The clone happens once per request even if the session
+    // is absent — acceptable; merging into-place is the simplest semantics.
+    let mut tags: HashMap<String, String> = (*role_tags).clone();
     let mut session_policy = None;
     if let Some(data) = session_data {
-        // Parse session policy.
-        if let Some(json_str) = data.session_policy {
-            match PolicyDocument::from_json(&json_str) {
-                Ok(doc) => session_policy = Some(doc),
-                Err(e) => {
-                    tracing::error!("Authorization: unparseable session policy: {e}");
-                    return Err(DynamoDbError::AccessDeniedException(
-                        "Not authorized to perform this action (policy evaluation error)"
-                            .to_owned(),
-                    ));
-                }
-            }
-        }
-        // Merge session tags (session wins on conflict).
-        for (k, v) in data.session_tags {
-            tags.insert(k, v);
+        session_policy = data.session_policy.clone();
+        // Merge session tags (session wins on conflict). The session_data
+        // value is shared via Arc; iterate borrowed and clone-on-insert.
+        for (k, v) in &data.session_tags {
+            tags.insert(k.clone(), v.clone());
         }
     }
-
     Ok((session_policy, tags))
 }

--- a/crates/server/src/authz_cache.rs
+++ b/crates/server/src/authz_cache.rs
@@ -1,0 +1,1267 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `CachedAuthzStore` — a stale-while-revalidate cache layered on top of any
+//! [`extenddb_storage::AuthorizationStore`].
+//!
+//! Caches the inputs to IAM evaluation:
+//!
+//! - Identity policies (user / role) — as parsed `Arc<PolicyDocument>`s,
+//!   eliminating per-request JSON parse cost.
+//! - Group policies for a user — same shape.
+//! - Permissions boundary — `Option<Arc<PolicyDocument>>`.
+//! - Principal tags — pre-flattened `HashMap<String, String>`.
+//! - Resource tags — same.
+//! - Role-session data (policy + session tags) — pre-parsed.
+//!
+//! Self-induced changes from the management API are propagated via the
+//! [`AuthCacheRegistry`] (write-through invalidation). Off-instance changes
+//! propagate within the configured TTL.
+//!
+//! See `docs/design/12-auth-authz-cache.md` for the full design.
+
+#![allow(clippy::module_name_repetitions)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use extenddb_auth::policy::document::PolicyDocument;
+use extenddb_cache::{Loader, SwrCache, SwrCacheConfig};
+use extenddb_storage::authorization_store::{AuthorizationStore, SessionData};
+use extenddb_storage::management_store::{OpError, OpResult};
+use futures::FutureExt;
+use futures::future::BoxFuture;
+
+/// Pre-parsed session data: `session_policy` is parsed into a
+/// `PolicyDocument` (or absent), and `session_tags` is already a
+/// `HashMap` keyed by tag name.
+#[derive(Clone)]
+pub struct CachedSessionData {
+    pub session_policy: Option<Arc<PolicyDocument>>,
+    pub session_tags: HashMap<String, String>,
+}
+
+/// Configuration for the authorization cache. Each sub-cache is sized
+/// independently. Defaults match the recommendations in the design doc.
+#[derive(Debug, Clone)]
+pub struct AuthzCacheConfig {
+    pub identity_policies: SwrCacheConfig,
+    pub group_policies: SwrCacheConfig,
+    pub boundary: SwrCacheConfig,
+    pub principal_tags: SwrCacheConfig,
+    pub resource_tags: SwrCacheConfig,
+    pub session_data: SwrCacheConfig,
+}
+
+impl Default for AuthzCacheConfig {
+    fn default() -> Self {
+        let base = SwrCacheConfig::default();
+        Self {
+            identity_policies: SwrCacheConfig {
+                name: "identity_policies",
+                ..base.clone()
+            },
+            group_policies: SwrCacheConfig {
+                name: "group_policies",
+                ..base.clone()
+            },
+            boundary: SwrCacheConfig {
+                name: "boundary",
+                ..base.clone()
+            },
+            principal_tags: SwrCacheConfig {
+                name: "principal_tags",
+                ..base.clone()
+            },
+            resource_tags: SwrCacheConfig {
+                name: "resource_tags",
+                ..base.clone()
+            },
+            session_data: SwrCacheConfig {
+                name: "session_data",
+                ..base
+            },
+        }
+    }
+}
+
+/// Pre-parsed list of policies, wrapped in `Arc` so cache hits are O(1) —
+/// one atomic increment instead of an N-element Vec clone.
+pub type PolicyList = Arc<Vec<Arc<PolicyDocument>>>;
+
+/// Pre-parsed tag map, wrapped in `Arc` for the same reason.
+pub type TagMap = Arc<HashMap<String, String>>;
+
+/// Cached authorization store. Wraps any [`AuthorizationStore`] and exposes
+/// `fetch_*` methods that return pre-parsed values from an in-memory SWR
+/// cache.
+///
+/// Cloning is cheap; clones share the underlying caches.
+///
+/// Cache value types are wrapped in `Arc` so a hit is one atomic increment
+/// rather than an O(N) deep clone of a `Vec` / `HashMap` per request.
+#[derive(Clone)]
+pub struct CachedAuthzStore {
+    user_policies: SwrCache<(String, String), PolicyList, OpError>,
+    user_group_policies: SwrCache<(String, String), PolicyList, OpError>,
+    user_boundary: SwrCache<(String, String), Arc<PolicyDocument>, OpError>,
+    user_tags: SwrCache<(String, String), TagMap, OpError>,
+    role_policies: SwrCache<(String, String), PolicyList, OpError>,
+    role_boundary: SwrCache<(String, String), Arc<PolicyDocument>, OpError>,
+    role_tags: SwrCache<(String, String), TagMap, OpError>,
+    session_data: SwrCache<(String, String, String), Arc<CachedSessionData>, OpError>,
+    resource_tags: SwrCache<String, TagMap, OpError>,
+}
+
+impl CachedAuthzStore {
+    /// Wrap `inner` with the configured caches. The store is consumed into
+    /// `Arc<dyn AuthorizationStore>` so the loader closures share it.
+    #[must_use]
+    pub fn new(inner: Arc<dyn AuthorizationStore>, cfg: AuthzCacheConfig) -> Self {
+        Self::build(inner, cfg, false)
+    }
+
+    /// Construct a pass-through `CachedAuthzStore` that bypasses every
+    /// sub-cache, calling the underlying store directly. Used when
+    /// `auth.cache.enabled = false` to avoid the cache wrapping overhead
+    /// while keeping the call graph unchanged.
+    #[must_use]
+    pub fn pass_through(inner: Arc<dyn AuthorizationStore>, cfg: AuthzCacheConfig) -> Self {
+        Self::build(inner, cfg, true)
+    }
+
+    fn build(
+        inner: Arc<dyn AuthorizationStore>,
+        cfg: AuthzCacheConfig,
+        pass_through: bool,
+    ) -> Self {
+        // Closures can't be generic over the key/value/error types used by
+        // each subcache, so we inline the branch with a small helper fn.
+        fn mk_cache<K, V, E>(
+            loader: extenddb_cache::Loader<K, V, E>,
+            cache_cfg: extenddb_cache::SwrCacheConfig,
+            pass_through: bool,
+        ) -> extenddb_cache::SwrCache<K, V, E>
+        where
+            K: std::hash::Hash + Eq + Send + Sync + Clone + std::fmt::Debug + 'static,
+            V: Clone + Send + Sync + 'static,
+            E: Clone + Send + Sync + std::fmt::Debug + 'static,
+        {
+            if pass_through {
+                extenddb_cache::SwrCache::pass_through(loader, cache_cfg)
+            } else {
+                extenddb_cache::SwrCache::new(loader, cache_cfg)
+            }
+        }
+        Self {
+            user_policies: mk_cache(
+                make_user_policies_loader(inner.clone()),
+                cfg.identity_policies.clone(),
+                pass_through,
+            ),
+            user_group_policies: mk_cache(
+                make_user_group_policies_loader(inner.clone()),
+                cfg.group_policies.clone(),
+                pass_through,
+            ),
+            user_boundary: mk_cache(
+                make_user_boundary_loader(inner.clone()),
+                cfg.boundary.clone(),
+                pass_through,
+            ),
+            user_tags: mk_cache(
+                make_user_tags_loader(inner.clone()),
+                cfg.principal_tags.clone(),
+                pass_through,
+            ),
+            role_policies: mk_cache(
+                make_role_policies_loader(inner.clone()),
+                cfg.identity_policies.clone(),
+                pass_through,
+            ),
+            role_boundary: mk_cache(
+                make_role_boundary_loader(inner.clone()),
+                cfg.boundary,
+                pass_through,
+            ),
+            role_tags: mk_cache(
+                make_role_tags_loader(inner.clone()),
+                cfg.principal_tags,
+                pass_through,
+            ),
+            session_data: mk_cache(
+                make_session_data_loader(inner.clone()),
+                cfg.session_data,
+                pass_through,
+            ),
+            resource_tags: mk_cache(
+                make_resource_tags_loader(inner),
+                cfg.resource_tags,
+                pass_through,
+            ),
+        }
+    }
+
+    // ── Read methods used by `authorization.rs` ────────────────────────
+
+    /// Fetch the user's inline + attached identity policies, parsed.
+    ///
+    /// Returns an `Arc<Vec<...>>` so cache hits are O(1). Callers that need
+    /// `&[Arc<PolicyDocument>]` can `&*` through the outer Arc.
+    pub async fn fetch_user_policies(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> OpResult<PolicyList> {
+        Ok(self
+            .user_policies
+            .get((account_id.to_owned(), user_name.to_owned()))
+            .await?
+            .unwrap_or_else(|| Arc::new(Vec::new())))
+    }
+
+    /// Fetch all policies attached to the user via group membership.
+    pub async fn fetch_user_group_policies(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> OpResult<PolicyList> {
+        Ok(self
+            .user_group_policies
+            .get((account_id.to_owned(), user_name.to_owned()))
+            .await?
+            .unwrap_or_else(|| Arc::new(Vec::new())))
+    }
+
+    /// Fetch the user's permissions boundary, parsed. Returns `None` if no
+    /// boundary is set.
+    pub async fn fetch_user_boundary(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> OpResult<Option<Arc<PolicyDocument>>> {
+        self.user_boundary
+            .get((account_id.to_owned(), user_name.to_owned()))
+            .await
+    }
+
+    /// Fetch the user's principal tags as a flat map.
+    pub async fn fetch_user_tags(&self, account_id: &str, user_name: &str) -> OpResult<TagMap> {
+        Ok(self
+            .user_tags
+            .get((account_id.to_owned(), user_name.to_owned()))
+            .await?
+            .unwrap_or_else(|| Arc::new(HashMap::new())))
+    }
+
+    /// Fetch the role's inline + attached identity policies, parsed.
+    pub async fn fetch_role_policies(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> OpResult<PolicyList> {
+        Ok(self
+            .role_policies
+            .get((account_id.to_owned(), role_name.to_owned()))
+            .await?
+            .unwrap_or_else(|| Arc::new(Vec::new())))
+    }
+
+    /// Fetch the role's permissions boundary, parsed.
+    pub async fn fetch_role_boundary(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> OpResult<Option<Arc<PolicyDocument>>> {
+        self.role_boundary
+            .get((account_id.to_owned(), role_name.to_owned()))
+            .await
+    }
+
+    /// Fetch the role's principal tags.
+    pub async fn fetch_role_tags(&self, account_id: &str, role_name: &str) -> OpResult<TagMap> {
+        Ok(self
+            .role_tags
+            .get((account_id.to_owned(), role_name.to_owned()))
+            .await?
+            .unwrap_or_else(|| Arc::new(HashMap::new())))
+    }
+
+    /// Fetch role-session data (parsed session policy + tags).
+    pub async fn fetch_session_data(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        session_name: &str,
+    ) -> OpResult<Option<Arc<CachedSessionData>>> {
+        self.session_data
+            .get((
+                account_id.to_owned(),
+                role_name.to_owned(),
+                session_name.to_owned(),
+            ))
+            .await
+    }
+
+    /// Fetch resource tags as a flat map. Empty for wildcard resources.
+    pub async fn fetch_resource_tags(&self, arn: &str) -> OpResult<TagMap> {
+        if arn.ends_with("/*") {
+            return Ok(Arc::new(HashMap::new()));
+        }
+        Ok(self
+            .resource_tags
+            .get(arn.to_owned())
+            .await?
+            .unwrap_or_else(|| Arc::new(HashMap::new())))
+    }
+
+    // ── Invalidation API ───────────────────────────────────────────────
+
+    pub async fn invalidate_user_policies(&self, account_id: &str, user_name: &str) {
+        self.user_policies
+            .invalidate(&(account_id.to_owned(), user_name.to_owned()))
+            .await;
+    }
+
+    pub async fn invalidate_user_group_policies(&self, account_id: &str, user_name: &str) {
+        self.user_group_policies
+            .invalidate(&(account_id.to_owned(), user_name.to_owned()))
+            .await;
+    }
+
+    /// Invalidate user-group-policy entries for **every** member of `group_name`.
+    ///
+    /// Group-policy mutations (PutGroupPolicy, AttachGroupPolicy, etc.) affect
+    /// every user in that group. Since the cache key is `(account_id, user)`,
+    /// not group, we use `invalidate_if` over the user's group memberships.
+    /// In practice, the simpler approach is to take the set of member user
+    /// names from the caller (the management endpoint already had to list
+    /// them) and invalidate each.
+    pub async fn invalidate_users(&self, account_id: &str, user_names: &[String]) {
+        for u in user_names {
+            self.invalidate_user_policies(account_id, u).await;
+            self.invalidate_user_group_policies(account_id, u).await;
+        }
+    }
+
+    pub async fn invalidate_user_boundary(&self, account_id: &str, user_name: &str) {
+        self.user_boundary
+            .invalidate(&(account_id.to_owned(), user_name.to_owned()))
+            .await;
+    }
+
+    pub async fn invalidate_user_tags(&self, account_id: &str, user_name: &str) {
+        self.user_tags
+            .invalidate(&(account_id.to_owned(), user_name.to_owned()))
+            .await;
+    }
+
+    pub async fn invalidate_role_policies(&self, account_id: &str, role_name: &str) {
+        self.role_policies
+            .invalidate(&(account_id.to_owned(), role_name.to_owned()))
+            .await;
+    }
+
+    pub async fn invalidate_role_boundary(&self, account_id: &str, role_name: &str) {
+        self.role_boundary
+            .invalidate(&(account_id.to_owned(), role_name.to_owned()))
+            .await;
+    }
+
+    pub async fn invalidate_role_tags(&self, account_id: &str, role_name: &str) {
+        self.role_tags
+            .invalidate(&(account_id.to_owned(), role_name.to_owned()))
+            .await;
+    }
+
+    pub async fn invalidate_session(&self, account_id: &str, role_name: &str, session_name: &str) {
+        self.session_data
+            .invalidate(&(
+                account_id.to_owned(),
+                role_name.to_owned(),
+                session_name.to_owned(),
+            ))
+            .await;
+    }
+
+    pub async fn invalidate_resource_tags(&self, arn: &str) {
+        self.resource_tags.invalidate(&arn.to_owned()).await;
+    }
+
+    /// Drop every cached session-data entry for `(account_id, role_name)`.
+    /// Used when a role is deleted; the cache's key is
+    /// `(account, role, session)`, so we predicate on the first two.
+    pub fn invalidate_role_sessions(&self, account_id: &str, role_name: &str) {
+        let acct = account_id.to_owned();
+        let role = role_name.to_owned();
+        // Best-effort: log on failure (only happens at shutdown).
+        if let Err(e) = self
+            .session_data
+            .invalidate_if(move |k| k.0 == acct && k.1 == role)
+        {
+            tracing::warn!(
+                ?e,
+                "session_data invalidate_role_sessions predicate registration failed"
+            );
+        }
+    }
+
+    /// Invalidate every cached entry across every subcache that belongs to
+    /// `account_id`. Used by `delete_account`.
+    ///
+    /// Each subcache is iterated independently since their key shapes
+    /// differ. The resource-tags cache is keyed by ARN; we match the
+    /// account-id segment structurally (5th colon-delimited field) rather
+    /// than via substring search to avoid false positives if an ARN has
+    /// the same digits embedded elsewhere.
+    pub fn invalidate_account(&self, account_id: &str) {
+        let acct = account_id.to_owned();
+        let user_acct = acct.clone();
+        let pred_user = move |k: &(String, String)| k.0 == user_acct;
+        let user_acct = acct.clone();
+        let pred_session = move |k: &(String, String, String)| k.0 == user_acct;
+        let pred_arn = move |k: &String| {
+            // ARN format: arn:aws:dynamodb:{region}:{account_id}:table/...
+            // We only need the 5th segment, so plain `split` works (we
+            // never look past the 6th segment, which may contain colons
+            // for stream labels).
+            k.split(':').nth(4) == Some(acct.as_str())
+        };
+
+        let log_err = |name: &str, e: extenddb_cache::PredicateError| {
+            tracing::warn!(
+                cache = name,
+                ?e,
+                "invalidate_account predicate registration failed"
+            );
+        };
+
+        if let Err(e) = self.user_policies.invalidate_if(pred_user.clone()) {
+            log_err("user_policies", e);
+        }
+        if let Err(e) = self.user_group_policies.invalidate_if(pred_user.clone()) {
+            log_err("user_group_policies", e);
+        }
+        if let Err(e) = self.user_boundary.invalidate_if(pred_user.clone()) {
+            log_err("user_boundary", e);
+        }
+        if let Err(e) = self.user_tags.invalidate_if(pred_user.clone()) {
+            log_err("user_tags", e);
+        }
+        if let Err(e) = self.role_policies.invalidate_if(pred_user.clone()) {
+            log_err("role_policies", e);
+        }
+        if let Err(e) = self.role_boundary.invalidate_if(pred_user.clone()) {
+            log_err("role_boundary", e);
+        }
+        if let Err(e) = self.role_tags.invalidate_if(pred_user) {
+            log_err("role_tags", e);
+        }
+        if let Err(e) = self.session_data.invalidate_if(pred_session) {
+            log_err("session_data", e);
+        }
+        if let Err(e) = self.resource_tags.invalidate_if(pred_arn) {
+            log_err("resource_tags", e);
+        }
+    }
+
+    /// Snapshot per-sub-cache counters for export to `/auth-cache-metrics`.
+    /// Returns `None` if metrics are unavailable for any reason (currently
+    /// always returns `Some`).
+    pub fn metrics_snapshot(&self) -> Option<AuthzCacheMetricsSnapshot> {
+        Some(AuthzCacheMetricsSnapshot {
+            user_policies: self.user_policies.metrics().snapshot(),
+            user_group_policies: self.user_group_policies.metrics().snapshot(),
+            user_boundary: self.user_boundary.metrics().snapshot(),
+            user_tags: self.user_tags.metrics().snapshot(),
+            role_policies: self.role_policies.metrics().snapshot(),
+            role_boundary: self.role_boundary.metrics().snapshot(),
+            role_tags: self.role_tags.metrics().snapshot(),
+            session_data: self.session_data.metrics().snapshot(),
+            resource_tags: self.resource_tags.metrics().snapshot(),
+        })
+    }
+
+    /// Returns `true` when every sub-cache is in pass-through mode (i.e. the
+    /// authz cache was constructed via `pass_through`). All sub-caches are
+    /// configured with the same `pass_through` flag at construction time, so
+    /// a single sub-cache's state is representative of the whole.
+    #[must_use]
+    pub fn is_pass_through(&self) -> bool {
+        self.user_policies.is_pass_through()
+    }
+}
+
+/// Per-sub-cache metric snapshot for the `/auth-cache-metrics` endpoint.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AuthzCacheMetricsSnapshot {
+    pub user_policies: extenddb_cache::SwrMetricsSnapshot,
+    pub user_group_policies: extenddb_cache::SwrMetricsSnapshot,
+    pub user_boundary: extenddb_cache::SwrMetricsSnapshot,
+    pub user_tags: extenddb_cache::SwrMetricsSnapshot,
+    pub role_policies: extenddb_cache::SwrMetricsSnapshot,
+    pub role_boundary: extenddb_cache::SwrMetricsSnapshot,
+    pub role_tags: extenddb_cache::SwrMetricsSnapshot,
+    pub session_data: extenddb_cache::SwrMetricsSnapshot,
+    pub resource_tags: extenddb_cache::SwrMetricsSnapshot,
+}
+
+impl extenddb_auth::AuthzCacheInvalidator for CachedAuthzStore {
+    fn invalidate_user_policies<'a>(
+        &'a self,
+        account_id: &'a str,
+        user_name: &'a str,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(self.invalidate_user_policies(account_id, user_name))
+    }
+
+    fn invalidate_user_group_policies<'a>(
+        &'a self,
+        account_id: &'a str,
+        user_name: &'a str,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(self.invalidate_user_group_policies(account_id, user_name))
+    }
+
+    fn invalidate_users<'a>(
+        &'a self,
+        account_id: &'a str,
+        user_names: &'a [String],
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(self.invalidate_users(account_id, user_names))
+    }
+
+    fn invalidate_user_boundary<'a>(
+        &'a self,
+        account_id: &'a str,
+        user_name: &'a str,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(self.invalidate_user_boundary(account_id, user_name))
+    }
+
+    fn invalidate_user_tags<'a>(
+        &'a self,
+        account_id: &'a str,
+        user_name: &'a str,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(self.invalidate_user_tags(account_id, user_name))
+    }
+
+    fn invalidate_role_policies<'a>(
+        &'a self,
+        account_id: &'a str,
+        role_name: &'a str,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(self.invalidate_role_policies(account_id, role_name))
+    }
+
+    fn invalidate_role_boundary<'a>(
+        &'a self,
+        account_id: &'a str,
+        role_name: &'a str,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(self.invalidate_role_boundary(account_id, role_name))
+    }
+
+    fn invalidate_role_tags<'a>(
+        &'a self,
+        account_id: &'a str,
+        role_name: &'a str,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(self.invalidate_role_tags(account_id, role_name))
+    }
+
+    fn invalidate_session<'a>(
+        &'a self,
+        account_id: &'a str,
+        role_name: &'a str,
+        session_name: &'a str,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(self.invalidate_session(account_id, role_name, session_name))
+    }
+
+    fn invalidate_resource_tags<'a>(&'a self, arn: &'a str) -> BoxFuture<'a, ()> {
+        Box::pin(self.invalidate_resource_tags(arn))
+    }
+
+    fn invalidate_role_sessions<'a>(
+        &'a self,
+        account_id: &'a str,
+        role_name: &'a str,
+    ) -> BoxFuture<'a, ()> {
+        // The synchronous fanout returns immediately; wrap in a ready future
+        // to satisfy the trait signature.
+        self.invalidate_role_sessions(account_id, role_name);
+        Box::pin(std::future::ready(()))
+    }
+
+    fn invalidate_account<'a>(&'a self, account_id: &'a str) -> BoxFuture<'a, ()> {
+        self.invalidate_account(account_id);
+        Box::pin(std::future::ready(()))
+    }
+}
+
+// ── Loader factories ───────────────────────────────────────────────────
+//
+// Each `make_*_loader` returns a `Loader` that issues the corresponding
+// `AuthorizationStore` call and, where applicable, parses JSON into
+// `Arc<PolicyDocument>`. Parse failures bubble up as `OpError::Internal`,
+// which the caller in `authorization.rs` translates to a fail-closed
+// `AccessDeniedException`.
+
+type PolDocsLoader = Loader<(String, String), PolicyList, OpError>;
+type BoundaryLoader = Loader<(String, String), Arc<PolicyDocument>, OpError>;
+type TagsLoader = Loader<(String, String), TagMap, OpError>;
+type SessionLoader = Loader<(String, String, String), Arc<CachedSessionData>, OpError>;
+type ResourceTagsLoader = Loader<String, TagMap, OpError>;
+
+// Policy loaders surface `Ok(None)` when the underlying store returns an
+// empty Vec — same rationale as the tag loaders below. "Principal exists
+// with no inline policies" is functionally identical to "principal does
+// not exist" through this API, AND both should expire on the short
+// `negative_ttl`, not the long `ttl`. Otherwise probes against
+// nonexistent principals fill the LRU with empty positive entries.
+fn make_user_policies_loader(inner: Arc<dyn AuthorizationStore>) -> PolDocsLoader {
+    Arc::new(move |(account_id, user_name): (String, String)|
+        -> BoxFuture<'static, OpResult<Option<PolicyList>>> {
+        let inner = inner.clone();
+        async move {
+            let raw = inner.fetch_user_policies(&account_id, &user_name).await?;
+            policy_list_if_nonempty(&raw)
+        }
+        .boxed()
+    })
+}
+
+fn make_user_group_policies_loader(inner: Arc<dyn AuthorizationStore>) -> PolDocsLoader {
+    Arc::new(move |(account_id, user_name): (String, String)|
+        -> BoxFuture<'static, OpResult<Option<PolicyList>>> {
+        let inner = inner.clone();
+        async move {
+            let raw = inner.fetch_user_group_policies(&account_id, &user_name).await?;
+            policy_list_if_nonempty(&raw)
+        }
+        .boxed()
+    })
+}
+
+fn make_role_policies_loader(inner: Arc<dyn AuthorizationStore>) -> PolDocsLoader {
+    Arc::new(move |(account_id, role_name): (String, String)|
+        -> BoxFuture<'static, OpResult<Option<PolicyList>>> {
+        let inner = inner.clone();
+        async move {
+            let raw = inner.fetch_role_policies(&account_id, &role_name).await?;
+            policy_list_if_nonempty(&raw)
+        }
+        .boxed()
+    })
+}
+
+/// Parse `raw` JSON policy strings; return `Ok(None)` if `raw` is empty
+/// (so the SWR cache stores it as a negative entry with the short
+/// `negative_ttl`); otherwise wrap the parsed documents in `Some`.
+/// Parse errors propagate.
+fn policy_list_if_nonempty(raw: &[String]) -> OpResult<Option<PolicyList>> {
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    parse_documents(raw).map(|v| Some(Arc::new(v)))
+}
+
+fn make_user_boundary_loader(inner: Arc<dyn AuthorizationStore>) -> BoundaryLoader {
+    Arc::new(move |(account_id, user_name): (String, String)|
+        -> BoxFuture<'static, OpResult<Option<Arc<PolicyDocument>>>> {
+        let inner = inner.clone();
+        async move {
+            match inner.fetch_user_boundary(&account_id, &user_name).await? {
+                Some(json_str) => Ok(Some(parse_document(&json_str)?)),
+                None => Ok(None),
+            }
+        }
+        .boxed()
+    })
+}
+
+fn make_role_boundary_loader(inner: Arc<dyn AuthorizationStore>) -> BoundaryLoader {
+    Arc::new(move |(account_id, role_name): (String, String)|
+        -> BoxFuture<'static, OpResult<Option<Arc<PolicyDocument>>>> {
+        let inner = inner.clone();
+        async move {
+            match inner.fetch_role_boundary(&account_id, &role_name).await? {
+                Some(json_str) => Ok(Some(parse_document(&json_str)?)),
+                None => Ok(None),
+            }
+        }
+        .boxed()
+    })
+}
+
+// Tag loaders surface `Ok(None)` when the underlying store returns an
+// empty Vec. The storage trait can't distinguish "principal exists with no
+// tags" from "principal does not exist" — both yield an empty Vec — but
+// for the cache that distinction is moot: both must return an empty
+// `TagMap` to the caller, AND both should expire on the short
+// `negative_ttl`, not the long `ttl`. Otherwise an attacker probing
+// random principals fills the LRU with empty entries that linger for
+// `ttl_seconds`, evicting useful entries. With negative-caching, those
+// probes are bounded to `negative_ttl_seconds`.
+fn make_user_tags_loader(inner: Arc<dyn AuthorizationStore>) -> TagsLoader {
+    Arc::new(move |(account_id, user_name): (String, String)|
+        -> BoxFuture<'static, OpResult<Option<TagMap>>> {
+        let inner = inner.clone();
+        async move {
+            let pairs = inner.fetch_user_tags(&account_id, &user_name).await?;
+            Ok(map_if_nonempty(pairs))
+        }
+        .boxed()
+    })
+}
+
+fn make_role_tags_loader(inner: Arc<dyn AuthorizationStore>) -> TagsLoader {
+    Arc::new(move |(account_id, role_name): (String, String)|
+        -> BoxFuture<'static, OpResult<Option<TagMap>>> {
+        let inner = inner.clone();
+        async move {
+            let pairs = inner.fetch_role_tags(&account_id, &role_name).await?;
+            Ok(map_if_nonempty(pairs))
+        }
+        .boxed()
+    })
+}
+
+/// Wrap a tag pair list as a positive cache entry only if non-empty;
+/// otherwise return `None` so the SWR cache stores it as a negative entry
+/// with the short `negative_ttl`. See the loader comment above for the
+/// rationale.
+fn map_if_nonempty(pairs: Vec<(String, String)>) -> Option<TagMap> {
+    if pairs.is_empty() {
+        None
+    } else {
+        Some(Arc::new(pairs.into_iter().collect()))
+    }
+}
+
+fn make_resource_tags_loader(inner: Arc<dyn AuthorizationStore>) -> ResourceTagsLoader {
+    Arc::new(
+        move |arn: String| -> BoxFuture<'static, OpResult<Option<TagMap>>> {
+            let inner = inner.clone();
+            async move {
+                let pairs = inner.fetch_resource_tags(&arn).await?;
+                Ok(map_if_nonempty(pairs))
+            }
+            .boxed()
+        },
+    )
+}
+
+fn make_session_data_loader(inner: Arc<dyn AuthorizationStore>) -> SessionLoader {
+    Arc::new(move |(account_id, role_name, session_name): (String, String, String)|
+        -> BoxFuture<'static, OpResult<Option<Arc<CachedSessionData>>>> {
+        let inner = inner.clone();
+        async move {
+            let raw: Option<SessionData> = inner
+                .fetch_session_data(&account_id, &role_name, &session_name)
+                .await?;
+            let Some(data) = raw else { return Ok(None) };
+
+            let session_policy = match data.session_policy {
+                Some(json_str) => Some(parse_document(&json_str)?),
+                None => None,
+            };
+            let session_tags: HashMap<String, String> = data.session_tags.into_iter().collect();
+            Ok(Some(Arc::new(CachedSessionData {
+                session_policy,
+                session_tags,
+            })))
+        }
+        .boxed()
+    })
+}
+
+fn parse_documents(jsons: &[String]) -> OpResult<Vec<Arc<PolicyDocument>>> {
+    let mut docs = Vec::with_capacity(jsons.len());
+    for s in jsons {
+        docs.push(parse_document(s)?);
+    }
+    Ok(docs)
+}
+
+fn parse_document(s: &str) -> OpResult<Arc<PolicyDocument>> {
+    PolicyDocument::from_json(s)
+        .map(Arc::new)
+        .map_err(|e| OpError::Internal(format!("policy parse failed: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use extenddb_storage::authorization_store::{AuthorizationStore, SessionData};
+    use extenddb_storage::management_store::OpResult;
+    use futures::future::BoxFuture;
+
+    use super::*;
+
+    type PrincipalKey = (String, String);
+    type SessionKey = (String, String, String);
+    type TagPairs = Vec<(String, String)>;
+
+    /// Counts calls per method so tests can assert the cache prevents repeats.
+    #[derive(Default)]
+    struct CountingAuthzStore {
+        user_policies_calls: AtomicUsize,
+        user_group_policies_calls: AtomicUsize,
+        user_boundary_calls: AtomicUsize,
+        user_tags_calls: AtomicUsize,
+        role_policies_calls: AtomicUsize,
+        role_boundary_calls: AtomicUsize,
+        role_tags_calls: AtomicUsize,
+        session_data_calls: AtomicUsize,
+        resource_tags_calls: AtomicUsize,
+
+        user_policies: Mutex<HashMap<PrincipalKey, Vec<String>>>,
+        user_group_policies: Mutex<HashMap<PrincipalKey, Vec<String>>>,
+        user_boundary: Mutex<HashMap<PrincipalKey, Option<String>>>,
+        user_tags: Mutex<HashMap<PrincipalKey, TagPairs>>,
+        role_policies: Mutex<HashMap<PrincipalKey, Vec<String>>>,
+        role_boundary: Mutex<HashMap<PrincipalKey, Option<String>>>,
+        role_tags: Mutex<HashMap<PrincipalKey, TagPairs>>,
+        session_data: Mutex<HashMap<SessionKey, Option<SessionData>>>,
+        resource_tags: Mutex<HashMap<String, TagPairs>>,
+    }
+
+    impl AuthorizationStore for CountingAuthzStore {
+        fn fetch_user_policies(
+            &self,
+            account_id: &str,
+            user_name: &str,
+        ) -> BoxFuture<'_, OpResult<Vec<String>>> {
+            self.user_policies_calls.fetch_add(1, Ordering::SeqCst);
+            let key = (account_id.to_owned(), user_name.to_owned());
+            let v = self
+                .user_policies
+                .lock()
+                .unwrap()
+                .get(&key)
+                .cloned()
+                .unwrap_or_default();
+            Box::pin(async move { Ok(v) })
+        }
+
+        fn fetch_user_group_policies(
+            &self,
+            account_id: &str,
+            user_name: &str,
+        ) -> BoxFuture<'_, OpResult<Vec<String>>> {
+            self.user_group_policies_calls
+                .fetch_add(1, Ordering::SeqCst);
+            let key = (account_id.to_owned(), user_name.to_owned());
+            let v = self
+                .user_group_policies
+                .lock()
+                .unwrap()
+                .get(&key)
+                .cloned()
+                .unwrap_or_default();
+            Box::pin(async move { Ok(v) })
+        }
+
+        fn fetch_user_boundary(
+            &self,
+            account_id: &str,
+            user_name: &str,
+        ) -> BoxFuture<'_, OpResult<Option<String>>> {
+            self.user_boundary_calls.fetch_add(1, Ordering::SeqCst);
+            let key = (account_id.to_owned(), user_name.to_owned());
+            let v = self
+                .user_boundary
+                .lock()
+                .unwrap()
+                .get(&key)
+                .cloned()
+                .unwrap_or(None);
+            Box::pin(async move { Ok(v) })
+        }
+
+        fn fetch_user_tags(
+            &self,
+            account_id: &str,
+            user_name: &str,
+        ) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+            self.user_tags_calls.fetch_add(1, Ordering::SeqCst);
+            let key = (account_id.to_owned(), user_name.to_owned());
+            let v = self
+                .user_tags
+                .lock()
+                .unwrap()
+                .get(&key)
+                .cloned()
+                .unwrap_or_default();
+            Box::pin(async move { Ok(v) })
+        }
+
+        fn fetch_role_policies(
+            &self,
+            account_id: &str,
+            role_name: &str,
+        ) -> BoxFuture<'_, OpResult<Vec<String>>> {
+            self.role_policies_calls.fetch_add(1, Ordering::SeqCst);
+            let key = (account_id.to_owned(), role_name.to_owned());
+            let v = self
+                .role_policies
+                .lock()
+                .unwrap()
+                .get(&key)
+                .cloned()
+                .unwrap_or_default();
+            Box::pin(async move { Ok(v) })
+        }
+
+        fn fetch_role_boundary(
+            &self,
+            account_id: &str,
+            role_name: &str,
+        ) -> BoxFuture<'_, OpResult<Option<String>>> {
+            self.role_boundary_calls.fetch_add(1, Ordering::SeqCst);
+            let key = (account_id.to_owned(), role_name.to_owned());
+            let v = self
+                .role_boundary
+                .lock()
+                .unwrap()
+                .get(&key)
+                .cloned()
+                .unwrap_or(None);
+            Box::pin(async move { Ok(v) })
+        }
+
+        fn fetch_role_tags(
+            &self,
+            account_id: &str,
+            role_name: &str,
+        ) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+            self.role_tags_calls.fetch_add(1, Ordering::SeqCst);
+            let key = (account_id.to_owned(), role_name.to_owned());
+            let v = self
+                .role_tags
+                .lock()
+                .unwrap()
+                .get(&key)
+                .cloned()
+                .unwrap_or_default();
+            Box::pin(async move { Ok(v) })
+        }
+
+        fn fetch_session_data(
+            &self,
+            account_id: &str,
+            role_name: &str,
+            session_name: &str,
+        ) -> BoxFuture<'_, OpResult<Option<SessionData>>> {
+            self.session_data_calls.fetch_add(1, Ordering::SeqCst);
+            let key = (
+                account_id.to_owned(),
+                role_name.to_owned(),
+                session_name.to_owned(),
+            );
+            let v = self
+                .session_data
+                .lock()
+                .unwrap()
+                .get(&key)
+                .cloned()
+                .unwrap_or(None);
+            Box::pin(async move { Ok(v) })
+        }
+
+        fn fetch_resource_tags(&self, arn: &str) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+            self.resource_tags_calls.fetch_add(1, Ordering::SeqCst);
+            let key = arn.to_owned();
+            let v = self
+                .resource_tags
+                .lock()
+                .unwrap()
+                .get(&key)
+                .cloned()
+                .unwrap_or_default();
+            Box::pin(async move { Ok(v) })
+        }
+    }
+
+    fn fast_authz_cfg() -> AuthzCacheConfig {
+        let base = SwrCacheConfig {
+            ttl: Duration::from_millis(200),
+            soft_ttl: Duration::from_millis(50),
+            negative_ttl: Duration::from_millis(50),
+            max_entries: 100,
+            name: "test",
+        };
+        AuthzCacheConfig {
+            identity_policies: SwrCacheConfig {
+                name: "ip",
+                ..base.clone()
+            },
+            group_policies: SwrCacheConfig {
+                name: "gp",
+                ..base.clone()
+            },
+            boundary: SwrCacheConfig {
+                name: "b",
+                ..base.clone()
+            },
+            principal_tags: SwrCacheConfig {
+                name: "pt",
+                ..base.clone()
+            },
+            resource_tags: SwrCacheConfig {
+                name: "rt",
+                ..base.clone()
+            },
+            session_data: SwrCacheConfig { name: "sd", ..base },
+        }
+    }
+
+    fn allow_policy(action: &str) -> String {
+        format!(
+            r#"{{"Version":"2012-10-17","Statement":[{{"Effect":"Allow","Action":"{action}","Resource":"*"}}]}}"#
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn user_policies_cache_round_trip() {
+        let inner = Arc::new(CountingAuthzStore::default());
+        inner.user_policies.lock().unwrap().insert(
+            ("a".to_owned(), "u".to_owned()),
+            vec![allow_policy("dynamodb:GetItem")],
+        );
+        let cache = CachedAuthzStore::new(inner.clone(), fast_authz_cfg());
+
+        let p1 = cache.fetch_user_policies("a", "u").await.unwrap();
+        let p2 = cache.fetch_user_policies("a", "u").await.unwrap();
+
+        assert_eq!(p1.len(), 1);
+        assert_eq!(p2.len(), 1);
+        assert_eq!(
+            inner.user_policies_calls.load(Ordering::SeqCst),
+            1,
+            "second call must hit cache"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn invalidate_user_policies_forces_refetch() {
+        let inner = Arc::new(CountingAuthzStore::default());
+        inner.user_policies.lock().unwrap().insert(
+            ("a".to_owned(), "u".to_owned()),
+            vec![allow_policy("dynamodb:GetItem")],
+        );
+        let cache = CachedAuthzStore::new(inner.clone(), fast_authz_cfg());
+
+        cache.fetch_user_policies("a", "u").await.unwrap();
+        cache.invalidate_user_policies("a", "u").await;
+        cache.fetch_user_policies("a", "u").await.unwrap();
+
+        assert_eq!(
+            inner.user_policies_calls.load(Ordering::SeqCst),
+            2,
+            "invalidation forces re-fetch"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn unparseable_policy_yields_error() {
+        let inner = Arc::new(CountingAuthzStore::default());
+        inner.user_policies.lock().unwrap().insert(
+            ("a".to_owned(), "u".to_owned()),
+            vec!["not-json".to_owned()],
+        );
+        let cache = CachedAuthzStore::new(inner, fast_authz_cfg());
+
+        let result = cache.fetch_user_policies("a", "u").await;
+        assert!(matches!(result, Err(OpError::Internal(_))));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn missing_boundary_returns_none() {
+        let inner = Arc::new(CountingAuthzStore::default());
+        let cache = CachedAuthzStore::new(inner, fast_authz_cfg());
+
+        let r = cache.fetch_user_boundary("a", "u").await.unwrap();
+        assert!(r.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn resource_tags_wildcard_short_circuits() {
+        let inner = Arc::new(CountingAuthzStore::default());
+        let cache = CachedAuthzStore::new(inner.clone(), fast_authz_cfg());
+
+        let tags = cache
+            .fetch_resource_tags("arn:aws:dynamodb:us-east-1:1:table/*")
+            .await
+            .unwrap();
+        assert!(tags.is_empty());
+        assert_eq!(
+            inner.resource_tags_calls.load(Ordering::SeqCst),
+            0,
+            "wildcard resource ARN must short-circuit before any DB call"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn user_tags_round_trip() {
+        let inner = Arc::new(CountingAuthzStore::default());
+        inner.user_tags.lock().unwrap().insert(
+            ("a".to_owned(), "u".to_owned()),
+            vec![("Team".to_owned(), "Eng".to_owned())],
+        );
+        let cache = CachedAuthzStore::new(inner.clone(), fast_authz_cfg());
+
+        let t1 = cache.fetch_user_tags("a", "u").await.unwrap();
+        let t2 = cache.fetch_user_tags("a", "u").await.unwrap();
+
+        assert_eq!(t1.get("Team"), Some(&"Eng".to_owned()));
+        assert_eq!(t2.get("Team"), Some(&"Eng".to_owned()));
+        assert_eq!(inner.user_tags_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn session_data_round_trip() {
+        let inner = Arc::new(CountingAuthzStore::default());
+        inner.session_data.lock().unwrap().insert(
+            ("a".to_owned(), "r".to_owned(), "s".to_owned()),
+            Some(SessionData {
+                session_policy: Some(allow_policy("dynamodb:Query")),
+                session_tags: vec![("Project".to_owned(), "Atlas".to_owned())],
+            }),
+        );
+        let cache = CachedAuthzStore::new(inner.clone(), fast_authz_cfg());
+
+        let s1 = cache
+            .fetch_session_data("a", "r", "s")
+            .await
+            .unwrap()
+            .unwrap();
+        let s2 = cache
+            .fetch_session_data("a", "r", "s")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(s1.session_policy.is_some());
+        assert!(s2.session_policy.is_some());
+        assert_eq!(s1.session_tags.get("Project"), Some(&"Atlas".to_owned()));
+        assert_eq!(inner.session_data_calls.load(Ordering::SeqCst), 1);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // PR3 tests — fanout invalidation
+    // ─────────────────────────────────────────────────────────────────
+
+    /// `invalidate_role_sessions` drops every cached session for a given
+    /// (account, role), regardless of session_name.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn invalidate_role_sessions_drops_all_sessions_for_role() {
+        let inner = Arc::new(CountingAuthzStore::default());
+        // Two sessions for the same role.
+        for s in &["s1", "s2"] {
+            inner.session_data.lock().unwrap().insert(
+                ("a".to_owned(), "r".to_owned(), (*s).to_owned()),
+                Some(SessionData {
+                    session_policy: None,
+                    session_tags: vec![],
+                }),
+            );
+        }
+        // One session for a different role — must NOT be invalidated.
+        inner.session_data.lock().unwrap().insert(
+            ("a".to_owned(), "other-role".to_owned(), "s1".to_owned()),
+            Some(SessionData {
+                session_policy: None,
+                session_tags: vec![],
+            }),
+        );
+        let cache = CachedAuthzStore::new(inner.clone(), fast_authz_cfg());
+
+        // Prime all three sessions.
+        cache.fetch_session_data("a", "r", "s1").await.unwrap();
+        cache.fetch_session_data("a", "r", "s2").await.unwrap();
+        cache
+            .fetch_session_data("a", "other-role", "s1")
+            .await
+            .unwrap();
+        let primed = inner.session_data_calls.load(Ordering::SeqCst);
+
+        cache.invalidate_role_sessions("a", "r");
+        // moka's invalidate_entries_if is async; let it settle.
+        cache.session_data.run_pending_tasks().await;
+
+        // Now re-fetch — sessions for role "r" hit the inner store again;
+        // the session for "other-role" remains cached.
+        cache.fetch_session_data("a", "r", "s1").await.unwrap();
+        cache.fetch_session_data("a", "r", "s2").await.unwrap();
+        cache
+            .fetch_session_data("a", "other-role", "s1")
+            .await
+            .unwrap();
+
+        let after = inner.session_data_calls.load(Ordering::SeqCst);
+        assert_eq!(
+            after - primed,
+            2,
+            "sessions for role 'r' must be re-fetched (got {} new calls)",
+            after - primed
+        );
+    }
+
+    /// `invalidate_account` drops every cached entry across every authz
+    /// subcache that belongs to an account, leaving entries for other
+    /// accounts intact.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn invalidate_account_drops_every_subcache_for_that_account() {
+        let inner = Arc::new(CountingAuthzStore::default());
+        // Account "a1": user policy + boundary + tags.
+        inner.user_policies.lock().unwrap().insert(
+            ("a1".to_owned(), "u".to_owned()),
+            vec![allow_policy("dynamodb:GetItem")],
+        );
+        inner.user_tags.lock().unwrap().insert(
+            ("a1".to_owned(), "u".to_owned()),
+            vec![("Team".to_owned(), "Eng".to_owned())],
+        );
+        // Account "a2": should be untouched.
+        inner.user_policies.lock().unwrap().insert(
+            ("a2".to_owned(), "u".to_owned()),
+            vec![allow_policy("dynamodb:Query")],
+        );
+        let cache = CachedAuthzStore::new(inner.clone(), fast_authz_cfg());
+
+        // Prime caches.
+        cache.fetch_user_policies("a1", "u").await.unwrap();
+        cache.fetch_user_tags("a1", "u").await.unwrap();
+        cache.fetch_user_policies("a2", "u").await.unwrap();
+
+        let policies_calls = inner.user_policies_calls.load(Ordering::SeqCst);
+        let tags_calls = inner.user_tags_calls.load(Ordering::SeqCst);
+
+        cache.invalidate_account("a1");
+        cache.user_policies.run_pending_tasks().await;
+        cache.user_tags.run_pending_tasks().await;
+
+        // Re-fetch a1 → cache miss; a2 → still cached.
+        cache.fetch_user_policies("a1", "u").await.unwrap();
+        cache.fetch_user_tags("a1", "u").await.unwrap();
+        cache.fetch_user_policies("a2", "u").await.unwrap();
+
+        assert_eq!(
+            inner.user_policies_calls.load(Ordering::SeqCst),
+            policies_calls + 1,
+            "a1 user_policies re-fetched, a2 untouched"
+        );
+        assert_eq!(
+            inner.user_tags_calls.load(Ordering::SeqCst),
+            tags_calls + 1,
+            "a1 user_tags re-fetched"
+        );
+    }
+}

--- a/crates/server/src/authz_cache.rs
+++ b/crates/server/src/authz_cache.rs
@@ -329,17 +329,21 @@ impl CachedAuthzStore {
             .await;
     }
 
-    /// Invalidate user-group-policy entries for **every** member of `group_name`.
+    /// Fan out a group-membership-affecting event (group deleted, group
+    /// policy attached/detached) to the cached `user_group_policies` entry
+    /// for each member.
     ///
-    /// Group-policy mutations (PutGroupPolicy, AttachGroupPolicy, etc.) affect
-    /// every user in that group. Since the cache key is `(account_id, user)`,
-    /// not group, we use `invalidate_if` over the user's group memberships.
-    /// In practice, the simpler approach is to take the set of member user
-    /// names from the caller (the management endpoint already had to list
-    /// them) and invalidate each.
-    pub async fn invalidate_users(&self, account_id: &str, user_names: &[String]) {
+    /// The `user_group_policies` cache is keyed by `(account_id, user_name)`,
+    /// not by group, because the loader flattens group membership at fetch
+    /// time. Callers pass the member list they already had to enumerate
+    /// (e.g. via `get_group_detail`) so we don't re-query.
+    ///
+    /// Per-user attributes that aren't touched by group events
+    /// (`user_policies`, `user_boundary`, `user_tags`) are intentionally
+    /// out of scope — they have their own invalidation methods called from
+    /// the corresponding per-user mutation sites.
+    pub async fn invalidate_users_group_policies(&self, account_id: &str, user_names: &[String]) {
         for u in user_names {
-            self.invalidate_user_policies(account_id, u).await;
             self.invalidate_user_group_policies(account_id, u).await;
         }
     }
@@ -523,12 +527,12 @@ impl extenddb_auth::AuthzCacheInvalidator for CachedAuthzStore {
         Box::pin(self.invalidate_user_group_policies(account_id, user_name))
     }
 
-    fn invalidate_users<'a>(
+    fn invalidate_users_group_policies<'a>(
         &'a self,
         account_id: &'a str,
         user_names: &'a [String],
     ) -> BoxFuture<'a, ()> {
-        Box::pin(self.invalidate_users(account_id, user_names))
+        Box::pin(self.invalidate_users_group_policies(account_id, user_names))
     }
 
     fn invalidate_user_boundary<'a>(

--- a/crates/server/src/authz_cache.rs
+++ b/crates/server/src/authz_cache.rs
@@ -619,6 +619,10 @@ impl extenddb_auth::AuthzCacheInvalidator for CachedAuthzStore {
         self.invalidate_account(account_id);
         Box::pin(std::future::ready(()))
     }
+
+    fn invalidate_all(&self) {
+        self.invalidate_all();
+    }
 }
 
 // ── Loader factories ───────────────────────────────────────────────────

--- a/crates/server/src/authz_cache.rs
+++ b/crates/server/src/authz_cache.rs
@@ -469,6 +469,22 @@ impl CachedAuthzStore {
         }
     }
 
+    /// Drop every cached entry across every sub-cache. Used by the manual
+    /// `cache invalidate all` admin endpoint; not called from any normal
+    /// write-through path. The credential cache lives in `extenddb-auth`
+    /// and is swept separately by the caller.
+    pub fn invalidate_all(&self) {
+        self.user_policies.invalidate_all();
+        self.user_group_policies.invalidate_all();
+        self.user_boundary.invalidate_all();
+        self.user_tags.invalidate_all();
+        self.role_policies.invalidate_all();
+        self.role_boundary.invalidate_all();
+        self.role_tags.invalidate_all();
+        self.session_data.invalidate_all();
+        self.resource_tags.invalidate_all();
+    }
+
     /// Snapshot per-sub-cache counters for export to `/auth-cache-metrics`.
     /// Returns `None` if metrics are unavailable for any reason (currently
     /// always returns `Some`).

--- a/crates/server/src/console/html.rs
+++ b/crates/server/src/console/html.rs
@@ -172,6 +172,7 @@ pub fn nav_bar(identity_label: &str) -> String {
 <a href="/console/accounts">Accounts</a>
 <a href="/console/metrics">Metrics</a>
 <a href="/console/settings">Settings</a>
+<a href="/console/cache">Cache</a>
 <span class="spacer"></span>
 <span>{identity}</span>
 <form class="inline" method="post" action="/console/logout">

--- a/crates/server/src/console/mod.rs
+++ b/crates/server/src/console/mod.rs
@@ -44,6 +44,11 @@ pub struct ConsoleState {
     /// Runtime documentation store. `None` if `docs_dir` is not configured or
     /// the directory is missing/invalid.
     pub docs_store: Option<docs_embed::DocsStore>,
+    /// Auth/authz cache registry. Used by mutation handlers to issue
+    /// write-through invalidations after IAM changes — the same hooks the
+    /// management API calls. Without this, console-driven mutations leave
+    /// stale entries in the cache for up to `auth.cache.ttl_seconds`.
+    pub auth_cache: extenddb_auth::AuthCacheRegistry,
 }
 
 /// Build the console router.

--- a/crates/server/src/console/mod.rs
+++ b/crates/server/src/console/mod.rs
@@ -46,15 +46,11 @@ pub struct ConsoleState {
     pub docs_store: Option<docs_embed::DocsStore>,
     /// Auth/authz cache registry. Used by mutation handlers to issue
     /// write-through invalidations after IAM changes — the same hooks the
-    /// management API calls. Without this, console-driven mutations leave
-    /// stale entries in the cache for up to `auth.cache.ttl_seconds`.
+    /// management API calls. Also used by the `/console/cache` admin
+    /// break-glass page to drive manual invalidation. Without this,
+    /// console-driven mutations leave stale entries in the cache for up
+    /// to `auth.cache.ttl_seconds`.
     pub auth_cache: extenddb_auth::AuthCacheRegistry,
-    /// Concrete authorization cache handle. Required by the
-    /// `/console/cache` admin break-glass page so it can call the same
-    /// `apply` helper used by `POST /management/cache/invalidate`.
-    pub authz_cache: Arc<crate::CachedAuthzStore>,
-    /// Concrete TableKeyInfo cache handle. Same rationale as `authz_cache`.
-    pub table_key_info_cache: Arc<crate::CachedTableKeyInfoStore>,
 }
 
 /// Build the console router.

--- a/crates/server/src/console/mod.rs
+++ b/crates/server/src/console/mod.rs
@@ -49,6 +49,12 @@ pub struct ConsoleState {
     /// management API calls. Without this, console-driven mutations leave
     /// stale entries in the cache for up to `auth.cache.ttl_seconds`.
     pub auth_cache: extenddb_auth::AuthCacheRegistry,
+    /// Concrete authorization cache handle. Required by the
+    /// `/console/cache` admin break-glass page so it can call the same
+    /// `apply` helper used by `POST /management/cache/invalidate`.
+    pub authz_cache: Arc<crate::CachedAuthzStore>,
+    /// Concrete TableKeyInfo cache handle. Same rationale as `authz_cache`.
+    pub table_key_info_cache: Arc<crate::CachedTableKeyInfoStore>,
 }
 
 /// Build the console router.
@@ -68,6 +74,10 @@ pub fn router() -> Router<Arc<ConsoleState>> {
         .route("/metrics", get(pages::metrics_page))
         // Settings (read-only, admin-only)
         .route("/settings", get(pages::settings_page))
+        // Cache (admin-only break-glass invalidation).
+        // See docs/design/12-auth-authz-cache.md §6.1.
+        .route("/cache", get(pages::cache_page))
+        .route("/cache/invalidate", post(pages::invalidate_cache))
         // Accounts
         .route("/accounts", get(pages::list_accounts))
         .route("/accounts/new", get(pages::new_account_form))

--- a/crates/server/src/console/pages/access_key_pages.rs
+++ b/crates/server/src/console/pages/access_key_pages.rs
@@ -65,6 +65,12 @@ pub async fn create_access_key(
         .await
     {
         Ok(key) => {
+            // Drop any negative cache entry for this newly-issued key id —
+            // mirrors management::iam_user_self::create_access_key.
+            state
+                .auth_cache
+                .invalidate_credential(&key.access_key_id)
+                .await;
             let content = format!(
                 r#"{crumbs}<h1>Access Key Created</h1>
 {}
@@ -138,8 +144,12 @@ pub async fn delete_access_key(
         .delete_access_key(&account_id, &user_name, &key_id)
         .await
     {
-        Ok(()) => Redirect::to(&format!("/console/accounts/{account_id}/users/{user_name}"))
-            .into_response(),
+        Ok(()) => {
+            // Mirror management::iam_user_self::delete_access_key.
+            state.auth_cache.invalidate_credential(&key_id).await;
+            Redirect::to(&format!("/console/accounts/{account_id}/users/{user_name}"))
+                .into_response()
+        }
         Err(e) => {
             let nav = html::nav_bar(&identity_label(&session.identity));
             let content = format!("<h1>Error</h1>{}", html::alert_error(&op_error_message(e)));

--- a/crates/server/src/console/pages/account_pages.rs
+++ b/crates/server/src/console/pages/account_pages.rs
@@ -376,7 +376,13 @@ pub async fn delete_account(
     }
 
     match state.catalog_store.delete_account(&account_id).await {
-        Ok(()) => Redirect::to("/console/accounts").into_response(),
+        Ok(()) => {
+            // Mirror management::account::delete_account: cascade invalidate
+            // every cached entry across every authz subcache (and the
+            // credential cache) that belongs to this account.
+            state.auth_cache.invalidate_account(&account_id).await;
+            Redirect::to("/console/accounts").into_response()
+        }
         Err(e) => {
             let nav = html::nav_bar(&identity_label(&session.identity));
             let msg = op_error_message(e);

--- a/crates/server/src/console/pages/cache_pages.rs
+++ b/crates/server/src/console/pages/cache_pages.rs
@@ -54,8 +54,6 @@ pub async fn cache_page(State(state): State<Arc<ConsoleState>>, headers: HeaderM
 Drops cached entries on this instance. Complements the automatic write-through
 hooks; reach for this when off-instance changes have not yet expired or when a
 test needs a deterministic flush.
-See the <a href="/console/docs/12-auth-authz-cache">design doc</a> for scope
-semantics.
 </p>
 <form method="post" action="/console/cache/invalidate">
 <label for="scope">Scope</label>
@@ -70,35 +68,70 @@ semantics.
 <option value="all">all — flush every cache (requires confirmation)</option>
 </select>
 
-<label for="account_id">account_id <span style="color:#999;font-size:0.85rem">(account, user, role, group_members, table_key_info)</span></label>
+<div class="sel" data-scopes="account user role group_members table_key_info">
+<label for="account_id">account_id</label>
 <input id="account_id" name="account_id" type="text" autocomplete="off">
+</div>
 
-<label for="user_name">user_name <span style="color:#999;font-size:0.85rem">(user)</span></label>
+<div class="sel" data-scopes="user">
+<label for="user_name">user_name</label>
 <input id="user_name" name="user_name" type="text" autocomplete="off">
+</div>
 
-<label for="role_name">role_name <span style="color:#999;font-size:0.85rem">(role)</span></label>
+<div class="sel" data-scopes="role">
+<label for="role_name">role_name</label>
 <input id="role_name" name="role_name" type="text" autocomplete="off">
+</div>
 
-<label for="user_names">user_names <span style="color:#999;font-size:0.85rem">(group_members, comma-separated)</span></label>
+<div class="sel" data-scopes="group_members">
+<label for="user_names">user_names <span style="color:#999;font-size:0.85rem">(comma-separated)</span></label>
 <input id="user_names" name="user_names" type="text" autocomplete="off" placeholder="alice, bob, charlie">
+</div>
 
-<label for="access_key_id">access_key_id <span style="color:#999;font-size:0.85rem">(credential)</span></label>
+<div class="sel" data-scopes="credential">
+<label for="access_key_id">access_key_id</label>
 <input id="access_key_id" name="access_key_id" type="text" autocomplete="off">
+</div>
 
-<label for="table_name">table_name <span style="color:#999;font-size:0.85rem">(table_key_info)</span></label>
+<div class="sel" data-scopes="table_key_info">
+<label for="table_name">table_name</label>
 <input id="table_name" name="table_name" type="text" autocomplete="off">
+</div>
 
-<label for="arn">arn <span style="color:#999;font-size:0.85rem">(resource_tags)</span></label>
+<div class="sel" data-scopes="resource_tags">
+<label for="arn">arn</label>
 <input id="arn" name="arn" type="text" autocomplete="off">
+</div>
 
-<label for="confirm">Confirmation <span style="color:#999;font-size:0.85rem">(scope=all only — type "{ALL_CONFIRMATION_TOKEN}")</span></label>
+<div class="sel" data-scopes="all">
+<label for="confirm">Confirmation <span style="color:#999;font-size:0.85rem">(type "{ALL_CONFIRMATION_TOKEN}")</span></label>
 <input id="confirm" name="confirm" type="text" autocomplete="off">
+</div>
 
 <div style="margin-top:1rem">
 <button class="btn btn-primary" type="submit">Invalidate</button>
 <a href="/console" class="btn">Cancel</a>
 </div>
 </form>
+<script>
+// Progressive disclosure: hide selector fields that don't apply to the
+// chosen scope. Submitted values for hidden fields are ignored by the
+// server (the shared `apply` helper validates per-scope), so this is
+// purely UX. The page works without JS — every field is visible.
+(function() {{
+  var sel = document.getElementById('scope');
+  var rows = document.querySelectorAll('.sel');
+  function apply() {{
+    var s = sel.value;
+    rows.forEach(function(row) {{
+      var scopes = row.getAttribute('data-scopes').split(' ');
+      row.style.display = scopes.indexOf(s) >= 0 ? '' : 'none';
+    }});
+  }}
+  sel.addEventListener('change', apply);
+  apply();
+}})();
+</script>
 </div>"#
     );
 
@@ -205,33 +238,18 @@ pub async fn invalidate_cache(
 
     let request = InvalidateRequest { scope, selectors };
 
-    match apply_invalidation(
-        &state.auth_cache,
-        &state.authz_cache,
-        &state.table_key_info_cache,
-        request,
-        &admin_name,
-    )
-    .await
-    {
+    match apply_invalidation(&state.auth_cache, request, &admin_name).await {
         Ok(resp) => render_success(&session, &resp),
         Err(msg) => render_error(&session, &msg),
     }
 }
 
 fn parse_scope(s: &str) -> Result<Scope, String> {
-    // Console form sends snake_case values matching the API enum.
-    Ok(match s {
-        "all" => Scope::All,
-        "account" => Scope::Account,
-        "credential" => Scope::Credential,
-        "user" => Scope::User,
-        "role" => Scope::Role,
-        "group_members" => Scope::GroupMembers,
-        "table_key_info" => Scope::TableKeyInfo,
-        "resource_tags" => Scope::ResourceTags,
-        other => return Err(format!("unknown scope: {other}")),
-    })
+    // Drive parsing through Scope's snake_case Deserialize impl so the
+    // form, the API JSON, the CLI, and the design doc table all stay in
+    // sync from one source. Adding a scope variant Just Works.
+    serde_json::from_value(serde_json::Value::String(s.to_owned()))
+        .map_err(|_| format!("unknown scope: {s}"))
 }
 
 fn optional(s: &str) -> Option<String> {
@@ -262,12 +280,12 @@ fn render_success(
         r#"{crumbs}
 <h1>Cache invalidated</h1>
 <div class="card">
-<p>Scope: <code>{scope:?}</code></p>
+<p>Scope: <code>{scope}</code></p>
 <p>Subcaches touched:</p>
 <ul>{invalidated_html}</ul>
 <p style="margin-top:1rem"><a class="btn" href="/console/cache">Back</a></p>
 </div>"#,
-        scope = resp.scope,
+        scope = resp.scope.as_str(),
     );
     Html(html::layout_csrf(
         "Cache invalidated",

--- a/crates/server/src/console/pages/cache_pages.rs
+++ b/crates/server/src/console/pages/cache_pages.rs
@@ -1,0 +1,302 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Console cache page — admin-only break-glass invalidation form.
+//!
+//! Mirrors `POST /management/cache/invalidate` (see
+//! `docs/design/12-auth-authz-cache.md` §6.1). Both paths delegate to
+//! `crate::management::cache_invalidate::apply` so behavior stays
+//! identical regardless of how the operator triggers it.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{Html, IntoResponse, Response};
+use serde::Deserialize;
+
+use crate::console::ConsoleState;
+use crate::console::html;
+use crate::management::cache_invalidate::{
+    self, InvalidateRequest, Scope, Selectors, apply as apply_invalidation,
+};
+
+use super::{identity_label, is_admin, require_csrf, require_session};
+
+/// Confirmation token the operator must type for `scope=all`. Mirrors
+/// the CLI's `--yes` requirement; intentionally distinctive so the
+/// operator can't pass it by muscle memory.
+const ALL_CONFIRMATION_TOKEN: &str = "INVALIDATE";
+
+/// `GET /console/cache` — page with the invalidation form (admin-only).
+pub async fn cache_page(State(state): State<Arc<ConsoleState>>, headers: HeaderMap) -> Response {
+    let session = match require_session(&headers, &state).await {
+        Ok(s) => s,
+        Err(redirect) => return redirect,
+    };
+    if !is_admin(&session.identity) {
+        return (
+            StatusCode::FORBIDDEN,
+            "Cache controls are visible to admin users only",
+        )
+            .into_response();
+    }
+
+    let nav = html::nav_bar(&identity_label(&session.identity));
+    let crumbs = html::breadcrumb(&[("Console", Some("/console")), ("Cache", None)]);
+
+    let content = format!(
+        r#"{crumbs}
+<h1>Cache</h1>
+<div class="card">
+<h2>Manual invalidation</h2>
+<p style="font-size:0.85rem;color:#666">
+Drops cached entries on this instance. Complements the automatic write-through
+hooks; reach for this when off-instance changes have not yet expired or when a
+test needs a deterministic flush.
+See the <a href="/console/docs/12-auth-authz-cache">design doc</a> for scope
+semantics.
+</p>
+<form method="post" action="/console/cache/invalidate">
+<label for="scope">Scope</label>
+<select id="scope" name="scope" required>
+<option value="user">user — drop everything cached about an IAM user</option>
+<option value="role">role — drop everything cached about an IAM role</option>
+<option value="account">account — sweep one account across every cache</option>
+<option value="credential">credential — drop one access key</option>
+<option value="group_members">group_members — fan out to a list of users</option>
+<option value="table_key_info">table_key_info — drop one table's key info</option>
+<option value="resource_tags">resource_tags — drop one ARN's resource tags</option>
+<option value="all">all — flush every cache (requires confirmation)</option>
+</select>
+
+<label for="account_id">account_id <span style="color:#999;font-size:0.85rem">(account, user, role, group_members, table_key_info)</span></label>
+<input id="account_id" name="account_id" type="text" autocomplete="off">
+
+<label for="user_name">user_name <span style="color:#999;font-size:0.85rem">(user)</span></label>
+<input id="user_name" name="user_name" type="text" autocomplete="off">
+
+<label for="role_name">role_name <span style="color:#999;font-size:0.85rem">(role)</span></label>
+<input id="role_name" name="role_name" type="text" autocomplete="off">
+
+<label for="user_names">user_names <span style="color:#999;font-size:0.85rem">(group_members, comma-separated)</span></label>
+<input id="user_names" name="user_names" type="text" autocomplete="off" placeholder="alice, bob, charlie">
+
+<label for="access_key_id">access_key_id <span style="color:#999;font-size:0.85rem">(credential)</span></label>
+<input id="access_key_id" name="access_key_id" type="text" autocomplete="off">
+
+<label for="table_name">table_name <span style="color:#999;font-size:0.85rem">(table_key_info)</span></label>
+<input id="table_name" name="table_name" type="text" autocomplete="off">
+
+<label for="arn">arn <span style="color:#999;font-size:0.85rem">(resource_tags)</span></label>
+<input id="arn" name="arn" type="text" autocomplete="off">
+
+<label for="confirm">Confirmation <span style="color:#999;font-size:0.85rem">(scope=all only — type "{ALL_CONFIRMATION_TOKEN}")</span></label>
+<input id="confirm" name="confirm" type="text" autocomplete="off">
+
+<div style="margin-top:1rem">
+<button class="btn btn-primary" type="submit">Invalidate</button>
+<a href="/console" class="btn">Cancel</a>
+</div>
+</form>
+</div>"#
+    );
+
+    Html(html::layout_csrf(
+        "Cache",
+        &nav,
+        &content,
+        &session.csrf_token,
+    ))
+    .into_response()
+}
+
+/// Form payload for `POST /console/cache/invalidate`. All selector
+/// fields are optional; the shared `apply` helper validates the
+/// scope-specific subset.
+#[derive(Debug, Deserialize)]
+pub struct InvalidateForm {
+    #[serde(rename = "_csrf", default)]
+    pub csrf: String,
+    pub scope: String,
+    #[serde(default)]
+    pub account_id: String,
+    #[serde(default)]
+    pub user_name: String,
+    #[serde(default)]
+    pub role_name: String,
+    #[serde(default)]
+    pub user_names: String,
+    #[serde(default)]
+    pub access_key_id: String,
+    #[serde(default)]
+    pub table_name: String,
+    #[serde(default)]
+    pub arn: String,
+    #[serde(default)]
+    pub confirm: String,
+}
+
+/// `POST /console/cache/invalidate` — handle the form submission.
+pub async fn invalidate_cache(
+    State(state): State<Arc<ConsoleState>>,
+    headers: HeaderMap,
+    axum::Form(form): axum::Form<InvalidateForm>,
+) -> Response {
+    let session = match require_session(&headers, &state).await {
+        Ok(s) => s,
+        Err(r) => return r,
+    };
+    if !is_admin(&session.identity) {
+        return (
+            StatusCode::FORBIDDEN,
+            "Cache controls are visible to admin users only",
+        )
+            .into_response();
+    }
+    if let Err(r) = require_csrf(&form.csrf, &session) {
+        return r;
+    }
+
+    let admin_name = match &session.identity {
+        crate::management::CallerIdentity::Admin(n) => n.clone(),
+        crate::management::CallerIdentity::IamUser { .. } => unreachable!("checked by is_admin"),
+    };
+
+    let scope = match parse_scope(&form.scope) {
+        Ok(s) => s,
+        Err(msg) => return render_error(&session, &msg),
+    };
+
+    // The console form-confirmation pattern: scope=all requires the
+    // operator to type the literal token in the confirm field.
+    let confirm_ok = scope != Scope::All || form.confirm == ALL_CONFIRMATION_TOKEN;
+    if scope == Scope::All && !confirm_ok {
+        return render_error(
+            &session,
+            &format!(
+                r#"scope "all" requires typing "{ALL_CONFIRMATION_TOKEN}" in the confirmation field"#
+            ),
+        );
+    }
+
+    let user_names = if form.user_names.trim().is_empty() {
+        None
+    } else {
+        Some(
+            form.user_names
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>(),
+        )
+    };
+    let selectors = Selectors {
+        account_id: optional(&form.account_id),
+        user_name: optional(&form.user_name),
+        role_name: optional(&form.role_name),
+        user_names,
+        access_key_id: optional(&form.access_key_id),
+        table_name: optional(&form.table_name),
+        arn: optional(&form.arn),
+        confirm: Some(confirm_ok),
+    };
+
+    let request = InvalidateRequest { scope, selectors };
+
+    match apply_invalidation(
+        &state.auth_cache,
+        &state.authz_cache,
+        &state.table_key_info_cache,
+        request,
+        &admin_name,
+    )
+    .await
+    {
+        Ok(resp) => render_success(&session, &resp),
+        Err(msg) => render_error(&session, &msg),
+    }
+}
+
+fn parse_scope(s: &str) -> Result<Scope, String> {
+    // Console form sends snake_case values matching the API enum.
+    Ok(match s {
+        "all" => Scope::All,
+        "account" => Scope::Account,
+        "credential" => Scope::Credential,
+        "user" => Scope::User,
+        "role" => Scope::Role,
+        "group_members" => Scope::GroupMembers,
+        "table_key_info" => Scope::TableKeyInfo,
+        "resource_tags" => Scope::ResourceTags,
+        other => return Err(format!("unknown scope: {other}")),
+    })
+}
+
+fn optional(s: &str) -> Option<String> {
+    let t = s.trim();
+    if t.is_empty() {
+        None
+    } else {
+        Some(t.to_owned())
+    }
+}
+
+fn render_success(
+    session: &super::SessionData,
+    resp: &cache_invalidate::InvalidateResponse,
+) -> Response {
+    let nav = html::nav_bar(&identity_label(&session.identity));
+    let crumbs = html::breadcrumb(&[
+        ("Console", Some("/console")),
+        ("Cache", Some("/console/cache")),
+        ("Invalidated", None),
+    ]);
+    let invalidated_html: String = resp
+        .invalidated
+        .iter()
+        .map(|s| format!("<li><code>{}</code></li>", html::escape(s)))
+        .collect();
+    let content = format!(
+        r#"{crumbs}
+<h1>Cache invalidated</h1>
+<div class="card">
+<p>Scope: <code>{scope:?}</code></p>
+<p>Subcaches touched:</p>
+<ul>{invalidated_html}</ul>
+<p style="margin-top:1rem"><a class="btn" href="/console/cache">Back</a></p>
+</div>"#,
+        scope = resp.scope,
+    );
+    Html(html::layout_csrf(
+        "Cache invalidated",
+        &nav,
+        &content,
+        &session.csrf_token,
+    ))
+    .into_response()
+}
+
+fn render_error(session: &super::SessionData, msg: &str) -> Response {
+    let nav = html::nav_bar(&identity_label(&session.identity));
+    let crumbs = html::breadcrumb(&[
+        ("Console", Some("/console")),
+        ("Cache", Some("/console/cache")),
+        ("Error", None),
+    ]);
+    let content = format!(
+        r#"{crumbs}
+<h1>Cache</h1>
+{alert}
+<p style="margin-top:1rem"><a class="btn" href="/console/cache">Back</a></p>"#,
+        alert = html::alert_error(msg),
+    );
+    Html(html::layout_csrf(
+        "Cache",
+        &nav,
+        &content,
+        &session.csrf_token,
+    ))
+    .into_response()
+}

--- a/crates/server/src/console/pages/group_pages.rs
+++ b/crates/server/src/console/pages/group_pages.rs
@@ -255,12 +255,37 @@ pub async fn delete_group(
         return r;
     }
 
+    // Mirror management::iam_group::delete_group: snapshot members BEFORE
+    // delete so we can drop their cached user_group_policies after the
+    // FK cascade removes membership rows.
+    let members: Vec<String> = match state
+        .catalog_store
+        .get_group_detail(&account_id, &group_name)
+        .await
+    {
+        Ok(Some(detail)) => detail.members,
+        Ok(None) => Vec::new(),
+        Err(e) => {
+            tracing::warn!(
+                "console delete_group: get_group_detail failed before delete; member \
+                 cache invalidation will rely on TTL: {e:?}"
+            );
+            Vec::new()
+        }
+    };
+
     match state
         .catalog_store
         .delete_group(&account_id, &group_name)
         .await
     {
-        Ok(()) => Redirect::to(&format!("/console/accounts/{account_id}")).into_response(),
+        Ok(()) => {
+            state
+                .auth_cache
+                .invalidate_users(&account_id, &members)
+                .await;
+            Redirect::to(&format!("/console/accounts/{account_id}")).into_response()
+        }
         Err(e) => {
             let nav = html::nav_bar(&identity_label(&session.identity));
             let content = format!(
@@ -313,7 +338,16 @@ pub async fn add_group_member(
         .add_group_member(&account_id, &group_name, &form.user_name)
         .await
     {
-        Ok(()) => Redirect::to(&redirect).into_response(),
+        Ok(()) => {
+            // Mirror management::iam_group::add_member: the user's
+            // group_policies cache flattens membership at fetch time, so
+            // adding the user changes their effective policy set.
+            state
+                .auth_cache
+                .invalidate_user_group_policies(&account_id, &form.user_name)
+                .await;
+            Redirect::to(&redirect).into_response()
+        }
         Err(e) => {
             let nav = html::nav_bar(&identity_label(&session.identity));
             let content = format!(
@@ -359,7 +393,13 @@ pub async fn remove_group_member(
         .remove_group_member(&account_id, &group_name, &user_name)
         .await
     {
-        Ok(()) => Redirect::to(&redirect).into_response(),
+        Ok(()) => {
+            state
+                .auth_cache
+                .invalidate_user_group_policies(&account_id, &user_name)
+                .await;
+            Redirect::to(&redirect).into_response()
+        }
         Err(e) => {
             let nav = html::nav_bar(&identity_label(&session.identity));
             let content = format!(

--- a/crates/server/src/console/pages/group_pages.rs
+++ b/crates/server/src/console/pages/group_pages.rs
@@ -282,7 +282,7 @@ pub async fn delete_group(
         Ok(()) => {
             state
                 .auth_cache
-                .invalidate_users(&account_id, &members)
+                .invalidate_users_group_policies(&account_id, &members)
                 .await;
             Redirect::to(&format!("/console/accounts/{account_id}")).into_response()
         }

--- a/crates/server/src/console/pages/mod.rs
+++ b/crates/server/src/console/pages/mod.rs
@@ -10,6 +10,7 @@
 mod access_key_pages;
 mod account_pages;
 mod auth_pages;
+mod cache_pages;
 mod docs_page;
 mod group_pages;
 mod metrics_content;
@@ -24,6 +25,7 @@ pub use account_pages::{
     account_detail, create_account, dashboard, delete_account, list_accounts, new_account_form,
 };
 pub use auth_pages::{login_page, login_submit, logout};
+pub use cache_pages::{cache_page, invalidate_cache};
 pub use docs_page::{docs_page, docs_pdf, docs_view};
 pub use group_pages::{
     add_group_member, create_group, delete_group, group_detail, new_group_form, remove_group_member,

--- a/crates/server/src/console/pages/policy_pages.rs
+++ b/crates/server/src/console/pages/policy_pages.rs
@@ -297,7 +297,10 @@ async fn put_policy(
         )
         .await
     {
-        Ok(()) => Redirect::to(redirect_url).into_response(),
+        Ok(()) => {
+            invalidate_policy_caches(state, account_id, principal_type, principal_name).await;
+            Redirect::to(redirect_url).into_response()
+        }
         Err(e) => {
             let nav = html::nav_bar(&identity_label(&session.identity));
             let content = format!(
@@ -343,7 +346,10 @@ async fn delete_policy(
         .delete_policy(account_id, principal_type, principal_name, policy_name)
         .await
     {
-        Ok(()) => Redirect::to(redirect_url).into_response(),
+        Ok(()) => {
+            invalidate_policy_caches(state, account_id, principal_type, principal_name).await;
+            Redirect::to(redirect_url).into_response()
+        }
         Err(e) => {
             let nav = html::nav_bar(&identity_label(&session.identity));
             let content = format!(
@@ -358,5 +364,51 @@ async fn delete_policy(
             ))
             .into_response()
         }
+    }
+}
+
+/// Drop the cache entries affected by a policy mutation on the given
+/// principal. Mirrors `management::iam_policy::invalidate_policy_caches`.
+async fn invalidate_policy_caches(
+    state: &Arc<ConsoleState>,
+    account_id: &str,
+    principal_type: &str,
+    principal_name: &str,
+) {
+    match principal_type {
+        "user" => {
+            state
+                .auth_cache
+                .invalidate_user_policies(account_id, principal_name)
+                .await;
+        }
+        "role" => {
+            state
+                .auth_cache
+                .invalidate_role_policies(account_id, principal_name)
+                .await;
+        }
+        "group" => {
+            let members = match state
+                .catalog_store
+                .get_group_detail(account_id, principal_name)
+                .await
+            {
+                Ok(Some(detail)) => detail.members,
+                Ok(None) => Vec::new(),
+                Err(e) => {
+                    tracing::warn!(
+                        "console invalidate_policy_caches: get_group_detail failed for \
+                         {principal_name}: {e:?}; members' cached group policies will age out at TTL"
+                    );
+                    Vec::new()
+                }
+            };
+            state
+                .auth_cache
+                .invalidate_users(account_id, &members)
+                .await;
+        }
+        _ => {}
     }
 }

--- a/crates/server/src/console/pages/policy_pages.rs
+++ b/crates/server/src/console/pages/policy_pages.rs
@@ -406,7 +406,7 @@ async fn invalidate_policy_caches(
             };
             state
                 .auth_cache
-                .invalidate_users(account_id, &members)
+                .invalidate_users_group_policies(account_id, &members)
                 .await;
         }
         _ => {}

--- a/crates/server/src/console/pages/role_pages.rs
+++ b/crates/server/src/console/pages/role_pages.rs
@@ -272,7 +272,32 @@ pub async fn delete_role(
         .delete_role(&account_id, &role_name)
         .await
     {
-        Ok(()) => Redirect::to(&format!("/console/accounts/{account_id}")).into_response(),
+        Ok(()) => {
+            // Mirror management::iam_role::delete_role: cascade invalidate
+            // session credentials, role-level authz, and any cached
+            // session_data entries for this role.
+            state
+                .auth_cache
+                .invalidate_principal_credentials(&account_id, &role_name)
+                .await;
+            state
+                .auth_cache
+                .invalidate_role_policies(&account_id, &role_name)
+                .await;
+            state
+                .auth_cache
+                .invalidate_role_boundary(&account_id, &role_name)
+                .await;
+            state
+                .auth_cache
+                .invalidate_role_tags(&account_id, &role_name)
+                .await;
+            state
+                .auth_cache
+                .invalidate_role_sessions(&account_id, &role_name)
+                .await;
+            Redirect::to(&format!("/console/accounts/{account_id}")).into_response()
+        }
         Err(e) => {
             let nav = html::nav_bar(&identity_label(&session.identity));
             let content = format!(

--- a/crates/server/src/console/pages/user_pages.rs
+++ b/crates/server/src/console/pages/user_pages.rs
@@ -331,12 +331,55 @@ pub async fn delete_user(
         return r;
     }
 
+    // Mirror management::iam_user::delete_user: snapshot the user's access
+    // keys BEFORE deletion so cache fanout can drop them after the cascade
+    // succeeds. The defensive principal-fanout below covers any keys
+    // created concurrently with this delete.
+    let access_key_ids: Vec<String> = match state
+        .catalog_store
+        .list_access_keys(&account_id, &user_name)
+        .await
+    {
+        Ok(rows) => rows.into_iter().map(|(id, _, _)| id).collect(),
+        Err(e) => {
+            tracing::warn!(
+                "console delete_user: list_access_keys failed before delete; cache invalidation will rely on TTL: {e:?}"
+            );
+            Vec::new()
+        }
+    };
+
     match state
         .catalog_store
         .delete_user(&account_id, &user_name)
         .await
     {
-        Ok(()) => Redirect::to(&format!("/console/accounts/{account_id}")).into_response(),
+        Ok(()) => {
+            for key_id in &access_key_ids {
+                state.auth_cache.invalidate_credential(key_id).await;
+            }
+            state
+                .auth_cache
+                .invalidate_principal_credentials(&account_id, &user_name)
+                .await;
+            state
+                .auth_cache
+                .invalidate_user_policies(&account_id, &user_name)
+                .await;
+            state
+                .auth_cache
+                .invalidate_user_group_policies(&account_id, &user_name)
+                .await;
+            state
+                .auth_cache
+                .invalidate_user_boundary(&account_id, &user_name)
+                .await;
+            state
+                .auth_cache
+                .invalidate_user_tags(&account_id, &user_name)
+                .await;
+            Redirect::to(&format!("/console/accounts/{account_id}")).into_response()
+        }
         Err(e) => {
             let nav = html::nav_bar(&identity_label(&session.identity));
             let content = format!(

--- a/crates/server/src/handler.rs
+++ b/crates/server/src/handler.rs
@@ -109,7 +109,7 @@ pub(crate) async fn handle_request(
     let authz_start = std::time::Instant::now();
     let pre_fetched_key_info;
     {
-        let Some(catalog_store) = &state.catalog_store else {
+        if state.catalog_store.is_none() {
             tracing::error!("Authorization required but catalog_store is not configured");
             return error_response(
                 &DynamoDbError::AccessDeniedException(
@@ -118,16 +118,7 @@ pub(crate) async fn handle_request(
                 &request_id,
             );
         };
-        match authorize_request(
-            &state,
-            catalog_store.as_ref(),
-            &identity,
-            &input,
-            &operation,
-            &account_id,
-        )
-        .await
-        {
+        match authorize_request(&state, &identity, &input, &operation, &account_id).await {
             Ok(ki) => pre_fetched_key_info = ki,
             Err(e) => return error_response(&e, &request_id),
         }
@@ -144,6 +135,10 @@ pub(crate) async fn handle_request(
         import_paths: state.import_paths.clone(),
         export_paths: state.export_paths.clone(),
         pre_fetched_key_info,
+        auth_cache: state.auth_cache.clone(),
+        table_key_info_lookup: Some(
+            state.table_key_info_cache.clone() as Arc<dyn extenddb_storage::TableKeyInfoLookup>
+        ),
     };
 
     let table_name = extract_table_name(&input);

--- a/crates/server/src/key_info_cache.rs
+++ b/crates/server/src/key_info_cache.rs
@@ -1,0 +1,172 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `CachedTableKeyInfoStore` — stale-while-revalidate cache for
+//! `TableKeyInfo` lookups.
+//!
+//! `TableKeyInfo` is fetched per request by the auth path
+//! (`request_helpers.rs::authorize_request` for `LeadingKeys` extraction)
+//! and by engine handlers that operate on multiple tables (batch / transact
+//! operations). Caching it eliminates a catalog roundtrip per request on the
+//! steady-state hot path.
+//!
+//! Negative results — `Err(TableNotFound)` or table missing — are stored as
+//! `None` and capped at the configured `negative_ttl` (defaults to 5s) so
+//! newly-created tables become available quickly without restart.
+//!
+//! Write-through invalidation is exposed via [`CachedTableKeyInfoStore::invalidate`].
+//! Engine handlers for `CreateTable`, `UpdateTable`, and `DeleteTable` (and
+//! anything that mutates the catalog row, like `UpdateTimeToLive` or stream
+//! enable/disable) call it after the catalog mutation succeeds.
+//!
+//! See `docs/design/12-auth-authz-cache.md` for the full design.
+
+#![allow(clippy::module_name_repetitions)]
+
+use std::sync::Arc;
+
+use extenddb_cache::{Loader, SwrCache, SwrCacheConfig};
+use extenddb_core::types::TableKeyInfo;
+use extenddb_storage::StorageEngine;
+use extenddb_storage::error::StorageError;
+use futures::FutureExt;
+use futures::future::BoxFuture;
+
+/// Cache for `TableKeyInfo` lookups.
+///
+/// Cloning is cheap; clones share the underlying cache and the inner storage
+/// reference.
+#[derive(Clone)]
+pub struct CachedTableKeyInfoStore {
+    cache: SwrCache<(String, String), TableKeyInfo, StorageError>,
+}
+
+impl CachedTableKeyInfoStore {
+    /// Wrap `inner` (typically the same `Arc<dyn StorageEngine>` held in
+    /// `AppState.storage`) with a TTL'd cache.
+    #[must_use]
+    pub fn new(inner: Arc<dyn StorageEngine>, config: SwrCacheConfig) -> Self {
+        Self {
+            cache: SwrCache::new(Self::build_loader(inner), config),
+        }
+    }
+
+    /// Construct a pass-through wrapper that bypasses the cache on every
+    /// lookup. Used when `auth.cache.enabled = false`.
+    #[must_use]
+    pub fn pass_through(inner: Arc<dyn StorageEngine>, config: SwrCacheConfig) -> Self {
+        Self {
+            cache: SwrCache::pass_through(Self::build_loader(inner), config),
+        }
+    }
+
+    fn build_loader(
+        inner: Arc<dyn StorageEngine>,
+    ) -> Loader<(String, String), TableKeyInfo, StorageError> {
+        Arc::new(
+            move |(account_id, table_name): (String, String)|
+                  -> BoxFuture<'static, Result<Option<TableKeyInfo>, StorageError>> {
+                let inner = inner.clone();
+                async move {
+                    match inner.table_key_info(&account_id, &table_name).await {
+                        Ok(info) => Ok(Some(info)),
+                        // Map "not found" to negative cache.
+                        Err(StorageError::TableNotFound(_)) => Ok(None),
+                        // Other errors (TableNotActive, Connection, Internal, etc.)
+                        // are not cached.
+                        Err(e) => Err(e),
+                    }
+                }
+                .boxed()
+            },
+        )
+    }
+
+    /// Look up `TableKeyInfo` for the (account, table) pair.
+    ///
+    /// Returns the cached value if fresh, schedules a background refresh if
+    /// stale-but-usable, or blocks on a fresh load on hard miss. Negative
+    /// hits are reported back to the caller as `Err(TableNotFound)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StorageError::TableNotFound` for missing tables (cached
+    /// negatively for `negative_ttl`). Returns the underlying storage error
+    /// for any other failure (these errors are not cached).
+    pub async fn get(
+        &self,
+        account_id: &str,
+        table_name: &str,
+    ) -> Result<TableKeyInfo, StorageError> {
+        match self
+            .cache
+            .get((account_id.to_owned(), table_name.to_owned()))
+            .await
+        {
+            Ok(Some(info)) => Ok(info),
+            Ok(None) => Err(StorageError::TableNotFound(table_name.to_owned())),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Same as `get`, but returns `Ok(None)` for missing tables — matches the
+    /// `.ok()` semantic used by the auth path's `LeadingKeys` extraction.
+    pub async fn get_optional(&self, account_id: &str, table_name: &str) -> Option<TableKeyInfo> {
+        self.cache
+            .get((account_id.to_owned(), table_name.to_owned()))
+            .await
+            .ok()
+            .flatten()
+    }
+
+    /// Drop the cached entry for `(account_id, table_name)`.
+    ///
+    /// Called by engine handlers after `CreateTable`, `UpdateTable`,
+    /// `DeleteTable`, and any other operation that changes the table's
+    /// key schema, indexes, stream specification, or active state.
+    pub async fn invalidate(&self, account_id: &str, table_name: &str) {
+        self.cache
+            .invalidate(&(account_id.to_owned(), table_name.to_owned()))
+            .await;
+    }
+
+    /// Snapshot the cache's internal counters.
+    #[must_use]
+    pub fn metrics(&self) -> Arc<extenddb_cache::SwrMetrics> {
+        self.cache.metrics()
+    }
+
+    #[must_use]
+    pub fn entry_count(&self) -> u64 {
+        self.cache.entry_count()
+    }
+
+    /// Returns `true` when the cache was constructed in pass-through mode
+    /// (`auth.cache.enabled = false`). Used by the metrics endpoint so
+    /// operators can distinguish "cache disabled" from "cache cold".
+    #[must_use]
+    pub fn is_pass_through(&self) -> bool {
+        self.cache.is_pass_through()
+    }
+}
+
+impl extenddb_storage::TableKeyInfoLookup for CachedTableKeyInfoStore {
+    fn lookup<'a>(
+        &'a self,
+        account_id: &'a str,
+        table_name: &'a str,
+    ) -> BoxFuture<'a, Result<TableKeyInfo, StorageError>> {
+        Box::pin(self.get(account_id, table_name))
+    }
+}
+
+impl extenddb_auth::TableKeyInfoCacheInvalidator for CachedTableKeyInfoStore {
+    fn invalidate<'a>(&'a self, account_id: &'a str, table_name: &'a str) -> BoxFuture<'a, ()> {
+        Box::pin(self.invalidate(account_id, table_name))
+    }
+}
+
+// No unit tests in this module: the SWR mechanics are covered by the
+// extenddb-cache crate's tests (same `Loader<K, V, E>` shape), and the
+// table_key_info round-trip is exercised end-to-end by tests/test_cache_coherence.py
+// against a live Postgres backend.

--- a/crates/server/src/key_info_cache.rs
+++ b/crates/server/src/key_info_cache.rs
@@ -170,6 +170,10 @@ impl extenddb_auth::TableKeyInfoCacheInvalidator for CachedTableKeyInfoStore {
     fn invalidate<'a>(&'a self, account_id: &'a str, table_name: &'a str) -> BoxFuture<'a, ()> {
         Box::pin(self.invalidate(account_id, table_name))
     }
+
+    fn invalidate_all(&self) {
+        self.invalidate_all();
+    }
 }
 
 // No unit tests in this module: the SWR mechanics are covered by the

--- a/crates/server/src/key_info_cache.rs
+++ b/crates/server/src/key_info_cache.rs
@@ -130,6 +130,12 @@ impl CachedTableKeyInfoStore {
             .await;
     }
 
+    /// Drop every cached entry. Used by the manual `cache invalidate all`
+    /// admin endpoint; not called from any normal write-through path.
+    pub fn invalidate_all(&self) {
+        self.cache.invalidate_all();
+    }
+
     /// Snapshot the cache's internal counters.
     #[must_use]
     pub fn metrics(&self) -> Arc<extenddb_cache::SwrMetrics> {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -9,8 +9,10 @@
 //! Supports TLS via `axum-server` with rustls when configured.
 
 pub(crate) mod authorization;
+pub mod authz_cache;
 pub mod console;
 mod handler;
+pub mod key_info_cache;
 pub mod management;
 mod metrics_endpoint;
 pub mod rate_limit;
@@ -27,10 +29,13 @@ use axum::extract::DefaultBodyLimit;
 use axum::http::{HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Redirect};
 use axum::routing::{get, post};
-use extenddb_auth::AuthProvider;
+use extenddb_auth::{AuthCacheRegistry, AuthProvider};
 use extenddb_core::limits::LimitsConfig;
 use extenddb_core::metrics::MetricsCollector;
 use extenddb_core::throttle::ThrottleManager;
+
+pub use authz_cache::{AuthzCacheConfig, CachedAuthzStore, CachedSessionData};
+pub use key_info_cache::CachedTableKeyInfoStore;
 use serde_json::json;
 use tower::ServiceBuilder;
 use tower_http::set_header::SetResponseHeaderLayer;
@@ -59,6 +64,17 @@ pub struct AppState {
     pub export_paths: Arc<[Arc<std::path::PathBuf>]>,
     /// Token bucket throttle manager for provisioned throughput enforcement.
     pub throttle: Arc<ThrottleManager>,
+    /// Auth/authz cache handles. Used by the management API to issue
+    /// write-through invalidations after IAM mutations. Empty when caching
+    /// is disabled.
+    pub auth_cache: AuthCacheRegistry,
+    /// Authorization cache used by the request hot path. The same underlying
+    /// cache instance is referenced trait-object style by `auth_cache.authz`.
+    pub authz_cache: Arc<CachedAuthzStore>,
+    /// `TableKeyInfo` cache used by the request hot path and engine batch /
+    /// transact paths. Invalidated by control-plane handlers after Create /
+    /// Update / Delete table.
+    pub table_key_info_cache: Arc<CachedTableKeyInfoStore>,
     /// Static configuration entries from the `.toml` file for the console
     /// settings page. Each entry is `(key, display_value)` — sensitive values
     /// are pre-redacted by the caller.
@@ -95,6 +111,10 @@ pub async fn start_server(
 
     let tls_enabled = state.tls_enabled;
     let catalog_store = state.catalog_store.clone();
+    let auth_cache_for_mgmt = state.auth_cache.clone();
+    let auth_cache_for_console = state.auth_cache.clone();
+    let authz_cache_for_mgmt = state.authz_cache.clone();
+    let table_key_info_cache_for_mgmt = state.table_key_info_cache.clone();
     let version_info = state.version_info.clone();
     let docs_store = state.docs_store.clone();
     let listen_url = {
@@ -124,6 +144,11 @@ pub async fn start_server(
         .route("/", post(handler::handle_request))
         .layer(DefaultBodyLimit::max(DYNAMODB_BODY_LIMIT))
         .route("/health", get(health_check))
+        // REQ-OBS-005: Prometheus-compatible metrics endpoint. Public by
+        // design (Prometheus scrapers expect no auth on the scrape URL);
+        // operators who need stricter access should expose this on a
+        // separate bind via firewall/proxy. Returns aggregate metrics
+        // only; per-request data is in the management API.
         .route("/metrics", get(metrics_endpoint::metrics_endpoint))
         // S-6: Explicit small body limit for non-DynamoDB endpoints.
         .layer(DefaultBodyLimit::max(1024))
@@ -133,6 +158,9 @@ pub async fn start_server(
     if let Some(catalog_store) = catalog_store {
         let mgmt_state = Arc::new(management::ManagementState {
             catalog_store: catalog_store.clone(),
+            auth_cache: auth_cache_for_mgmt,
+            authz_cache: authz_cache_for_mgmt,
+            table_key_info_cache: table_key_info_cache_for_mgmt,
         });
         let mgmt_router = management::router().with_state(mgmt_state);
         app = app.nest("/management", mgmt_router);
@@ -144,6 +172,7 @@ pub async fn start_server(
             config_entries,
             catalog_store,
             docs_store: docs_store.clone(),
+            auth_cache: auth_cache_for_console,
         });
         let console_router = console::router().with_state(console_state);
         app = app

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -114,9 +114,7 @@ pub async fn start_server(
     let auth_cache_for_mgmt = state.auth_cache.clone();
     let auth_cache_for_console = state.auth_cache.clone();
     let authz_cache_for_mgmt = state.authz_cache.clone();
-    let authz_cache_for_console = state.authz_cache.clone();
     let table_key_info_cache_for_mgmt = state.table_key_info_cache.clone();
-    let table_key_info_cache_for_console = state.table_key_info_cache.clone();
     let version_info = state.version_info.clone();
     let docs_store = state.docs_store.clone();
     let listen_url = {
@@ -175,8 +173,6 @@ pub async fn start_server(
             catalog_store,
             docs_store: docs_store.clone(),
             auth_cache: auth_cache_for_console,
-            authz_cache: authz_cache_for_console,
-            table_key_info_cache: table_key_info_cache_for_console,
         });
         let console_router = console::router().with_state(console_state);
         app = app

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -114,7 +114,9 @@ pub async fn start_server(
     let auth_cache_for_mgmt = state.auth_cache.clone();
     let auth_cache_for_console = state.auth_cache.clone();
     let authz_cache_for_mgmt = state.authz_cache.clone();
+    let authz_cache_for_console = state.authz_cache.clone();
     let table_key_info_cache_for_mgmt = state.table_key_info_cache.clone();
+    let table_key_info_cache_for_console = state.table_key_info_cache.clone();
     let version_info = state.version_info.clone();
     let docs_store = state.docs_store.clone();
     let listen_url = {
@@ -173,6 +175,8 @@ pub async fn start_server(
             catalog_store,
             docs_store: docs_store.clone(),
             auth_cache: auth_cache_for_console,
+            authz_cache: authz_cache_for_console,
+            table_key_info_cache: table_key_info_cache_for_console,
         });
         let console_router = console::router().with_state(console_state);
         app = app

--- a/crates/server/src/management/account.rs
+++ b/crates/server/src/management/account.rs
@@ -126,7 +126,14 @@ pub async fn delete_account(
     }
 
     match state.catalog_store.delete_account(&id).await {
-        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Ok(()) => {
+            // Cascade invalidation: drop every cached entry across every
+            // authz subcache (and the credential cache) that belongs to
+            // this account, so a recreate (same id) doesn't inherit the
+            // deleted account's principals/policies.
+            state.auth_cache.invalidate_account(&id).await;
+            StatusCode::NO_CONTENT.into_response()
+        }
         Err(e) => op_err_to_response(super::ops::OpError::from_storage(e)),
     }
 }

--- a/crates/server/src/management/assume_role.rs
+++ b/crates/server/src/management/assume_role.rs
@@ -163,6 +163,7 @@ pub async fn assume_role(
 
     generate_and_store_session(
         &*state.catalog_store,
+        &state.auth_cache,
         &account_id,
         &role_name,
         &request,
@@ -174,6 +175,7 @@ pub async fn assume_role(
 /// Generate ASIA* credentials, encrypt, store session, and return the response.
 async fn generate_and_store_session(
     store: &dyn extenddb_storage::CatalogStore,
+    auth_cache: &extenddb_auth::AuthCacheRegistry,
     account_id: &str,
     role_name: &str,
     request: &AssumeRoleRequest,
@@ -228,6 +230,15 @@ async fn generate_and_store_session(
         .await
     {
         Ok(()) => {
+            // Drop any negative-cached entry for this newly-issued access
+            // key (e.g. from a probe before the session existed). Also drop
+            // any cached session-data for this exact (role, session) tuple
+            // — overwriting an existing session via re-assume would
+            // otherwise serve stale policies/tags until TTL.
+            auth_cache.invalidate_credential(&access_key_id).await;
+            auth_cache
+                .invalidate_session(account_id, role_name, &request.session_name)
+                .await;
             tracing::warn!(
                 target: "extenddb::audit::manage",
                 "assume-role: account={}, role={}, session={}, caller={}",

--- a/crates/server/src/management/cache_invalidate.rs
+++ b/crates/server/src/management/cache_invalidate.rs
@@ -23,7 +23,6 @@ use serde::{Deserialize, Serialize};
 
 use super::ManagementState;
 use super::auth::authenticate_admin;
-use crate::{CachedAuthzStore, CachedTableKeyInfoStore};
 
 /// Request body for `POST /management/cache/invalidate`. The `scope`
 /// discriminator drives validation of `selectors`.
@@ -47,6 +46,26 @@ pub enum Scope {
     GroupMembers,
     TableKeyInfo,
     ResourceTags,
+}
+
+impl Scope {
+    /// Canonical snake_case name (matches the JSON wire format, the CLI
+    /// subcommand names, and the design doc table). Used in audit logs
+    /// and the console success page so operators see the same
+    /// identifier across every surface.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::Account => "account",
+            Self::Credential => "credential",
+            Self::User => "user",
+            Self::Role => "role",
+            Self::GroupMembers => "group_members",
+            Self::TableKeyInfo => "table_key_info",
+            Self::ResourceTags => "resource_tags",
+        }
+    }
 }
 
 /// Scope-specific parameters. Each field is optional; the handler
@@ -101,15 +120,7 @@ pub async fn invalidate(
         Err(e) => return (StatusCode::BAD_REQUEST, e.body_text()).into_response(),
     };
 
-    match apply(
-        &state.auth_cache,
-        &state.authz_cache,
-        &state.table_key_info_cache,
-        body,
-        &admin_name,
-    )
-    .await
-    {
+    match apply(&state.auth_cache, body, &admin_name).await {
         Ok(resp) => (StatusCode::OK, axum::Json(resp)).into_response(),
         Err(e) => (StatusCode::BAD_REQUEST, e).into_response(),
     }
@@ -118,15 +129,14 @@ pub async fn invalidate(
 /// Apply an invalidation request. Shared between the management API
 /// and the console form handler so the two paths stay byte-identical.
 ///
-/// Takes the cache handles directly rather than `ManagementState` so the
-/// console (which doesn't share that struct) can reuse it.
+/// Takes only the registry; both `Scope::All` and the per-scope
+/// composites flow through registry methods, including
+/// `invalidate_all_caches` for the global flush.
 ///
 /// On success returns the response body to send (or render). On
 /// validation failure returns a human-readable error string.
 pub async fn apply(
     auth_cache: &extenddb_auth::AuthCacheRegistry,
-    authz_cache: &CachedAuthzStore,
-    table_key_info_cache: &CachedTableKeyInfoStore,
     body: InvalidateRequest,
     admin_name: &str,
 ) -> Result<InvalidateResponse, String> {
@@ -141,12 +151,7 @@ pub async fn apply(
                         .to_owned(),
                 );
             }
-            // Sweep every cache. Order is irrelevant; each is independent.
-            authz_cache.invalidate_all();
-            table_key_info_cache.invalidate_all();
-            if let Some(c) = &auth_cache.credential {
-                c.invalidate_all();
-            }
+            auth_cache.invalidate_all_caches();
             vec!["authz", "table_key_info", "credentials"]
         }
         Scope::Account => {
@@ -236,12 +241,14 @@ pub async fn apply(
         }
     };
 
-    // Forensic audit trail. Operators can correlate this with the
-    // matching jump in the `invalidations` counter on auth-cache-metrics.
+    // Forensic audit trail. Includes every selector that was set so a
+    // post-incident reader can identify the exact target — `?selectors`
+    // skips `None` fields. Operators correlate this with the matching
+    // jump in the `invalidations` counter on /auth-cache-metrics.
     tracing::info!(
         admin = admin_name,
-        ?scope,
-        account_id = s.account_id.as_deref().unwrap_or(""),
+        scope = scope.as_str(),
+        selectors = ?s,
         "auth_cache: admin-triggered invalidation"
     );
 

--- a/crates/server/src/management/cache_invalidate.rs
+++ b/crates/server/src/management/cache_invalidate.rs
@@ -1,0 +1,256 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Admin break-glass cache invalidation endpoint.
+//!
+//! `POST /management/cache/invalidate` — drop cached entries on demand
+//! from any of the auth/authz/table-key-info caches. Complements the
+//! automatic write-through hooks (see `docs/design/12-auth-authz-cache.md`
+//! §6 / §6.1) for cases the hooks miss: off-instance changes before TTL,
+//! bugs in the write-through plumbing, or test scenarios needing a
+//! deterministic flush.
+//!
+//! Both this endpoint and the console form (`/console/cache/invalidate`)
+//! delegate to [`apply`] so behavior is identical regardless of how it's
+//! invoked.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use serde::{Deserialize, Serialize};
+
+use super::ManagementState;
+use super::auth::authenticate_admin;
+use crate::{CachedAuthzStore, CachedTableKeyInfoStore};
+
+/// Request body for `POST /management/cache/invalidate`. The `scope`
+/// discriminator drives validation of `selectors`.
+#[derive(Debug, Deserialize)]
+pub struct InvalidateRequest {
+    pub scope: Scope,
+    #[serde(default)]
+    pub selectors: Selectors,
+}
+
+/// Scope discriminator. Matches the CLI subcommands and the `scope`
+/// field of the design doc's table.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Scope {
+    All,
+    Account,
+    Credential,
+    User,
+    Role,
+    GroupMembers,
+    TableKeyInfo,
+    ResourceTags,
+}
+
+/// Scope-specific parameters. Each field is optional; the handler
+/// validates that the right ones are present for the chosen scope so
+/// invalid combinations return 400 with a clear message rather than
+/// silently no-op'ing.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct Selectors {
+    pub account_id: Option<String>,
+    pub user_name: Option<String>,
+    pub role_name: Option<String>,
+    pub user_names: Option<Vec<String>>,
+    pub access_key_id: Option<String>,
+    pub table_name: Option<String>,
+    pub arn: Option<String>,
+    /// For `scope: all`, callers must pass `confirm: true`. The CLI sets
+    /// this when `--yes` is given; the console template uses a typed
+    /// confirmation field. Refused without it to avoid catastrophic
+    /// flushes from a stray request.
+    pub confirm: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct InvalidateResponse {
+    pub scope: Scope,
+    /// Names of subcaches that were touched. Useful for confirming that
+    /// composite scopes (`user`, `role`) did what the operator expected.
+    pub invalidated: Vec<&'static str>,
+}
+
+/// `POST /management/cache/invalidate` — admin-only manual invalidation.
+pub async fn invalidate(
+    State(state): State<Arc<ManagementState>>,
+    headers: HeaderMap,
+    body: Result<axum::Json<InvalidateRequest>, axum::extract::rejection::JsonRejection>,
+) -> Response {
+    let admin_name = match authenticate_admin(
+        &headers,
+        &*state.catalog_store,
+        &*state.catalog_store,
+        None,
+    )
+    .await
+    {
+        Ok(name) => name,
+        Err(e) => return e,
+    };
+
+    let body = match body {
+        Ok(axum::Json(b)) => b,
+        Err(e) => return (StatusCode::BAD_REQUEST, e.body_text()).into_response(),
+    };
+
+    match apply(
+        &state.auth_cache,
+        &state.authz_cache,
+        &state.table_key_info_cache,
+        body,
+        &admin_name,
+    )
+    .await
+    {
+        Ok(resp) => (StatusCode::OK, axum::Json(resp)).into_response(),
+        Err(e) => (StatusCode::BAD_REQUEST, e).into_response(),
+    }
+}
+
+/// Apply an invalidation request. Shared between the management API
+/// and the console form handler so the two paths stay byte-identical.
+///
+/// Takes the cache handles directly rather than `ManagementState` so the
+/// console (which doesn't share that struct) can reuse it.
+///
+/// On success returns the response body to send (or render). On
+/// validation failure returns a human-readable error string.
+pub async fn apply(
+    auth_cache: &extenddb_auth::AuthCacheRegistry,
+    authz_cache: &CachedAuthzStore,
+    table_key_info_cache: &CachedTableKeyInfoStore,
+    body: InvalidateRequest,
+    admin_name: &str,
+) -> Result<InvalidateResponse, String> {
+    let s = body.selectors;
+    let scope = body.scope;
+
+    let invalidated: Vec<&'static str> = match scope {
+        Scope::All => {
+            if !s.confirm.unwrap_or(false) {
+                return Err(
+                    "scope 'all' requires \"confirm\": true to prevent accidental flushes"
+                        .to_owned(),
+                );
+            }
+            // Sweep every cache. Order is irrelevant; each is independent.
+            authz_cache.invalidate_all();
+            table_key_info_cache.invalidate_all();
+            if let Some(c) = &auth_cache.credential {
+                c.invalidate_all();
+            }
+            vec!["authz", "table_key_info", "credentials"]
+        }
+        Scope::Account => {
+            let account_id = require(&s.account_id, "account_id")?;
+            auth_cache.invalidate_account(account_id).await;
+            vec!["authz_account", "credentials_account"]
+        }
+        Scope::Credential => {
+            let key = require(&s.access_key_id, "access_key_id")?;
+            auth_cache.invalidate_credential(key).await;
+            vec!["credential"]
+        }
+        Scope::User => {
+            let account_id = require(&s.account_id, "account_id")?;
+            let user_name = require(&s.user_name, "user_name")?;
+            auth_cache
+                .invalidate_user_policies(account_id, user_name)
+                .await;
+            auth_cache
+                .invalidate_user_group_policies(account_id, user_name)
+                .await;
+            auth_cache
+                .invalidate_user_boundary(account_id, user_name)
+                .await;
+            auth_cache.invalidate_user_tags(account_id, user_name).await;
+            auth_cache
+                .invalidate_principal_credentials(account_id, user_name)
+                .await;
+            vec![
+                "user_policies",
+                "user_group_policies",
+                "user_boundary",
+                "user_tags",
+                "principal_credentials",
+            ]
+        }
+        Scope::Role => {
+            let account_id = require(&s.account_id, "account_id")?;
+            let role_name = require(&s.role_name, "role_name")?;
+            auth_cache
+                .invalidate_role_policies(account_id, role_name)
+                .await;
+            auth_cache
+                .invalidate_role_boundary(account_id, role_name)
+                .await;
+            auth_cache.invalidate_role_tags(account_id, role_name).await;
+            auth_cache
+                .invalidate_role_sessions(account_id, role_name)
+                .await;
+            auth_cache
+                .invalidate_principal_credentials(account_id, role_name)
+                .await;
+            vec![
+                "role_policies",
+                "role_boundary",
+                "role_tags",
+                "role_sessions",
+                "principal_credentials",
+            ]
+        }
+        Scope::GroupMembers => {
+            let account_id = require(&s.account_id, "account_id")?;
+            let user_names = s
+                .user_names
+                .as_deref()
+                .ok_or_else(|| "user_names is required for scope 'group_members'".to_owned())?;
+            if user_names.is_empty() {
+                return Err("user_names must not be empty for scope 'group_members'".to_owned());
+            }
+            auth_cache
+                .invalidate_users_group_policies(account_id, user_names)
+                .await;
+            vec!["user_group_policies"]
+        }
+        Scope::TableKeyInfo => {
+            let account_id = require(&s.account_id, "account_id")?;
+            let table_name = require(&s.table_name, "table_name")?;
+            auth_cache
+                .invalidate_table_key_info(account_id, table_name)
+                .await;
+            vec!["table_key_info"]
+        }
+        Scope::ResourceTags => {
+            let arn = require(&s.arn, "arn")?;
+            auth_cache.invalidate_resource_tags(arn).await;
+            vec!["resource_tags"]
+        }
+    };
+
+    // Forensic audit trail. Operators can correlate this with the
+    // matching jump in the `invalidations` counter on auth-cache-metrics.
+    tracing::info!(
+        admin = admin_name,
+        ?scope,
+        account_id = s.account_id.as_deref().unwrap_or(""),
+        "auth_cache: admin-triggered invalidation"
+    );
+
+    Ok(InvalidateResponse { scope, invalidated })
+}
+
+fn require<'a>(field: &'a Option<String>, name: &'static str) -> Result<&'a str, String> {
+    field
+        .as_deref()
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| format!("{name} is required for the chosen scope"))
+}

--- a/crates/server/src/management/cache_metrics.rs
+++ b/crates/server/src/management/cache_metrics.rs
@@ -1,0 +1,95 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Auth/authz cache metrics endpoint.
+//!
+//! Exposes per-cache hit/miss/refresh counters and current entry counts.
+//! Authenticated as admin so workload-fingerprinting telemetry is not
+//! readable by anyone scraping the public API port.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use serde_json::json;
+
+use super::ManagementState;
+use super::auth::authenticate_admin;
+
+/// `GET /management/auth-cache-metrics` — JSON snapshot of cache counters.
+///
+/// Returns per-cache counters (hits, stale-hits, misses, refresh-success,
+/// refresh-failure, refresh-skipped-inflight, refresh-dropped-epoch,
+/// negative-hits, invalidations) and current entry counts.
+pub async fn auth_cache_metrics(
+    State(state): State<Arc<ManagementState>>,
+    headers: HeaderMap,
+) -> Response {
+    if let Err(e) =
+        authenticate_admin(&headers, &*state.catalog_store, &*state.catalog_store, None).await
+    {
+        return e;
+    }
+
+    let mut out = serde_json::Map::new();
+
+    if let Some(c) = &state.auth_cache.credential {
+        out.insert(
+            "credential".to_owned(),
+            serde_json::to_value(snapshot_to_json(
+                &c.metrics().snapshot(),
+                c.entry_count(),
+                c.is_pass_through(),
+            ))
+            .unwrap_or_default(),
+        );
+    }
+    out.insert(
+        "table_key_info".to_owned(),
+        serde_json::to_value(snapshot_to_json(
+            &state.table_key_info_cache.metrics().snapshot(),
+            state.table_key_info_cache.entry_count(),
+            state.table_key_info_cache.is_pass_through(),
+        ))
+        .unwrap_or_default(),
+    );
+    if let Some(authz_metrics) = state.authz_cache.metrics_snapshot() {
+        // The authz block carries one entry per sub-cache plus a single
+        // pass_through flag for the whole authz cache (sub-caches share
+        // construction-time configuration).
+        let mut authz_value =
+            serde_json::to_value(authz_metrics).unwrap_or(serde_json::Value::Null);
+        if let Some(obj) = authz_value.as_object_mut() {
+            obj.insert(
+                "pass_through".to_owned(),
+                serde_json::Value::Bool(state.authz_cache.is_pass_through()),
+            );
+        }
+        out.insert("authz".to_owned(), authz_value);
+    }
+
+    (StatusCode::OK, axum::Json(serde_json::Value::Object(out))).into_response()
+}
+
+fn snapshot_to_json(
+    s: &extenddb_cache::SwrMetricsSnapshot,
+    entry_count: u64,
+    pass_through: bool,
+) -> serde_json::Value {
+    json!({
+        "hits": s.hits,
+        "stale_hits": s.stale_hits,
+        "misses": s.misses,
+        "negative_hits": s.negative_hits,
+        "refresh_success": s.refresh_success,
+        "refresh_failure": s.refresh_failure,
+        "refresh_skipped_inflight": s.refresh_skipped_inflight,
+        "refresh_dropped_epoch": s.refresh_dropped_epoch,
+        "invalidations": s.invalidations,
+        "entry_count": entry_count,
+        // True when the cache is in kill-switch mode (auth.cache.enabled = false).
+        // Distinguishes "cache disabled" from "cache cold" for operators.
+        "pass_through": pass_through,
+    })
+}

--- a/crates/server/src/management/iam_group.rs
+++ b/crates/server/src/management/iam_group.rs
@@ -109,12 +109,41 @@ pub async fn delete_group(
         return e;
     }
 
+    // Snapshot members BEFORE deletion so we can invalidate their cached
+    // user-group-policies once the FK cascade has dropped membership rows.
+    // A failed enumeration falls back to TTL-based propagation (logged).
+    let members: Vec<String> = match state
+        .catalog_store
+        .get_group_detail(&account_id, &group_name)
+        .await
+    {
+        Ok(Some(detail)) => detail.members,
+        Ok(None) => Vec::new(),
+        Err(e) => {
+            tracing::warn!(
+                "delete_group: get_group_detail failed before delete; member \
+                 cache invalidation will rely on TTL: {e:?}"
+            );
+            Vec::new()
+        }
+    };
+
     match state
         .catalog_store
         .delete_group(&account_id, &group_name)
         .await
     {
-        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Ok(()) => {
+            // After the catalog write commits, drop user-group-policies
+            // for every member so policies attached to the (now-gone)
+            // group are removed from each member's effective policy set
+            // immediately.
+            state
+                .auth_cache
+                .invalidate_users(&account_id, &members)
+                .await;
+            StatusCode::NO_CONTENT.into_response()
+        }
         Err(e) => op_err_to_response(OpError::from_storage(e)),
     }
 }
@@ -137,7 +166,16 @@ pub async fn add_member(
         .add_group_member(&account_id, &group_name, &body.user_name)
         .await
     {
-        Ok(()) => (StatusCode::CREATED, "Member added").into_response(),
+        Ok(()) => {
+            // The user's group_policies cache flattens group membership at fetch
+            // time. Adding the user to the group changes the set of policies
+            // they inherit — drop the cached entry.
+            state
+                .auth_cache
+                .invalidate_user_group_policies(&account_id, &body.user_name)
+                .await;
+            (StatusCode::CREATED, "Member added").into_response()
+        }
         Err(e) => op_err_to_response(OpError::from_storage(e)),
     }
 }
@@ -159,7 +197,13 @@ pub async fn remove_member(
         .remove_group_member(&account_id, &group_name, &user_name)
         .await
     {
-        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Ok(()) => {
+            state
+                .auth_cache
+                .invalidate_user_group_policies(&account_id, &user_name)
+                .await;
+            StatusCode::NO_CONTENT.into_response()
+        }
         Err(e) => op_err_to_response(OpError::from_storage(e)),
     }
 }

--- a/crates/server/src/management/iam_group.rs
+++ b/crates/server/src/management/iam_group.rs
@@ -140,7 +140,7 @@ pub async fn delete_group(
             // immediately.
             state
                 .auth_cache
-                .invalidate_users(&account_id, &members)
+                .invalidate_users_group_policies(&account_id, &members)
                 .await;
             StatusCode::NO_CONTENT.into_response()
         }

--- a/crates/server/src/management/iam_policy.rs
+++ b/crates/server/src/management/iam_policy.rs
@@ -203,7 +203,10 @@ async fn put_policy(
         )
         .await
     {
-        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Ok(()) => {
+            invalidate_policy_caches(state, account_id, principal_type, principal_name).await;
+            StatusCode::NO_CONTENT.into_response()
+        }
         Err(e) => op_err_to_response(OpError::from_storage(e)),
     }
 }
@@ -265,7 +268,62 @@ async fn delete_policy(
         .delete_policy(account_id, principal_type, principal_name, policy_name)
         .await
     {
-        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Ok(()) => {
+            invalidate_policy_caches(state, account_id, principal_type, principal_name).await;
+            StatusCode::NO_CONTENT.into_response()
+        }
         Err(e) => op_err_to_response(OpError::from_storage(e)),
+    }
+}
+
+/// Drop the cache entries affected by a policy mutation on the given principal.
+///
+/// - **user**: invalidates `user_policies` for that user.
+/// - **role**: invalidates `role_policies` for that role.
+/// - **group**: invalidates `user_group_policies` for **every member** of the
+///   group (the cache key is per-user, since membership is flattened during the
+///   loader fetch). A failed member listing leaves stale entries that age out
+///   at the configured TTL.
+async fn invalidate_policy_caches(
+    state: &ManagementState,
+    account_id: &str,
+    principal_type: &str,
+    principal_name: &str,
+) {
+    match principal_type {
+        "user" => {
+            state
+                .auth_cache
+                .invalidate_user_policies(account_id, principal_name)
+                .await;
+        }
+        "role" => {
+            state
+                .auth_cache
+                .invalidate_role_policies(account_id, principal_name)
+                .await;
+        }
+        "group" => {
+            let members = match state
+                .catalog_store
+                .get_group_detail(account_id, principal_name)
+                .await
+            {
+                Ok(Some(detail)) => detail.members,
+                Ok(None) => Vec::new(),
+                Err(e) => {
+                    tracing::warn!(
+                        "invalidate_policy_caches: get_group_detail failed for {principal_name}: {e:?}; \
+                         members' cached group policies will age out at TTL"
+                    );
+                    Vec::new()
+                }
+            };
+            state
+                .auth_cache
+                .invalidate_users(account_id, &members)
+                .await;
+        }
+        _ => {}
     }
 }

--- a/crates/server/src/management/iam_policy.rs
+++ b/crates/server/src/management/iam_policy.rs
@@ -321,7 +321,7 @@ async fn invalidate_policy_caches(
             };
             state
                 .auth_cache
-                .invalidate_users(account_id, &members)
+                .invalidate_users_group_policies(account_id, &members)
                 .await;
         }
         _ => {}

--- a/crates/server/src/management/iam_role.rs
+++ b/crates/server/src/management/iam_role.rs
@@ -136,7 +136,34 @@ pub async fn delete_role(
         .delete_role(&account_id, &role_name)
         .await
     {
-        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Ok(()) => {
+            // Cascade invalidations: every cached entry keyed by this role
+            // must be dropped. ASIA* session credentials issued for this
+            // role are dropped via `invalidate_principal_credentials`
+            // (their `principal_name` is the role name); session-data
+            // entries are dropped via the role-session predicate.
+            state
+                .auth_cache
+                .invalidate_principal_credentials(&account_id, &role_name)
+                .await;
+            state
+                .auth_cache
+                .invalidate_role_policies(&account_id, &role_name)
+                .await;
+            state
+                .auth_cache
+                .invalidate_role_boundary(&account_id, &role_name)
+                .await;
+            state
+                .auth_cache
+                .invalidate_role_tags(&account_id, &role_name)
+                .await;
+            state
+                .auth_cache
+                .invalidate_role_sessions(&account_id, &role_name)
+                .await;
+            StatusCode::NO_CONTENT.into_response()
+        }
         Err(e) => op_err_to_response(OpError::from_storage(e)),
     }
 }
@@ -179,6 +206,10 @@ pub async fn tag_role(
         .await
     {
         Ok(()) => {
+            state
+                .auth_cache
+                .invalidate_role_tags(&account_id, &role_name)
+                .await;
             tracing::warn!(
                 target: "extenddb::audit::manage",
                 "tag-role: account={}, role={}, keys=[{}]",
@@ -210,6 +241,10 @@ pub async fn untag_role(
         .await
     {
         Ok(()) => {
+            state
+                .auth_cache
+                .invalidate_role_tags(&account_id, &role_name)
+                .await;
             tracing::warn!(
                 target: "extenddb::audit::manage",
                 "untag-role: account={}, role={}, keys=[{}]",

--- a/crates/server/src/management/iam_user.rs
+++ b/crates/server/src/management/iam_user.rs
@@ -149,12 +149,66 @@ pub async fn delete_user(
         return e;
     }
 
+    // Snapshot the user's access keys before deletion so we can invalidate
+    // their cached credentials after the cascade delete succeeds. A failed
+    // list shouldn't block deletion — fall back to TTL-based propagation
+    // (auth.cache.ttl_seconds).
+    //
+    // The snapshot is racy by design: a CreateAccessKey concurrent with this
+    // delete may produce a key not in `access_key_ids`. The defensive
+    // `invalidate_principal_credentials` fanout below handles that case by
+    // matching on (account_id, principal_name) over the cache values.
+    let access_key_ids: Vec<String> = match state
+        .catalog_store
+        .list_access_keys(&account_id, &user_name)
+        .await
+    {
+        Ok(rows) => rows.into_iter().map(|(id, _, _)| id).collect(),
+        Err(e) => {
+            tracing::warn!(
+                "delete_user: list_access_keys failed before delete; cache invalidation will rely on TTL: {e:?}"
+            );
+            Vec::new()
+        }
+    };
+
     match state
         .catalog_store
         .delete_user(&account_id, &user_name)
         .await
     {
-        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Ok(()) => {
+            // Cascade invalidations: every cached entry keyed by this user
+            // must be dropped so a subsequent recreate (same name) doesn't
+            // inherit the deleted user's policies/tags.
+            for key_id in &access_key_ids {
+                state.auth_cache.invalidate_credential(key_id).await;
+            }
+            // Defensive: any cached credential whose principal_name matches
+            // the deleted user (e.g. a key not in our snapshot due to race
+            // conditions) is also dropped.
+            state
+                .auth_cache
+                .invalidate_principal_credentials(&account_id, &user_name)
+                .await;
+            state
+                .auth_cache
+                .invalidate_user_policies(&account_id, &user_name)
+                .await;
+            state
+                .auth_cache
+                .invalidate_user_group_policies(&account_id, &user_name)
+                .await;
+            state
+                .auth_cache
+                .invalidate_user_boundary(&account_id, &user_name)
+                .await;
+            state
+                .auth_cache
+                .invalidate_user_tags(&account_id, &user_name)
+                .await;
+            StatusCode::NO_CONTENT.into_response()
+        }
         Err(e) => op_err_to_response(OpError::from_storage(e)),
     }
 }
@@ -197,6 +251,10 @@ pub async fn tag_user(
         .await
     {
         Ok(()) => {
+            state
+                .auth_cache
+                .invalidate_user_tags(&account_id, &user_name)
+                .await;
             tracing::warn!(
                 target: "extenddb::audit::manage",
                 "tag-user: account={}, user={}, keys=[{}]",
@@ -228,6 +286,10 @@ pub async fn untag_user(
         .await
     {
         Ok(()) => {
+            state
+                .auth_cache
+                .invalidate_user_tags(&account_id, &user_name)
+                .await;
             tracing::warn!(
                 target: "extenddb::audit::manage",
                 "untag-user: account={}, user={}, keys=[{}]",

--- a/crates/server/src/management/iam_user_self.rs
+++ b/crates/server/src/management/iam_user_self.rs
@@ -79,14 +79,23 @@ pub async fn create_access_key(
         .create_access_key(&account_id, &user_name)
         .await
     {
-        Ok(key) => (
-            StatusCode::CREATED,
-            axum::Json(AccessKeyCreated {
-                access_key_id: key.access_key_id,
-                secret_access_key: key.secret_access_key,
-            }),
-        )
-            .into_response(),
+        Ok(key) => {
+            // Write-through invalidation: the new key may have a cached negative
+            // (Ok(None)) entry from a prior lookup attempt. Drop it so the next
+            // SigV4 verification picks up the credential immediately.
+            state
+                .auth_cache
+                .invalidate_credential(&key.access_key_id)
+                .await;
+            (
+                StatusCode::CREATED,
+                axum::Json(AccessKeyCreated {
+                    access_key_id: key.access_key_id,
+                    secret_access_key: key.secret_access_key,
+                }),
+            )
+                .into_response()
+        }
         Err(e) => op_err_to_response(OpError::from_storage(e)),
     }
 }
@@ -151,7 +160,12 @@ pub async fn delete_access_key(
         .delete_access_key(&account_id, &user_name, &key_id)
         .await
     {
-        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Ok(()) => {
+            // Write-through invalidation: ensure subsequent SigV4 verifications
+            // for the deleted key see UnrecognizedClientException without TTL lag.
+            state.auth_cache.invalidate_credential(&key_id).await;
+            StatusCode::NO_CONTENT.into_response()
+        }
         Err(e) => op_err_to_response(OpError::from_storage(e)),
     }
 }
@@ -196,6 +210,10 @@ pub async fn change_user_password(
         .change_user_password(&account_id, &user_name, &hash)
         .await
     {
+        // No cache invalidation: passwords are only used by the management
+        // API's Basic auth path, which queries the catalog directly and
+        // does not consult the auth cache. SigV4 (the cached path) uses
+        // access keys, not passwords.
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(e) => op_err_to_response(OpError::from_storage(e)),
     }
@@ -268,7 +286,14 @@ pub async fn import_access_key(
         )
         .await
     {
-        Ok(()) => (StatusCode::CREATED, "Access key imported").into_response(),
+        Ok(()) => {
+            // Drop any cached negative entry for this key.
+            state
+                .auth_cache
+                .invalidate_credential(&body.access_key_id)
+                .await;
+            (StatusCode::CREATED, "Access key imported").into_response()
+        }
         Err(e) => op_err_to_response(OpError::from_storage(e)),
     }
 }

--- a/crates/server/src/management/mod.rs
+++ b/crates/server/src/management/mod.rs
@@ -13,6 +13,7 @@ pub(crate) use account::generate_account_id;
 mod admin;
 mod assume_role;
 mod auth;
+mod cache_metrics;
 pub(crate) mod crypto;
 mod iam_group;
 mod iam_policy;
@@ -36,6 +37,17 @@ pub use auth::CallerIdentity;
 pub struct ManagementState {
     /// Catalog store implementing operational storage traits.
     pub catalog_store: Arc<dyn extenddb_storage::CatalogStore>,
+    /// Auth/authz cache registry. Used by mutation handlers to issue
+    /// write-through invalidations so self-induced IAM changes propagate
+    /// instantly within the local instance.
+    pub auth_cache: extenddb_auth::AuthCacheRegistry,
+    /// Concrete authorization cache handle, used by the `/management/auth-cache-metrics`
+    /// endpoint to expose per-sub-cache counters. The same instance is held
+    /// trait-object-style in `auth_cache.authz` for invalidation calls.
+    pub authz_cache: Arc<crate::CachedAuthzStore>,
+    /// Concrete TableKeyInfo cache handle, used by the auth-cache-metrics
+    /// endpoint. Same instance is held in `auth_cache.table_key_info`.
+    pub table_key_info_cache: Arc<crate::CachedTableKeyInfoStore>,
 }
 
 /// Build the management API router.
@@ -186,6 +198,13 @@ pub fn router() -> Router<Arc<ManagementState>> {
         .route("/settings", get(settings::list_settings))
         .route("/settings/{key}", get(settings::get_setting))
         .route("/settings/{key}", put(settings::set_setting))
+        // Cache observability (admin only). Exposes per-cache hit/miss/
+        // refresh counters and current entry counts. Authenticated via the
+        // standard admin Basic auth.
+        .route(
+            "/auth-cache-metrics",
+            get(cache_metrics::auth_cache_metrics),
+        )
 }
 
 /// Validate an IAM name: 1-128 chars, alphanumeric, hyphens, underscores, dots, plus, equals, at.

--- a/crates/server/src/management/mod.rs
+++ b/crates/server/src/management/mod.rs
@@ -13,6 +13,7 @@ pub(crate) use account::generate_account_id;
 mod admin;
 mod assume_role;
 mod auth;
+pub mod cache_invalidate;
 mod cache_metrics;
 pub(crate) mod crypto;
 mod iam_group;
@@ -205,6 +206,9 @@ pub fn router() -> Router<Arc<ManagementState>> {
             "/auth-cache-metrics",
             get(cache_metrics::auth_cache_metrics),
         )
+        // Manual cache invalidation (admin only break-glass tool).
+        // See docs/design/12-auth-authz-cache.md §6.1.
+        .route("/cache/invalidate", post(cache_invalidate::invalidate))
 }
 
 /// Validate an IAM name: 1-128 chars, alphanumeric, hyphens, underscores, dots, plus, equals, at.

--- a/crates/server/src/management/permissions_boundary.rs
+++ b/crates/server/src/management/permissions_boundary.rs
@@ -112,7 +112,10 @@ async fn set_boundary(
     };
 
     match result {
-        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Ok(()) => {
+            invalidate_boundary_cache(state, account_id, principal_type, principal_name).await;
+            StatusCode::NO_CONTENT.into_response()
+        }
         Err(e) => op_err_to_response(OpError::from_storage(e)),
     }
 }
@@ -202,7 +205,33 @@ async fn delete_boundary(
     };
 
     match result {
-        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Ok(()) => {
+            invalidate_boundary_cache(state, account_id, principal_type, principal_name).await;
+            StatusCode::NO_CONTENT.into_response()
+        }
         Err(e) => op_err_to_response(OpError::from_storage(e)),
+    }
+}
+
+async fn invalidate_boundary_cache(
+    state: &ManagementState,
+    account_id: &str,
+    principal_type: &str,
+    principal_name: &str,
+) {
+    match principal_type {
+        "user" => {
+            state
+                .auth_cache
+                .invalidate_user_boundary(account_id, principal_name)
+                .await;
+        }
+        "role" => {
+            state
+                .auth_cache
+                .invalidate_role_boundary(account_id, principal_name)
+                .await;
+        }
+        _ => {}
     }
 }

--- a/crates/server/src/request_helpers.rs
+++ b/crates/server/src/request_helpers.rs
@@ -51,9 +51,12 @@ pub(crate) fn extract_table_name(input: &Value) -> Option<String> {
 /// Returns the pre-fetched `TableKeyInfo` for single-table item-level operations
 /// (P118 optimization #2). The caller passes this into `OperationContext` to
 /// avoid a redundant catalog roundtrip in the engine layer.
+///
+/// All authorization data is fetched via `state.authz_cache`, which sits on
+/// top of the underlying `AuthorizationStore` and serves cached, pre-parsed
+/// `PolicyDocument`s.
 pub(crate) async fn authorize_request(
     state: &AppState,
-    store: &dyn extenddb_storage::authorization_store::AuthorizationStore,
     identity: &extenddb_auth::AuthIdentity,
     input: &Value,
     operation: &str,
@@ -62,13 +65,16 @@ pub(crate) async fn authorize_request(
     let table_name = extract_table_name(input);
     let resource_arn = build_resource_arn(&state.region, account_id, table_name.as_deref());
 
-    // P118: Fetch table_key_info for item-level operations. The result is both
-    // used for LeadingKeys extraction here AND returned to the caller to avoid
-    // a redundant fetch in the engine layer.
+    // P118: Fetch table_key_info for item-level operations via the SWR cache.
+    // The result is used for LeadingKeys extraction here AND returned to the
+    // caller to avoid a redundant fetch in the engine layer.
     let key_info = match operation {
         "GetItem" | "PutItem" | "DeleteItem" | "UpdateItem" | "Query" | "Scan" => {
             if let Some(ref tn) = table_name {
-                state.storage.table_key_info(account_id, tn).await.ok()
+                state
+                    .table_key_info_cache
+                    .get_optional(account_id, tn)
+                    .await
             } else {
                 None
             }
@@ -98,7 +104,7 @@ pub(crate) async fn authorize_request(
         ..Default::default()
     };
     authorization::check_authorization(
-        store,
+        state.authz_cache.as_ref(),
         identity,
         operation,
         &resource_arn,

--- a/crates/storage-postgres/src/credential_store.rs
+++ b/crates/storage-postgres/src/credential_store.rs
@@ -138,6 +138,7 @@ impl DbCredentialStore {
             is_session: false,
             session_token: None,
             is_active,
+            expires_at: None,
         }))
     }
 
@@ -195,6 +196,7 @@ impl DbCredentialStore {
             is_session: true,
             session_token: Some(session_token),
             is_active: true,
+            expires_at: Some(expires_at),
         }))
     }
 }

--- a/crates/storage-postgres/src/data/update_item.rs
+++ b/crates/storage-postgres/src/data/update_item.rs
@@ -165,38 +165,36 @@ impl PostgresEngine {
                     return Err(StorageError::ConditionFailed(winner_item));
                 }
             }
+        } else if old_json.is_some() {
+            let update_sql = format!("UPDATE {ddb_table} SET item_data = $2 WHERE pk = $1");
+            sqlx::query(&update_sql)
+                .bind(pk_text.as_ref())
+                .bind(&item_json)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
         } else {
-            if old_json.is_some() {
-                let update_sql = format!("UPDATE {ddb_table} SET item_data = $2 WHERE pk = $1");
-                sqlx::query(&update_sql)
+            let insert_sql = format!(
+                "INSERT INTO {ddb_table} (pk, item_data) VALUES ($1, $2) \
+                 ON CONFLICT (pk) DO NOTHING"
+            );
+            let result = sqlx::query(&insert_sql)
+                .bind(pk_text.as_ref())
+                .bind(&item_json)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if result.rows_affected() == 0 {
+                // Another transaction inserted between our SELECT and INSERT.
+                // Fetch the winner to return with ConditionFailed.
+                let winner_sql = format!("SELECT item_data FROM {ddb_table} WHERE pk = $1");
+                let winner: Option<(serde_json::Value,)> = sqlx::query_as(&winner_sql)
                     .bind(pk_text.as_ref())
-                    .bind(&item_json)
-                    .execute(&mut *tx)
+                    .fetch_optional(&mut *tx)
                     .await
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
-            } else {
-                let insert_sql = format!(
-                    "INSERT INTO {ddb_table} (pk, item_data) VALUES ($1, $2) \
-                     ON CONFLICT (pk) DO NOTHING"
-                );
-                let result = sqlx::query(&insert_sql)
-                    .bind(pk_text.as_ref())
-                    .bind(&item_json)
-                    .execute(&mut *tx)
-                    .await
-                    .map_err(|e| StorageError::Internal(e.to_string()))?;
-                if result.rows_affected() == 0 {
-                    // Another transaction inserted between our SELECT and INSERT.
-                    // Fetch the winner to return with ConditionFailed.
-                    let winner_sql = format!("SELECT item_data FROM {ddb_table} WHERE pk = $1");
-                    let winner: Option<(serde_json::Value,)> = sqlx::query_as(&winner_sql)
-                        .bind(pk_text.as_ref())
-                        .fetch_optional(&mut *tx)
-                        .await
-                        .map_err(|e| StorageError::Internal(e.to_string()))?;
-                    let winner_item = winner.map(|(v,)| json_to_item(v)).transpose()?;
-                    return Err(StorageError::ConditionFailed(winner_item));
-                }
+                let winner_item = winner.map(|(v,)| json_to_item(v)).transpose()?;
+                return Err(StorageError::ConditionFailed(winner_item));
             }
         }
 

--- a/crates/storage-postgres/src/lib.rs
+++ b/crates/storage-postgres/src/lib.rs
@@ -331,7 +331,7 @@ impl PostgresEngine {
 // ServerComponents Factory Registration
 // ============================================================================
 
-use extenddb_auth::BuiltinAuthProvider;
+use extenddb_auth::CredentialStore;
 use extenddb_storage::hooks::{ServerRuntimeHooks, WorkerContext};
 use extenddb_storage::server_components::{
     BackendError, ServerComponents, ServerComponentsRegistration,
@@ -504,8 +504,8 @@ inventory::submit! {
                 // Create auth provider
                 let enc_key = extenddb_storage::CatalogStore::cached_encryption_key(&*catalog_store)
                     .ok_or(BackendError::MissingEncryptionKey)?;
-                let cred_store = DbCredentialStore::new(catalog_pool.clone(), enc_key);
-                let auth_provider = Arc::new(BuiltinAuthProvider::new(cred_store));
+                let cred_store: Arc<dyn CredentialStore> =
+                    Arc::new(DbCredentialStore::new(catalog_pool.clone(), enc_key));
 
                 // Create runtime hooks
                 let runtime_hooks = Box::new(PostgresRuntimeHooks {
@@ -518,7 +518,7 @@ inventory::submit! {
                 Ok(ServerComponents {
                     engine,
                     catalog_store,
-                    auth_provider,
+                    credential_store: cred_store,
                     runtime_hooks: Some(runtime_hooks),
                 })
             })

--- a/crates/storage/src/authorization_store.rs
+++ b/crates/storage/src/authorization_store.rs
@@ -80,6 +80,7 @@ pub trait AuthorizationStore: Send + Sync {
 }
 
 /// Session data returned by [`AuthorizationStore::fetch_session_data`].
+#[derive(Debug, Clone)]
 pub struct SessionData {
     /// The inline session policy document, if any.
     pub session_policy: Option<String>,

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use extenddb_core::types::{CancellationReason, Item};
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum StorageError {
     #[error("Table not found: {0}")]
     TableNotFound(String),

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -29,6 +29,27 @@ pub use server_components::{
 
 pub use hooks::{ServerRuntimeHooks, WorkerContext};
 
+/// Pluggable lookup for `TableKeyInfo`.
+///
+/// Allows the engine layer to consult an in-memory cache transparently
+/// instead of calling `StorageEngine::table_key_info` directly. The server
+/// crate provides a SWR-cached implementation; tests and embedded uses can
+/// pass `None` to fall back to direct storage lookups.
+///
+/// Defined here (rather than in `extenddb-engine`) so the cache wrapper in
+/// `extenddb-server` can implement it without creating a circular crate
+/// dependency.
+pub trait TableKeyInfoLookup: Send + Sync {
+    fn lookup<'a>(
+        &'a self,
+        account_id: &'a str,
+        table_name: &'a str,
+    ) -> futures::future::BoxFuture<
+        'a,
+        Result<extenddb_core::types::TableKeyInfo, error::StorageError>,
+    >;
+}
+
 pub mod util;
 
 use std::sync::Arc;

--- a/crates/storage/src/management_store/types.rs
+++ b/crates/storage/src/management_store/types.rs
@@ -6,7 +6,7 @@
 // ── Error types ────────────────────────────────────────────────────────
 
 /// Error from a management or operational storage operation.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum OpError {
     /// Input validation failed (caller should have caught this).
     Validation(String),

--- a/crates/storage/src/server_components.rs
+++ b/crates/storage/src/server_components.rs
@@ -11,7 +11,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use extenddb_auth::AuthProvider;
+use extenddb_auth::CredentialStore;
 
 use crate::config::StorageConfig;
 use crate::hooks::ServerRuntimeHooks;
@@ -28,8 +28,10 @@ pub struct ServerComponents {
     /// Catalog store for management API operations
     pub catalog_store: Arc<dyn CatalogStore>,
 
-    /// Auth provider (wraps credential store internally)
-    pub auth_provider: Arc<dyn AuthProvider>,
+    /// Raw (uncached) credential store. The bin layer wraps this in
+    /// `CachedCredentialStore` using the operator-configured TTL before
+    /// constructing the auth provider.
+    pub credential_store: Arc<dyn CredentialStore>,
 
     /// Optional backend-specific runtime hooks for worker spawning
     pub runtime_hooks: Option<Box<dyn ServerRuntimeHooks>>,

--- a/docs/design/11-high-availability.md
+++ b/docs/design/11-high-availability.md
@@ -150,11 +150,18 @@ This is the minimal mechanism needed to honor DynamoDB's consistency model. It w
 
 ## 6. Design Decisions
 
-### D1: No In-Process State (Preserved)
+### D1: No In-Process State on the Data Path (Preserved, with one explicit revision)
 
-The existing "No Caching Rule" is preserved and strengthened. Frontends remain stateless. This is what makes horizontal frontend scaling trivial — any frontend can serve any request because all state lives in the catalog.
+The "No Caching Rule" applies to data-path state: items, query results, throttle buckets, stream cursors, and anything that varies per write. Frontends remain stateless on the data path — any frontend can serve any data request because all data state lives in the catalog.
 
-**Rationale:** Multiple frontends sharing a catalog would have stale caches. The No Caching Rule already anticipated this.
+**Revision (2026-05):** The auth/authz layer now caches IAM data (credentials, parsed policies, principal/resource tags, table key info) in-process for the request hot path. See [`12-auth-authz-cache.md`](12-auth-authz-cache.md) for the full design. This was a deliberate trade-off, not a violation of D1:
+
+- Auth/authz reads on the hot path were ~6 catalog queries per request (now ~0 in steady state). The performance gap had no other fix.
+- IAM data has bounded staleness tolerance: AWS IAM itself documents policy-propagation delays of ~30 s–2 min. ExtendDB exposes the same bound as `auth.cache.ttl_seconds` (default 60 s) and makes it operator-tunable.
+- Self-induced changes (admin API mutations) propagate **instantly** within a single instance via write-through invalidation hooks. Off-instance changes (multi-frontend, or direct DB writes) are bounded by the configured TTL.
+- The kill switch (`auth.cache.enabled = false`) restores the original "no caching" behavior without restart-triggered code changes.
+
+**Rationale (still valid for the data path):** Multiple frontends sharing a catalog would have stale caches. For data, that's intolerable. For IAM, bounded staleness is the same trade-off real AWS IAM exposes. Cross-frontend invalidation fanout for the IAM cache is designed in [Appendix B of `12-auth-authz-cache.md`](12-auth-authz-cache.md#appendix-b--multi-instance-cache-invalidation-deferred) but not yet implemented; deployments running multiple frontends should treat `auth.cache.ttl_seconds` as the worst-case lag for off-instance IAM mutations.
 
 ### D2: Consistency Routing Lives in the Storage Adapter
 
@@ -234,14 +241,16 @@ The `extenddb.toml` configuration accepts `pool_size` per connection target. The
 - DynamoDB's API doesn't expose partitioning to clients — any frontend must be able to serve any request.
 - Contradicts the "equally comfortable on a Raspberry Pi" requirement.
 
-### A3: Frontend-Level Read Replicas (Cached Reads)
+### A3: Frontend-Level Read Replicas (Cached Data Reads)
 
-**Approach:** Frontends cache recent reads and serve eventually-consistent reads from cache.
+**Approach:** Frontends cache recent **data** reads (item bodies, query results) and serve eventually-consistent reads from cache.
 
 **Rejected because:**
-- Violates the No Caching Rule.
-- Cache invalidation across frontends is the exact problem the No Caching Rule was designed to avoid.
+- Violates the No Caching Rule for data-path state.
+- Cache invalidation across frontends for arbitrary item writes is the exact problem the No Caching Rule was designed to avoid — every PutItem/UpdateItem would need to fan out to every frontend.
 - PostgreSQL's buffer pool already provides memory-resident access to hot data.
+
+**Note:** A narrow, bounded cache for **IAM data** (credentials, policies, tags) is implemented in [`12-auth-authz-cache.md`](12-auth-authz-cache.md). It applies the trade-off described in D1: bounded staleness on a slow-mutation, high-read-rate dataset, with TTLs that match AWS IAM's documented propagation window. That cache does not extend to data-path reads.
 
 ### A4: Single-Writer with Read Replicas at Frontend Level
 

--- a/docs/design/12-auth-authz-cache.md
+++ b/docs/design/12-auth-authz-cache.md
@@ -1,0 +1,507 @@
+# Auth / Authz Cache — Design
+
+> Status: implemented (single-instance). Multi-instance fanout in
+> Appendix B is designed but deferred — implementation is gated on a
+> separate review.
+> Author: assisted, reviewed by repository owner
+> Companion document to: [05-component-auth.md](05-component-auth.md), [06-component-server.md](06-component-server.md)
+>
+> Note: this cache is the deliberate revision of the "No In-Process State"
+> rule in [`11-high-availability.md`](11-high-availability.md) §D1. The
+> revision is scoped to IAM data only (credentials, policies, tags, table
+> key info). The data path remains uncached.
+
+## 1. Motivation
+
+Each DynamoDB request issues 6+ catalog queries before dispatch can begin:
+
+| # | Data | Source |
+|---|------|--------|
+| 1 | Decrypted credential lookup | `DbCredentialStore::lookup_credential` |
+| 2 | Identity policies (user or role) | `AuthorizationStore::fetch_user_policies` / `fetch_role_policies` |
+| 3 | Group policies (users only) | `fetch_user_group_policies` |
+| 4 | Permissions boundary | `fetch_user_boundary` / `fetch_role_boundary` |
+| 5 | Principal tags | `fetch_user_tags` / `fetch_role_tags` (+ `fetch_session_data` for role sessions) |
+| 6 | Resource tags | `fetch_resource_tags` |
+| 7 | TableKeyInfo (item-level ops only) | `request_helpers.rs::authorize_request` (serial, outside the `try_join!`) |
+
+Queries 2–6 fan out concurrently via `tokio::try_join!` (`crates/server/src/authorization.rs:82`), but they still each consume a connection from the catalog pool. With a 1024-connection catalog pool (post-PR #46), the pool itself is no longer the limit — but the **per-request DB roundtrips and JSON-parse cost** are now the dominant overhead before dispatch.
+
+In addition, every call to `fetch_policies` reparses policy JSON via `PolicyDocument::from_json` (`crates/server/src/authorization.rs:189`). Caching parsed `PolicyDocument` values eliminates that cost, not just the DB roundtrip.
+
+This document specifies an in-memory cache with stale-while-revalidate semantics that eliminates the steady-state cost of these queries while preserving correctness on credential rotation and policy change.
+
+## 2. Goals
+
+- Eliminate the per-request catalog roundtrips for credentials, policies, boundaries, principal tags, resource tags, and TableKeyInfo on the steady-state hot path.
+- Eliminate the per-request `PolicyDocument::from_json` parse cost.
+- Refresh stale entries **without** making the user request wait (refresh-ahead, a.k.a. stale-while-revalidate).
+- Bound memory with an LRU upper limit per cache.
+- Allow operators to disable the cache entirely as a kill switch.
+- Propagate self-induced changes (admin API mutations) instantly within a single process via write-through invalidation hooks.
+
+## 3. Non-goals
+
+- **Cross-process cache coherence** for multi-instance deployments. Fanout invalidation across nodes is out of scope. Operators running multiple instances accept the configured TTL as the worst-case lag for off-instance changes. This is documented and made explicit.
+- **Persistence across restarts.** Cold-start performance is identical to today; warm-up is fast (a few seconds at production traffic).
+- **Caching mutable, transactional state** like throttle buckets or stream cursors. This document is strictly about IAM and table metadata.
+- **Caching successful authorization decisions.** We cache the inputs (policies, tags), not the verdict. Re-evaluating the policies in CPU is essentially free once the inputs are cached, and verdict caching has subtle correctness issues with conditions that depend on per-request context.
+
+## 4. Refresh strategy: stale-while-revalidate (SWR), not background scan
+
+Each cache entry has two timestamps:
+
+```
+fetched_at ──── soft_ttl ──── hard_ttl ──── ∞
+              fresh        stale-but-usable   miss
+```
+
+| State | Action |
+|-------|--------|
+| `now − fetched_at < soft_ttl` | Return cached value. No work. |
+| `soft_ttl ≤ now − fetched_at < hard_ttl` | Return cached value. **Spawn** a tokio task to refetch and replace. |
+| `now − fetched_at ≥ hard_ttl` | Cache miss. Await refetch. Single-flight: concurrent misses for the same key share one in-flight load. |
+
+**Why not a background worker that periodically scans and refreshes the cache?**
+
+- It refreshes entries that may never be touched again (waste).
+- It must walk the cache, contending on the very lock we're trying to take off the hot path.
+- Refresh-on-access naturally distributes refresh load over time.
+- Under any non-trivial load, every entry is touched well before its hard TTL anyway.
+
+A background scan only adds value under traffic so light that some hot entry might cross the soft-TTL boundary and stay there until eviction. That is not a real scenario for this system.
+
+**Why not "if-modified-since" / version-column refresh?**
+
+Considered: fetch a cheap `updated_at` first, only refetch full data if changed. Rejected. The full refetch query has the same RTT as the change-check query (network is the bottleneck, not row size), and the saved JSON parse is a small fraction of the total cost. The complexity of a two-query refetch isn't worth the marginal gain.
+
+## 5. Negative caching
+
+Negative results (`Ok(None)` — key not found) are cached for a **short** TTL (default: 5 seconds). Reasons:
+
+- Stops attackers from hammering the catalog with random `AKIA...` access keys.
+- 5s ensures newly-created keys become usable quickly without manual cache flush.
+
+**Errors are never cached.** Transient DB failures must not poison the cache.
+
+## 6. Invalidation: write-through hooks
+
+When the management API **or the web console** mutates IAM data, it invalidates the corresponding cache entry **synchronously, in-process**. Both admin paths share `AuthCacheRegistry` and call the same hooks, so it doesn't matter whether an admin clicks through the console or hits the management API: self-induced changes propagate instantly on the local instance.
+
+| Mutation | Invalidates |
+|----------|-------------|
+| `CreateAccessKey`, `DeleteAccessKey`, `ImportAccessKey` | credential cache for that `access_key_id` |
+| `AssumeRole` | credential cache for the new ASIA*; session_data for `(account, role, session_name)` |
+| `PutUserPolicy`, `DeleteUserPolicy` | user-policies cache for `(account_id, user_name)` |
+| `AddUserToGroup`, `RemoveUserFromGroup` | user-group-policies cache for `(account_id, user_name)` |
+| `PutGroupPolicy`, `DeleteGroupPolicy` | user-group-policies for **every member** of that group (cheap: lookup membership, invalidate each) |
+| `PutUserPermissionsBoundary`, `DeleteUserPermissionsBoundary` | user-boundary cache |
+| `TagUser`, `UntagUser` | user-tags cache |
+| `PutRolePolicy`, `DeleteRolePolicy` | role-policies cache for `(account_id, role_name)` |
+| `PutRolePermissionsBoundary`, `DeleteRolePermissionsBoundary` | role-boundary cache |
+| `TagRole`, `UntagRole` | role-tags cache |
+| `TagResource`, `UntagResource` | resource-tags cache for that ARN |
+| `CreateTable`, `DeleteTable`, `UpdateTable` (key schema, indexes, streams, throughput) | TableKeyInfo cache for `(account_id, table_name)`; `CreateTable` and `DeleteTable` also invalidate `resource_tags` for the table ARN |
+| `ImportTable`, `RestoreTableFromBackup` | TableKeyInfo cache for the new table |
+| `DeleteUser` | credential (per-key + principal-fanout), user-policies, user-group-policies, user-boundary, user-tags |
+| `DeleteRole` | credential (principal-fanout for ASIA*), role-policies, role-boundary, role-tags, all session_data for the role |
+| `DeleteGroup` | user-group-policies for every member |
+| `DeleteAccount` | every cached entry across every authz subcache + credentials, scoped to the account_id |
+
+`UpdateTimeToLive` does NOT invalidate `TableKeyInfo` because TTL state is not part of `TableKeyInfo`.
+
+A cross-process invalidation channel is **not** added in this iteration. Multi-node deployments document the configured TTL as the worst-case lag.
+
+## 7. Configuration
+
+Static configuration in `extenddb.toml`:
+
+```toml
+[auth.cache]
+# All fields optional; defaults shown.
+enabled            = true
+ttl_seconds        = 60   # hard TTL — entries beyond this are full misses
+soft_ttl_seconds   = 30   # entries beyond soft_ttl trigger background refresh on access
+negative_ttl_seconds = 5  # how long to cache "not found" results
+max_entries        = 10000 # per-cache LRU size limit
+```
+
+Default rationale:
+
+- **60 s hard TTL** mirrors AWS IAM's "policy propagation" expectation (~30 s–2 min). Long enough to absorb the perf bottleneck (60 s of caching → 99.99%+ hit rate per hot key under any meaningful load), short enough to bound the blast radius of off-instance credential revocation.
+- **30 s soft TTL** = TTL / 2 keeps refreshes from clustering at the boundary.
+- **5 s negative TTL** is short enough that newly-issued keys work quickly, long enough to absorb a dictionary attack against `lookup_credential`.
+- **10 000 entries per cache** is a generous default for typical deployments; under memory pressure the LRU evicts cold entries.
+- **`enabled = false`** is a kill switch for incident response.
+
+The cache is configured statically (`extenddb.toml`). Runtime tunability is not added — cache TTL changes are rare and a server restart is acceptable. Adding it to the existing `settings` poller table is an option for a follow-up if operationally needed.
+
+## 8. Architecture: decorator pattern, one cache per data shape
+
+Caching is layered as **wrapper types** over the existing trait implementations, not inlined into the storage layer. This preserves a clean test seam and keeps the storage-postgres crate focused on Postgres.
+
+```
+                                 ┌─────────────────────────┐
+                                 │ AuthProvider            │
+                                 │ (BuiltinAuthProvider)   │
+                                 └────────────┬────────────┘
+                                              │
+                                              ▼
+                              ┌────────────────────────────────────┐
+                              │ CachedCredentialStore<Inner>       │  ← new
+                              │   .lookup_credential() with SWR    │
+                              └────────────┬───────────────────────┘
+                                           │
+                                           ▼
+                              ┌────────────────────────────────────┐
+                              │ DbCredentialStore                  │  ← existing
+                              │   (PostgreSQL queries)             │
+                              └────────────────────────────────────┘
+
+
+                       ┌──────────────────────────────────────────┐
+                       │ authorization::check_authorization       │
+                       │ (now uses parsed PolicyDocuments)        │
+                       └──────────────────┬───────────────────────┘
+                                          │
+                                          ▼
+                       ┌─────────────────────────────────────────────┐
+                       │ CachedAuthorizationStore                    │  ← new
+                       │   wraps Arc<dyn AuthorizationStore>         │
+                       │   caches:                                   │
+                       │     user/role policies → Vec<Arc<PolicyDoc>>│
+                       │     boundaries        → Option<Arc<PolicyDoc>>│
+                       │     principal tags    → HashMap<String, String>│
+                       │     resource tags     → HashMap<String, String>│
+                       │     session data      → SessionData          │
+                       └────────────────┬────────────────────────────┘
+                                        │
+                                        ▼
+                       ┌─────────────────────────────────────────────┐
+                       │ PostgresCatalogStore                         │
+                       │ (impl AuthorizationStore via JSON columns)   │
+                       └─────────────────────────────────────────────┘
+
+
+                              ┌────────────────────────────────────┐
+                              │ CachedTableKeyInfoStore (helper)   │  ← new
+                              │   wraps Arc<dyn StorageEngine>     │
+                              │   on .table_key_info()             │
+                              └────────────┬───────────────────────┘
+                                           │
+                                           ▼
+                              ┌────────────────────────────────────┐
+                              │ PostgresEngine::fetch_table_key_info│
+                              └────────────────────────────────────┘
+```
+
+The auth cache stores **parsed `PolicyDocument`s** wrapped in `Arc<PolicyDocument>` — multiple cache entries (e.g. a shared inline policy attached to several users) share the parsed document via `Arc::clone`. The `check_authorization` path is updated to call a new method on the cached wrapper that returns parsed documents, eliminating the `from_json` step from the request hot path.
+
+## 9. Library choice: `moka`
+
+The implementation uses the `moka` crate (`features = ["future"]`):
+
+- Async-aware (`moka::future::Cache`) integrates cleanly with `tokio`.
+- Built-in time-based expiration with O(1) eviction.
+- Bounded with LRU/W-TinyLFU eviction policy under memory pressure.
+- **Single-flight** via `entry().or_insert_with(future)` — concurrent misses for the same key share one load future. This is critical: prevents thundering herd at cache cold-start.
+- Internal sharding — no global lock contention.
+
+The SWR layer is a thin (~80 line) wrapper on top of `moka` that adds the soft-TTL / spawn-refresh logic. We do **not** hand-roll the cache itself; that would be 200+ lines of subtle concurrency code with the same external behavior.
+
+The `moka` `future` feature uses `tokio` internals consistent with the rest of the codebase. License is MIT/Apache-2.0 — compatible with our Apache-2.0 license.
+
+## 10. Cache key shapes and value types
+
+```rust
+// Credentials
+key:   String                // access_key_id (e.g. "AKIA...")
+value: Option<StoredCredential>
+
+// Identity policies (user or role) — parsed
+key:   (String, String)      // (account_id, principal_name)
+value: Vec<Arc<PolicyDocument>>
+
+// Group policies for a user — flattens membership server-side
+key:   (String, String)      // (account_id, user_name)
+value: Vec<Arc<PolicyDocument>>
+
+// Boundaries — parsed
+key:   (String, String)      // (account_id, principal_name)
+value: Option<Arc<PolicyDocument>>
+
+// Principal tags
+key:   (String, String)      // (account_id, principal_name)
+value: HashMap<String, String>
+
+// Resource tags
+key:   String                // ARN
+value: HashMap<String, String>
+
+// Role-session data
+key:   (String, String, String) // (account_id, role_name, session_name)
+value: Option<SessionData>      // already a struct, no parsing
+
+// TableKeyInfo
+key:   (String, String)      // (account_id, table_name)
+value: Result<TableKeyInfo, NotFoundOrInactive>
+```
+
+`Arc<PolicyDocument>` is the value type for parsed policies so multiple cache entries can share the underlying document without cloning.
+
+## 11. Metrics
+
+Per-cache counters and entry counts are exposed as a JSON snapshot at the
+admin-authenticated `GET /management/auth-cache-metrics` endpoint (Basic
+auth, admin user). The response shape is:
+
+```json
+{
+  "credential":     { "hits": …, "stale_hits": …, "misses": …,
+                       "negative_hits": …, "refresh_success": …,
+                       "refresh_failure": …, "refresh_skipped_inflight": …,
+                       "refresh_dropped_epoch": …, "invalidations": …,
+                       "entry_count": … },
+  "table_key_info": { … same fields … },
+  "authz": {
+    "user_policies":       { … same fields, no entry_count … },
+    "user_group_policies": { … },
+    "user_boundary":       { … },
+    "user_tags":           { … },
+    "role_policies":       { … },
+    "role_boundary":       { … },
+    "role_tags":           { … },
+    "session_data":        { … },
+    "resource_tags":       { … }
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `hits` | Fresh cache hits (younger than `soft_ttl`). |
+| `stale_hits` | Hits between `soft_ttl` and `ttl` — served immediately, refresh spawned. |
+| `misses` | Hard misses (caller waited for the loader). |
+| `negative_hits` | Cached `None` returned (negative cache). |
+| `refresh_success` | Background refresh wrote a fresh entry. |
+| `refresh_failure` | Background refresh failed (stale entry retained until hard TTL). |
+| `refresh_skipped_inflight` | Refresh trigger skipped because one was already running for the entry. |
+| `refresh_dropped_epoch` | Refresh result discarded (an explicit invalidation or a hard miss replaced the slot). |
+| `invalidations` | Explicit `invalidate*` calls (admin mutations). |
+| `entry_count` | Best-effort current size (top-level caches only). |
+
+The endpoint is admin-only because cache hit-rate and entry-count signals
+are workload-fingerprinting telemetry. A future revision may add Prometheus
+gauges/counters under `/metrics`; until then, scrape the JSON endpoint.
+
+## 12. Error semantics
+
+- DB errors during a **request-blocking load** propagate to the caller as today (`InternalServerError`).
+- DB errors during a **background refresh** are logged and counted in `auth_cache_refresh_failure`. The stale entry is **not** evicted — the next request continues serving it (until the hard TTL passes, at which point it transitions back to a request-blocking load).
+- Decrypt failures during a credential load return `InternalServerError` and are not cached.
+
+## 13. Test strategy
+
+**Unit tests** (per-wrapper):
+
+1. Hit path: second call to the wrapper does not invoke the inner store.
+2. TTL: after `ttl_seconds`, the next call invokes the inner store.
+3. SWR: between `soft_ttl` and `ttl`, the call returns immediately and the inner is invoked exactly once on a background task.
+4. Single-flight: `N` concurrent misses for the same key invoke the inner store exactly once.
+5. Negative cache: `Ok(None)` is cached, expires at `negative_ttl`.
+6. Errors are not cached.
+7. Invalidation: `invalidate(key)` causes the next call to miss.
+8. LRU bound: `max_entries + 1` insertions evict an entry.
+
+**Integration tests** (end-to-end against a running server):
+
+- 1000 sequential `GetItem` calls with the same access key produce **1** credential lookup against the inner DB. Verified via a counter on the inner store wired in test mode.
+- Mutating `Put-User-Policy` causes the next `PutItem` to see the new policy (write-through invalidation works end-to-end).
+- After deletion of an access key, in-flight requests using the cached value succeed only until the next invalidation; new requests see `UnrecognizedClientException`.
+- Deletion of an IAM user invalidates all its caches.
+- `auth.cache.enabled = false` produces identical behavior to today (regression check).
+
+**Property tests** (focused on the SWR cache primitive):
+
+- Concurrent reads + occasional writes never observe a stale value beyond `ttl_seconds`.
+- Concurrent invalidation + reads always observe the post-invalidation value on the next call.
+
+## 14. Phased rollout
+
+| Phase | Scope | Risk |
+|-------|-------|------|
+| 1 | `SwrCache<K, V>` primitive + `moka` dep | low — pure library code, no behavior change |
+| 2 | `CachedCredentialStore` + invalidation hooks for access-key mutations | medium — touches auth path |
+| 3 | `CachedAuthorizationStore` (with parsed `PolicyDocument` cache) + invalidation hooks for IAM mutations | medium — touches authorization path |
+| 4 | `CachedTableKeyInfoStore` + invalidation hooks on `CreateTable`/`UpdateTable`/`DeleteTable` | low |
+| 5 | Documentation, config sample, `init` template, admin guide, metrics console row | trivial |
+
+Each phase is a separate PR. After each phase the test suite runs green and the system is shippable. Phases 2/3/4 each independently improve hot-path performance.
+
+## 15. Operator guide (excerpt for admin manual)
+
+> ExtendDB caches authentication and authorization data in memory to eliminate per-request catalog lookups. The cache uses **stale-while-revalidate**: stale entries are served immediately while a background refresh runs.
+>
+> **Propagation timing for invalidations**:
+>
+> - **Single-key invalidations** (e.g. `DeleteAccessKey`, `PutUserPolicy`) bump an internal epoch counter and drop the moka entry immediately. The next request blocks on a fresh load.
+> - **Fanout invalidations** (e.g. `DeleteAccount`, `DeleteRole`'s session sweep, `DeleteGroup`'s member fanout) use moka's `invalidate_entries_if`, which is **asynchronous** — predicate evaluation runs on moka's internal worker after the management call returns. There is a small window (~ms) between the API responding 200/204 and the matching entries actually being evicted from the underlying store. The accompanying epoch bump ensures any in-flight refresh on those keys is dropped on completion, but a request that reads the slot during this window can still see the pre-invalidation value. Operators should treat fanout invalidation as "eventually consistent within a few ms"; for hard cutover (e.g. revoking a compromised key), prefer the single-key invalidations (`DeleteAccessKey`) over the cascade ones.
+> - **Off-instance changes** (a separate process modifying the catalog directly, or a different instance in a multi-node deployment) take up to `auth.cache.ttl_seconds` to propagate. The cross-process invalidation channel described in Appendix B is not yet implemented.
+>
+> Self-induced single-key changes via the admin API or the web console propagate instantly on the local instance via write-through invalidation; both paths share the same `AuthCacheRegistry`.
+>
+> To force-flush the cache without restart: not currently supported. To disable: set `auth.cache.enabled = false` in `extenddb.toml` and restart.
+
+---
+
+## Appendix A — alternatives considered
+
+- **No cache, just larger pool.** Insufficient. The catalog roundtrip itself is ~1 ms on a co-located DB; per-request 6× roundtrips × 1 ms = 6 ms of pre-dispatch latency that is impossible to remove without caching. No pool size fixes this.
+- **Verdict cache (cache `Allow`/`Deny` for `(principal, action, resource)`).** Considered. Rejected: condition expressions can depend on per-request context (`aws:CurrentTime`, request IP, leading keys, attribute names) that varies per call. Caching the verdict requires either invalidating on every condition-relevant input change (impractical) or only caching for a subset of verdicts (complexity not worth it). Caching the inputs and re-evaluating in CPU per request gives the same throughput at lower complexity and zero correctness risk.
+- **Hand-roll the cache primitive.** Rejected. ~200 lines of concurrent code we'd then have to maintain, vs. ~80 lines on top of `moka`. `moka` is well-tested and widely used.
+- **Background scan worker for refresh.** Rejected, see §4.
+- **Cross-process invalidation via Postgres `LISTEN/NOTIFY`.** Considered for the multi-node case. Out of scope for this iteration; see Appendix B for the full proposed design.
+- **Long TTL (5 minutes or more).** Rejected. The marginal perf gain over 60 s is negligible (cache hit rates are already 99.9%+ at 60 s under load). Long TTLs trade safety for nothing.
+
+---
+
+## Appendix B — Multi-instance cache invalidation (deferred)
+
+> **Status:** designed, **not implemented**. Single-instance correctness is the focus of the initial cache PR; multi-instance fanout requires additional engineering review (failure modes, schema, ordering guarantees) before implementation.
+>
+> When this lands, every IAM-mutation handler will replace its single in-process `invalidate_*` call with a transactional pair: enqueue a row + `pg_notify`. Listeners on every other instance receive the notification and apply the local invalidation.
+
+### B.1 Why the current state is not enough for multi-instance deployments
+
+In a multi-instance deployment (multiple extenddb processes sharing a catalog DB), each instance's in-memory cache is local. Self-induced changes propagate instantly **on the local instance** via the existing write-through hooks. Off-instance changes — an admin-API mutation on instance A, where instance B is serving the same principal — only become visible on instance B when its cache entry expires (`auth.cache.ttl_seconds`, default 60 s).
+
+For an auth/authz cache, "60 seconds of stale policy" can mean a deleted access key still authenticates, or a Deny statement still being shadowed by a stale Allow. That window is acceptable for soft state but not for IAM revocation.
+
+### B.2 Proposed architecture: Postgres LISTEN/NOTIFY + a durable backstop table
+
+```text
+   Instance A           Instance B           Instance C
+       │                    │                    │
+       │  pg_notify(...)    │                    │
+       │   (in TX commit)   │                    │
+       │  ──────────────►   │  (LISTEN task)     │
+       │                    │  ──────────────►   │  (LISTEN task)
+       │
+       │  Same NOTIFY also delivered to A's listener — skipped via instance_id
+       │
+   cache_invalidations table (durable backstop for reconnect catch-up)
+```
+
+**Schema** (new migration, additive):
+
+```sql
+CREATE TABLE cache_invalidations (
+    seq          BIGSERIAL PRIMARY KEY,
+    cache_name   TEXT NOT NULL,           -- "credential" | "user_policies" | ...
+    key_payload  JSONB NOT NULL,          -- shape depends on cache_name
+    instance_id  UUID NOT NULL,           -- sender's identity, used to skip self
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX cache_inval_seq_idx ON cache_invalidations (seq);
+CREATE INDEX cache_inval_created_at_idx ON cache_invalidations (created_at);
+```
+
+**Write path.** Every IAM-mutation handler that today calls `state.auth_cache.invalidate_*(...)` does, **in the same transaction as the catalog write**:
+
+1. INSERT a row into `cache_invalidations`. `RETURNING seq` gives the assigned sequence number.
+2. `SELECT pg_notify('extenddb_cache', payload)` where `payload` is `{"seq", "cache", "key", "from": <instance_uuid>}`.
+3. Locally invalidate via the existing in-process call (so the sending instance's cache is correct without a network roundtrip).
+
+Postgres delivers NOTIFY only on commit, so ordering between the catalog write and the remote invalidations is provably correct: a remote instance never sees an invalidation for a write that hasn't committed.
+
+**Listener task.** One per instance, on a dedicated long-lived Postgres connection. Pseudocode:
+
+```rust
+loop {
+    let notification = listener.recv().await?;
+    let payload: Payload = serde_json::from_str(&notification.payload)?;
+    if payload.from == self.instance_id {
+        // We sent it; already invalidated locally.
+        continue;
+    }
+    // Apply locally. The same `invalidate_*` methods used by self-induced
+    // mutations.
+    apply_invalidation(&self.auth_cache, payload).await;
+    self.last_seen_seq.fetch_max(payload.seq, Ordering::AcqRel);
+}
+```
+
+**Reconnect catch-up.** When the listener reconnects after a transient failure (network hiccup, DB restart, NOTIFY queue overflow), it must replay any invalidations it missed:
+
+```rust
+async fn catch_up(&self, last_seen: u64) -> Result<()> {
+    let rows = sqlx::query("SELECT seq, cache_name, key_payload, instance_id
+                            FROM cache_invalidations
+                            WHERE seq > $1 ORDER BY seq")
+        .bind(last_seen as i64).fetch_all(&self.pool).await?;
+    for r in rows {
+        if r.instance_id == self.instance_id { continue; }
+        apply_invalidation(&self.auth_cache, r.payload).await;
+        self.last_seen_seq.store(r.seq as u64, Ordering::Release);
+    }
+    Ok(())
+}
+```
+
+If the catch-up scan exceeds the cleanup window (B.4), assume too much state has been missed and call `cache.invalidate_all()` on every cache as a safe fallback. This is no worse than today's TTL-only behavior.
+
+**Cleanup worker.** A periodic background task DELETEs rows older than `4 × ttl_seconds` (default ≈ 4 minutes). Safe because any instance offline that long would have TTL-flushed every entry anyway.
+
+### B.3 Failure modes
+
+| Scenario | Behavior |
+|----------|----------|
+| Listener connection drops, reconnects within the cleanup window | Catch-up via table scan. No data loss. |
+| Listener can't drain fast enough → NOTIFY queue overflow | Same — catch-up via table scan on next iteration. |
+| Network partition between instance and DB | NOTIFY paused; catch-up on heal. |
+| Instance offline > cleanup window | `invalidate_all` on every cache. Equivalent to a fresh start; correct but cold. |
+| Total LISTEN channel failure | Falls back gracefully to TTL-bounded propagation. No worse than today. |
+| Sender's pg_notify fails after row INSERT commits | Row is durable; receivers catch up on next NOTIFY or polling sweep. |
+| Sender's row INSERT fails | Catalog write is rolled back (same TX); no inconsistency. |
+
+### B.4 Latency expectations
+
+- Within-DC: typical NOTIFY roundtrip < 50 ms.
+- Across-region (rare; multi-region should usually use one extenddb cluster per region): bounded by the catalog DB's replication lag.
+- Worst case (listener disconnected): catch-up window equals the cleanup window (default 4 min). Operators tune by adjusting the cleanup interval.
+
+### B.5 What this does **not** solve
+
+- **Direct DB writes outside the management API.** Anything that bypasses `extenddb` writes won't generate notifications. Operators who modify the catalog directly must accept the configured TTL as the propagation window.
+- **Process crash between INSERT and NOTIFY.** The row is committed but no NOTIFY fires. The next LISTEN's reconnect-catch-up picks it up. Bounded latency = cleanup interval.
+- **Cross-cluster replication.** Out of scope; one cluster per region remains the recommended deployment shape.
+
+### B.6 Configuration sketch
+
+```toml
+[auth.cache.fanout]
+# Multi-instance invalidation fanout via Postgres LISTEN/NOTIFY.
+# Default: false (safe for single-instance; no extra connection overhead).
+enabled = false
+# DELETE rows older than this many seconds. Default: 4 × ttl_seconds.
+# cleanup_interval_seconds = 240
+```
+
+### B.7 Implementation cost estimate
+
+- ~400–500 LOC, self-contained, in `crates/storage-postgres/src/cache_fanout.rs`.
+- One new migration.
+- ~10 lines per IAM mutation handler to insert the row and trigger NOTIFY.
+- Behind the `auth.cache.fanout.enabled` flag (default off) so single-instance deployments are unaffected.
+
+### B.8 Open questions
+
+These should be resolved before implementation:
+
+1. **Schema location.** `cache_invalidations` lives in the catalog DB. Should it have its own `cache_*` schema for isolation, or sit alongside `tables`/`accounts`?
+2. **Backpressure semantics.** When the cleanup worker can't keep up with insert rate, do we drop oldest, or pause writers? Latter conflicts with the "in-line with catalog write TX" model.
+3. **Compaction.** Multiple invalidations for the same `(cache_name, key)` in the cleanup window are redundant. Worth deduping at write time, or at catch-up?
+4. **Auth-token rotation.** When the postgres auth method changes (rare), the listener's long-lived connection becomes invalid. Is the existing reconnect loop's exponential backoff sufficient, or do we need a credential-refresh hook?
+5. **Multi-tenant deployments.** Different accounts on the same instance share one channel. Is the per-channel filtering by `instance_id` sufficient, or do we need per-account channels for noise reduction?
+
+These are flagged for review by other engineers (deployment shape, durability requirements, network topology) before this lands.

--- a/docs/design/12-auth-authz-cache.md
+++ b/docs/design/12-auth-authz-cache.md
@@ -139,6 +139,8 @@ Both the management API and the web console expose this surface; the CLI (`exten
 
 Composite scopes (`user`, `role`) match what an operator most often actually wants when they reach for this tool ("forget everything about user X"). The narrow scopes are still exposed for surgical use. `all` is the broadest hammer and requires `--yes` from the CLI / a confirmation token from the console.
 
+`account` sweeps the authz and credential caches but not `table_key_info` (the `TableKeyInfo` cache is keyed by `(account, table)` and the registry's `invalidate_account` does not currently fan out across it). To clear cached table-key-info for an account, either call `scope: table_key_info` per table or use `scope: all`. This is a deliberate scoping choice — the table-key-info cache rarely diverges per account in practice, so the narrower `invalidate_account` semantics keep the most common path cheap.
+
 ### Response shape
 
 ```json

--- a/docs/design/12-auth-authz-cache.md
+++ b/docs/design/12-auth-authz-cache.md
@@ -112,6 +112,73 @@ When the management API **or the web console** mutates IAM data, it invalidates 
 
 A cross-process invalidation channel is **not** added in this iteration. Multi-node deployments document the configured TTL as the worst-case lag.
 
+## 6.1. Manual invalidation: admin break-glass API
+
+Write-through hooks (§6) cover every IAM mutation we own. They do **not** cover off-instance changes on multi-node deployments before TTL kicks in, bugs in the write-through plumbing, or test scenarios that need a deterministic flush. For those cases, an admin-authenticated **manual invalidation API** complements the automatic hooks.
+
+Both the management API and the web console expose this surface; the CLI (`extenddb manage cache invalidate ...`) is a thin client over the management API. The console route and the management API route call the same handler logic, so behavior is identical regardless of how it's invoked. All three paths use the existing admin authentication mechanism (Basic auth for the API, session-based auth for the console — neither introduces a new auth path).
+
+### HTTP endpoint
+
+`POST /management/cache/invalidate` — admin-only, JSON body, returns 200 with an audit-friendly response or 400 on malformed scope.
+
+```json
+{ "scope": "<scope-tag>", "selectors": { ... } }
+```
+
+| `scope` | Required selectors | Maps to (in `AuthCacheRegistry`) |
+|---------|--------------------|----------------------------------|
+| `all` | (none; requires explicit confirmation) | every authz subcache + credentials + table_key_info |
+| `account` | `account_id` | `invalidate_account` |
+| `credential` | `access_key_id` | `invalidate_credential` |
+| `user` | `account_id`, `user_name` | composite: user_policies + user_group_policies + user_boundary + user_tags + principal_credentials |
+| `role` | `account_id`, `role_name` | composite: role_policies + role_boundary + role_tags + role_sessions + principal_credentials |
+| `group_members` | `account_id`, `user_names[]` | `invalidate_users_group_policies` |
+| `table_key_info` | `account_id`, `table_name` | `invalidate_table_key_info` |
+| `resource_tags` | `arn` | `invalidate_resource_tags` |
+
+Composite scopes (`user`, `role`) match what an operator most often actually wants when they reach for this tool ("forget everything about user X"). The narrow scopes are still exposed for surgical use. `all` is the broadest hammer and requires `--yes` from the CLI / a confirmation token from the console.
+
+### Response shape
+
+```json
+{ "scope": "user", "invalidated": ["user_policies", "user_group_policies", "user_boundary", "user_tags", "principal_credentials"] }
+```
+
+The `invalidated` array tells operators which subcaches were touched — useful for confirming that composite scopes did what was expected, and for the console UI's success banner.
+
+### Audit trail
+
+Every invocation logs at INFO via `tracing`:
+
+```
+auth_cache: admin-triggered invalidation scope=user account_id=... user_name=... admin=alice
+```
+
+Cache invalidation counters on each subcache (exposed via `/management/auth-cache-metrics`) also increase. The structured log line gives forensic context ("who flushed, when, why") that the counter alone cannot.
+
+### Behavior when caches are disabled
+
+When `auth.cache.enabled = false`, the cache layer is in pass-through mode and there is nothing to invalidate. The endpoint still returns 200 — the `AuthCacheRegistry` invalidate methods are no-ops in this state, and the operator's contract ("cache-driven staleness for X is now cleared") is trivially satisfied.
+
+### CLI
+
+```
+extenddb manage --user admin --password ... cache invalidate <scope> [...selectors]
+```
+
+Concrete subcommands match the `scope` taxonomy 1:1: `cache invalidate all --yes`, `cache invalidate account --account-id ...`, `cache invalidate user --account-id ... --user-name ...`, etc. The `all` form requires `--yes` mirroring `extenddb destroy` and `import-access-key`. Authentication is the standard admin Basic-auth flow shared with every other `manage` subcommand.
+
+### Console
+
+A new admin-only page at `/console/cache` renders a form whose scope `<select>` reveals the relevant selector inputs via JS. Submitting POSTs to `/console/cache/invalidate` (CSRF-protected, admin-gated). The page also shows a live read of `/management/auth-cache-metrics` so operators can see what's cached before flushing it. Submitting `scope=all` requires typing `INVALIDATE` into a confirmation field, mirroring the CLI's `--yes`.
+
+### What this is *not*
+
+- **Not cross-instance.** Manual invalidation only clears the local instance's caches. Operators of multi-frontend deployments must call this on each instance, or wait `ttl_seconds` for natural expiry. Cross-instance fanout is the same Appendix B work that's deferred from automatic invalidation; it would land for both paths together.
+- **Not a cache inspector.** "What's currently cached for user X?" has different threat-model implications (admin-readable mirror of cached credential material) and is out of scope.
+- **Not for routine use.** This is break-glass tooling; the write-through hooks (§6) remain the primary mechanism.
+
 ## 7. Configuration
 
 Static configuration in `extenddb.toml`:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1284,6 +1284,30 @@ catalog_pool_size = 50
 - **Same item:** Concurrent writes to the same item serialize on PostgreSQL's row lock (`SELECT ... FOR UPDATE`). All updates succeed, but throughput for a single hot item is bounded by single-row transaction rate.
 - **Reads:** GetItem and Query do not acquire row locks and proceed concurrently with writes.
 
+### Auth/authz caching
+
+Each DynamoDB request normally issues ~6 catalog queries during auth/authz (credential lookup, identity policies, group policies, permissions boundary, principal tags, resource tags) plus a 7th for the table's key schema. ExtendDB layers an in-memory stale-while-revalidate cache over each of these to eliminate the round-trip in steady state.
+
+Configured via `[auth.cache]`:
+
+```toml
+[auth.cache]
+enabled            = true   # master kill switch
+ttl_seconds        = 60     # hard TTL — entries older than this are full misses
+soft_ttl_seconds   = 30     # entries older than this serve cached AND trigger
+                            #   a background refresh (request does not block)
+negative_ttl_seconds = 5    # how long "not found" results are remembered
+max_entries        = 10000  # per-cache LRU cap
+```
+
+**Self-induced changes** (admin API and console mutations: `CreateAccessKey`, `PutUserPolicy`, `TagResource`, `CreateTable`, etc.) propagate instantly via write-through invalidation on the local instance.
+
+**Fanout invalidations** (`DeleteAccount`, `DeleteRole` session sweep, `DeleteGroup` member fanout) complete asynchronously; there is a brief (~ms) window between the API responding success and the eviction landing. For hard cutover, prefer single-key invalidations (`DeleteAccessKey`) over cascades.
+
+**Off-instance changes** (multi-node deployments, or direct DB writes outside the management API) take up to `ttl_seconds` to propagate.
+
+Cache statistics are exposed at `/management/auth-cache-metrics` (JSON, admin-authenticated): hit / stale-hit / miss counts, refresh successes and failures, current entry counts per cache, and a `pass_through` flag per cache (distinguishes "disabled" from "cold").
+
 ## Troubleshooting
 
 See `docs/troubleshooting.md` for common errors and fixes.

--- a/docs/manuals/05-admin-guide.md
+++ b/docs/manuals/05-admin-guide.md
@@ -83,6 +83,26 @@ These settings require a server restart to take effect.
 |-----|---------|-------------|
 | `provider` | `builtin` | Auth provider: `builtin` (SigV4 + IAM). The server refuses to start with `"none"`. |
 
+#### [auth.cache]
+
+In-memory stale-while-revalidate caches eliminate the per-request catalog roundtrip for credentials, IAM policies, principal/resource tags, and table key info. Self-induced changes (admin API and console mutations) propagate instantly via write-through invalidation; off-instance changes take up to `ttl_seconds` to propagate.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enabled` | `true` | Master kill switch. When `false`, all caches operate in pass-through mode. |
+| `ttl_seconds` | `60` | Hard TTL — entries older than this trigger a fresh, request-blocking load. |
+| `soft_ttl_seconds` | `30` | Stale-but-usable threshold; older entries still serve immediately while a background task refreshes them. |
+| `negative_ttl_seconds` | `5` | Negative-cache TTL for "not found" results. |
+| `max_entries` | `10000` | Per-cache LRU cap. |
+
+Statistics are exposed at `/management/auth-cache-metrics` (JSON, admin-authenticated). The per-cache `pass_through` flag distinguishes "cache disabled" from "cache cold."
+
+**Invalidation timing**:
+
+- **Single-key invalidations** (e.g. `DeleteAccessKey`, `PutUserPolicy`) drop the cached entry immediately; the next request sees the post-mutation state.
+- **Fanout invalidations** (e.g. `DeleteAccount`, `DeleteRole` session sweep, `DeleteGroup` member fanout) are **asynchronous** — there is a small window (~ms) between the API returning success and the matching entries being evicted. For hard cutover (e.g. revoking a compromised key), prefer the single-key path (`DeleteAccessKey`) over the cascade.
+- **Off-instance changes** (multi-node deployments, or direct catalog writes) wait up to `ttl_seconds` to be observed locally.
+
 #### [server.tls]
 
 | Key | Default | Description |

--- a/extenddb.sample.toml
+++ b/extenddb.sample.toml
@@ -60,6 +60,30 @@
                                 # with provider = "none". Run `extenddb init` to create the
                                 # encryption key and admin user before first start.
 
+[auth.cache]
+# In-memory stale-while-revalidate caches sit between the request hot path
+# and the catalog database. Each request would otherwise issue ~6 catalog
+# queries during auth/authz; caching reduces this to ~0 in steady state.
+#
+# Self-induced changes (admin API mutations) propagate instantly via
+# write-through invalidation. Off-instance changes (multi-node deployments
+# or direct DB writes) take up to `ttl_seconds` to propagate.
+# enabled = true                # Master kill switch. When false, the
+                                # cache wrappers bypass moka entirely
+                                # (no lookup, no insert, no LRU pressure)
+                                # and forward every request to the catalog.
+                                # Use during incident response.
+# ttl_seconds = 60              # Hard TTL — entries older than this trigger
+                                # a fresh, request-blocking load.
+# soft_ttl_seconds = 30         # Stale-but-usable threshold. Older entries
+                                # are returned immediately while a background
+                                # task refreshes them. Set equal to
+                                # ttl_seconds to disable refresh-ahead.
+# negative_ttl_seconds = 5      # Negative-cache TTL for "not found" results.
+                                # Short by design so newly-created entities
+                                # become usable quickly.
+# max_entries = 10000           # Per-cache LRU cap.
+
 # Management web console is served at /console/ on the same port as the
 # DynamoDB API. No separate configuration needed — it uses the same bind
 # address and port as [server]. The console requires auth.provider = "builtin"

--- a/tests/management_helpers.py
+++ b/tests/management_helpers.py
@@ -393,3 +393,24 @@ class ManagementClient:
             auth=self.admin_auth,
             timeout=self.timeout, verify=self.verify,
         )
+
+    # -- Cache (admin break-glass) --
+
+    def invalidate_cache(
+        self,
+        scope: str,
+        selectors: dict | None = None,
+        *,
+        auth=None,
+    ) -> requests.Response:
+        """POST /management/cache/invalidate.
+
+        ``auth`` defaults to admin credentials; pass a tuple to test auth gating.
+        """
+        body = {"scope": scope, "selectors": selectors or {}}
+        return requests.post(
+            f"{self.base_url}/cache/invalidate",
+            json=body,
+            auth=auth or self.admin_auth,
+            timeout=self.timeout, verify=self.verify,
+        )

--- a/tests/test_cache_coherence.py
+++ b/tests/test_cache_coherence.py
@@ -1,0 +1,282 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end tests for write-through cache invalidation.
+
+These tests exercise the round-trip: mutate IAM via the management API,
+issue a SigV4 request immediately, observe the new behavior **without
+waiting for any TTL**.
+
+If the cache invalidation path is broken, these tests fail because the
+old (stale) state still applies for up to `auth.cache.ttl_seconds`.
+
+Prerequisites mirror tests/test_auth_integration.py: a running extenddb
+with `auth.provider = "builtin"` on EXTENDDB_TEST_ENDPOINT, plus admin
+credentials in EXTENDDB_ADMIN_USER / EXTENDDB_ADMIN_PASSWORD.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from typing import Any
+
+import boto3
+import pytest
+from botocore.config import Config as BotoConfig
+from botocore.exceptions import ClientError
+
+from conftest import wait_for_active, wait_for_deleted
+from management_helpers import ManagementClient
+
+
+def _require_auth_env() -> tuple[str, str, str]:
+    endpoint = os.environ.get("EXTENDDB_TEST_ENDPOINT", "").strip()
+    admin_user = os.environ.get("EXTENDDB_ADMIN_USER", "").strip()
+    admin_pass = os.environ.get("EXTENDDB_ADMIN_PASSWORD", "").strip()
+    if not endpoint or not admin_user or not admin_pass:
+        pytest.fail(
+            "MISCONFIGURED: Cache-coherence tests require EXTENDDB_TEST_ENDPOINT, "
+            "EXTENDDB_ADMIN_USER, EXTENDDB_ADMIN_PASSWORD."
+        )
+    return endpoint, admin_user, admin_pass
+
+
+@pytest.fixture(scope="module")
+def auth_env() -> tuple[str, str, str]:
+    return _require_auth_env()
+
+
+@pytest.fixture(scope="module")
+def mgmt(auth_env) -> ManagementClient:
+    endpoint, admin_user, admin_pass = auth_env
+    return ManagementClient(endpoint, admin_user, admin_pass)
+
+
+@pytest.fixture(scope="module")
+def account_id(mgmt) -> str:
+    acct_id = f"{uuid.uuid4().int % 10**12:012d}"
+    resp = mgmt.create_account(acct_id, f"cache-coh-{acct_id}")
+    assert resp.status_code == 201, resp.text
+    yield acct_id
+    mgmt.delete_account(acct_id)
+
+
+@pytest.fixture
+def user(mgmt, account_id):
+    user_name = f"cache-user-{uuid.uuid4().hex[:8]}"
+    resp = mgmt.create_user(account_id, user_name, password=None)
+    assert resp.status_code == 201, resp.text
+    yield user_name
+    # Best-effort delete; some tests delete the user themselves.
+    try:
+        mgmt.delete_user(account_id, user_name)
+    except Exception:
+        pass
+
+
+def _ddb_client(endpoint_url: str, access_key: str, secret_key: str) -> Any:
+    region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+    cfg = BotoConfig(
+        region_name=region,
+        signature_version="v4",
+        retries={"max_attempts": 0, "mode": "standard"},
+    )
+    return boto3.client(
+        "dynamodb",
+        endpoint_url=endpoint_url,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        config=cfg,
+        verify=False,  # local TLS uses a self-signed cert
+    )
+
+
+def _put_allow_policy(mgmt, account_id, user_name, action: str):
+    """Replace the user's policy with one allowing `action` on `*`."""
+    doc = {
+        "Version": "2012-10-17",
+        "Statement": [{"Effect": "Allow", "Action": action, "Resource": "*"}],
+    }
+    resp = mgmt.put_user_policy(account_id, user_name, "test-policy", doc)
+    assert resp.status_code in (200, 204), resp.text
+
+
+def _put_deny_policy(mgmt, account_id, user_name, action: str):
+    """Replace the user's policy with one explicitly denying `action`."""
+    doc = {
+        "Version": "2012-10-17",
+        "Statement": [{"Effect": "Deny", "Action": action, "Resource": "*"}],
+    }
+    resp = mgmt.put_user_policy(account_id, user_name, "test-policy", doc)
+    assert resp.status_code in (200, 204), resp.text
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_put_user_policy_takes_effect_immediately(auth_env, mgmt, account_id, user):
+    """After PutUserPolicy, the next request sees the new policy without TTL wait."""
+    endpoint, _, _ = auth_env
+
+    # Issue a key for the user.
+    resp = mgmt.create_access_key(account_id, user)
+    assert resp.status_code == 201, resp.text
+    creds = resp.json()
+    access_key, secret_key = creds["access_key_id"], creds["secret_access_key"]
+
+    # Initially the user has no policy → ListTables denied.
+    ddb = _ddb_client(endpoint, access_key, secret_key)
+    with pytest.raises(ClientError) as exc:
+        ddb.list_tables()
+    assert "AccessDenied" in str(exc.value) or "AccessDeniedException" in str(exc.value)
+
+    # Grant ListTables.
+    _put_allow_policy(mgmt, account_id, user, "dynamodb:ListTables")
+
+    # Same user, same key — must succeed on the very next call (cache
+    # invalidation is supposed to be instant for self-induced changes).
+    resp = ddb.list_tables()
+    assert "TableNames" in resp
+
+
+def test_put_deny_policy_takes_effect_immediately(auth_env, mgmt, account_id, user):
+    """An attached Deny shadows a prior Allow without TTL wait."""
+    endpoint, _, _ = auth_env
+
+    resp = mgmt.create_access_key(account_id, user)
+    creds = resp.json()
+    ddb = _ddb_client(endpoint, creds["access_key_id"], creds["secret_access_key"])
+
+    # Allow ListTables.
+    _put_allow_policy(mgmt, account_id, user, "dynamodb:ListTables")
+    ddb.list_tables()  # warms the cache with the Allow policy
+
+    # Replace with a Deny policy.
+    _put_deny_policy(mgmt, account_id, user, "dynamodb:ListTables")
+
+    # Next call must be denied.
+    with pytest.raises(ClientError) as exc:
+        ddb.list_tables()
+    assert "AccessDenied" in str(exc.value) or "AccessDeniedException" in str(exc.value)
+
+
+def test_delete_access_key_takes_effect_immediately(auth_env, mgmt, account_id, user):
+    """A deleted access key is rejected on the next request without TTL wait."""
+    endpoint, _, _ = auth_env
+
+    resp = mgmt.create_access_key(account_id, user)
+    creds = resp.json()
+    access_key = creds["access_key_id"]
+    ddb = _ddb_client(endpoint, access_key, creds["secret_access_key"])
+    _put_allow_policy(mgmt, account_id, user, "dynamodb:ListTables")
+    ddb.list_tables()  # warms credential + policy caches
+
+    # Delete the key.
+    resp = mgmt.delete_access_key(account_id, user, access_key)
+    assert resp.status_code in (200, 204)
+
+    # Next SigV4 request rejects with UnrecognizedClientException.
+    with pytest.raises(ClientError) as exc:
+        ddb.list_tables()
+    msg = str(exc.value)
+    assert (
+        "UnrecognizedClientException" in msg
+        or "InvalidSignatureException" in msg
+        or "security token" in msg.lower()
+    ), f"unexpected error: {msg}"
+
+
+def test_delete_user_drops_all_cached_state_for_user(auth_env, mgmt, account_id, user):
+    """DeleteUser cascades: access keys, policies, tags all invalidated."""
+    endpoint, _, _ = auth_env
+
+    resp = mgmt.create_access_key(account_id, user)
+    creds = resp.json()
+    access_key = creds["access_key_id"]
+    ddb = _ddb_client(endpoint, access_key, creds["secret_access_key"])
+    _put_allow_policy(mgmt, account_id, user, "dynamodb:ListTables")
+    ddb.list_tables()  # warm caches
+
+    # Delete the user.
+    resp = mgmt.delete_user(account_id, user)
+    assert resp.status_code in (200, 204), resp.text
+
+    # The cached credential must be invalid on the next call.
+    with pytest.raises(ClientError) as exc:
+        ddb.list_tables()
+    msg = str(exc.value)
+    assert (
+        "UnrecognizedClientException" in msg
+        or "InvalidSignatureException" in msg
+        or "AccessDenied" in msg
+    ), f"unexpected error after user delete: {msg}"
+
+
+def test_create_table_visible_to_authorized_caller_immediately(
+    auth_env, mgmt, account_id, user
+):
+    """CreateTable invalidates TableKeyInfo cache; subsequent reads see it."""
+    endpoint, _, _ = auth_env
+    resp = mgmt.create_access_key(account_id, user)
+    creds = resp.json()
+    ddb = _ddb_client(endpoint, creds["access_key_id"], creds["secret_access_key"])
+    _put_allow_policy(mgmt, account_id, user, "dynamodb:*")
+
+    # Probe a not-yet-existing table — ResourceNotFoundException seeds the
+    # negative cache.
+    table_name = f"cache-test-{uuid.uuid4().hex[:8]}"
+    with pytest.raises(ClientError) as exc:
+        ddb.describe_table(TableName=table_name)
+    assert "ResourceNotFound" in str(exc.value)
+
+    # Create the table.
+    ddb.create_table(
+        TableName=table_name,
+        AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    wait_for_active(ddb, table_name)
+
+    # describe_table now finds it. The negative-cache entry must have been
+    # dropped by the CreateTable invalidation hook (engine layer).
+    resp = ddb.describe_table(TableName=table_name)
+    assert resp["Table"]["TableName"] == table_name
+
+    # Cleanup.
+    ddb.delete_table(TableName=table_name)
+    wait_for_deleted(ddb, table_name)
+
+
+def test_delete_table_invalidates_table_key_info_cache(
+    auth_env, mgmt, account_id, user
+):
+    """DeleteTable invalidates the cached TableKeyInfo entry."""
+    endpoint, _, _ = auth_env
+    resp = mgmt.create_access_key(account_id, user)
+    creds = resp.json()
+    ddb = _ddb_client(endpoint, creds["access_key_id"], creds["secret_access_key"])
+    _put_allow_policy(mgmt, account_id, user, "dynamodb:*")
+
+    table_name = f"cache-test-{uuid.uuid4().hex[:8]}"
+    ddb.create_table(
+        TableName=table_name,
+        AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    wait_for_active(ddb, table_name)
+    ddb.describe_table(TableName=table_name)  # warm cache
+
+    ddb.delete_table(TableName=table_name)
+    wait_for_deleted(ddb, table_name)
+
+    # Subsequent describe must see ResourceNotFoundException, not the cached
+    # pre-delete description.
+    with pytest.raises(ClientError) as exc:
+        ddb.describe_table(TableName=table_name)
+    assert "ResourceNotFound" in str(exc.value)

--- a/tests/test_cache_coherence.py
+++ b/tests/test_cache_coherence.py
@@ -258,11 +258,12 @@ def test_create_table_visible_to_authorized_caller_immediately(
 # ---------------------------------------------------------------------------
 
 
-def _metrics_invalidations(mgmt, subcache_path: list[str]) -> int:
-    """Read the auth-cache-metrics endpoint and walk to a subcache's
-    `invalidations` counter.
+def _metrics_counter(mgmt, subcache_path: list[str], counter: str) -> int:
+    """Read the auth-cache-metrics endpoint and return one named counter
+    on a specific subcache.
 
     `subcache_path` example: `["authz", "user_policies"]` or `["credential"]`.
+    `counter` is the JSON field name (e.g. `invalidations`, `misses`, `hits`).
     """
     import requests
     url = f"{mgmt.base_url}/auth-cache-metrics"
@@ -272,20 +273,28 @@ def _metrics_invalidations(mgmt, subcache_path: list[str]) -> int:
     node = resp.json()
     for k in subcache_path:
         node = node[k]
-    return int(node["invalidations"])
+    return int(node[counter])
 
 
-def test_manual_invalidate_user_increments_counters(auth_env, mgmt, account_id, user):
-    """scope=user touches each per-user authz subcache."""
+def _metrics_invalidations(mgmt, subcache_path: list[str]) -> int:
+    return _metrics_counter(mgmt, subcache_path, "invalidations")
+
+
+def test_manual_invalidate_user_forces_refetch(auth_env, mgmt, account_id, user):
+    """scope=user actually drops the cached entry: the next request
+    misses the cache (forcing a re-fetch) instead of getting served
+    from the warm slot."""
     endpoint, _, _ = auth_env
-    # Prime the per-user policy cache.
+    # Prime the per-user policy cache so we have a warm hit-able entry.
     resp = mgmt.create_access_key(account_id, user)
     creds = resp.json()
     ddb = _ddb_client(endpoint, creds["access_key_id"], creds["secret_access_key"])
     _put_allow_policy(mgmt, account_id, user, "dynamodb:ListTables")
-    ddb.list_tables()  # populates user_policies + credential caches
+    ddb.list_tables()  # populates user_policies cache
+    ddb.list_tables()  # second call should be a hit (proves warm)
 
-    before = _metrics_invalidations(mgmt, ["authz", "user_policies"])
+    invalidations_before = _metrics_invalidations(mgmt, ["authz", "user_policies"])
+    misses_before = _metrics_counter(mgmt, ["authz", "user_policies"], "misses")
 
     resp = mgmt.invalidate_cache(
         "user", {"account_id": account_id, "user_name": user}
@@ -303,8 +312,20 @@ def test_manual_invalidate_user_increments_counters(auth_env, mgmt, account_id, 
     }
     assert expected.issubset(set(body["invalidated"]))
 
-    after = _metrics_invalidations(mgmt, ["authz", "user_policies"])
-    assert after > before, f"user_policies invalidations: {before} → {after}"
+    invalidations_after = _metrics_invalidations(mgmt, ["authz", "user_policies"])
+    assert invalidations_after > invalidations_before, (
+        f"user_policies invalidations: {invalidations_before} → {invalidations_after}"
+    )
+
+    # Real proof of behavior: the next request must miss the cache and
+    # re-load from the inner store. If invalidation were broken, the
+    # warm entry would still be served and `misses` wouldn't move.
+    ddb.list_tables()
+    misses_after = _metrics_counter(mgmt, ["authz", "user_policies"], "misses")
+    assert misses_after > misses_before, (
+        f"expected user_policies miss after invalidation; "
+        f"misses: {misses_before} → {misses_after}"
+    )
 
 
 def test_manual_invalidate_account_does_not_break_subsequent_traffic(

--- a/tests/test_cache_coherence.py
+++ b/tests/test_cache_coherence.py
@@ -252,6 +252,129 @@ def test_create_table_visible_to_authorized_caller_immediately(
     wait_for_deleted(ddb, table_name)
 
 
+# ---------------------------------------------------------------------------
+# Manual cache invalidation API (POST /management/cache/invalidate)
+# Covered by docs/design/12-auth-authz-cache.md §6.1.
+# ---------------------------------------------------------------------------
+
+
+def _metrics_invalidations(mgmt, subcache_path: list[str]) -> int:
+    """Read the auth-cache-metrics endpoint and walk to a subcache's
+    `invalidations` counter.
+
+    `subcache_path` example: `["authz", "user_policies"]` or `["credential"]`.
+    """
+    import requests
+    url = f"{mgmt.base_url}/auth-cache-metrics"
+    resp = requests.get(url, auth=mgmt.admin_auth,
+                        timeout=mgmt.timeout, verify=mgmt.verify)
+    assert resp.status_code == 200, resp.text
+    node = resp.json()
+    for k in subcache_path:
+        node = node[k]
+    return int(node["invalidations"])
+
+
+def test_manual_invalidate_user_increments_counters(auth_env, mgmt, account_id, user):
+    """scope=user touches each per-user authz subcache."""
+    endpoint, _, _ = auth_env
+    # Prime the per-user policy cache.
+    resp = mgmt.create_access_key(account_id, user)
+    creds = resp.json()
+    ddb = _ddb_client(endpoint, creds["access_key_id"], creds["secret_access_key"])
+    _put_allow_policy(mgmt, account_id, user, "dynamodb:ListTables")
+    ddb.list_tables()  # populates user_policies + credential caches
+
+    before = _metrics_invalidations(mgmt, ["authz", "user_policies"])
+
+    resp = mgmt.invalidate_cache(
+        "user", {"account_id": account_id, "user_name": user}
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["scope"] == "user"
+    # Composite scope reports each subcache it touched.
+    expected = {
+        "user_policies",
+        "user_group_policies",
+        "user_boundary",
+        "user_tags",
+        "principal_credentials",
+    }
+    assert expected.issubset(set(body["invalidated"]))
+
+    after = _metrics_invalidations(mgmt, ["authz", "user_policies"])
+    assert after > before, f"user_policies invalidations: {before} → {after}"
+
+
+def test_manual_invalidate_account_does_not_break_subsequent_traffic(
+    auth_env, mgmt, account_id, user
+):
+    """scope=account sweeps every cache for the account; the user must still
+    work (re-fetched from the catalog) on the next request."""
+    endpoint, _, _ = auth_env
+    resp = mgmt.create_access_key(account_id, user)
+    creds = resp.json()
+    ddb = _ddb_client(endpoint, creds["access_key_id"], creds["secret_access_key"])
+    _put_allow_policy(mgmt, account_id, user, "dynamodb:ListTables")
+    ddb.list_tables()  # warm
+
+    resp = mgmt.invalidate_cache("account", {"account_id": account_id})
+    assert resp.status_code == 200, resp.text
+
+    # Cache is cold but the IAM state is unchanged → request succeeds.
+    ddb.list_tables()
+
+
+def test_manual_invalidate_all_requires_confirmation(auth_env, mgmt):
+    """scope=all without confirm:true is rejected with 400."""
+    resp = mgmt.invalidate_cache("all", {})
+    assert resp.status_code == 400, resp.text
+    assert "confirm" in resp.text.lower()
+
+
+def test_manual_invalidate_all_with_confirmation(auth_env, mgmt):
+    """scope=all with confirm:true sweeps every cache and returns 200."""
+    resp = mgmt.invalidate_cache("all", {"confirm": True})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["scope"] == "all"
+    assert {"authz", "table_key_info", "credentials"} == set(body["invalidated"])
+
+
+def test_manual_invalidate_missing_selector_returns_400(auth_env, mgmt, account_id):
+    """scope=user without user_name is a 400, not a silent no-op."""
+    resp = mgmt.invalidate_cache("user", {"account_id": account_id})
+    assert resp.status_code == 400, resp.text
+    assert "user_name" in resp.text
+
+
+def test_manual_invalidate_requires_admin_auth(auth_env, mgmt, account_id, user):
+    """IAM users cannot invalidate cache; missing/wrong creds → 401."""
+    import requests
+    # IAM user with valid console password but not admin → 403
+    pw = uuid.uuid4().hex
+    iam_user = f"cache-iam-{uuid.uuid4().hex[:8]}"
+    mgmt.create_user(account_id, iam_user, password=pw)
+    try:
+        resp = mgmt.invalidate_cache(
+            "all",
+            {"confirm": True},
+            auth=(f"{account_id}/{iam_user}", pw),
+        )
+        assert resp.status_code == 403, resp.text
+    finally:
+        mgmt.delete_user(account_id, iam_user)
+
+    # No credentials at all → 401.
+    resp = requests.post(
+        f"{mgmt.base_url}/cache/invalidate",
+        json={"scope": "all", "selectors": {"confirm": True}},
+        timeout=mgmt.timeout, verify=mgmt.verify,
+    )
+    assert resp.status_code == 401, resp.text
+
+
 def test_delete_table_invalidates_table_key_info_cache(
     auth_env, mgmt, account_id, user
 ):

--- a/tests/test_console_cache_coherence.py
+++ b/tests/test_console_cache_coherence.py
@@ -1,0 +1,361 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end cache-coherence tests driving the **web console** (not the
+management API).
+
+Purpose: the web console mutates IAM via form posts that run a separate
+code path from the JSON management API. Both paths share the same
+`AuthCacheRegistry`, but the console wiring is easy to break because the
+console pages live in a different module tree. These tests assert that
+console-driven mutations propagate to the auth/authz cache instantly,
+just like the management API path (verified by
+``tests/test_cache_coherence.py``).
+
+If a console handler ever forgets to call the matching ``invalidate_*``
+hook, the mutation it performs will appear to "not stick" until
+``auth.cache.ttl_seconds`` elapses — these tests reproduce that lag and
+fail.
+
+Prerequisites mirror tests/test_cache_coherence.py.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from typing import Any
+
+import boto3
+import pytest
+import requests
+from botocore.config import Config as BotoConfig
+from botocore.exceptions import ClientError
+
+from management_helpers import ManagementClient
+
+
+_CSRF_RE = re.compile(r'<meta name="csrf-token" content="([^"]+)"')
+
+
+def _require_auth_env() -> tuple[str, str, str]:
+    endpoint = os.environ.get("EXTENDDB_TEST_ENDPOINT", "").strip()
+    admin_user = os.environ.get("EXTENDDB_ADMIN_USER", "").strip()
+    admin_pass = os.environ.get("EXTENDDB_ADMIN_PASSWORD", "").strip()
+    if not endpoint or not admin_user or not admin_pass:
+        pytest.fail(
+            "MISCONFIGURED: console-cache-coherence tests require "
+            "EXTENDDB_TEST_ENDPOINT, EXTENDDB_ADMIN_USER, EXTENDDB_ADMIN_PASSWORD."
+        )
+    return endpoint, admin_user, admin_pass
+
+
+@pytest.fixture(scope="module")
+def auth_env() -> tuple[str, str, str]:
+    return _require_auth_env()
+
+
+@pytest.fixture(scope="module")
+def mgmt(auth_env) -> ManagementClient:
+    endpoint, admin_user, admin_pass = auth_env
+    return ManagementClient(endpoint, admin_user, admin_pass)
+
+
+@pytest.fixture(scope="module")
+def account_id(mgmt) -> str:
+    acct_id = f"{uuid.uuid4().int % 10**12:012d}"
+    resp = mgmt.create_account(acct_id, f"console-coh-{acct_id}")
+    assert resp.status_code == 201, resp.text
+    yield acct_id
+    mgmt.delete_account(acct_id)
+
+
+class _ConsoleSession:
+    """Minimal browser-like client for the /console/* endpoints.
+
+    Holds a `requests.Session`, performs the form-based login, and exposes
+    helpers to extract CSRF tokens and post mutation forms.
+    """
+
+    def __init__(self, base_url: str, username: str, password: str) -> None:
+        self.base = base_url.rstrip("/")
+        self.s = requests.Session()
+        self.s.verify = False  # local TLS uses a self-signed cert
+        # Form-based login.
+        r = self.s.post(
+            f"{self.base}/console/login",
+            data={"username": username, "password": password},
+            allow_redirects=False,
+            timeout=30,
+        )
+        if r.status_code != 303:
+            raise RuntimeError(
+                f"Console login failed: status={r.status_code}, body={r.text[:200]}"
+            )
+
+    def csrf(self) -> str:
+        """Fetch a page and extract the CSRF token from the <meta> tag."""
+        r = self.s.get(f"{self.base}/console", timeout=30)
+        r.raise_for_status()
+        m = _CSRF_RE.search(r.text)
+        if not m:
+            raise RuntimeError("CSRF meta tag not found on /console")
+        return m.group(1)
+
+    def post_form(self, path: str, fields: dict) -> requests.Response:
+        """POST a form, automatically attaching the current CSRF token."""
+        body = dict(fields)
+        body["_csrf"] = self.csrf()
+        return self.s.post(
+            f"{self.base}{path}",
+            data=body,
+            allow_redirects=False,
+            timeout=30,
+        )
+
+
+def _ddb_client(endpoint_url: str, access_key: str, secret_key: str) -> Any:
+    region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+    cfg = BotoConfig(
+        region_name=region,
+        signature_version="v4",
+        retries={"max_attempts": 0, "mode": "standard"},
+    )
+    return boto3.client(
+        "dynamodb",
+        endpoint_url=endpoint_url,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        config=cfg,
+        verify=False,
+    )
+
+
+@pytest.fixture(scope="module")
+def console(auth_env) -> _ConsoleSession:
+    endpoint, admin_user, admin_pass = auth_env
+    return _ConsoleSession(endpoint, admin_user, admin_pass)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_console_put_user_policy_takes_effect_immediately(
+    auth_env, mgmt, account_id, console
+):
+    """Console-driven PutUserPolicy must invalidate the user_policies cache."""
+    endpoint, _, _ = auth_env
+    user = f"con-pol-{uuid.uuid4().hex[:8]}"
+    resp = mgmt.create_user(account_id, user, password=None)
+    assert resp.status_code == 201, resp.text
+    try:
+        resp = mgmt.create_access_key(account_id, user)
+        creds = resp.json()
+        ddb = _ddb_client(endpoint, creds["access_key_id"], creds["secret_access_key"])
+
+        # No policy yet → ListTables denied. This warms the user_policies
+        # cache as an empty/negative entry.
+        with pytest.raises(ClientError) as exc:
+            ddb.list_tables()
+        assert "AccessDenied" in str(exc.value) or "AccessDeniedException" in str(exc.value)
+
+        # Console adds an Allow policy via form post.
+        policy_doc = (
+            '{"Version":"2012-10-17","Statement":'
+            '[{"Effect":"Allow","Action":"dynamodb:ListTables","Resource":"*"}]}'
+        )
+        r = console.post_form(
+            f"/console/accounts/{account_id}/users/{user}/policies/new",
+            {"policy_name": "test-policy", "policy_document": policy_doc},
+        )
+        assert r.status_code in (302, 303), f"unexpected status {r.status_code}: {r.text[:200]}"
+
+        # The cached negative entry must have been invalidated by the
+        # console handler. The next SigV4 call sees the new policy
+        # without any TTL wait.
+        result = ddb.list_tables()
+        assert "TableNames" in result
+    finally:
+        try:
+            mgmt.delete_user(account_id, user)
+        except Exception:
+            pass
+
+
+def test_console_delete_user_policy_takes_effect_immediately(
+    auth_env, mgmt, account_id, console
+):
+    """Console-driven DeleteUserPolicy must invalidate the user_policies cache."""
+    endpoint, _, _ = auth_env
+    user = f"con-del-{uuid.uuid4().hex[:8]}"
+    mgmt.create_user(account_id, user, password=None)
+    try:
+        creds = mgmt.create_access_key(account_id, user).json()
+        ddb = _ddb_client(endpoint, creds["access_key_id"], creds["secret_access_key"])
+
+        # Allow policy via console.
+        policy_doc = (
+            '{"Version":"2012-10-17","Statement":'
+            '[{"Effect":"Allow","Action":"dynamodb:ListTables","Resource":"*"}]}'
+        )
+        r = console.post_form(
+            f"/console/accounts/{account_id}/users/{user}/policies/new",
+            {"policy_name": "p", "policy_document": policy_doc},
+        )
+        assert r.status_code in (302, 303), r.text[:200]
+        ddb.list_tables()  # warms the cache with the Allow policy.
+
+        # Delete via console — must invalidate.
+        r = console.post_form(
+            f"/console/accounts/{account_id}/users/{user}/policies/p/delete",
+            {},
+        )
+        assert r.status_code in (302, 303), r.text[:200]
+
+        # Next call must be denied (no policy now).
+        with pytest.raises(ClientError) as exc:
+            ddb.list_tables()
+        assert "AccessDenied" in str(exc.value) or "AccessDeniedException" in str(exc.value)
+    finally:
+        try:
+            mgmt.delete_user(account_id, user)
+        except Exception:
+            pass
+
+
+def test_console_delete_access_key_takes_effect_immediately(
+    auth_env, mgmt, account_id, console
+):
+    """Console DeleteAccessKey must invalidate the credential cache."""
+    endpoint, _, _ = auth_env
+    user = f"con-key-{uuid.uuid4().hex[:8]}"
+    mgmt.create_user(account_id, user, password=None)
+    try:
+        # Issue key + Allow policy so the credential gets cached as Some(_).
+        creds = mgmt.create_access_key(account_id, user).json()
+        access_key = creds["access_key_id"]
+        mgmt.put_user_policy(
+            account_id, user, "p",
+            {"Version": "2012-10-17", "Statement": [
+                {"Effect": "Allow", "Action": "dynamodb:ListTables", "Resource": "*"}
+            ]},
+        )
+        ddb = _ddb_client(endpoint, access_key, creds["secret_access_key"])
+        ddb.list_tables()  # warm credential cache
+
+        # Console deletes the key.
+        r = console.post_form(
+            f"/console/accounts/{account_id}/users/{user}/access-keys/{access_key}/delete",
+            {},
+        )
+        assert r.status_code in (302, 303), r.text[:200]
+
+        # Next SigV4 call must be rejected immediately.
+        with pytest.raises(ClientError) as exc:
+            ddb.list_tables()
+        msg = str(exc.value)
+        assert (
+            "UnrecognizedClientException" in msg
+            or "InvalidSignatureException" in msg
+            or "security token" in msg.lower()
+        ), f"unexpected error after console delete-access-key: {msg}"
+    finally:
+        try:
+            mgmt.delete_user(account_id, user)
+        except Exception:
+            pass
+
+
+def test_console_delete_user_drops_all_cached_state(auth_env, mgmt, account_id, console):
+    """Console DeleteUser must cascade-invalidate every user-keyed cache."""
+    endpoint, _, _ = auth_env
+    user = f"con-du-{uuid.uuid4().hex[:8]}"
+    mgmt.create_user(account_id, user, password=None)
+    try:
+        creds = mgmt.create_access_key(account_id, user).json()
+        access_key = creds["access_key_id"]
+        mgmt.put_user_policy(
+            account_id, user, "p",
+            {"Version": "2012-10-17", "Statement": [
+                {"Effect": "Allow", "Action": "dynamodb:ListTables", "Resource": "*"}
+            ]},
+        )
+        ddb = _ddb_client(endpoint, access_key, creds["secret_access_key"])
+        ddb.list_tables()  # warm credential + policy caches
+
+        # Console deletes the user.
+        r = console.post_form(
+            f"/console/accounts/{account_id}/users/{user}/delete",
+            {},
+        )
+        assert r.status_code in (302, 303), r.text[:200]
+
+        # Next SigV4 request must be rejected.
+        with pytest.raises(ClientError) as exc:
+            ddb.list_tables()
+        msg = str(exc.value)
+        assert (
+            "UnrecognizedClientException" in msg
+            or "InvalidSignatureException" in msg
+            or "AccessDenied" in msg
+        ), f"unexpected error after console delete-user: {msg}"
+    finally:
+        # Best-effort: user already deleted by the console flow above.
+        try:
+            mgmt.delete_user(account_id, user)
+        except Exception:
+            pass
+
+
+def test_console_add_group_member_propagates_group_policies(
+    auth_env, mgmt, account_id, console
+):
+    """Adding a user to a group via the console must invalidate that user's
+    cached user_group_policies, so the group's policies become effective
+    immediately."""
+    endpoint, _, _ = auth_env
+    user = f"con-gm-{uuid.uuid4().hex[:8]}"
+    group = f"con-grp-{uuid.uuid4().hex[:8]}"
+    mgmt.create_user(account_id, user, password=None)
+    try:
+        # Create group + attach policy via management API (group endpoints
+        # via console for these would work too; we want to isolate the
+        # bug-under-test to the add-member flow).
+        resp = mgmt.create_group(account_id, group)
+        assert resp.status_code == 201, resp.text
+        mgmt.put_group_policy(
+            account_id, group, "p",
+            {"Version": "2012-10-17", "Statement": [
+                {"Effect": "Allow", "Action": "dynamodb:ListTables", "Resource": "*"}
+            ]},
+        )
+
+        creds = mgmt.create_access_key(account_id, user).json()
+        ddb = _ddb_client(endpoint, creds["access_key_id"], creds["secret_access_key"])
+
+        # No membership yet → denied. Warms user_group_policies as empty.
+        with pytest.raises(ClientError):
+            ddb.list_tables()
+
+        # Console adds the user to the group.
+        r = console.post_form(
+            f"/console/accounts/{account_id}/groups/{group}/members/add",
+            {"user_name": user},
+        )
+        assert r.status_code in (302, 303), r.text[:200]
+
+        # Next call must succeed (group policy now in effect).
+        result = ddb.list_tables()
+        assert "TableNames" in result
+    finally:
+        try:
+            mgmt.delete_group(account_id, group)
+        except Exception:
+            pass
+        try:
+            mgmt.delete_user(account_id, user)
+        except Exception:
+            pass

--- a/tests/test_console_cache_coherence.py
+++ b/tests/test_console_cache_coherence.py
@@ -359,3 +359,103 @@ def test_console_add_group_member_propagates_group_policies(
             mgmt.delete_user(account_id, user)
         except Exception:
             pass
+
+
+# ---------------------------------------------------------------------------
+# Console cache invalidation form (admin break-glass).
+# Mirrors POST /management/cache/invalidate; both call the same `apply`
+# helper. See docs/design/12-auth-authz-cache.md §6.1.
+# ---------------------------------------------------------------------------
+
+
+def test_console_cache_page_admin_only(auth_env):
+    """A non-logged-in browser is redirected to login; the form requires admin."""
+    endpoint, _, _ = auth_env
+    r = requests.get(
+        f"{endpoint}/console/cache",
+        verify=False,
+        timeout=30,
+        allow_redirects=False,
+    )
+    # Unauthenticated → redirect to login.
+    assert r.status_code in (302, 303), r.status_code
+
+
+def test_console_cache_invalidate_user(auth_env, mgmt, account_id, console):
+    """Submitting the cache form for scope=user returns the rendered success
+    page listing the touched subcaches."""
+    user = f"con-cache-{uuid.uuid4().hex[:8]}"
+    resp = mgmt.create_user(account_id, user, password=None)
+    assert resp.status_code == 201, resp.text
+    try:
+        r = console.post_form(
+            "/console/cache/invalidate",
+            {
+                "scope": "user",
+                "account_id": account_id,
+                "user_name": user,
+                "user_names": "",
+                "role_name": "",
+                "access_key_id": "",
+                "table_name": "",
+                "arn": "",
+                "confirm": "",
+            },
+        )
+        assert r.status_code == 200, r.text[:200]
+        # Success page lists every subcache the composite scope touched.
+        for label in (
+            "user_policies",
+            "user_group_policies",
+            "user_boundary",
+            "user_tags",
+            "principal_credentials",
+        ):
+            assert label in r.text, f"missing {label} in response"
+    finally:
+        try:
+            mgmt.delete_user(account_id, user)
+        except Exception:
+            pass
+
+
+def test_console_cache_invalidate_all_requires_typed_confirmation(
+    auth_env, mgmt, account_id, console
+):
+    """scope=all on the console form refuses without the typed token, accepts with it."""
+    # Refused without confirmation.
+    r = console.post_form(
+        "/console/cache/invalidate",
+        {
+            "scope": "all",
+            "account_id": "",
+            "user_name": "",
+            "user_names": "",
+            "role_name": "",
+            "access_key_id": "",
+            "table_name": "",
+            "arn": "",
+            "confirm": "wrong",
+        },
+    )
+    assert r.status_code == 200  # error page rendered
+    assert "INVALIDATE" in r.text  # error mentions the required token
+
+    # Accepted with the typed token.
+    r = console.post_form(
+        "/console/cache/invalidate",
+        {
+            "scope": "all",
+            "account_id": "",
+            "user_name": "",
+            "user_names": "",
+            "role_name": "",
+            "access_key_id": "",
+            "table_name": "",
+            "arn": "",
+            "confirm": "INVALIDATE",
+        },
+    )
+    assert r.status_code == 200, r.text[:200]
+    for label in ("authz", "table_key_info", "credentials"):
+        assert label in r.text


### PR DESCRIPTION
## Why

Each DynamoDB request issues ~6 catalog queries before dispatch can begin: credential lookup, identity policies, group policies, permissions boundary, principal tags, resource tags, plus a 7th lookup for `TableKeyInfo` on item-level operations. Queries 2–6 fan out concurrently via `tokio::try_join!`, but they each consume a catalog-pool connection and reparse policy JSON on every hit. Under load this is the dominant pre-dispatch overhead — no pool size fixes it, because the bottleneck is the round-trip itself.

This PR layers an in-memory stale-while-revalidate cache over each of those reads to drive steady-state catalog roundtrips to ~0 while keeping the pre-cache behavior reachable via a kill switch.

## What

Adds an `extenddb-cache` crate (`SwrCache<K, V, E>` primitive on top of moka) plus three wrappers:

- **`CachedCredentialStore`** wraps any `CredentialStore`. Re-validates `expires_at` on every cache hit so cached ASIA* sessions cannot outlive their issued lifetime.
- **`CachedAuthzStore`** wraps any `AuthorizationStore` with 9 sub-caches (user/role policies, group policies, boundaries, principal tags, resource tags, session data). Cache values are `Arc`-wrapped so a hit is one atomic increment instead of an N-element clone.
- **`CachedTableKeyInfoStore`** wraps `StorageEngine.table_key_info` with negative caching for `TableNotFound`.

A new `AuthCacheRegistry` threads invalidation hooks through `ServerComponents` and `AppState` so every IAM mutation — from both the management API and the web console — invalidates the matching cache entry write-through. Self-induced changes propagate instantly within the local instance.

Configuration (`[auth.cache]` in `extenddb.toml`):

```toml
enabled              = true   # master kill switch
ttl_seconds          = 60     # hard TTL — entries beyond this are full misses
soft_ttl_seconds     = 30     # stale-but-usable threshold; refresh-ahead
negative_ttl_seconds = 5      # how long "not found" results are remembered
max_entries          = 10000  # per-cache LRU cap
```

When `enabled = false`, the wrappers operate in pass-through mode and forward every request directly to the underlying store. The pass-through path allocates no underlying moka instance (`Option<MokaCache>`) — it's a true kill switch, not a configured-to-expire-instantly cache.

## Tradeoffs

**Bounded staleness for IAM data.** AWS IAM itself documents policy-propagation delays of ~30s–2min; we expose the same trade-off as `auth.cache.ttl_seconds`, configurable. This is a deliberate, scoped revision of the project's "No In-Process State" rule (`docs/design/11-high-availability.md` §D1) — see that doc for the full discussion. The data path remains uncached.

**No verdict caching.** We cache the inputs to authorization (policies, tags), not `Allow`/`Deny` decisions. Verdict caching has subtle correctness issues with conditions that depend on per-request context (`aws:CurrentTime`, IP, leading keys) and would need invalidation on every condition-relevant input change. Re-evaluating policies in CPU per request is essentially free once the inputs are cached.

**Async fanout invalidation has a small window.** Single-key invalidations (`DeleteAccessKey`, `PutUserPolicy`) drop the cache slot synchronously. Fanout invalidations (`DeleteAccount`, `DeleteRole` session sweep, `DeleteGroup` member fanout) use moka's `invalidate_entries_if`, which evaluates predicates asynchronously — there is a brief (~ms) window between the API responding success and the matching entries actually being evicted. Documented in the operator guide; for hard cutover (e.g. revoking a compromised key), prefer the single-key path.

**Memory is bounded.** Default 10,000 entries per cache (≈90,000 across the 9-cache authz block + credential + table-key-info), LRU-evicted under pressure. Empty results from tag and policy loaders cache at the short `negative_ttl` so probes don't fill the LRU with empty positive entries.

## Out of scope (deferred)

**Multi-instance cache invalidation.** In a multi-frontend deployment, off-instance changes (a separate process modifying the catalog directly, or a different instance) wait up to `ttl_seconds` to propagate locally. Cross-process invalidation fanout is designed in detail in [Appendix B of `docs/design/12-auth-authz-cache.md`](../blob/feat/auth-cache-pr/docs/design/12-auth-authz-cache.md#appendix-b--multi-instance-cache-invalidation-deferred) (Postgres `LISTEN`/`NOTIFY` + durable backstop table for reconnect catch-up) but **not implemented in this PR**. The implementation is gated on a separate review pass — failure modes, schema, ordering guarantees, and operational backpressure semantics all need engineering input before the change lands. For now, multi-instance deployments must accept `auth.cache.ttl_seconds` as the worst-case lag; tune accordingly against IAM-revocation timing requirements.

## Public type changes

`StoredCredential` gains one public field:

```rust
pub expires_at: Option<time::OffsetDateTime>,
```

`None` for long-lived AKIA* credentials, `Some` for ASIA* sessions. Required to enforce session expiry on the cache-hit path. No out-of-tree consumers of `extenddb-auth` exist today, but third-party `CredentialStore` implementations (if any) would need to populate this field.

## Observability

`/management/auth-cache-metrics` (admin-authenticated JSON) exposes per-cache hit / stale-hit / miss / negative-hit / refresh-success / refresh-failure / refresh-skipped-inflight / refresh-dropped-epoch / invalidation counters and entry counts. Each cache also reports a `pass_through: bool` so operators can distinguish "cache disabled" from "cache cold."

The endpoint is admin-only because cache hit-rate and entry-count signals are workload-fingerprinting telemetry; operators who want Prometheus scraping should expose this via reverse proxy. (A future PR could mirror these into `/metrics`.)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --release --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 27 cache crate tests, 132 auth tests, 18 server tests, 219 core, 16 engine, 3 storage; all green.
- [x] `extenddb init` + `serve` against a clean Postgres; `/health` and `/management/auth-cache-metrics` smoke-tested.
- [x] Targeted `pytest -k "test_abac or test_cache_coherence or test_console_cache_coherence"`: 17/17 pass.
- [x] Full `pytest`: 354 passed, 6 failed. The 6 failures are pre-existing concurrency + import/export issues unrelated to this work and are unchanged from `main`.

New tests added in this PR:

- `crates/cache/src/tests.rs`: 27 unit tests covering single-flight, soft/hard TTL, negative caching, refresh-vs-invalidate races, refresh-vs-hard-miss races (Arc identity guard), panic safety, LRU bounds, pass-through, config validation.
- Round-trip + invalidation tests in `credential_cache.rs` and `authz_cache.rs`.
- `tests/test_cache_coherence.py`: end-to-end mgmt-API → SigV4 round-trips against a live server.
- `tests/test_console_cache_coherence.py`: same invariants driven via the web console (form posts with CSRF) so management / console parity stays locked in against future refactor drift.

## Documentation

- `docs/design/12-auth-authz-cache.md` — full design (motivation, SWR refresh strategy, library choice, cache key shapes, error semantics, metrics, operator guide).
- Appendix B of the same doc: deferred multi-instance fanout proposal.
- `docs/design/11-high-availability.md` §D1 / §A3 — D1's "No In-Process State" rule reconciled with the new cache (scoped revision for IAM data only; data path remains uncached).
- `docs/manuals/05-admin-guide.md` — `[auth.cache]` config reference + invalidation timing notes (sync vs. async + off-instance).
- `docs/getting-started.md` — operator-level summary.

