### PR TITLE
fix: persist GSI queue to PostgreSQL for crash safety

### DIFF
--- a/crates/bin/src/cmd_migrate.rs
+++ b/crates/bin/src/cmd_migrate.rs
@@ -52,7 +52,7 @@ pub async fn run(args: MigrateArgs) -> anyhow::Result<()> {
             .await
             .map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
-    // Show current version.
+    // Show current catalog version.
     println!("--- Checking current catalog version...");
     let current = bootstrap
         .read_catalog_version()
@@ -62,25 +62,59 @@ pub async fn run(args: MigrateArgs) -> anyhow::Result<()> {
     println!("  Current version: {current_display}");
 
     let expected = bootstrap.expected_catalog_version();
-    if current.as_deref() == Some(expected.as_str()) {
+    let catalog_pending = current.as_deref() != Some(expected.as_str());
+
+    // Data migrations are tracked in the data database's own ledger, separate
+    // from and independent of the catalog version, so they must be checked (and
+    // applied) on their own — a release that only changes the data schema does
+    // not bump the catalog version.
+    println!("--- Checking data migrations...");
+    let data_pending = bootstrap
+        .pending_data_migrations()
+        .await
+        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    if data_pending.is_empty() {
+        println!("  Data migrations up to date.");
+    } else {
+        println!("  Pending: {}", data_pending.join(", "));
+    }
+
+    if !catalog_pending && data_pending.is_empty() {
         println!();
-        println!("Catalog is up to date (version {expected}). No migrations needed.");
+        println!("Everything is up to date (catalog version {expected}). No migrations needed.");
         return Ok(());
     }
 
     if !args.yes {
+        let mut what = Vec::new();
+        if catalog_pending {
+            what.push(format!("catalog {current_display} -> {expected}"));
+        }
+        if !data_pending.is_empty() {
+            what.push(format!("data migrations [{}]", data_pending.join(", ")));
+        }
         anyhow::bail!(
-            "--yes is required to apply migrations. \
-             Current version: {current_display}, target version: {expected}."
+            "--yes is required to apply migrations. Pending: {}.",
+            what.join("; ")
         );
     }
 
+    if catalog_pending {
+        bootstrap
+            .run_catalog_migrations()
+            .await
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    }
+
+    // Always run data migrations: the data-database ledger is idempotent
+    // (already-applied migrations are skipped) and independent of the catalog
+    // version, so an upgrade that only touched the data schema is still applied.
     bootstrap
-        .run_catalog_migrations()
+        .run_data_migrations()
         .await
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
-    // Read new version.
+    // Read new catalog version.
     let new = bootstrap
         .read_catalog_version()
         .await

--- a/crates/storage-postgres/data_migrations/002_gsi_pending.sql
+++ b/crates/storage-postgres/data_migrations/002_gsi_pending.sql
@@ -1,0 +1,34 @@
+-- Copyright 2026 ExtendDB contributors
+-- SPDX-License-Identifier: Apache-2.0
+-- Persistent queue for async GSI propagation.
+--
+-- Rows are inserted atomically within the base write transaction and consumed
+-- by background workers in a single claim+apply+delete transaction, so an
+-- uncommitted claim rolls back and the row is reprocessed after a crash.
+--
+-- Each row is self-describing: `index_context` carries the base key schema,
+-- attribute definitions, and the target index definitions captured at enqueue
+-- time, so workers apply updates with zero catalog reads. A GSI's key schema
+-- and projection are immutable after creation, so the snapshot can never be
+-- stale relative to the live index definition.
+--
+-- `worker_partition` is a stable hash of the base table key. All updates to a
+-- given base item share a partition and are consumed by a single worker in `id`
+-- order, preserving per-key FIFO ordering (so successive updates to the same
+-- item never race in the index and converge to the latest state).
+
+CREATE TABLE IF NOT EXISTS gsi_pending (
+    id BIGSERIAL PRIMARY KEY,
+    table_id TEXT NOT NULL,
+    worker_partition INTEGER NOT NULL,
+    old_item JSONB,
+    new_item JSONB,
+    index_context JSONB NOT NULL,
+    ready_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Serves the worker claim: WHERE worker_partition = $1 AND ready_at <= NOW()
+-- ORDER BY id. The leading partition column also keeps each worker's scan
+-- confined to its own rows.
+CREATE INDEX IF NOT EXISTS idx_gsi_pending_claim
+    ON gsi_pending (worker_partition, ready_at, id);

--- a/crates/storage-postgres/src/bootstrapper.rs
+++ b/crates/storage-postgres/src/bootstrapper.rs
@@ -209,6 +209,11 @@ impl Bootstrapper for PostgresBootstrapper {
         migrations::run_data_migrations(&pool).await
     }
 
+    async fn pending_data_migrations(&self) -> OpResult<Vec<String>> {
+        let pool = self.app_pool(&self.config.data_db).await?;
+        migrations::pending_data_migrations(&pool).await
+    }
+
     async fn record_data_connection(&self) -> OpResult<()> {
         let pool = self.app_pool(&self.config.catalog_db).await?;
         let data_conn = self.app_connection_url(&self.config.data_db);

--- a/crates/storage-postgres/src/data/delete_item.rs
+++ b/crates/storage-postgres/src/data/delete_item.rs
@@ -9,7 +9,7 @@ use extenddb_storage::StreamCapture;
 use extenddb_storage::error::StorageError;
 use extenddb_storage::util::{SortKeyValue, parse_sk, pk_to_text, sk_column, sk_info};
 
-use super::index::{enqueue_async_indexes, fetch_indexes_for_table, pk_hash, sync_indexes};
+use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
 use super::query::check_condition;
 use super::tx_helpers::write_stream_record_in_tx;
 use super::{data_table_name, json_to_item};
@@ -128,7 +128,6 @@ impl PostgresEngine {
                         .transpose()?;
                     sync_indexes(
                         &mut tx,
-                        &key_info.table_id,
                         &key_info.key_schema,
                         &key_info.attribute_definitions,
                         &indexes,
@@ -155,26 +154,26 @@ impl PostgresEngine {
                     )
                     .await?;
                 }
+                // Persist async GSI work inside the same transaction — one row
+                // per async index, each honoring its own propagation delay.
+                let async_enqueued = enqueue_async_indexes(
+                    &mut tx,
+                    key_info,
+                    &indexes,
+                    old_item_for_idx.as_ref(),
+                    None,
+                    sys_delay,
+                )
+                .await?;
+
                 tx.commit()
                     .await
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
 
-                // Enqueue async GSI updates after commit (D-4).
-                if let Some(ref q) = self.gsi_queue {
-                    enqueue_async_indexes(
-                        q,
-                        pk_hash(pk_text.as_ref()),
-                        &key_info.account_id,
-                        &key_info.table_name,
-                        &key_info.table_id,
-                        &key_info.key_schema,
-                        &key_info.attribute_definitions,
-                        &indexes,
-                        old_item_for_idx.as_ref(),
-                        None,
-                        sys_delay,
-                    )
-                    .await;
+                if async_enqueued > 0
+                    && let Some(ref q) = self.gsi_queue
+                {
+                    q.notify_workers();
                 }
 
                 if return_old {
@@ -266,7 +265,6 @@ impl PostgresEngine {
                         .transpose()?;
                     sync_indexes(
                         &mut tx,
-                        &key_info.table_id,
                         &key_info.key_schema,
                         &key_info.attribute_definitions,
                         &indexes,
@@ -293,26 +291,26 @@ impl PostgresEngine {
                     )
                     .await?;
                 }
+                // Persist async GSI work inside the same transaction — one row
+                // per async index, each honoring its own propagation delay.
+                let async_enqueued = enqueue_async_indexes(
+                    &mut tx,
+                    key_info,
+                    &indexes,
+                    old_item_for_idx.as_ref(),
+                    None,
+                    sys_delay,
+                )
+                .await?;
+
                 tx.commit()
                     .await
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
 
-                // Enqueue async GSI updates after commit (D-4).
-                if let Some(ref q) = self.gsi_queue {
-                    enqueue_async_indexes(
-                        q,
-                        pk_hash(pk_text.as_ref()),
-                        &key_info.account_id,
-                        &key_info.table_name,
-                        &key_info.table_id,
-                        &key_info.key_schema,
-                        &key_info.attribute_definitions,
-                        &indexes,
-                        old_item_for_idx.as_ref(),
-                        None,
-                        sys_delay,
-                    )
-                    .await;
+                if async_enqueued > 0
+                    && let Some(ref q) = self.gsi_queue
+                {
+                    q.notify_workers();
                 }
 
                 if return_old {

--- a/crates/storage-postgres/src/data/index.rs
+++ b/crates/storage-postgres/src/data/index.rs
@@ -9,17 +9,30 @@
 
 use extenddb_core::types::{
     AttributeDefinition, Item, KeySchemaElement, Projection, ProjectionType, ScalarAttributeType,
+    TableKeyInfo,
 };
 use extenddb_storage::error::StorageError;
 use extenddb_storage::util::SortKeyValue;
 use extenddb_storage::util::{composite_pk_to_text, parse_sk, sk_column, sk_column_n};
 
 use super::{all_sort_key_info, index_table_name};
+use crate::gsi_queue::{GsiApplyContext, GsiIndexDef, enqueue_gsi_pending};
+
+/// Map a `sqlx` error to `StorageError`, preserving the SQLSTATE code in the
+/// message. The async GSI worker keys off the code (e.g. `42P01`,
+/// undefined_table) to tell a dropped-index race apart from a real failure;
+/// `sqlx`'s `Display` only carries the human text, so the code must be kept.
+fn db_error(e: sqlx::Error) -> StorageError {
+    match e.as_database_error().and_then(|d| d.code()) {
+        Some(code) => StorageError::Internal(format!("SQLSTATE {code}: {e}")),
+        None => StorageError::Internal(e.to_string()),
+    }
+}
 
 /// Metadata for a single index, used during write-path GSI/LSI sync.
 pub(crate) struct IndexMeta {
-    pub(super) index_name: String,
     pub(super) index_id: String,
+    pub(super) index_name: String,
     pub(super) index_type: String,
     pub(super) key_schema: Vec<KeySchemaElement>,
     pub(super) projection: Projection,
@@ -34,7 +47,7 @@ pub(crate) async fn fetch_indexes_for_table(
     pool: &sqlx::PgPool,
 ) -> Result<Vec<IndexMeta>, StorageError> {
     let rows: Vec<(String, String, String, serde_json::Value, serde_json::Value, Option<i32>)> = sqlx::query_as(
-        "SELECT index_name, index_id, index_type, key_schema, projection, propagation_delay_ms FROM indexes WHERE table_id = $1",
+        "SELECT index_id, index_name, index_type, key_schema, projection, propagation_delay_ms FROM indexes WHERE table_id = $1",
     )
     .bind(table_id)
     .fetch_all(pool)
@@ -42,14 +55,14 @@ pub(crate) async fn fetch_indexes_for_table(
     .map_err(|e| StorageError::Internal(e.to_string()))?;
 
     rows.into_iter()
-        .map(|(name, id, idx_type, ks_json, proj_json, delay)| {
+        .map(|(id, index_name, idx_type, ks_json, proj_json, delay)| {
             let key_schema: Vec<KeySchemaElement> = serde_json::from_value(ks_json)
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
             let projection: Projection = serde_json::from_value(proj_json)
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
             Ok(IndexMeta {
-                index_name: name,
                 index_id: id,
+                index_name,
                 index_type: idx_type,
                 key_schema,
                 projection,
@@ -124,11 +137,10 @@ pub(super) fn effective_delay(idx: &IndexMeta, system_default: u64) -> u64 {
 ///
 /// Called within the same PG transaction as the base table write.
 /// Only processes indexes where `effective_delay == 0`. Async indexes are
-/// handled by `enqueue_async_indexes` after the transaction commits.
+/// handled by the persistent `gsi_pending` queue after the transaction commits.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn sync_indexes(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-    _table_id: &str,
     base_key_schema: &[KeySchemaElement],
     attr_defs: &[AttributeDefinition],
     indexes: &[IndexMeta],
@@ -148,8 +160,7 @@ pub(crate) async fn sync_indexes(
         if let Some(old) = old_item
             && item_has_index_keys(old, &idx.key_schema)
         {
-            delete_index_row_multi(tx, &idx_table, old, base_key_schema, attr_defs, &base_sks)
-                .await?;
+            delete_index_row_multi(tx, &idx_table, old, base_key_schema, &base_sks).await?;
         }
 
         // Insert new index row if the new item has index keys
@@ -165,7 +176,6 @@ pub(crate) async fn sync_indexes(
                 &projected,
                 &idx.key_schema,
                 base_key_schema,
-                attr_defs,
                 &idx_sks,
                 &base_sks,
             )
@@ -175,56 +185,50 @@ pub(crate) async fn sync_indexes(
     Ok(())
 }
 
-/// Enqueue async GSI updates for indexes with non-zero propagation delay.
+/// Enqueue async GSI propagation for a write, **one `gsi_pending` row per
+/// async index**.
 ///
-/// Called after the base table transaction commits. The queue workers apply
-/// the index updates after a random delay within the configured range.
-#[allow(clippy::too_many_arguments)]
+/// For every GSI (LSIs are always synchronous) whose effective propagation
+/// delay is non-zero, a self-describing row is inserted carrying that single
+/// index's definition and its own effective delay (see [`enqueue_gsi_pending`],
+/// which applies per-index jitter and the partition-monotonic `ready_at`
+/// clamp). Splitting per index — rather than bundling every index into one row
+/// with one `ready_at` — is what lets each GSI honor its own
+/// `propagation_delay_ms` and propagate independently.
+///
+/// Returns the number of rows enqueued, so callers can skip waking the workers
+/// when nothing was queued. Must be called inside the base write's transaction
+/// so the pending rows commit atomically with the item mutation.
 pub(crate) async fn enqueue_async_indexes(
-    gsi_queue: &crate::gsi_queue::GsiQueue,
-    pk_hash: u64,
-    account_id: &str,
-    table_name: &str,
-    table_id: &str,
-    base_key_schema: &[KeySchemaElement],
-    attr_defs: &[AttributeDefinition],
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    key_info: &TableKeyInfo,
     indexes: &[IndexMeta],
     old_item: Option<&Item>,
     new_item: Option<&Item>,
     system_default_delay: u64,
-) {
+) -> Result<usize, StorageError> {
+    let mut enqueued = 0usize;
     for idx in indexes {
+        if idx.index_type == "LSI" {
+            continue; // LSIs are always synchronous.
+        }
         let delay = effective_delay(idx, system_default_delay);
         if delay == 0 {
-            continue; // Sync — already handled in transaction.
+            continue; // Synchronous GSI — handled in-transaction by sync_indexes.
         }
-        if idx.index_type == "LSI" {
-            continue; // LSIs are always synchronous — already handled in transaction.
-        }
-        gsi_queue
-            .enqueue(
-                pk_hash,
-                account_id,
-                table_name,
-                table_id,
-                base_key_schema,
-                attr_defs,
-                &idx.index_name,
-                &idx.index_id,
-                &idx.key_schema,
-                &idx.projection,
-                old_item,
-                new_item,
-                delay,
-            )
-            .await;
+        let context = GsiApplyContext {
+            base_key_schema: key_info.key_schema.clone(),
+            attribute_definitions: key_info.attribute_definitions.clone(),
+            index: GsiIndexDef {
+                index_id: idx.index_id.clone(),
+                key_schema: idx.key_schema.clone(),
+                projection: idx.projection.clone(),
+            },
+        };
+        enqueue_gsi_pending(tx, &key_info.table_id, old_item, new_item, delay, &context).await?;
+        enqueued += 1;
     }
-}
-
-/// Compute a hash of the partition key text for queue partitioning.
-/// Uses crc32 for stability across Rust versions (`DefaultHasher` is not stable).
-pub(crate) fn pk_hash(pk_text: &str) -> u64 {
-    u64::from(crc32fast::hash(pk_text.as_bytes()))
+    Ok(enqueued)
 }
 
 /// Delete a row from an index table using base table key columns.
@@ -233,7 +237,6 @@ pub(crate) async fn delete_index_row_multi(
     idx_table: &str,
     item: &Item,
     base_ks: &[KeySchemaElement],
-    _attr_defs: &[AttributeDefinition],
     base_sks: &[(&str, ScalarAttributeType)],
 ) -> Result<(), StorageError> {
     let base_pk_text = composite_pk_to_text(item, base_ks)?;
@@ -266,10 +269,7 @@ pub(crate) async fn delete_index_row_multi(
         }
     }
 
-    query
-        .execute(&mut **tx)
-        .await
-        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    query.execute(&mut **tx).await.map_err(db_error)?;
     Ok(())
 }
 
@@ -282,7 +282,6 @@ pub(crate) async fn insert_index_row_multi(
     projected: &Item,
     index_ks: &[KeySchemaElement],
     base_ks: &[KeySchemaElement],
-    _attr_defs: &[AttributeDefinition],
     idx_sks: &[(&str, ScalarAttributeType)],
     base_sks: &[(&str, ScalarAttributeType)],
 ) -> Result<(), StorageError> {
@@ -347,9 +346,6 @@ pub(crate) async fn insert_index_row_multi(
     // Bind item_data
     query = query.bind(item_json);
 
-    query
-        .execute(&mut **tx)
-        .await
-        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    query.execute(&mut **tx).await.map_err(db_error)?;
     Ok(())
 }

--- a/crates/storage-postgres/src/data/put_item.rs
+++ b/crates/storage-postgres/src/data/put_item.rs
@@ -9,7 +9,7 @@ use extenddb_storage::StreamCapture;
 use extenddb_storage::error::StorageError;
 use extenddb_storage::util::{composite_pk_to_text, parse_sk, pk_to_text, sk_column, sk_info};
 
-use super::index::{enqueue_async_indexes, fetch_indexes_for_table, pk_hash, sync_indexes};
+use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
 use super::query::check_condition;
 use super::tx_helpers::write_stream_record_in_tx;
 use super::{data_table_name, json_to_item};
@@ -140,7 +140,6 @@ impl PostgresEngine {
                         .transpose()?;
                     sync_indexes(
                         &mut tx,
-                        &key_info.table_id,
                         &key_info.key_schema,
                         &key_info.attribute_definitions,
                         &indexes,
@@ -167,26 +166,26 @@ impl PostgresEngine {
                     )
                     .await?;
                 }
+                // Persist async GSI work inside the same transaction — one row
+                // per async index, each honoring its own propagation delay.
+                let async_enqueued = enqueue_async_indexes(
+                    &mut tx,
+                    key_info,
+                    &indexes,
+                    old_item_for_idx.as_ref(),
+                    Some(&item),
+                    sys_delay,
+                )
+                .await?;
+
                 tx.commit()
                     .await
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
 
-                // Enqueue async GSI updates after commit (D-4).
-                if let Some(ref q) = self.gsi_queue {
-                    enqueue_async_indexes(
-                        q,
-                        pk_hash(pk_text.as_str()),
-                        &key_info.account_id,
-                        &key_info.table_name,
-                        &key_info.table_id,
-                        &key_info.key_schema,
-                        &key_info.attribute_definitions,
-                        &indexes,
-                        old_item_for_idx.as_ref(),
-                        Some(&item),
-                        sys_delay,
-                    )
-                    .await;
+                if async_enqueued > 0
+                    && let Some(ref q) = self.gsi_queue
+                {
+                    q.notify_workers();
                 }
 
                 if return_old {
@@ -285,7 +284,6 @@ impl PostgresEngine {
                         .transpose()?;
                     sync_indexes(
                         &mut tx,
-                        &key_info.table_id,
                         &key_info.key_schema,
                         &key_info.attribute_definitions,
                         &indexes,
@@ -312,26 +310,26 @@ impl PostgresEngine {
                     )
                     .await?;
                 }
+                // Persist async GSI work inside the same transaction — one row
+                // per async index, each honoring its own propagation delay.
+                let async_enqueued = enqueue_async_indexes(
+                    &mut tx,
+                    key_info,
+                    &indexes,
+                    old_item_for_idx.as_ref(),
+                    Some(&item),
+                    sys_delay,
+                )
+                .await?;
+
                 tx.commit()
                     .await
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
 
-                // Enqueue async GSI updates after commit (D-4).
-                if let Some(ref q) = self.gsi_queue {
-                    enqueue_async_indexes(
-                        q,
-                        pk_hash(pk_text.as_str()),
-                        &key_info.account_id,
-                        &key_info.table_name,
-                        &key_info.table_id,
-                        &key_info.key_schema,
-                        &key_info.attribute_definitions,
-                        &indexes,
-                        old_item_for_idx.as_ref(),
-                        Some(&item),
-                        sys_delay,
-                    )
-                    .await;
+                if async_enqueued > 0
+                    && let Some(ref q) = self.gsi_queue
+                {
+                    q.notify_workers();
                 }
 
                 if return_old {

--- a/crates/storage-postgres/src/data/transactions.rs
+++ b/crates/storage-postgres/src/data/transactions.rs
@@ -11,12 +11,9 @@ use extenddb_core::types::{
 };
 use extenddb_core::validation;
 use extenddb_storage::error::StorageError;
-use extenddb_storage::util::pk_to_text;
 use extenddb_storage::{TransactGetOp, TransactWriteOp};
 
-use super::index::{
-    IndexMeta, enqueue_async_indexes, fetch_indexes_for_table, pk_hash, sync_indexes,
-};
+use super::index::{IndexMeta, enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
 use super::tx_helpers::{
     check_idempotency_token_in_tx, delete_item_in_tx, fetch_item_for_update, fetch_item_in_tx,
     upsert_item_in_tx, write_stream_record_in_tx,
@@ -170,49 +167,41 @@ impl PostgresEngine {
             }
         }
 
+        // Persist async GSI work inside the transaction.
+        let mut needs_notify = false;
+        for (op, (old_item, new_item)) in ops.iter().zip(op_items.iter()) {
+            // ConditionCheck (and any op that touched no item) — no index changes.
+            if old_item.is_none() && new_item.is_none() {
+                continue;
+            }
+            let indexes = &table_indexes[transact_op_table_name(op)];
+            let key_info = match op {
+                TransactWriteOp::Put { key_info, .. }
+                | TransactWriteOp::Delete { key_info, .. }
+                | TransactWriteOp::Update { key_info, .. }
+                | TransactWriteOp::ConditionCheck { key_info, .. } => key_info,
+            };
+            // One row per async index, each honoring its own propagation delay.
+            let n = enqueue_async_indexes(
+                &mut tx,
+                key_info,
+                indexes,
+                old_item.as_ref(),
+                new_item.as_ref(),
+                sys_delay,
+            )
+            .await?;
+            if n > 0 {
+                needs_notify = true;
+            }
+        }
+
         tx.commit()
             .await
             .map_err(|e| StorageError::Internal(e.to_string()))?;
 
-        // D-4: Enqueue async GSI updates after commit using the old/new items
-        // collected during transaction execution (M-3 fix).
-        if let Some(ref q) = self.gsi_queue {
-            for (op, (old_item, new_item)) in ops.iter().zip(op_items.iter()) {
-                let indexes = &table_indexes[transact_op_table_name(op)];
-                if indexes.is_empty() {
-                    continue;
-                }
-                let key_info = match op {
-                    TransactWriteOp::Put { key_info, .. }
-                    | TransactWriteOp::Delete { key_info, .. }
-                    | TransactWriteOp::Update { key_info, .. }
-                    | TransactWriteOp::ConditionCheck { key_info, .. } => key_info,
-                };
-                let pk_name = &key_info.key_schema[0].attribute_name;
-                // Derive pk_text from whichever item is available.
-                let pk_item = new_item.as_ref().or(old_item.as_ref());
-                let Some(pk_item) = pk_item else { continue }; // ConditionCheck — no index changes
-                let Some(pk_value) = pk_item.get(pk_name) else {
-                    continue;
-                };
-                let Ok(pk_text) = pk_to_text(pk_value) else {
-                    continue;
-                };
-                enqueue_async_indexes(
-                    q,
-                    pk_hash(&pk_text),
-                    &key_info.account_id,
-                    &key_info.table_name,
-                    &key_info.table_id,
-                    &key_info.key_schema,
-                    &key_info.attribute_definitions,
-                    indexes,
-                    old_item.as_ref(),
-                    new_item.as_ref(),
-                    sys_delay,
-                )
-                .await;
-            }
+        if needs_notify && let Some(ref q) = self.gsi_queue {
+            q.notify_workers();
         }
 
         Ok(())
@@ -353,7 +342,6 @@ async fn execute_transact_write_op(
             if !indexes.is_empty() {
                 sync_indexes(
                     tx,
-                    &key_info.table_id,
                     &key_info.key_schema,
                     &key_info.attribute_definitions,
                     indexes,
@@ -397,7 +385,6 @@ async fn execute_transact_write_op(
             if !indexes.is_empty() {
                 sync_indexes(
                     tx,
-                    &key_info.table_id,
                     &key_info.key_schema,
                     &key_info.attribute_definitions,
                     indexes,
@@ -469,7 +456,6 @@ async fn execute_transact_write_op(
             if !indexes.is_empty() {
                 sync_indexes(
                     tx,
-                    &key_info.table_id,
                     &key_info.key_schema,
                     &key_info.attribute_definitions,
                     indexes,

--- a/crates/storage-postgres/src/data/update_item.rs
+++ b/crates/storage-postgres/src/data/update_item.rs
@@ -10,7 +10,7 @@ use extenddb_storage::StreamCapture;
 use extenddb_storage::error::StorageError;
 use extenddb_storage::util::{parse_sk, pk_to_text, sk_column, sk_info};
 
-use super::index::{enqueue_async_indexes, fetch_indexes_for_table, pk_hash, sync_indexes};
+use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
 use super::query::check_condition;
 use super::tx_helpers::write_stream_record_in_tx;
 use super::{data_table_name, json_to_item};
@@ -202,7 +202,6 @@ impl PostgresEngine {
         if !indexes.is_empty() {
             sync_indexes(
                 &mut tx,
-                &key_info.table_id,
                 &key_info.key_schema,
                 &key_info.attribute_definitions,
                 &indexes,
@@ -224,26 +223,26 @@ impl PostgresEngine {
             )
             .await?;
         }
+        // Persist async GSI work inside the same transaction — one row per
+        // async index, each honoring its own propagation delay.
+        let async_enqueued = enqueue_async_indexes(
+            &mut tx,
+            key_info,
+            &indexes,
+            pre_mutation_item.as_ref(),
+            Some(&item),
+            sys_delay,
+        )
+        .await?;
+
         tx.commit()
             .await
             .map_err(|e| StorageError::Internal(e.to_string()))?;
 
-        // Enqueue async GSI updates after commit (D-4).
-        if let Some(ref q) = self.gsi_queue {
-            enqueue_async_indexes(
-                q,
-                pk_hash(pk_text.as_ref()),
-                &key_info.account_id,
-                &key_info.table_name,
-                &key_info.table_id,
-                &key_info.key_schema,
-                &key_info.attribute_definitions,
-                &indexes,
-                pre_mutation_item.as_ref(),
-                Some(&item),
-                sys_delay,
-            )
-            .await;
+        if async_enqueued > 0
+            && let Some(ref q) = self.gsi_queue
+        {
+            q.notify_workers();
         }
 
         Ok((old_item, new_item))

--- a/crates/storage-postgres/src/delete_table.rs
+++ b/crates/storage-postgres/src/delete_table.rs
@@ -101,6 +101,18 @@ impl PostgresEngine {
                 Self::drop_index_data_table(&mut data_tx, idx_id).await?;
             }
             Self::drop_data_table(&mut data_tx, &row.table_id).await?;
+
+            // Drop any still-pending GSI propagation rows for this table in the
+            // same transaction that drops the tables. Workers tolerate orphans
+            // (savepoint-skip on 42P01), but removing them here avoids the
+            // wasted claim→deserialize→attempt→skip cycle and the log noise,
+            // especially when many items were written just before deletion.
+            sqlx::query("DELETE FROM gsi_pending WHERE table_id = $1")
+                .bind(&row.table_id)
+                .execute(&mut *data_tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
             data_tx
                 .commit()
                 .await

--- a/crates/storage-postgres/src/gsi_queue.rs
+++ b/crates/storage-postgres/src/gsi_queue.rs
@@ -1,38 +1,78 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Async GSI update queue (D-4, D-5, D-6).
+//! Persistent GSI update queue (D-4, D-5, D-6).
 //!
-//! Base table writes commit independently. For GSIs with a non-zero
-//! propagation delay, index updates are enqueued here and applied after a
-//! random delay, simulating real `DynamoDB` eventual consistency.
+//! Base table writes insert a row into `gsi_pending` within the same
+//! transaction as the item mutation. Each row is **self-describing**: it
+//! carries the base key schema, attribute definitions, and the target index
+//! definitions captured at enqueue time (`GsiApplyContext`), so workers apply
+//! updates with **zero catalog reads**. A GSI's key schema and projection are
+//! immutable after creation, so the snapshot can never be stale relative to
+//! the live index definition; if the index is dropped, the apply is skipped.
 //!
-//! Each queue partition is consumed by a single worker task, guaranteeing
-//! per-key FIFO ordering. Workers are event-driven via `Notify` and sleep
-//! when the queue is empty.
+//! Workers claim, apply, and delete each row inside a **single transaction**
+//! (`SELECT ... FOR UPDATE SKIP LOCKED` → index writes → `DELETE` → `COMMIT`).
+//! A crash or transient error before `COMMIT` rolls the whole unit back, so the
+//! pending row reappears and is reprocessed — nothing is lost once enqueued.
+//!
+//! Rows are partitioned by a stable hash of the base table key, and each worker
+//! owns one partition, so all updates to a given base item are applied in `id`
+//! order by a single worker (**per-key FIFO**) while distinct keys propagate
+//! concurrently.
 
-use std::collections::VecDeque;
 use std::sync::Arc;
 
 use extenddb_core::types::{AttributeDefinition, Item, KeySchemaElement, Projection};
 use extenddb_storage::error::StorageError;
+use extenddb_storage::util::composite_pk_to_text;
+use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::Notify;
 
 use crate::data::{
     all_sort_key_info, delete_index_row_multi, index_table_name, insert_index_row_multi,
     item_has_index_keys, project_item_for_index,
 };
 
-/// Number of queue partitions. Each partition has one consumer task.
-const NUM_PARTITIONS: usize = 4;
+/// Number of worker tasks consuming from the persistent queue.
+///
+/// Fixed invariant: a row's `worker_partition` is `hash(base_key) % NUM_WORKERS`
+/// and worker `i` consumes partition `i`, so all updates for a base item are
+/// applied in `id` order by a single worker (per-key FIFO). Changing this while
+/// the queue is non-empty could split a key's pending rows across workers; a
+/// rolling restart drains in-flight rows first, so changing it between deploys
+/// is safe.
+const NUM_WORKERS: u64 = 4;
 
-/// `PostgreSQL` SQLSTATE code for "`undefined_table`" (relation does not exist).
-const PG_UNDEFINED_TABLE: &str = "42P01";
+/// Maximum rows a single `process_batch` call claims before yielding. Each row
+/// is processed in its own transaction, so this bounds work per wakeup without
+/// holding a long-lived transaction.
+const BATCH_SIZE: usize = 100;
+
+/// Marker for PostgreSQL's "undefined_table" SQLSTATE (42P01) as embedded in
+/// `StorageError` messages by `db_error`. Matching the full `SQLSTATE 42P01`
+/// prefix (rather than the bare code) avoids false positives from item or
+/// index data that happens to contain the substring `42P01`.
+const PG_UNDEFINED_TABLE: &str = "SQLSTATE 42P01";
+
+/// Stable partition for a base-table key (FNV-1a, mapped to a worker). Routes
+/// all updates for one base item to a single worker for in-order apply. A local
+/// hash (not `std`'s, which is not guaranteed stable across builds) keeps the
+/// mapping fixed for a given key forever.
+fn partition_for(base_pk_text: &str) -> i32 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325; // FNV-1a offset basis
+    for byte in base_pk_text.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3); // FNV prime
+    }
+    (hash % NUM_WORKERS) as i32
+}
 
 /// Check if a `StorageError` is caused by an undefined table (SQLSTATE 42P01).
 ///
-/// This occurs when a table is deleted while async GSI propagation is in flight.
+/// This occurs when an index table is dropped (table deleted) while an async
+/// GSI update is still queued. The pending row is consumed rather than retried.
 fn is_undefined_table(err: &StorageError) -> bool {
     match err {
         StorageError::Internal(msg) => msg.contains(PG_UNDEFINED_TABLE),
@@ -40,207 +80,387 @@ fn is_undefined_table(err: &StorageError) -> bool {
     }
 }
 
-/// A pending GSI update operation.
-struct GsiUpdate {
-    _account_id: String,
-    table_name: String,
-    _table_id: String,
-    base_key_schema: Vec<KeySchemaElement>,
-    attr_defs: Vec<AttributeDefinition>,
-    index_name: String,
-    index_id: String,
-    index_key_schema: Vec<KeySchemaElement>,
-    index_projection: Projection,
-    old_item: Option<Item>,
-    new_item: Option<Item>,
-    delay_ms: u64,
+/// A single target index definition, snapshotted at enqueue time.
+///
+/// Only the fields the worker needs to apply the update: the propagation delay
+/// is not stored because it is already encoded in the row's `ready_at`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct GsiIndexDef {
+    pub(crate) index_id: String,
+    pub(crate) key_schema: Vec<KeySchemaElement>,
+    pub(crate) projection: Projection,
 }
 
-/// Partitioned in-memory queue for async GSI updates.
+/// Everything a worker needs to apply a pending GSI update without touching the
+/// catalog. Serialized into the `gsi_pending.index_context` column at enqueue.
+///
+/// Each `gsi_pending` row targets exactly **one** index. A base write that
+/// touches several async GSIs enqueues one row per index, so each index keeps
+/// its own propagation delay (encoded in the row's `ready_at`) and propagates
+/// independently — mirroring the per-index queue items of the original
+/// in-memory design. Rows for the same base item share a `worker_partition`
+/// and are applied in `id` order, preserving per-key FIFO.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct GsiApplyContext {
+    pub(crate) base_key_schema: Vec<KeySchemaElement>,
+    pub(crate) attribute_definitions: Vec<AttributeDefinition>,
+    pub(crate) index: GsiIndexDef,
+}
+
+/// A row claimed from `gsi_pending`:
+/// `(id, table_id, old_item, new_item, index_context)`.
+type ClaimedRow = (
+    i64,
+    String,
+    Option<serde_json::Value>,
+    Option<serde_json::Value>,
+    serde_json::Value,
+);
+
+/// Persistent GSI propagation queue backed by the `gsi_pending` table.
 pub struct GsiQueue {
-    partitions: Vec<Arc<Partition>>,
-}
-
-struct Partition {
-    queue: Mutex<VecDeque<GsiUpdate>>,
-    notify: Notify,
+    data_pool: PgPool,
+    notify: Arc<Notify>,
 }
 
 impl GsiQueue {
-    /// Create a new queue and spawn worker tasks.
-    pub fn spawn(pool: PgPool) -> Arc<Self> {
-        let mut partitions = Vec::with_capacity(NUM_PARTITIONS);
-        for _ in 0..NUM_PARTITIONS {
-            partitions.push(Arc::new(Partition {
-                queue: Mutex::new(VecDeque::new()),
-                notify: Notify::new(),
-            }));
-        }
-        let q = Arc::new(Self { partitions });
+    /// Create the queue and spawn worker tasks.
+    pub fn spawn(data_pool: PgPool) -> Arc<Self> {
+        let q = Arc::new(Self {
+            data_pool,
+            notify: Arc::new(Notify::new()),
+        });
 
-        for (i, part) in q.partitions.iter().enumerate() {
-            let part = Arc::clone(part);
-            let pool = pool.clone();
+        for worker_id in 0..NUM_WORKERS {
+            let q = Arc::clone(&q);
             tokio::spawn(async move {
-                worker(i, part, pool).await;
+                worker(worker_id, q).await;
             });
         }
 
         q
     }
 
-    /// Enqueue an async GSI update for a single index.
-    ///
-    /// The `pk_hash` determines which partition receives the update,
-    /// guaranteeing per-key FIFO ordering.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn enqueue(
-        &self,
-        pk_hash: u64,
-        account_id: &str,
-        table_name: &str,
-        table_id: &str,
-        base_key_schema: &[KeySchemaElement],
-        attr_defs: &[AttributeDefinition],
-        index_name: &str,
-        index_id: &str,
-        index_key_schema: &[KeySchemaElement],
-        index_projection: &Projection,
-        old_item: Option<&Item>,
-        new_item: Option<&Item>,
-        delay_ms: u64,
-    ) {
-        let update = GsiUpdate {
-            _account_id: account_id.to_owned(),
-            table_name: table_name.to_owned(),
-            _table_id: table_id.to_owned(),
-            base_key_schema: base_key_schema.to_vec(),
-            attr_defs: attr_defs.to_vec(),
-            index_name: index_name.to_owned(),
-            index_id: index_id.to_owned(),
-            index_key_schema: index_key_schema.to_vec(),
-            index_projection: index_projection.clone(),
-            old_item: old_item.cloned(),
-            new_item: new_item.cloned(),
-            delay_ms,
-        };
-
-        let partition_idx = (pk_hash as usize) % NUM_PARTITIONS;
-        let part = &self.partitions[partition_idx];
-        part.queue.lock().await.push_back(update);
-        part.notify.notify_one();
+    /// Wake workers after a write inserts into `gsi_pending`.
+    pub fn notify_workers(&self) {
+        self.notify.notify_waiters();
     }
 }
 
-/// Worker loop for a single partition. Processes updates with their
-/// configured delay, then sleeps until notified.
-async fn worker(partition_id: usize, part: Arc<Partition>, pool: PgPool) {
-    // Defensive sweep timeout — wake periodically even without notification.
-    const SWEEP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+/// Compute a jittered propagation delay (milliseconds) for a single enqueue.
+///
+/// Restores the non-deterministic propagation the original in-memory queue had
+/// — a fixed `NOW() + delay` is perfectly predictable, which is not how
+/// DynamoDB's eventual consistency behaves — while keeping the configured delay
+/// a **meaningful lower bound**: the result is uniformly distributed in
+/// `[delay_ms / 2, delay_ms]`. (The original literally drew `1..=delay`, but
+/// jittering all the way to ~0 makes the configured delay almost meaningless
+/// and the behaviour impossible to assert on; clustering in the upper half
+/// models a propagation latency that varies but does not vanish.) `delay_ms <=
+/// 1` is returned unchanged. Callers only enqueue async indexes, so `delay_ms`
+/// is always `>= 1` here.
+fn jitter_delay_ms(delay_ms: u64) -> u64 {
+    if delay_ms <= 1 {
+        delay_ms
+    } else {
+        use rand::Rng;
+        rand::rng().random_range(delay_ms / 2 + 1..=delay_ms)
+    }
+}
 
-    tracing::debug!("GSI worker {partition_id} started");
+/// Insert a pending GSI update for a **single** index within an existing
+/// transaction.
+///
+/// `delay_ms` is the index's effective propagation delay; a per-enqueue jitter
+/// is applied (see [`jitter_delay_ms`]) so propagation is not perfectly
+/// deterministic. `context` is the self-describing snapshot the worker uses to
+/// apply the update without a catalog read.
+///
+/// `ready_at` is clamped to be **monotonically non-decreasing within the
+/// worker partition**: `GREATEST(NOW() + jitter, MAX(ready_at) in partition)`.
+/// The worker drains its partition in `id` order but only sees rows whose
+/// `ready_at` has elapsed, so without this clamp a later write that drew a
+/// smaller jitter could become eligible first and be applied before an earlier
+/// write — leaving the index reflecting a stale value. The clamp guarantees a
+/// row's `ready_at` never precedes that of a lower-`id` row in the same
+/// partition, preserving per-key FIFO convergence while still adding jitter.
+/// This matches the original design, where a partition's single consumer slept
+/// sequentially and so could never reorder updates.
+pub(crate) async fn enqueue_gsi_pending(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    table_id: &str,
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+    delay_ms: u64,
+    context: &GsiApplyContext,
+) -> Result<(), StorageError> {
+    let old_json = old_item
+        .map(serde_json::to_value)
+        .transpose()
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let new_json = new_item
+        .map(serde_json::to_value)
+        .transpose()
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let context_json =
+        serde_json::to_value(context).map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    // Route all updates for a given base item to one worker (per-key FIFO).
+    // The base key is immutable over an item's lifetime; `new_item` carries it
+    // for puts/updates, `old_item` for deletes.
+    let worker_partition = match new_item.or(old_item) {
+        Some(item) => partition_for(&composite_pk_to_text(item, &context.base_key_schema)?),
+        None => 0,
+    };
+
+    let delay_interval = jitter_delay_ms(delay_ms) as f64 / 1000.0;
+    sqlx::query(
+        "INSERT INTO gsi_pending \
+         (table_id, worker_partition, old_item, new_item, index_context, ready_at) \
+         VALUES ($1, $2, $3, $4, $5, GREATEST( \
+             NOW() + make_interval(secs => $6), \
+             COALESCE( \
+                 (SELECT MAX(ready_at) FROM gsi_pending WHERE worker_partition = $2), \
+                 NOW() \
+             ) \
+         ))",
+    )
+    .bind(table_id)
+    .bind(worker_partition)
+    .bind(old_json)
+    .bind(new_json)
+    .bind(context_json)
+    .bind(delay_interval)
+    .execute(&mut **tx)
+    .await
+    .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    Ok(())
+}
+
+/// Worker loop. Drains ready rows in its partition, then sleeps until the next
+/// row is due or a write notifies it — whichever is sooner.
+async fn worker(worker_id: u64, q: Arc<GsiQueue>) {
+    // Backstop so a missed notification or clock skew can never stall the
+    // worker indefinitely when rows are (or will be) pending.
+    const MAX_IDLE: std::time::Duration = std::time::Duration::from_secs(1);
+
+    tracing::debug!("GSI worker {worker_id} started");
 
     loop {
-        // Drain the queue.
-        loop {
-            let update = {
-                let mut q = part.queue.lock().await;
-                q.pop_front()
-            };
-            let Some(update) = update else { break };
-
-            // Apply the configured delay.
-            if update.delay_ms > 0 {
-                let delay = if update.delay_ms > 1 {
-                    use rand::Rng;
-                    let mut rng = rand::rng();
-                    rng.random_range(1..=update.delay_ms)
-                } else {
-                    1
-                };
-                tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+        match process_batch(worker_id, &q).await {
+            Ok(0) => {
+                // Nothing ready in this partition. Sleep until the earliest
+                // not-yet-due row becomes eligible (honoring the propagation
+                // delay to the millisecond) or until a write wakes us.
+                let wait = next_ready_wait(&q.data_pool, worker_id)
+                    .await
+                    .unwrap_or(MAX_IDLE)
+                    .min(MAX_IDLE);
+                tokio::time::timeout(wait, q.notify.notified()).await.ok();
             }
-
-            if let Err(e) = apply_gsi_update(&pool, &update).await {
-                // D-4: Table deletion races with async GSI propagation.
-                // When the target relation no longer exists, this is a
-                // normal condition — not an error. Match on PostgreSQL
-                // SQLSTATE 42P01 (undefined_table).
-                if is_undefined_table(&e) {
-                    tracing::debug!(
-                        "GSI worker {partition_id}: skipping update for deleted table {}.{}: {e}",
-                        update.table_name,
-                        update.index_name,
-                    );
-                } else {
-                    tracing::error!(
-                        "GSI worker {partition_id}: failed to apply index update for {}.{}: {e}",
-                        update.table_name,
-                        update.index_name,
-                    );
-                }
+            Ok(_) => continue,
+            Err(e) => {
+                tracing::error!("GSI worker {worker_id}: batch error: {e}");
+                tokio::time::sleep(MAX_IDLE).await;
             }
         }
-
-        // Sleep until notified or sweep timeout.
-        tokio::time::timeout(SWEEP_TIMEOUT, part.notify.notified())
-            .await
-            .ok();
     }
 }
 
-/// Apply a single GSI update within a transaction.
-async fn apply_gsi_update(pool: &PgPool, update: &GsiUpdate) -> Result<(), StorageError> {
-    let idx_table = index_table_name(&update.index_id);
-    let idx_sks = all_sort_key_info(&update.index_key_schema, &update.attr_defs);
-    let base_sks = all_sort_key_info(&update.base_key_schema, &update.attr_defs);
+/// Time until the earliest not-yet-due row in this worker's partition becomes
+/// eligible. `None` when the partition has no pending rows (caller waits its
+/// backstop interval). A row already due maps to a near-zero wait so the loop
+/// re-claims promptly.
+async fn next_ready_wait(pool: &PgPool, worker_id: u64) -> Option<std::time::Duration> {
+    let secs: Option<f64> = sqlx::query_scalar(
+        "SELECT EXTRACT(EPOCH FROM (MIN(ready_at) - NOW())) FROM gsi_pending \
+         WHERE worker_partition = $1",
+    )
+    .bind(worker_id as i32)
+    .fetch_one(pool)
+    .await
+    .ok()
+    .flatten();
+    secs.map(|s| {
+        if s <= 0.0 {
+            std::time::Duration::from_millis(1)
+        } else {
+            std::time::Duration::from_secs_f64(s)
+        }
+    })
+}
 
-    let mut tx = pool
-        .begin()
+/// Claim and process up to `BATCH_SIZE` ready rows from this worker's partition.
+/// Returns the number applied.
+///
+/// Each row is claimed, applied, and deleted inside a **single transaction**:
+///   1. `SELECT ... WHERE worker_partition = $1 AND ready_at <= NOW() ORDER BY id LIMIT 1 FOR UPDATE SKIP LOCKED`
+///   2. apply the snapshotted index updates (savepoint-guarded per index)
+///   3. `DELETE` the claimed row
+///   4. `COMMIT`
+///
+/// A crash or error before the `COMMIT` rolls all of it back — the row stays in
+/// `gsi_pending` and is retried. Each worker owns one partition and processes it
+/// in `id` order, so updates to a given base item apply in order (per-key FIFO);
+/// distinct partitions run concurrently. Only rows whose `ready_at` has elapsed
+/// are eligible; the propagation delay is enforced by that timestamp.
+async fn process_batch(worker_id: u64, q: &GsiQueue) -> Result<usize, StorageError> {
+    let mut processed = 0usize;
+
+    for _ in 0..BATCH_SIZE {
+        let mut tx = q
+            .data_pool
+            .begin()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let row: Option<ClaimedRow> = sqlx::query_as(
+            "SELECT id, table_id, old_item, new_item, index_context FROM gsi_pending \
+             WHERE worker_partition = $1 AND ready_at <= NOW() \
+             ORDER BY id \
+             LIMIT 1 \
+             FOR UPDATE SKIP LOCKED",
+        )
+        .bind(worker_id as i32)
+        .fetch_optional(&mut *tx)
         .await
         .map_err(|e| StorageError::Internal(e.to_string()))?;
 
-    // Delete old index row if the old item had index keys.
-    if let Some(ref old) = update.old_item
-        && item_has_index_keys(old, &update.index_key_schema)
-    {
-        delete_index_row_multi(
-            &mut tx,
-            &idx_table,
-            old,
-            &update.base_key_schema,
-            &update.attr_defs,
-            &base_sks,
+        let Some((id, table_id, old_json, new_json, ctx_json)) = row else {
+            // No ready rows visible to this worker; end the batch.
+            let _ = tx.rollback().await;
+            break;
+        };
+
+        apply_claimed_row(
+            worker_id, &mut tx, id, &table_id, old_json, new_json, ctx_json,
         )
         .await?;
+
+        sqlx::query("DELETE FROM gsi_pending WHERE id = $1")
+            .bind(id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        processed += 1;
     }
 
-    // Insert new index row if the new item has index keys.
-    if let Some(ref new) = update.new_item
-        && item_has_index_keys(new, &update.index_key_schema)
+    Ok(processed)
+}
+
+/// Apply the GSI update for one claimed row, within the caller's transaction.
+///
+/// The row's single target index is applied under a `SAVEPOINT`: if the index
+/// table has been dropped (table deleted; SQLSTATE 42P01) the index is skipped
+/// and the row is still consumed. Any other error propagates, rolling back the
+/// whole transaction so the row is retried.
+#[allow(clippy::too_many_arguments)]
+async fn apply_claimed_row(
+    worker_id: u64,
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    id: i64,
+    table_id: &str,
+    old_json: Option<serde_json::Value>,
+    new_json: Option<serde_json::Value>,
+    ctx_json: serde_json::Value,
+) -> Result<(), StorageError> {
+    let old_item: Option<Item> = old_json
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let new_item: Option<Item> = new_json
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let context: GsiApplyContext =
+        serde_json::from_value(ctx_json).map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    // One index per row. Guard the apply with a savepoint so a dropped-index
+    // race (42P01) can be recovered and the row still consumed; aborting the
+    // subtransaction otherwise poisons the outer transaction and blocks the
+    // subsequent DELETE.
+    sqlx::query("SAVEPOINT gsi_apply")
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    match apply_index(
+        tx,
+        &context.index,
+        old_item.as_ref(),
+        new_item.as_ref(),
+        &context.base_key_schema,
+        &context.attribute_definitions,
+    )
+    .await
     {
-        let projected = project_item_for_index(
-            new,
-            &update.index_key_schema,
-            &update.base_key_schema,
-            &update.index_projection,
-        );
+        Ok(()) => {
+            sqlx::query("RELEASE SAVEPOINT gsi_apply")
+                .execute(&mut **tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+        }
+        Err(e) if is_undefined_table(&e) => {
+            // Index table dropped (table deleted) — recover the aborted
+            // subtransaction and skip; the row is still consumed.
+            sqlx::query("ROLLBACK TO SAVEPOINT gsi_apply")
+                .execute(&mut **tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            tracing::debug!(
+                "GSI worker {worker_id}: index {} gone, skipping id={id} table={table_id}",
+                context.index.index_id
+            );
+        }
+        Err(e) => return Err(e),
+    }
+
+    tracing::trace!("GSI worker {worker_id}: applied id={id} table={table_id}");
+    Ok(())
+}
+
+/// Apply a single index's delete-old / insert-new within the transaction.
+async fn apply_index(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    idx: &GsiIndexDef,
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+    base_key_schema: &[KeySchemaElement],
+    attr_defs: &[AttributeDefinition],
+) -> Result<(), StorageError> {
+    let idx_table = index_table_name(&idx.index_id);
+    let idx_sks = all_sort_key_info(&idx.key_schema, attr_defs);
+    let base_sks = all_sort_key_info(base_key_schema, attr_defs);
+
+    if let Some(old) = old_item
+        && item_has_index_keys(old, &idx.key_schema)
+    {
+        delete_index_row_multi(tx, &idx_table, old, base_key_schema, &base_sks).await?;
+    }
+
+    if let Some(new) = new_item
+        && item_has_index_keys(new, &idx.key_schema)
+    {
+        let projected =
+            project_item_for_index(new, &idx.key_schema, base_key_schema, &idx.projection);
         insert_index_row_multi(
-            &mut tx,
+            tx,
             &idx_table,
             new,
             &projected,
-            &update.index_key_schema,
-            &update.base_key_schema,
-            &update.attr_defs,
+            &idx.key_schema,
+            base_key_schema,
             &idx_sks,
             &base_sks,
         )
         .await?;
     }
 
-    tx.commit()
-        .await
-        .map_err(|e| StorageError::Internal(e.to_string()))?;
     Ok(())
 }

--- a/crates/storage-postgres/src/migrations.rs
+++ b/crates/storage-postgres/src/migrations.rs
@@ -31,28 +31,65 @@ pub(crate) async fn run_catalog_migrations(pool: &PgPool) -> OpResult<()> {
     Ok(())
 }
 
-/// Run data database migrations.
+/// Embedded data-database migration files, applied in order. Tracked in the
+/// data database's own `schema_history` table (a separate database from the
+/// catalog), so `extenddb migrate` applies exactly the pending migrations.
+pub(crate) const DATA_MIGRATIONS: &[(&str, &str)] = &[
+    (
+        "001_data_schema.sql",
+        include_str!("../../storage-postgres/data_migrations/001_data_schema.sql"),
+    ),
+    (
+        "002_gsi_pending.sql",
+        include_str!("../../storage-postgres/data_migrations/002_gsi_pending.sql"),
+    ),
+];
+
+/// Run data database migrations, skipping already-applied ones.
+///
+/// Mirrors [`run_catalog_migrations`]: each migration is recorded in
+/// `schema_history` and skipped on later runs. The data database has its own
+/// ledger because it is a separate database from the catalog.
 pub(crate) async fn run_data_migrations(pool: &PgPool) -> OpResult<()> {
-    let sql = include_str!("../../storage-postgres/data_migrations/001_data_schema.sql");
+    println!("--- Running data migrations...");
 
-    println!("--- Initializing data database schema...");
-    let initialized: bool = sqlx::query_scalar(
-        "SELECT EXISTS(SELECT 1 FROM information_schema.tables \
-         WHERE table_name = 'stream_shards' AND table_schema = 'public')",
+    // Ensure the data database has a migration ledger before tracking. (The
+    // catalog ledger lives in a different database and cannot be reused here.)
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS schema_history (\
+             filename TEXT PRIMARY KEY, \
+             applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\
+         )",
     )
-    .fetch_one(pool)
+    .execute(pool)
     .await
-    .map_err(|e| OpError::Internal(format!("Check data schema: {e}")))?;
+    .map_err(|e| OpError::Internal(format!("Create data schema_history: {e}")))?;
 
-    if initialized {
-        println!("    Data schema already initialized.");
-    } else {
+    // Adopt a pre-tracking deployment: if 001 was applied by an earlier version
+    // (its tables exist) but isn't recorded, record it WITHOUT re-running it.
+    // Re-running 001 would execute `setval('stream_seq', ...)` again and could
+    // regress the stream sequence on a live database, producing duplicate
+    // sequence numbers.
+    if !is_migration_applied(pool, "001_data_schema.sql").await?
+        && table_exists(pool, "stream_shards").await?
+    {
+        println!("    Adopting existing 001_data_schema.sql (pre-tracking deployment).");
+        record_migration(pool, "001_data_schema.sql").await?;
+    }
+
+    for (filename, sql) in DATA_MIGRATIONS {
+        if is_migration_applied(pool, filename).await? {
+            println!("    {filename} — already applied, skipping.");
+            continue;
+        }
+        println!("    Applying {filename}...");
         sqlx::raw_sql(sql)
             .execute(pool)
             .await
-            .map_err(|e| OpError::Internal(format!("Data migration failed: {e}")))?;
-        println!("    Data schema initialized.");
+            .map_err(|e| OpError::Internal(format!("Data migration {filename} failed: {e}")))?;
+        record_migration(pool, filename).await?;
     }
+    println!("    Data migrations applied.");
     Ok(())
 }
 
@@ -67,6 +104,33 @@ pub(crate) async fn table_exists(pool: &PgPool, name: &str) -> OpResult<bool> {
     .await
     .map_err(|e| OpError::Internal(format!("Check table exists: {e}")))?;
     Ok(exists)
+}
+
+/// Filenames of [`DATA_MIGRATIONS`] not yet applied to this data database.
+///
+/// Mirrors the apply logic in [`run_data_migrations`] without executing
+/// anything, so callers (e.g. `extenddb migrate`) can report and gate on
+/// pending work. A pre-tracking baseline (`001_data_schema.sql` whose tables
+/// already exist but isn't recorded) is treated as already applied: it will be
+/// adopted — recorded without re-running — not applied, so it is not reported
+/// as pending.
+pub(crate) async fn pending_data_migrations(pool: &PgPool) -> OpResult<Vec<String>> {
+    let has_history = table_exists(pool, "schema_history").await?;
+    // Pre-tracking deployment: 001 ran under an earlier version (its tables
+    // exist) but was never recorded. It is adopted, not re-run.
+    let adopts_baseline = !has_history && table_exists(pool, "stream_shards").await?;
+
+    let mut pending = Vec::new();
+    for (filename, _sql) in DATA_MIGRATIONS {
+        if is_migration_applied(pool, filename).await? {
+            continue;
+        }
+        if *filename == "001_data_schema.sql" && adopts_baseline {
+            continue;
+        }
+        pending.push((*filename).to_owned());
+    }
+    Ok(pending)
 }
 
 /// Check if a migration has already been applied.

--- a/crates/storage-postgres/src/table_helpers.rs
+++ b/crates/storage-postgres/src/table_helpers.rs
@@ -123,7 +123,6 @@ impl PostgresEngine {
                     &projected,
                     index_key_schema,
                     base_key_schema,
-                    attr_defs,
                     &idx_sks,
                     &base_sks,
                 )

--- a/crates/storage-postgres/src/worker_store.rs
+++ b/crates/storage-postgres/src/worker_store.rs
@@ -128,6 +128,16 @@ impl PostgresEngine {
                 Self::drop_index_data_table(&mut data_tx, idx_id).await?;
             }
             Self::drop_data_table(&mut data_tx, table_id).await?;
+
+            // Drop any still-pending GSI propagation rows for this table in the
+            // same transaction that drops the tables, so workers don't waste a
+            // claim→deserialize→attempt→skip cycle on now-orphaned rows.
+            sqlx::query("DELETE FROM gsi_pending WHERE table_id = $1")
+                .bind(table_id)
+                .execute(&mut *data_tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
             data_tx
                 .commit()
                 .await

--- a/crates/storage/src/bootstrapper.rs
+++ b/crates/storage/src/bootstrapper.rs
@@ -66,6 +66,15 @@ pub trait Bootstrapper: Send + Sync {
     /// Run data schema migrations (stream tables, sequences, etc.).
     async fn run_data_migrations(&self) -> OpResult<()>;
 
+    /// Filenames of data-database migrations that have not yet been applied.
+    ///
+    /// Excludes a pre-tracking baseline migration that already exists and will
+    /// be adopted (recorded without re-running) rather than applied. Data
+    /// migrations are tracked in the data database's own ledger, independent of
+    /// the catalog version, so `migrate` uses this to report accurately and to
+    /// decide whether confirmation is required — without running anything.
+    async fn pending_data_migrations(&self) -> OpResult<Vec<String>>;
+
     /// Record the data database connection string in the catalog.
     async fn record_data_connection(&self) -> OpResult<()>;
 

--- a/devtools/run-tests
+++ b/devtools/run-tests
@@ -428,7 +428,7 @@ if $RUN_PYTEST; then
     fi
     echo "  AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}"
     # CLI lifecycle tests manage their own server; exclude from main suite
-    PYTEST_ARGS=(python3 -m pytest tests/ -v --ignore=tests/python --ignore=tests/test_cli_lifecycle.py)
+    PYTEST_ARGS=(python3 -m pytest tests/ -v --ignore=tests/python --ignore=tests/test_cli_lifecycle.py --ignore=tests/test_gsi_async_queue.py)
     # Parallel execution (--parallel): distribute by file so module/class-scoped
     # fixtures stay within a single worker.
     if [[ -n "$PARALLEL" ]] && python3 -c "import xdist" 2>/dev/null; then

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,3 +188,6 @@ def scoped_table(
             client.delete_table(TableName=name)
         except client.exceptions.ResourceNotFoundException:
             pass  # Already deleted by the test itself.
+
+# Shared CLI/lifecycle fixture (used by lifecycle + GSI-queue integration tests).
+from lifecycle_helpers import cli_env  # noqa: F401

--- a/tests/lifecycle_helpers.py
+++ b/tests/lifecycle_helpers.py
@@ -1,0 +1,272 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI lifecycle tests for extenddb.
+
+These tests exercise the full extenddb CLI lifecycle:
+  extenddb init → extenddb serve → extenddb status → extenddb stop → extenddb destroy
+
+They require:
+  - A built extenddb binary (cargo build)
+  - A running PostgreSQL instance
+  - EXTENDDB_TEST_PG_CONNECTION_STRING env var pointing to a PostgreSQL server
+    (e.g., "postgresql://postgres:postgres@localhost:5432")
+
+Each test creates an isolated catalog database, config, and TLS certs to
+avoid interfering with other tests or a running extenddb instance.
+
+These tests are NOT run via the standard pytest suite (which tests the
+DynamoDB API). They are a separate test category for CLI behavior.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+import uuid
+
+import pytest
+
+# The extenddb binary path — built by cargo
+EXTENDDB_BINARY = os.environ.get(
+    "EXTENDDB_BINARY",
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "target",
+        "release",
+        "extenddb",
+    ),
+)
+
+# PostgreSQL connection string for creating test databases.
+PG_CONN = os.environ.get("EXTENDDB_TEST_PG_CONNECTION_STRING", "")
+
+# Admin connection for privileged ops (CREATE/DROP DATABASE, CREATE ROLE).
+# PG_CONN is the unprivileged app role; falls back to it for local superuser setups.
+PG_ADMIN_CONN = os.environ.get("EXTENDDB_TEST_PG_ADMIN_CONNECTION_STRING", "") or PG_CONN
+
+
+def _parse_pg_credentials(conn):
+    """Extract user and password from a connection string (postgresql://user:pass@host:port)."""
+    if not conn:
+        return None, None
+    from urllib.parse import urlparse
+    parsed = urlparse(conn)
+    return parsed.username, parsed.password
+
+
+PG_USER, PG_PASS = _parse_pg_credentials(PG_CONN)
+PG_ADMIN_USER, PG_ADMIN_PASS = _parse_pg_credentials(PG_ADMIN_CONN)
+
+
+def _fail_if_no_pg():
+    """Fail test if PostgreSQL is not available."""
+    if not PG_CONN:
+        pytest.fail(
+            "MISCONFIGURED: EXTENDDB_TEST_PG_CONNECTION_STRING not set. "
+            "CLI lifecycle tests require a PostgreSQL connection string."
+        )
+
+
+def _fail_if_no_binary():
+    """Fail test if extenddb binary is not built."""
+    if not os.path.isfile(EXTENDDB_BINARY):
+        pytest.fail(
+            f"MISCONFIGURED: extenddb binary not found at {EXTENDDB_BINARY}. "
+            "Build with: cargo build --release"
+        )
+
+
+def _pg_args():
+    """Return --pg-user and --pg-pass args for commands that connect as the
+    PostgreSQL admin (catalog database and application-role creation)."""
+    args = []
+    if PG_ADMIN_USER:
+        args.extend(["--pg-user", PG_ADMIN_USER])
+    if PG_ADMIN_PASS:
+        args.extend(["--pg-pass", PG_ADMIN_PASS])
+    return args
+
+
+def _patch_config_port(config_path, port):
+    """Patch the generated config to use a specific port.
+
+    Sets the HTTPS port whether the generated config ships it commented (the
+    default) or active, and without assuming a particular default value (the
+    default has changed across releases, e.g. 8000 -> 18443).
+    """
+    with open(config_path) as f:
+        content = f.read()
+    # Replace the first server `port = N` line (commented or not) with our port.
+    new_content, n = re.subn(
+        r"(?m)^[ \t]*#?[ \t]*port[ \t]*=[ \t]*\d+.*$",
+        f"port = {port}",
+        content,
+        count=1,
+    )
+    if n == 0:
+        # No port line at all — add one right after bind_addr.
+        new_content = content.replace(
+            'bind_addr = "127.0.0.1"',
+            f'bind_addr = "127.0.0.1"\nport = {port}',
+            1,
+        )
+    with open(config_path, "w") as f:
+        f.write(new_content)
+
+
+def _init_args(cli_env):
+    """Return CLI args for extenddb init including all connection details."""
+    args = list(_pg_args())
+    args.extend(["--pg-host", cli_env["pg_host"]])
+    args.extend(["--pg-port", cli_env["pg_port"]])
+    args.extend(["--catalog-db", cli_env["db_name"]])
+    if PG_USER:
+        args.extend(["--extenddb-user", PG_USER])
+    if PG_PASS:
+        args.extend(["--extenddb-pass", PG_PASS])
+    return args
+
+
+def _run_extenddb(*args, config=None, timeout=30, check=True, env_override=None):
+    """Run a extenddb CLI command and return the CompletedProcess.
+
+    Never passes stdin — extenddb commands must be fully non-interactive.
+    Use env_override to pass EXTENDDB_ADMIN_PASSWORD etc.
+    """
+    cmd = [EXTENDDB_BINARY]
+    cmd.extend(args)
+    if config:
+        cmd.extend(["--config", config])
+    env = None
+    if env_override:
+        env = os.environ.copy()
+        env.update(env_override)
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=check,
+        stdin=subprocess.DEVNULL,
+        env=env,
+    )
+
+
+@pytest.fixture()
+def cli_env(tmp_path):
+    """Create an isolated environment for CLI lifecycle testing.
+
+    Yields a dict with:
+      - db_name: unique PostgreSQL database name (catalog)
+      - config_path: path to the generated extenddb.toml
+      - run_dir: directory for PID files
+      - port: unique port for this test instance
+      - binary: path to the extenddb binary
+      - tls_dir: directory containing TLS certs (from ~/.extenddb/tls)
+    """
+    _fail_if_no_pg()
+    _fail_if_no_binary()
+
+    db_name = f"extenddb_test_{uuid.uuid4().hex[:8]}_catalog"
+    port = _find_free_port()
+    run_dir = str(tmp_path / "run")
+    os.makedirs(run_dir, exist_ok=True)
+
+    config_path = str(tmp_path / "extenddb.toml")
+
+    # Parse PG connection details from PG_CONN
+    from urllib.parse import urlparse
+    parsed = urlparse(PG_CONN)
+    pg_host = parsed.hostname or "localhost"
+    pg_port = str(parsed.port or 5432)
+
+    env = {
+        "db_name": db_name,
+        "config_path": config_path,
+        "run_dir": run_dir,
+        "tls_dir": os.path.expanduser("~/.extenddb/tls"),
+        "port": port,
+        "binary": EXTENDDB_BINARY,
+        "conn_string": f"{PG_CONN}/{db_name}",
+        "pg_host": pg_host,
+        "pg_port": pg_port,
+    }
+
+    yield env
+
+    # Cleanup: stop server if running, destroy, drop database
+    try:
+        _run_extenddb("stop", config=config_path, check=False, timeout=10)
+    except Exception:
+        pass
+    try:
+        _run_extenddb("destroy", "--yes", *_pg_args(), config=config_path, check=False, timeout=10)
+    except Exception:
+        pass
+    _drop_database(db_name)
+    # Also drop the data database (catalog name minus _catalog suffix)
+    if db_name.endswith("_catalog"):
+        _drop_database(db_name[:-len("_catalog")])
+
+
+def _find_free_port():
+    """Find a free TCP port."""
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _drop_database(db_name):
+    """Drop a PostgreSQL test database."""
+    import psycopg2
+
+    try:
+        conn = psycopg2.connect(PG_ADMIN_CONN + "/postgres")
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            # Terminate existing connections
+            cur.execute(
+                f"""
+                SELECT pg_terminate_backend(pid)
+                FROM pg_stat_activity
+                WHERE datname = '{db_name}' AND pid <> pg_backend_pid()
+                """
+            )
+            cur.execute(f'DROP DATABASE IF EXISTS "{db_name}"')
+        conn.close()
+    except Exception:
+        pass  # Best-effort cleanup
+
+
+def _wait_for_server(port, timeout=15):
+    """Wait for the server to become healthy."""
+    import urllib3
+
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    import urllib.request
+    import ssl
+
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            req = urllib.request.Request(f"https://127.0.0.1:{port}/health")
+            urllib.request.urlopen(req, context=ctx, timeout=2)
+            return True
+        except Exception:
+            time.sleep(0.5)
+    return False
+
+

--- a/tests/rust/src/lsi.rs
+++ b/tests/rust/src/lsi.rs
@@ -380,14 +380,48 @@ async fn seed_gsi_items(table: &str, count: usize) {
     }
 }
 
+/// Poll the hash-only `StatusGSI` until it reflects at least `expected` ACTIVE
+/// items, tolerating asynchronous GSI propagation. Bounded so it can't hang.
+/// Replaces fixed sleeps, which race the index-apply queue under load.
+async fn wait_for_gsi_items(table: &str, expected: usize) {
+    let c = client();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    loop {
+        let mut count = 0usize;
+        let mut esk: Option<HashMap<String, AttributeValue>> = None;
+        loop {
+            let mut req = c
+                .query()
+                .table_name(table)
+                .index_name("StatusGSI")
+                .key_condition_expression("nodeStatus = :s")
+                .expression_attribute_values(":s", s("ACTIVE"))
+                .limit(100);
+            if let Some(ref lek) = esk {
+                req = req.set_exclusive_start_key(Some(lek.clone()));
+            }
+            let resp = req.send().await.unwrap();
+            count += resp.items().len();
+            match resp.last_evaluated_key() {
+                Some(lek) => esk = Some(lek.to_owned()),
+                None => break,
+            }
+        }
+        if count >= expected || std::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}
+
 #[tokio::test]
 async fn gsi_hash_only_pagination() {
     let table = format!("GSIHashPag_{}", ts());
     create_hash_only_gsi_table(&table).await;
     seed_gsi_items(&table, 10).await;
 
-    // Allow GSI propagation
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    // Wait for asynchronous GSI propagation (bounded poll, not a fixed sleep).
+    wait_for_gsi_items(&table, 10).await;
 
     let c = client();
     let mut all_items: Vec<HashMap<String, AttributeValue>> = Vec::new();
@@ -440,7 +474,7 @@ async fn gsi_hash_only_page_two_returns_items() {
     create_hash_only_gsi_table(&table).await;
     seed_gsi_items(&table, 10).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    wait_for_gsi_items(&table, 10).await;
 
     let c = client();
 
@@ -486,7 +520,7 @@ async fn gsi_hash_only_no_duplicates() {
     create_hash_only_gsi_table(&table).await;
     seed_gsi_items(&table, 10).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    wait_for_gsi_items(&table, 10).await;
 
     let c = client();
     let mut all_ids: Vec<String> = Vec::new();

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -1,262 +1,35 @@
 # Copyright 2026 ExtendDB contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""CLI lifecycle tests for extenddb.
+"""CLI lifecycle tests for extenddb (init -> serve -> status -> stop -> destroy).
 
-These tests exercise the full extenddb CLI lifecycle:
-  extenddb init → extenddb serve → extenddb status → extenddb stop → extenddb destroy
-
-They require:
-  - A built extenddb binary (cargo build)
-  - A running PostgreSQL instance
-  - EXTENDDB_TEST_PG_CONNECTION_STRING env var pointing to a PostgreSQL server
-    (e.g., "postgresql://postgres:postgres@localhost:5432")
-
-Each test creates an isolated catalog database, config, and TLS certs to
-avoid interfering with other tests or a running extenddb instance.
-
-These tests are NOT run via the standard pytest suite (which tests the
-DynamoDB API). They are a separate test category for CLI behavior.
+Shared lifecycle helpers and the `cli_env` fixture live in `lifecycle_helpers.py`; the
+fixture is re-exported via `conftest.py` for auto-discovery. These require a
+PostgreSQL instance (EXTENDDB_TEST_PG_CONNECTION_STRING) and a built binary, and
+are excluded from the backend-agnostic pytest suite.
 """
 
-from __future__ import annotations
-
-import json
 import os
-import shutil
-import subprocess
-import tempfile
 import time
 import uuid
 
 import pytest
 
-# The extenddb binary path — built by cargo
-EXTENDDB_BINARY = os.environ.get(
-    "EXTENDDB_BINARY",
-    os.path.join(
-        os.path.dirname(__file__),
-        "..",
-        "target",
-        "release",
-        "extenddb",
-    ),
+from lifecycle_helpers import (
+    PG_ADMIN_CONN,
+    PG_ADMIN_PASS,
+    PG_ADMIN_USER,
+    PG_CONN,
+    _drop_database,
+    _fail_if_no_binary,
+    _fail_if_no_pg,
+    _find_free_port,
+    _init_args,
+    _patch_config_port,
+    _pg_args,
+    _run_extenddb,
+    _wait_for_server,
 )
-
-# PostgreSQL connection string for creating test databases.
-PG_CONN = os.environ.get("EXTENDDB_TEST_PG_CONNECTION_STRING", "")
-
-# Admin connection for privileged ops (CREATE/DROP DATABASE, CREATE ROLE).
-# PG_CONN is the unprivileged app role; falls back to it for local superuser setups.
-PG_ADMIN_CONN = os.environ.get("EXTENDDB_TEST_PG_ADMIN_CONNECTION_STRING", "") or PG_CONN
-
-
-def _parse_pg_credentials(conn):
-    """Extract user and password from a connection string (postgresql://user:pass@host:port)."""
-    if not conn:
-        return None, None
-    from urllib.parse import urlparse
-    parsed = urlparse(conn)
-    return parsed.username, parsed.password
-
-
-PG_USER, PG_PASS = _parse_pg_credentials(PG_CONN)
-PG_ADMIN_USER, PG_ADMIN_PASS = _parse_pg_credentials(PG_ADMIN_CONN)
-
-
-def _fail_if_no_pg():
-    """Fail test if PostgreSQL is not available."""
-    if not PG_CONN:
-        pytest.fail(
-            "MISCONFIGURED: EXTENDDB_TEST_PG_CONNECTION_STRING not set. "
-            "CLI lifecycle tests require a PostgreSQL connection string."
-        )
-
-
-def _fail_if_no_binary():
-    """Fail test if extenddb binary is not built."""
-    if not os.path.isfile(EXTENDDB_BINARY):
-        pytest.fail(
-            f"MISCONFIGURED: extenddb binary not found at {EXTENDDB_BINARY}. "
-            "Build with: cargo build --release"
-        )
-
-
-def _pg_args():
-    """Return --pg-user and --pg-pass args for commands that connect as the
-    PostgreSQL admin (catalog database and application-role creation)."""
-    args = []
-    if PG_ADMIN_USER:
-        args.extend(["--pg-user", PG_ADMIN_USER])
-    if PG_ADMIN_PASS:
-        args.extend(["--pg-pass", PG_ADMIN_PASS])
-    return args
-
-
-def _patch_config_port(config_path, port):
-    """Patch the generated config to use a specific port."""
-    with open(config_path) as f:
-        content = f.read()
-    # Replace commented port line or add port after bind_addr
-    if "# port = 18443" in content:
-        content = content.replace("# port = 18443", f"port = {port}")
-    elif "port = " not in content:
-        content = content.replace(
-            'bind_addr = "127.0.0.1"',
-            f'bind_addr = "127.0.0.1"\nport = {port}',
-        )
-    with open(config_path, "w") as f:
-        f.write(content)
-
-
-def _init_args(cli_env):
-    """Return CLI args for extenddb init including all connection details."""
-    args = list(_pg_args())
-    args.extend(["--pg-host", cli_env["pg_host"]])
-    args.extend(["--pg-port", cli_env["pg_port"]])
-    args.extend(["--catalog-db", cli_env["db_name"]])
-    if PG_USER:
-        args.extend(["--extenddb-user", PG_USER])
-    if PG_PASS:
-        args.extend(["--extenddb-pass", PG_PASS])
-    return args
-
-
-def _run_extenddb(*args, config=None, timeout=30, check=True, env_override=None):
-    """Run a extenddb CLI command and return the CompletedProcess.
-
-    Never passes stdin — extenddb commands must be fully non-interactive.
-    Use env_override to pass EXTENDDB_ADMIN_PASSWORD etc.
-    """
-    cmd = [EXTENDDB_BINARY]
-    cmd.extend(args)
-    if config:
-        cmd.extend(["--config", config])
-    env = None
-    if env_override:
-        env = os.environ.copy()
-        env.update(env_override)
-    return subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-        check=check,
-        stdin=subprocess.DEVNULL,
-        env=env,
-    )
-
-
-@pytest.fixture()
-def cli_env(tmp_path):
-    """Create an isolated environment for CLI lifecycle testing.
-
-    Yields a dict with:
-      - db_name: unique PostgreSQL database name (catalog)
-      - config_path: path to the generated extenddb.toml
-      - run_dir: directory for PID files
-      - port: unique port for this test instance
-      - binary: path to the extenddb binary
-      - tls_dir: directory containing TLS certs (from ~/.extenddb/tls)
-    """
-    _fail_if_no_pg()
-    _fail_if_no_binary()
-
-    db_name = f"extenddb_test_{uuid.uuid4().hex[:8]}_catalog"
-    port = _find_free_port()
-    run_dir = str(tmp_path / "run")
-    os.makedirs(run_dir, exist_ok=True)
-
-    config_path = str(tmp_path / "extenddb.toml")
-
-    # Parse PG connection details from PG_CONN
-    from urllib.parse import urlparse
-    parsed = urlparse(PG_CONN)
-    pg_host = parsed.hostname or "localhost"
-    pg_port = str(parsed.port or 5432)
-
-    env = {
-        "db_name": db_name,
-        "config_path": config_path,
-        "run_dir": run_dir,
-        "tls_dir": os.path.expanduser("~/.extenddb/tls"),
-        "port": port,
-        "binary": EXTENDDB_BINARY,
-        "conn_string": f"{PG_CONN}/{db_name}",
-        "pg_host": pg_host,
-        "pg_port": pg_port,
-    }
-
-    yield env
-
-    # Cleanup: stop server if running, destroy, drop database
-    try:
-        _run_extenddb("stop", config=config_path, check=False, timeout=10)
-    except Exception:
-        pass
-    try:
-        _run_extenddb("destroy", "--yes", *_pg_args(), config=config_path, check=False, timeout=10)
-    except Exception:
-        pass
-    _drop_database(db_name)
-    # Also drop the data database (catalog name minus _catalog suffix)
-    if db_name.endswith("_catalog"):
-        _drop_database(db_name[:-len("_catalog")])
-
-
-def _find_free_port():
-    """Find a free TCP port."""
-    import socket
-
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-
-
-def _drop_database(db_name):
-    """Drop a PostgreSQL test database."""
-    import psycopg2
-
-    try:
-        conn = psycopg2.connect(PG_ADMIN_CONN + "/postgres")
-        conn.autocommit = True
-        with conn.cursor() as cur:
-            # Terminate existing connections
-            cur.execute(
-                f"""
-                SELECT pg_terminate_backend(pid)
-                FROM pg_stat_activity
-                WHERE datname = '{db_name}' AND pid <> pg_backend_pid()
-                """
-            )
-            cur.execute(f'DROP DATABASE IF EXISTS "{db_name}"')
-        conn.close()
-    except Exception:
-        pass  # Best-effort cleanup
-
-
-def _wait_for_server(port, timeout=15):
-    """Wait for the server to become healthy."""
-    import urllib3
-
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-    import urllib.request
-    import ssl
-
-    ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
-
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            req = urllib.request.Request(f"https://127.0.0.1:{port}/health")
-            urllib.request.urlopen(req, context=ctx, timeout=2)
-            return True
-        except Exception:
-            time.sleep(0.5)
-    return False
-
 
 class TestCliLifecycle:
     """Test the full extenddb CLI lifecycle."""
@@ -279,6 +52,114 @@ class TestCliLifecycle:
         # TLS certs should exist
         assert os.path.isfile(os.path.join(cli_env["tls_dir"], "cert.pem"))
         assert os.path.isfile(os.path.join(cli_env["tls_dir"], "key.pem"))
+
+    def test_data_migrations_tracked(self, cli_env):
+        """init records every data migration in the data DB's schema_history.
+
+        Validates the data-migration registry: migrations are tracked (so
+        `extenddb migrate` knows what is pending and never re-runs an applied
+        one), and the GSI-pending migration is among them.
+        """
+        import psycopg2
+
+        result = _run_extenddb(
+            "init", *_init_args(cli_env),
+            config=cli_env["config_path"],
+            env_override={"EXTENDDB_ADMIN_PASSWORD": "TestPass1!"},
+        )
+        assert result.returncode == 0
+
+        # The data database is the catalog name without the "_catalog" suffix.
+        data_db = cli_env["db_name"][: -len("_catalog")]
+        conn = psycopg2.connect(PG_ADMIN_CONN + "/" + data_db)
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT filename FROM schema_history ORDER BY filename")
+                tracked = {row[0] for row in cur.fetchall()}
+        finally:
+            conn.close()
+
+        assert "001_data_schema.sql" in tracked, tracked
+        assert "002_gsi_pending.sql" in tracked, tracked
+
+    def test_migrate_applies_pending_data_migration(self, cli_env):
+        """`extenddb migrate` applies a pending *data* migration on an existing
+        deployment — not just catalog migrations.
+
+        Regression: data migrations live in the data database's own
+        `schema_history`, independent of the catalog version. `migrate`
+        previously only ran catalog migrations and returned "up to date" when
+        the catalog version matched, so a release that only added a data
+        migration (e.g. `002_gsi_pending.sql`) was never applied on upgrade —
+        the `gsi_pending` table was missing and every async-GSI write failed.
+
+        Simulates a pre-002 deployment by dropping `gsi_pending` and its
+        ledger row, then asserts `migrate` re-applies it (and refuses without
+        `--yes`).
+        """
+        import psycopg2
+
+        result = _run_extenddb(
+            "init", *_init_args(cli_env),
+            config=cli_env["config_path"],
+            env_override={"EXTENDDB_ADMIN_PASSWORD": "TestPass1!"},
+        )
+        assert result.returncode == 0
+
+        data_db = cli_env["db_name"][: -len("_catalog")]
+
+        def _data_conn():
+            return psycopg2.connect(PG_ADMIN_CONN + "/" + data_db)
+
+        # Simulate a deployment created before 002 existed.
+        conn = _data_conn()
+        try:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute("DROP TABLE IF EXISTS gsi_pending")
+                cur.execute(
+                    "DELETE FROM schema_history WHERE filename = '002_gsi_pending.sql'"
+                )
+                cur.execute("SELECT to_regclass('public.gsi_pending') IS NOT NULL")
+                assert cur.fetchone()[0] is False
+        finally:
+            conn.close()
+
+        # Without --yes, migrate must refuse while a data migration is pending.
+        refused = _run_extenddb(
+            "migrate", *_pg_args(),
+            config=cli_env["config_path"],
+            check=False,
+        )
+        assert refused.returncode != 0, refused.stdout + refused.stderr
+
+        # With --yes, migrate applies the pending data migration.
+        applied = _run_extenddb(
+            "migrate", "--yes", *_pg_args(),
+            config=cli_env["config_path"],
+            check=False,
+        )
+        assert applied.returncode == 0, applied.stdout + applied.stderr
+
+        conn = _data_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT to_regclass('public.gsi_pending') IS NOT NULL")
+                assert cur.fetchone()[0] is True
+                cur.execute(
+                    "SELECT EXISTS(SELECT 1 FROM schema_history "
+                    "WHERE filename = '002_gsi_pending.sql')"
+                )
+                assert cur.fetchone()[0] is True
+                # The 002 schema must carry the per-index queue columns.
+                cur.execute(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_name = 'gsi_pending'"
+                )
+                cols = {row[0] for row in cur.fetchall()}
+                assert {"worker_partition", "ready_at", "index_context"} <= cols, cols
+        finally:
+            conn.close()
 
     def test_init_serve_status_stop(self, cli_env):
         """Full lifecycle: init → serve → status → stop."""

--- a/tests/test_gsi_async_queue.py
+++ b/tests/test_gsi_async_queue.py
@@ -1,0 +1,417 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for the persistent GSI propagation queue (``gsi_pending``).
+
+These cover the queue's correctness guarantees end-to-end by driving the real
+server lifecycle, so they live alongside the CLI lifecycle tests and reuse their
+helpers/fixture:
+
+  * **crash recovery** — committed-but-unpropagated updates survive ``SIGKILL``
+    and are applied after restart;
+  * **per-key FIFO ordering** — successive updates to one base item converge to
+    the latest state with no stale index entries (the partitioned worker model);
+  * **dropped-index handling** — rows whose target index table was dropped are
+    consumed (savepoint skip), not retried forever.
+
+PostgreSQL-specific (the persistence lives in ``gsi_pending``), gated on
+``EXTENDDB_TEST_PG_CONNECTION_STRING``, and excluded from the backend-agnostic
+``--pytest`` suite.
+
+CRITICAL (crash recovery): the crash must be ``SIGKILL`` — never a graceful
+``extenddb stop``, which drains the queue before exiting and would let the test
+pass even with a non-persistent queue (a false positive).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import signal
+import subprocess
+import time
+import uuid
+
+import urllib3
+
+# Reuse the shared CLI-lifecycle infrastructure (lifecycle control, isolated
+# per-test deployment, cleanup). The `cli_env` fixture is provided by conftest.
+from lifecycle_helpers import (
+    PG_ADMIN_CONN,
+    _init_args,
+    _patch_config_port,
+    _run_extenddb,
+    _wait_for_server,
+)
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+ADMIN_PASSWORD = "TestPass1!"
+_TLS_CERT = os.path.expanduser("~/.extenddb/tls/cert.pem")
+_DEVTOOLS = os.path.join(os.path.dirname(__file__), "..", "devtools")
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _set_run_dir(config_path, run_dir):
+    """Pin the server's PID-file directory to the test's isolated run_dir."""
+    with open(config_path) as f:
+        content = f.read()
+    if re.search(r"^\s*#?\s*run_dir\s*=", content, re.M):
+        content = re.sub(
+            r"^\s*#?\s*run_dir\s*=.*$", f'run_dir = "{run_dir}"', content, count=1, flags=re.M
+        )
+    else:
+        content = content.replace(
+            'bind_addr = "127.0.0.1"',
+            f'bind_addr = "127.0.0.1"\nrun_dir = "{run_dir}"',
+            1,
+        )
+    with open(config_path, "w") as f:
+        f.write(content)
+
+
+def _set_gsi_delay(config_path, ms):
+    """Set the system GSI propagation delay (read by the server at startup).
+
+    ``--config`` must precede the ``set`` subcommand for the settings CLI.
+    """
+    _run_extenddb("settings", "--config", config_path, "set", "gsi_propagation_delay_ms", str(ms))
+
+
+def _server_pid_on_port(port):
+    """PID of the process *listening* on the port (filtered to LISTEN so a
+    client connection — including this test — is never returned)."""
+    out = subprocess.run(
+        ["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    pids = [int(p) for p in out.stdout.split()]
+    return pids[0] if pids else None
+
+
+def _provision_creds(port):
+    env = os.environ.copy()
+    env.update(
+        {
+            "EXTENDDB_TEST_ENDPOINT": f"https://127.0.0.1:{port}",
+            "EXTENDDB_ADMIN_USER": "admin",
+            "EXTENDDB_ADMIN_PASSWORD": ADMIN_PASSWORD,
+            "EXTENDDB_CA_CERT": _TLS_CERT,
+        }
+    )
+    res = subprocess.run(
+        ["python3", os.path.join(_DEVTOOLS, "provision-test-credentials")],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+        timeout=30,
+    )
+    creds = {}
+    for line in res.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("export "):
+            key, _, val = line[len("export ") :].partition("=")
+            creds[key] = val.strip().strip('"').strip("'")
+    assert "AWS_ACCESS_KEY_ID" in creds and "AWS_SECRET_ACCESS_KEY" in creds, (
+        f"provisioning did not return credentials: {res.stdout}"
+    )
+    return creds
+
+
+def _ddb_client(port, creds):
+    import boto3
+
+    return boto3.client(
+        "dynamodb",
+        endpoint_url=f"https://127.0.0.1:{port}",
+        region_name="us-east-1",
+        aws_access_key_id=creds["AWS_ACCESS_KEY_ID"],
+        aws_secret_access_key=creds["AWS_SECRET_ACCESS_KEY"],
+        verify=False,
+    )
+
+
+def _gsi_count(ddb, table, gpk):
+    return ddb.query(
+        TableName=table,
+        IndexName="gsi1",
+        KeyConditionExpression="gpk = :g",
+        ExpressionAttributeValues={":g": {"S": gpk}},
+    )["Count"]
+
+
+def _data_db_name(cli_env):
+    return cli_env["db_name"][: -len("_catalog")]
+
+
+def _gsi_pending_count(cli_env):
+    import psycopg2
+
+    conn = psycopg2.connect(PG_ADMIN_CONN + "/" + _data_db_name(cli_env))
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM gsi_pending")
+            return cur.fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _index_id(cli_env, table_name):
+    """Look up the GSI's index_id from the catalog."""
+    import psycopg2
+
+    conn = psycopg2.connect(PG_ADMIN_CONN + "/" + cli_env["db_name"])
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT i.index_id FROM indexes i "
+                "JOIN tables t ON t.table_id = i.table_id "
+                "WHERE t.table_name = %s AND i.index_name = 'gsi1'",
+                (table_name,),
+            )
+            row = cur.fetchone()
+            assert row, f"index_id not found for table {table_name}"
+            return row[0]
+    finally:
+        conn.close()
+
+
+def _drop_index_table(cli_env, index_id):
+    import psycopg2
+
+    conn = psycopg2.connect(PG_ADMIN_CONN + "/" + _data_db_name(cli_env))
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f'DROP TABLE IF EXISTS "_ddb_{index_id}"')
+    finally:
+        conn.close()
+
+
+def _init_serve(cli_env, delay_ms):
+    """Init an isolated deployment with the given GSI propagation delay, serve
+    it, and return a provisioned DynamoDB client."""
+    config = cli_env["config_path"]
+    port = cli_env["port"]
+    result = _run_extenddb(
+        "init",
+        *_init_args(cli_env),
+        config=config,
+        env_override={"EXTENDDB_ADMIN_PASSWORD": ADMIN_PASSWORD},
+    )
+    assert result.returncode == 0, result.stderr
+    _patch_config_port(config, port)
+    _set_run_dir(config, cli_env["run_dir"])
+    # Set before serving: the server reads the delay at startup.
+    _set_gsi_delay(config, delay_ms)
+    assert _run_extenddb("serve", config=config).returncode == 0
+    assert _wait_for_server(port), "server did not become healthy"
+    return _ddb_client(port, _provision_creds(port))
+
+
+def _create_gsi_table(ddb):
+    table = f"gsiq_{uuid.uuid4().hex[:8]}"
+    ddb.create_table(
+        TableName=table,
+        AttributeDefinitions=[
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "gpk", "AttributeType": "S"},
+        ],
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "gsi1",
+                "KeySchema": [{"AttributeName": "gpk", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    ddb.get_waiter("table_exists").wait(TableName=table)
+    return table
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+class TestGsiAsyncQueue:
+    """Correctness guarantees of the persistent GSI propagation queue."""
+
+    def test_pending_gsi_updates_survive_sigkill(self, cli_env):
+        """Committed-but-unpropagated GSI updates survive a hard crash."""
+        config = cli_env["config_path"]
+        port = cli_env["port"]
+        n_items = 5
+
+        ddb = _init_serve(cli_env, 5000)
+        table = _create_gsi_table(ddb)
+
+        for i in range(n_items):
+            ddb.put_item(
+                TableName=table, Item={"pk": {"S": f"pk{i}"}, "gpk": {"S": f"g{i}"}}
+            )
+
+        # Genuinely pending now AND still pending after a couple of seconds —
+        # proves the long delay took effect (so a pre-crash drain can't mask a
+        # non-persistent queue).
+        assert _gsi_count(ddb, table, "g0") == 0
+        time.sleep(2)
+        assert _gsi_count(ddb, table, "g0") == 0, "delay did not take effect"
+
+        # HARD crash (SIGKILL, not `extenddb stop`).
+        pid = _server_pid_on_port(port)
+        assert pid is not None, "could not locate the running server"
+        os.kill(pid, signal.SIGKILL)
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline and _server_pid_on_port(port) is not None:
+            time.sleep(0.2)
+        assert _server_pid_on_port(port) is None, "server did not die after SIGKILL"
+        for name in os.listdir(cli_env["run_dir"]):
+            if name.endswith(".pid"):
+                os.remove(os.path.join(cli_env["run_dir"], name))
+
+        # Restart and confirm every queued update was recovered.
+        assert _run_extenddb("serve", config=config).returncode == 0
+        assert _wait_for_server(port), "server did not restart"
+        ddb = _ddb_client(port, _provision_creds(port))
+
+        recovered = {}
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            recovered = {i: _gsi_count(ddb, table, f"g{i}") for i in range(n_items)}
+            if all(c == 1 for c in recovered.values()):
+                break
+            time.sleep(0.5)
+        assert all(recovered.get(i) == 1 for i in range(n_items)), (
+            f"GSI updates lost across crash: {recovered}"
+        )
+
+    def test_same_base_key_updates_apply_in_order(self, cli_env):
+        """Successive updates to one base item converge to the latest state with
+        no stale index entries — i.e. per-key FIFO ordering holds."""
+        ddb = _init_serve(cli_env, 1500)
+        table = _create_gsi_table(ddb)
+
+        # Rewrite the same item, changing its GSI key each time. All updates
+        # queue (long delay) and must be applied in order by one worker.
+        values = [f"v{i}" for i in range(6)]
+        for v in values:
+            ddb.put_item(TableName=table, Item={"pk": {"S": "X"}, "gpk": {"S": v}})
+
+        latest = values[-1]
+        stale = values[:-1]
+
+        # Wait for convergence: the latest key present, the queue drained.
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if _gsi_count(ddb, table, latest) == 1 and _gsi_pending_count(cli_env) == 0:
+                break
+            time.sleep(0.5)
+
+        assert _gsi_count(ddb, table, latest) == 1, "latest GSI entry missing after drain"
+        for v in stale:
+            assert _gsi_count(ddb, table, v) == 0, (
+                f"stale GSI entry for {v} survived — updates applied out of order"
+            )
+        # And the base item itself reflects the latest write.
+        item = ddb.get_item(TableName=table, Key={"pk": {"S": "X"}})["Item"]
+        assert item["gpk"]["S"] == latest
+
+    def test_dropped_index_rows_are_consumed(self, cli_env):
+        """Rows whose target index table was dropped (table-deletion race) are
+        consumed via the savepoint skip, not retried forever."""
+        ddb = _init_serve(cli_env, 3000)
+        table = _create_gsi_table(ddb)
+
+        for i in range(3):
+            ddb.put_item(
+                TableName=table, Item={"pk": {"S": f"pk{i}"}, "gpk": {"S": f"g{i}"}}
+            )
+        assert _gsi_pending_count(cli_env) == 3, "writes were not queued"
+
+        # Drop the index table out from under the pending rows (simulates a
+        # table deletion racing with async propagation).
+        _drop_index_table(cli_env, _index_id(cli_env, table))
+
+        # The worker must consume the now-unappliable rows (42P01 -> skip),
+        # draining the queue rather than looping forever.
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if _gsi_pending_count(cli_env) == 0:
+                break
+            time.sleep(0.5)
+        assert _gsi_pending_count(cli_env) == 0, "queue did not drain after index drop"
+
+        # Server is still healthy (not wedged on a poison row).
+        assert _wait_for_server(cli_env["port"], timeout=5)
+
+    def test_per_index_delay_overrides_system_default(self, cli_env):
+        """A GSI's own propagation delay is honored, not the system default.
+
+        Regression: the enqueue path passed the *system* default delay to every
+        pending row, so a per-index ``propagation_delay_ms`` override was
+        silently ignored (all async GSIs shared one delay). Here the system
+        default is 0 (synchronous); a GSI given its own 5s delay must still
+        defer — proving the per-index delay reaches the queue. With the bug the
+        write would propagate immediately at the system default.
+        """
+        import psycopg2
+
+        ddb = _init_serve(cli_env, 0)  # system default: synchronous
+        table = _create_gsi_table(ddb)
+
+        # Give gsi1 its own non-zero propagation delay in the catalog.
+        conn = psycopg2.connect(PG_ADMIN_CONN + "/" + cli_env["db_name"])
+        conn.autocommit = True
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE indexes SET propagation_delay_ms = 5000 "
+                    "FROM tables "
+                    "WHERE indexes.table_id = tables.table_id "
+                    "AND tables.table_name = %s AND indexes.index_name = 'gsi1'",
+                    (table,),
+                )
+                assert cur.rowcount == 1, "failed to set per-index delay"
+        finally:
+            conn.close()
+
+        ddb.put_item(TableName=table, Item={"pk": {"S": "X"}, "gpk": {"S": "g0"}})
+
+        # The per-index delay must defer propagation even though the system
+        # default is synchronous. With jitter the effective delay is in
+        # [delay/2, delay] = [2500ms, 5000ms], so at 1.5s the update is still
+        # queued, not yet applied. (With the bug — enqueue using the system
+        # default of 0 — it would have applied immediately.)
+        time.sleep(1.5)
+        assert _gsi_count(ddb, table, "g0") == 0, (
+            "per-index delay ignored — update applied at the system default"
+        )
+        assert _gsi_pending_count(cli_env) == 1, (
+            "update was not queued under the per-index delay"
+        )
+
+    def test_pending_rows_cleared_on_table_delete(self, cli_env):
+        """Deleting a table removes its still-pending ``gsi_pending`` rows in the
+        same transaction that drops the tables, so workers never have to
+        claim-and-skip orphaned rows after the index tables are gone."""
+        ddb = _init_serve(cli_env, 5000)  # long delay: rows stay pending
+        table = _create_gsi_table(ddb)
+
+        for i in range(4):
+            ddb.put_item(
+                TableName=table, Item={"pk": {"S": f"pk{i}"}, "gpk": {"S": f"g{i}"}}
+            )
+        assert _gsi_pending_count(cli_env) == 4, "writes were not queued"
+
+        ddb.delete_table(TableName=table)
+        ddb.get_waiter("table_not_exists").wait(TableName=table)
+
+        assert _gsi_pending_count(cli_env) == 0, (
+            "pending GSI rows were left behind after the table was deleted"
+        )


### PR DESCRIPTION
## What

Replaces the in-memory `VecDeque` GSI propagation queue with a PostgreSQL-backed **persistent, self-describing** queue (`gsi_pending`). Pending GSI updates are enqueued in the same transaction as the base write and applied by background workers, surviving process crash/restart with no lost updates.

Key design:
- New `gsi_pending` table (data migration `002_gsi_pending.sql`).
- **Self-describing rows:** each row carries an `index_context` snapshot (base key schema, attribute definitions, target index defs) captured at enqueue, so workers apply with **zero catalog reads**, no metadata cache. A GSI's key schema/projection are immutable after creation, so the snapshot is never stale.
- **Crash-safe apply:** a worker claims, applies, and deletes each row in a single transaction (`SELECT … FOR UPDATE SKIP LOCKED` → index writes → `DELETE` → `COMMIT`). A crash or error before commit rolls the unit back and the row is reprocessed.
- **Per-key FIFO ordering:** rows are partitioned by a stable hash of the base key; each worker owns one partition and drains it in `id` order, so successive updates to one item apply in order (matching the old in-memory queue) while distinct keys propagate concurrently.
- Propagation delay enforced by `ready_at`; the worker sleeps until the next due row rather than polling.
- Dropped-index race (table deleted mid-flight) handled per index via a `SAVEPOINT` (SQLSTATE 42P01 → skip, row consumed).
- Data migrations are tracked in the data DB's `schema_history` (registry), with safe adoption of pre-tracking deployments.

## Why

Closes #125. The in-memory queue lost all pending GSI updates on crash/restart, causing permanent GSI inconsistency with no recovery path.

## Note on this branch

Merges latest `main`. Beyond the original change it addresses review feedback (removes the index-metadata cache in favour of self-describing rows; removes the dead `index_name` field) and hardens crash safety and per-key ordering, with integration-test coverage.

## Testing done

- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --workspace` — pass
- New PG integration tests (`tests/test_gsi_async_queue.py`): crash recovery
  (SIGKILL → recovered after restart), per-key FIFO ordering, dropped-index
  consume; plus data-migration tracking (`test_cli_lifecycle.py`)
- Python integration suites — pass;

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any)

## Breaking changes

None to the API. `002_gsi_pending.sql` adds the `gsi_pending` table (with a `worker_partition` column); it is applied via the tracked data migration on `init`/`migrate`. Existing deployments gain crash-safe GSI propagation
transparently.