### PR TITLE
docs: clarify /metrics is JSON, not Prometheus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,7 +288,7 @@ Or use the web console at `https://127.0.0.1:8000/console/`.
 # Health check
 curl --cacert ~/.extenddb/tls/cert.pem https://127.0.0.1:8000/health
 
-# Prometheus metrics
+# JSON metrics (DynamoDB CloudWatch-style)
 curl --cacert ~/.extenddb/tls/cert.pem https://127.0.0.1:8000/metrics
 
 # Syslog (Linux)
@@ -376,7 +376,7 @@ python3 docs/build-docs.py
 - **Database:** `sqlx` with compile-time query checking (PostgreSQL)
 - **HTTP:** `axum` + `tower` + `hyper`
 - **Logging:** `tracing` + `tracing-subscriber`
-- **Metrics:** `metrics` + `metrics-exporter-prometheus`
+- **Metrics:** in-memory `MetricsCollector` (`crates/core/src/metrics/`), exposed as JSON via `/metrics` with DynamoDB CloudWatch-style metric names and dimensions
 - **TLS:** `rustls` + `axum-server`
 
 ### Naming Conventions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
@@ -596,22 +596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,15 +626,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -888,7 +863,7 @@ dependencies = [
  "hmac",
  "serde_json",
  "sha2",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tokio",
  "tracing",
@@ -903,7 +878,7 @@ dependencies = [
  "bigdecimal",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "uuid",
 ]
@@ -944,7 +919,6 @@ dependencies = [
  "extenddb-storage",
  "hyper",
  "metrics",
- "metrics-exporter-prometheus",
  "rand 0.9.4",
  "rustls",
  "serde",
@@ -969,7 +943,7 @@ dependencies = [
  "futures",
  "inventory",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "toml",
  "tracing",
@@ -1389,23 +1363,6 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls",
- "tower-service",
 ]
 
 [[package]]
@@ -1415,17 +1372,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
- "futures-channel",
- "futures-util",
  "http",
  "http-body",
  "hyper",
- "libc",
  "pin-project-lite",
- "socket2",
  "tokio",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1566,12 +1518,6 @@ checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
-
-[[package]]
-name = "ipnet"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1730,43 +1676,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics-exporter-prometheus"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
-dependencies = [
- "base64 0.22.1",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "indexmap",
- "ipnet",
- "metrics",
- "metrics-util",
- "quanta",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "metrics-util"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
- "hashbrown 0.15.5",
- "metrics",
- "quanta",
- "rand 0.9.4",
- "rand_xoshiro",
- "sketches-ddsketch",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,12 +1815,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-multimap"
@@ -2127,21 +2030,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quanta"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "once_cell",
- "raw-cpuid",
- "wasi",
- "web-sys",
- "winapi",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,30 +2110,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
-dependencies = [
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rapidhash"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "11.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -2379,18 +2249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,42 +2291,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -2615,12 +2441,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "sketches-ddsketch"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,7 +2526,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tokio",
  "tokio-stream",
@@ -2792,7 +2612,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tracing",
  "uuid",
@@ -2833,7 +2653,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tracing",
  "uuid",
@@ -2859,7 +2679,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tracing",
  "url",
@@ -2936,31 +2756,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -3274,12 +3074,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3400,15 +3194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3518,16 +3303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3554,28 +3329,6 @@ dependencies = [
  "libredox",
  "wasite",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -3854,7 +3607,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 syslog-tracing = "0.3"
 metrics = "0.24"
-metrics-exporter-prometheus = "0.16"
 
 # Config
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A DynamoDB-compatible API adapter, ExtendDB speaks the DynamoDB wire protocol â€
 - Web management console for account and credential administration
 - TLS with automatic self-signed certificate generation (replaceable with CA-signed certs)
 - CSRF protection, security headers, session management
-- Prometheus-compatible metrics endpoint
+- JSON metrics endpoint with DynamoDB CloudWatch-style metric names and dimensions
 - Daemon mode with syslog logging
 - PostgreSQL storage â€” use standard backup, replication, and HA tools
 
@@ -110,7 +110,7 @@ key_path = "/etc/extenddb/tls/key.pem"
 # Health check
 curl --cacert ~/.extenddb/tls/cert.pem https://127.0.0.1:8000/health
 
-# Prometheus metrics
+# JSON metrics (DynamoDB CloudWatch-style)
 curl --cacert ~/.extenddb/tls/cert.pem https://127.0.0.1:8000/metrics
 
 # Syslog (Linux)

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -24,7 +24,6 @@ tracing = { workspace = true }
 crc32fast = { workspace = true }
 uuid = { workspace = true }
 metrics = { workspace = true }
-metrics-exporter-prometheus = { workspace = true }
 anyhow = { workspace = true }
 bcrypt = { workspace = true }
 base64 = { workspace = true }

--- a/docs/design/01-requirements.md
+++ b/docs/design/01-requirements.md
@@ -482,7 +482,7 @@ The catalog database stores extenddb metadata: table definitions, indexes, tags,
 - REQ-OBS-002: Per-operation latency metrics (p50, p95, p99)
 - REQ-OBS-003: Per-operation request count and error count metrics
 - REQ-OBS-004: Per-table metrics (request count, consumed capacity)
-- REQ-OBS-005: Prometheus-compatible metrics endpoint (`/metrics`)
+- REQ-OBS-005: JSON metrics endpoint (`/metrics`) using DynamoDB CloudWatch-style metric names and dimensions
 - REQ-OBS-006: Health check endpoint (`/health`) returning 200 when the server is ready
 - REQ-OBS-007: Request ID propagation through all log entries
 

--- a/docs/design/02-high-level-design.md
+++ b/docs/design/02-high-level-design.md
@@ -434,7 +434,7 @@ There is no in-memory locking (no `Mutex`, `RwLock`, or similar) on the data pat
 | CLI | clap | Standard Rust CLI framework |
 | Config | config + serde | Layered config (file + env + defaults) |
 | Logging | tracing + tracing-subscriber | Structured, async-aware |
-| Metrics | metrics + metrics-exporter-prometheus | Prometheus-compatible |
+| Metrics | in-memory collector | JSON via `/metrics`, DynamoDB CloudWatch-style names |
 | UUID | uuid | Request ID generation |
 | Time | time | Timestamp handling (native sqlx support; chrono 0.4.31+ also fixed its localtime_r unsafety, but time has a leaner API) |
 | Decimal | bigdecimal | Arbitrary-precision decimal arithmetic for DynamoDB's 38-digit number type |

--- a/docs/design/06-component-server.md
+++ b/docs/design/06-component-server.md
@@ -301,16 +301,74 @@ Returns 200 when the server is accepting requests. Can optionally check storage 
 ### 7.2 Metrics
 
 ```
-GET /metrics → 200 OK (Prometheus text format)
+GET /metrics → 200 OK (application/json)
 ```
 
-Exposed metrics:
-- `dynamodb_requests_total{operation, status}` — request counter
-- `dynamodb_request_duration_seconds{operation}` — latency histogram
-- `dynamodb_consumed_rcu_milli_total{table}` — consumed read capacity (milli-RCU; divide by 1000 for RCU)
-- `dynamodb_consumed_wcu_milli_total{table}` — consumed write capacity (milli-WCU; divide by 1000 for WCU)
-- `dynamodb_active_connections` — current connection count
-- `dynamodb_errors_total{operation, error_type}` — error counter
+This is **not** Prometheus exposition format. The response is a custom JSON
+schema that uses DynamoDB CloudWatch-style metric names and dimensions.
+
+**Query parameters** (`MetricsQuery` in `crates/core/src/metrics/types.rs`):
+
+- `window`: `LastMinute` | `Last5Minutes` | `LastHour` | `LastDay` | `AllTime`
+- `start`, `end`: ISO 8601 (custom range, alternative to `window`)
+- `granularity`: `1m` | `5m` | `15m` | `1h` (auto-selected if omitted)
+- `table_name`: filter by table
+- `metric`: filter by metric name
+
+**Response shape** (`MetricsResponse`):
+
+```json
+{
+  "metrics":  [ { "metric": "SuccessfulRequestLatency",
+                  "dimensions": [ { "TableName": "Users" },
+                                  { "Operation":  "GetItem" } ],
+                  "window": "Last5Minutes",
+                  "sum": 26033.0, "count": 50, "min": 321.0, "max": 714.0 } ],
+  "buckets": [ { "timestamp": "2026-05-29T00:02:00Z",
+                  "metric": "SuccessfulRequestLatency",
+                  "dimensions": [ { "TableName": "Users" } ],
+                  "sum": 1234.0, "count": 5, "min": 200.0, "max": 410.0 } ],
+  "segments": [ { "operation": "GetItem", "count": 50,
+                  "avg": { "auth_us": 12.0, "authz_us": 4.0,
+                            "throttle_us": 1.0, "dispatch_us": 280.0,
+                            "response_us": 8.0, "total_us": 305.0 } } ],
+  "source":  "database"
+}
+```
+
+- `metrics` (`Vec<MetricSnapshot>`): aggregate over the requested window.
+- `buckets` (`Vec<MetricsBucket>`): time-series at the requested granularity
+  (omitted in the in-memory fallback path).
+- `segments` (`Vec<OperationSegments>`): per-operation latency breakdown
+  (auth / authz / throttle / dispatch / response in microseconds), in-memory only.
+- `source`: `"database"` when served from the persistent `MetricsStore`,
+  `"memory"` when served from the in-process `MetricsCollector` fallback.
+
+**Metric names** (from the `MetricName` enum in `crates/core/src/metrics/types.rs`):
+
+DynamoDB CloudWatch-aligned:
+- `ConsumedReadCapacityUnits`, `ConsumedWriteCapacityUnits`
+- `SuccessfulRequestLatency` (microseconds)
+- `SystemErrors`, `UserErrors`
+- `ThrottledRequests`, `ReadThrottleEvents`, `WriteThrottleEvents`
+- `ConditionalCheckFailedRequests`, `TransactionConflict`
+- `ReturnedItemCount`, `ReturnedBytes`
+- `TimeToLiveDeletedItemCount`, `TtlDeletionStaleness`
+
+ExtendDB-internal:
+- `RequestCount` (HTTP request count, dimension: `Operation`)
+- `StorageQueryCount`, `StorageQueryLatency` (dimensions: source, category)
+- `PoolActiveConnections`, `PoolIdleConnections`, `PoolAcquireLatency`
+- `WorkerLastSuccess`, `WorkerCycleLatency`, `WorkerErrorCount`
+
+**Dimensions** (from the `Dimension` enum):
+
+- `TableName(String)`
+- `GlobalSecondaryIndexName(String)`
+- `Operation(String)`
+
+Clients that need Prometheus, OpenMetrics, or CloudWatch wire formats must
+convert from this JSON externally.
 
 ## 8. Management API
 

--- a/docs/design/08-component-config.md
+++ b/docs/design/08-component-config.md
@@ -171,7 +171,7 @@ request_logging = true   # Log every request
 
 [metrics]
 enabled = true
-endpoint = "/metrics"    # Prometheus scrape endpoint path
+endpoint = "/metrics"    # JSON metrics endpoint path
 
 [ttl]
 enabled = true
@@ -280,22 +280,27 @@ Every request logs:
 
 ## 6. Metrics
 
-Using the `metrics` crate with `metrics-exporter-prometheus`:
+Metrics are collected in-memory by `MetricsCollector` (`crates/core/src/metrics/`)
+and exposed as JSON at `/metrics` (and persisted via `MetricsStore` for
+time-series queries). Names and dimensions follow the DynamoDB CloudWatch
+vocabulary; the wire format is custom JSON, not Prometheus exposition format.
+See `docs/design/06-component-server.md` §7.2 for the full schema and metric list.
+
+Recording is done through the collector's `record_*` methods rather than a
+generic `metrics` facade:
 
 ```rust
-use metrics::{counter, histogram};
+use extenddb_core::metrics::{MetricsCollector, MetricName, Dimension};
 
-pub fn record_request(operation: &str, status: u16, latency: Duration) {
-    counter!("dynamodb_requests_total", "operation" => operation.to_string(), "status" => status.to_string()).increment(1);
-    histogram!("dynamodb_request_duration_seconds", "operation" => operation.to_string()).record(latency.as_secs_f64());
-}
-
-pub fn record_capacity(table: &str, rcu: f64, wcu: f64) {
-    // Track in milli-units to preserve fractional capacity (e.g., 0.5 RCU for eventually consistent reads)
-    counter!("dynamodb_consumed_rcu_milli_total", "table" => table.to_string()).increment((rcu * 1000.0) as u64);
-    counter!("dynamodb_consumed_wcu_milli_total", "table" => table.to_string()).increment((wcu * 1000.0) as u64);
+fn record_request(metrics: &MetricsCollector, operation: &str, latency_us: f64) {
+    metrics.record(
+        MetricName::SuccessfulRequestLatency,
+        &[Dimension::Operation(operation.to_owned())],
+        latency_us,
+    );
 }
 ```
+
 
 ## 7. Background Workers
 

--- a/docs/design/10-dependency-licenses.md
+++ b/docs/design/10-dependency-licenses.md
@@ -193,7 +193,6 @@ This file is a human-controlled policy input and must not be modified by agents.
 | md-5 | 0.10.6 | MIT OR Apache-2.0 | Yes |
 | memchr | 2.8.0 | Unlicense OR MIT | Yes |
 | metrics | 0.24.3 | MIT | Yes |
-| metrics-exporter-prometheus | 0.16.2 | MIT | Yes |
 | metrics-util | 0.19.1 | MIT | Yes |
 | mime | 0.3.17 | MIT OR Apache-2.0 | Yes |
 | minimal-lexical | 0.2.1 | MIT/Apache-2.0 | Yes |

--- a/docs/manuals/01-architecture-guide.md
+++ b/docs/manuals/01-architecture-guide.md
@@ -113,7 +113,7 @@ HTTP/HTTPS server built on axum + tower. Responsibilities:
 - DynamoDB wire protocol endpoint (`POST /`)
 - Management REST API (`/management/*`)
 - Web console (`/console/*`) with CSRF protection and security headers
-- Health check (`/health`) and Prometheus metrics (`/metrics`)
+- Health check (`/health`) and JSON metrics (`/metrics`)
 - TLS via rustls (self-signed or CA-signed certificates)
 - Request ID generation, CRC32 checksums, content-type headers
 - Graceful shutdown on SIGTERM/SIGINT

--- a/docs/manuals/05-admin-guide.md
+++ b/docs/manuals/05-admin-guide.md
@@ -435,7 +435,7 @@ Targets: `extenddb::audit::manage` (management ops), `extenddb::audit::settings`
 curl --cacert ~/.extenddb/tls/cert.pem https://127.0.0.1:8000/metrics
 ```
 
-Prometheus-compatible metrics endpoint.
+JSON metrics endpoint with DynamoDB CloudWatch-style metric names and dimensions. The response shape is `{ metrics, buckets, segments, source }`. See `docs/design/06-component-server.md` §7.2 for the full schema and metric list.
 
 ### Health Check
 

--- a/docs/manuals/11-deployment-guide.md
+++ b/docs/manuals/11-deployment-guide.md
@@ -158,7 +158,7 @@ Requirements in the air-gapped environment:
 
 ### Monitoring
 
-- [ ] Scrape `/metrics` with Prometheus (or compatible collector)
+- [ ] Poll `/metrics` for JSON snapshots and forward to your monitoring system (the response is custom JSON, not Prometheus exposition format; convert as needed)
 - [ ] Forward syslog to a log aggregation service
 - [ ] Set up alerts on health check failures (`/health`)
 - [ ] Monitor extenddb process with systemd, supervisord, or equivalent


### PR DESCRIPTION
## What

Correct the documentation to match reality: `/metrics` returns JSON, not Prometheus exposition format.

Changes:

- Update README, AGENTS.md, 5 design docs, and 3 manuals to describe the actual JSON schema and the Amazon DynamoDB CloudWatch-style metric names and dimensions it uses.
- Drop the unused `metrics-exporter-prometheus` dependency.

## Why

Wiring local Grafana against ExtendDB, I expected Prometheus exposition format and got JSON. Match docs with whats implemented. 

Closes # n/a

## Testing done

Live `/metrics` capture against a local server:

```
$ curl -ksS -i 'https://127.0.0.1:8000/metrics?window=LastDay'
HTTP/2 200
content-type: application/json
```

Trimmed real response (field names and structure unmodified):

```json
{
  "metrics": [
    {
      "metric": "SuccessfulRequestLatency",
      "dimensions": [{ "TableName": "abac-prod-c73b90ce" }, { "Operation": "CreateTable" }],
      "window": "LastDay",
      "sum": 11521.0, "count": 1, "min": 11521.0, "max": 11521.0
    },
    {
      "metric": "UserErrors",
      "dimensions": [{ "TableName": "extenddb-ie-test-cc0e7284" }, { "Operation": "DescribeTable" }],
      "window": "LastDay",
      "sum": 1.0, "count": 1, "min": 1.0, "max": 1.0
    },
.
.
.
  ],
  "source": "database"
}
```
This is structured JSON with typed dimension keys, not line-oriented text with `# HELP` / `# TYPE` headers, so a Prometheus scraper cannot consume it.


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] All tests pass (`cargo test --workspace`) (no Rust source changed)
- [ ] Code is formatted (`cargo fmt --check`) (no Rust source changed)
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`) (no Rust source changed)
- [ ] I have added or updated tests for new functionality (n/a, documentation)
- [x] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (none)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface, an RFC has been accepted or is linked below. Otherwise, an ADR captures the decision. (n/a, documentation)

ADR / RFC: n/a

## Breaking changes

None.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
