### PR TITLE
fix: use compound condition for index ExclusiveStartKey pagination

### DIFF
--- a/crates/core/src/types/key_schema.rs
+++ b/crates/core/src/types/key_schema.rs
@@ -77,6 +77,12 @@ pub struct TableKeyInfo {
     pub account_id: String,
     pub table_id: String,
     pub key_schema: Vec<KeySchemaElement>,
+    /// The base table's key schema (always populated).
+    /// For base table operations this equals `key_schema`.
+    /// For index operations `key_schema` has the index's schema while this
+    /// retains the original table schema, enabling the storage layer to
+    /// derive base PK/SK info for pagination without a catalog query.
+    pub base_key_schema: Vec<KeySchemaElement>,
     pub attribute_definitions: Vec<AttributeDefinition>,
     /// Whether the table has at least one local secondary index.
     /// Used to decide whether `ItemCollectionMetrics` should be returned.
@@ -238,5 +244,41 @@ mod tests {
             let json = serde_json::to_string(&typ).unwrap();
             assert_eq!(json, expected);
         }
+    }
+
+    #[test]
+    fn table_key_info_base_key_schema_for_base_table() {
+        let schema = vec![ks("pk", KeyType::Hash), ks("sk", KeyType::Range)];
+        let info = TableKeyInfo {
+            table_name: "TestTable".into(),
+            account_id: "123".into(),
+            table_id: "t1".into(),
+            key_schema: schema.clone(),
+            base_key_schema: schema.clone(),
+            attribute_definitions: vec![],
+            has_lsi: false,
+            stream_specification: None,
+        };
+        assert_eq!(info.key_schema, info.base_key_schema);
+    }
+
+    #[test]
+    fn table_key_info_base_key_schema_for_index_query() {
+        let base_schema = vec![ks("pk", KeyType::Hash), ks("sk", KeyType::Range)];
+        let index_schema = vec![ks("gsi_pk", KeyType::Hash), ks("gsi_sk", KeyType::Range)];
+        let info = TableKeyInfo {
+            table_name: "TestTable".into(),
+            account_id: "123".into(),
+            table_id: "t1".into(),
+            key_schema: index_schema.clone(),
+            base_key_schema: base_schema.clone(),
+            attribute_definitions: vec![],
+            has_lsi: false,
+            stream_specification: None,
+        };
+        assert_eq!(info.key_schema, index_schema);
+        assert_eq!(info.base_key_schema, base_schema);
+        assert_ne!(info.key_schema, info.base_key_schema);
+        assert_eq!(info.base_key_schema[0].attribute_name, "pk");
     }
 }

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -88,6 +88,7 @@ pub async fn handle_query(
             account_id: key_info.account_id.clone(),
             table_id: key_info.table_id.clone(),
             key_schema: idx.key_schema.clone(),
+            base_key_schema: key_info.key_schema.clone(),
             attribute_definitions: key_info.attribute_definitions.clone(),
             has_lsi: key_info.has_lsi,
             stream_specification: None, // Queries don't capture stream records

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -129,6 +129,7 @@ pub async fn handle_scan(
             account_id: key_info.account_id.clone(),
             table_id: key_info.table_id.clone(),
             key_schema: idx.key_schema.clone(),
+            base_key_schema: key_info.key_schema.clone(),
             attribute_definitions: key_info.attribute_definitions.clone(),
             has_lsi: key_info.has_lsi,
             stream_specification: None, // Scans don't capture stream records

--- a/crates/storage-postgres/src/data/ddl.rs
+++ b/crates/storage-postgres/src/data/ddl.rs
@@ -295,6 +295,7 @@ impl PostgresEngine {
             table_name: table_name.to_owned(),
             account_id: account_id.to_owned(),
             table_id,
+            base_key_schema: key_schema.clone(),
             key_schema,
             attribute_definitions,
             has_lsi: has_lsi.unwrap_or(false),

--- a/crates/storage-postgres/src/data/query.rs
+++ b/crates/storage-postgres/src/data/query.rs
@@ -14,6 +14,22 @@ use extenddb_storage::error::StorageError;
 use extenddb_storage::util::SortKeyValue;
 use extenddb_storage::util::{parse_sk, pk_to_text, sk_info};
 
+/// Extra pagination bind values for index queries.
+///
+/// Built in `query_scan.rs` in the same branch that generates the SQL placeholders,
+/// then consumed here for binding. This ensures the bind order cannot diverge from
+/// the SQL — the variant determines exactly which values are bound and in what order.
+pub(crate) enum PaginationBinds {
+    /// Base table query or index query with no extra pagination binds needed.
+    None,
+    /// Index query where base table has no SK — only base_pk as tie-breaker.
+    BasePkOnly { pk_text: String },
+    /// Index query where base table has a SK — base_sk as tie-breaker.
+    BaseSkOnly { sk: SortKeyValue },
+    /// Hash-only index where base table has a SK — both base_pk and base_sk.
+    BasePkAndSk { pk_text: String, sk: SortKeyValue },
+}
+
 /// Evaluate a condition expression against an item inside a transaction.
 ///
 /// Returns `Ok(())` if the condition passes or is `None`.
@@ -122,6 +138,14 @@ pub(crate) fn build_sk_sql(
 }
 
 /// Execute a query SQL statement with dynamic parameter binding.
+///
+/// # Parameter binding order:
+/// 1. pk_text (partition key)
+/// 2. SK condition params (from `build_sk_sql`)
+/// 3. Extra SK equality params (multi-range schemas)
+/// 4. ExclusiveStartKey index SK value (if paginating with sort key)
+/// 5. Pagination extra binds (from `PaginationBinds` enum — built in `query_scan.rs`
+///    in the same branch that generates the SQL, so order cannot diverge)
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_query_sql(
     sql: &str,
@@ -131,6 +155,7 @@ pub(crate) async fn execute_query_sql(
     sk_info: Option<(&str, ScalarAttributeType)>,
     extra_sk_col_indices: &[(usize, ScalarAttributeType)],
     exclusive_start_key: Option<&Item>,
+    pagination_binds: &PaginationBinds,
     pool: &sqlx::PgPool,
 ) -> Result<Vec<serde_json::Value>, StorageError> {
     let mut query = sqlx::query_as::<_, (serde_json::Value,)>(sql);
@@ -150,12 +175,28 @@ pub(crate) async fn execute_query_sql(
         }
     }
 
-    // Bind exclusive start key SK value
+    // Bind exclusive start key SK value (index SK for the > / < comparison)
     if let (Some(start_key), Some((sk_name, sk_type))) = (exclusive_start_key, sk_info)
         && let Some(sk_val) = start_key.get(sk_name)
     {
         let sk = parse_sk(sk_val, sk_type)?;
         query = bind_sk_value(query, &sk);
+    }
+
+    // Bind pagination extra values — order is determined by the enum variant,
+    // which is constructed in the same code branch that generated the SQL placeholders.
+    match pagination_binds {
+        PaginationBinds::None => {}
+        PaginationBinds::BasePkOnly { pk_text } => {
+            query = query.bind(pk_text.clone());
+        }
+        PaginationBinds::BaseSkOnly { sk } => {
+            query = bind_sk_value(query, sk);
+        }
+        PaginationBinds::BasePkAndSk { pk_text, sk } => {
+            query = query.bind(pk_text.clone());
+            query = bind_sk_value(query, sk);
+        }
     }
 
     let rows: Vec<(serde_json::Value,)> = query
@@ -249,16 +290,23 @@ pub(crate) fn bind_sk_value<'q>(
 }
 
 /// Execute a scan SQL statement with dynamic parameter binding.
+///
+/// Bind order for index scans: pk, sk (if present), base_pk, base_sk (if present).
+/// Bind order for base table scans: pk, sk (if present).
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_scan_sql(
     sql: &str,
     exclusive_start_key: Option<&Item>,
     key_schema: &[KeySchemaElement],
     attr_defs: &[AttributeDefinition],
+    base_sk_info: Option<&(String, ScalarAttributeType)>,
+    base_pk_attr_name: Option<&str>,
     pool: &sqlx::PgPool,
 ) -> Result<Vec<serde_json::Value>, StorageError> {
     let mut query = sqlx::query_as::<_, (serde_json::Value,)>(sql);
 
     if let Some(start_key) = exclusive_start_key {
+        // Bind index/table PK
         let pk_name = &key_schema[0].attribute_name;
         let pk_val = start_key
             .get(pk_name)
@@ -266,11 +314,28 @@ pub(crate) async fn execute_scan_sql(
         let pk_text = pk_to_text(pk_val)?;
         query = query.bind(pk_text.into_owned());
 
+        // Bind index/table SK (if present)
         if let Some((sk_name, sk_type)) = sk_info(key_schema, attr_defs)
             && let Some(sk_val) = start_key.get(sk_name)
         {
             let sk = parse_sk(sk_val, sk_type)?;
             query = bind_sk_value(query, &sk);
+        }
+
+        // Bind base table PK for index scans
+        if let Some(base_pk_name) = base_pk_attr_name {
+            if let Some(base_pk_val) = start_key.get(base_pk_name) {
+                let base_pk_text = pk_to_text(base_pk_val)?;
+                query = query.bind(base_pk_text.into_owned());
+            }
+        }
+
+        // Bind base table SK for index scans (if base table has a sort key)
+        if let Some((base_sk_name, base_sk_type)) = base_sk_info {
+            if let Some(base_sk_val) = start_key.get(base_sk_name.as_str()) {
+                let sk = parse_sk(base_sk_val, *base_sk_type)?;
+                query = bind_sk_value(query, &sk);
+            }
         }
     }
 

--- a/crates/storage-postgres/src/data/query.rs
+++ b/crates/storage-postgres/src/data/query.rs
@@ -323,19 +323,19 @@ pub(crate) async fn execute_scan_sql(
         }
 
         // Bind base table PK for index scans
-        if let Some(base_pk_name) = base_pk_attr_name {
-            if let Some(base_pk_val) = start_key.get(base_pk_name) {
-                let base_pk_text = pk_to_text(base_pk_val)?;
-                query = query.bind(base_pk_text.into_owned());
-            }
+        if let Some(base_pk_name) = base_pk_attr_name
+            && let Some(base_pk_val) = start_key.get(base_pk_name)
+        {
+            let base_pk_text = pk_to_text(base_pk_val)?;
+            query = query.bind(base_pk_text.into_owned());
         }
 
         // Bind base table SK for index scans (if base table has a sort key)
-        if let Some((base_sk_name, base_sk_type)) = base_sk_info {
-            if let Some(base_sk_val) = start_key.get(base_sk_name.as_str()) {
-                let sk = parse_sk(base_sk_val, *base_sk_type)?;
-                query = bind_sk_value(query, &sk);
-            }
+        if let Some((base_sk_name, base_sk_type)) = base_sk_info
+            && let Some(base_sk_val) = start_key.get(base_sk_name.as_str())
+        {
+            let sk = parse_sk(base_sk_val, *base_sk_type)?;
+            query = bind_sk_value(query, &sk);
         }
     }
 

--- a/crates/storage-postgres/src/data/query_scan.rs
+++ b/crates/storage-postgres/src/data/query_scan.rs
@@ -46,6 +46,10 @@ fn build_pagination_where(
             } else {
                 ""
             };
+            // LSI: base SK follows ScanIndexForward because items share the
+            // same partition and the base SK is part of the composite sort order.
+            // GSI: base SK is always ">" (ascending) because it's only a
+            // uniqueness tie-breaker, not a user-visible sort dimension.
             let base_cmp = if is_lsi { cmp } else { ">" };
             format!(
                 " AND ({sk_col}{collate} {cmp} ${p1} OR \
@@ -297,7 +301,7 @@ impl PostgresEngine {
                 let base_pk_attr = &key_info.base_key_schema[0].attribute_name;
                 let base_pk = start_key
                     .get(base_pk_attr.as_str())
-                    .map(|v| pk_to_text(v))
+                    .map(pk_to_text)
                     .transpose()?
                     .map(|c| c.into_owned());
                 match (base_pk, &base_sk_info) {

--- a/crates/storage-postgres/src/data/query_scan.rs
+++ b/crates/storage-postgres/src/data/query_scan.rs
@@ -4,17 +4,89 @@
 //! `query` and `scan` implementations for the `PostgreSQL` backend.
 
 use extenddb_core::expression::{ExpressionMaps, KeyCondition};
-use extenddb_core::types::{Item, ScalarAttributeType, TableKeyInfo};
+use extenddb_core::types::{Item, KeySchemaElement, ScalarAttributeType, TableKeyInfo};
 use extenddb_storage::error::StorageError;
 use extenddb_storage::util::{
-    encode_netstring_composite, pk_to_text, sk_column, sk_column_n, sk_info,
+    encode_netstring_composite, parse_sk, pk_to_text, sk_column, sk_column_n, sk_info,
 };
 
 use super::query::{
-    build_key, build_sk_sql, execute_query_sql, execute_scan_sql, resolve_expr_to_av,
+    PaginationBinds, build_key, build_sk_sql, execute_query_sql, execute_scan_sql,
+    resolve_expr_to_av,
 };
 use super::{all_sort_key_info, data_table_name, index_table_name, json_to_item};
 use crate::PostgresEngine;
+
+/// Build the WHERE clause fragment for ExclusiveStartKey pagination.
+///
+/// Self-contained: takes `param_idx` (the next available placeholder number),
+/// returns a complete SQL fragment. No mutable state leaks out.
+fn build_pagination_where(
+    param_idx: u32,
+    sk_info_val: Option<(&str, ScalarAttributeType)>,
+    base_sk_info: &Option<(String, ScalarAttributeType)>,
+    is_index: bool,
+    is_lsi: bool,
+    forward: bool,
+) -> String {
+    if let Some((_, sk_type)) = sk_info_val {
+        let sk_col = sk_column(sk_type);
+        let collate = if sk_type == ScalarAttributeType::S {
+            " COLLATE \"C\""
+        } else {
+            ""
+        };
+        let cmp = if forward { ">" } else { "<" };
+
+        if let Some((_, base_sk_type)) = base_sk_info {
+            // Index with base SK tie-breaker
+            let base_col = format!("base_{}", sk_column(*base_sk_type));
+            let base_collate = if *base_sk_type == ScalarAttributeType::S {
+                " COLLATE \"C\""
+            } else {
+                ""
+            };
+            let base_cmp = if is_lsi { cmp } else { ">" };
+            format!(
+                " AND ({sk_col}{collate} {cmp} ${p1} OR \
+                 ({sk_col}{collate} = ${p1} AND {base_col}{base_collate} {base_cmp} ${p2}))",
+                p1 = param_idx,
+                p2 = param_idx + 1
+            )
+        } else if is_index {
+            // Index with no base SK — use base_pk as tie-breaker
+            format!(
+                " AND ({sk_col}{collate} {cmp} ${p1} OR \
+                 ({sk_col}{collate} = ${p1} AND base_pk COLLATE \"C\" > ${p2}))",
+                p1 = param_idx,
+                p2 = param_idx + 1
+            )
+        } else {
+            // Base table — simple comparison
+            format!(" AND {sk_col}{collate} {cmp} ${param_idx}")
+        }
+    } else if is_index {
+        // Hash-only index — paginate using base table PK
+        if let Some((_, base_sk_type)) = base_sk_info {
+            let base_sk_col = format!("base_{}", sk_column(*base_sk_type));
+            let base_sk_collate = if *base_sk_type == ScalarAttributeType::S {
+                " COLLATE \"C\""
+            } else {
+                ""
+            };
+            format!(
+                " AND (base_pk COLLATE \"C\" > ${p1} OR \
+                 (base_pk = ${p1} AND {base_sk_col}{base_sk_collate} > ${p2}))",
+                p1 = param_idx,
+                p2 = param_idx + 1
+            )
+        } else {
+            format!(" AND base_pk COLLATE \"C\" > ${param_idx}")
+        }
+    } else {
+        String::new()
+    }
+}
 
 impl PostgresEngine {
     /// Implementation of `DataEngine::query`.
@@ -31,13 +103,14 @@ impl PostgresEngine {
     ) -> Result<(Vec<Item>, Option<Item>), StorageError> {
         use std::fmt::Write;
 
-        let ddb_table = if let Some(idx_name) = index_name {
+        let (ddb_table, is_lsi) = if let Some(idx_name) = index_name {
             let idx_info = self
                 .fetch_index_info_by_table_id(&key_info.table_id, idx_name)
                 .await?;
-            index_table_name(&idx_info.index_id)
+            let lsi = idx_info.index_type == extenddb_core::types::IndexType::Lsi;
+            (index_table_name(&idx_info.index_id), lsi)
         } else {
-            data_table_name(&key_info.table_id)
+            (data_table_name(&key_info.table_id), false)
         };
 
         // Resolve partition key value(s) — for multi-part keys, encode
@@ -113,22 +186,30 @@ impl PostgresEngine {
             }
         }
 
-        // Pagination: exclusive start key
-        if let (Some(_), Some((_, sk_type))) = (exclusive_start_key, sk_info_val) {
-            let sk_col = sk_column(sk_type);
-            let collate = if sk_type == ScalarAttributeType::S {
-                " COLLATE \"C\""
-            } else {
-                ""
-            };
-            if forward {
-                let _ = write!(sql, " AND {sk_col}{collate} > ${param_idx}");
-            } else {
-                let _ = write!(sql, " AND {sk_col}{collate} < ${param_idx}");
-            }
-        } else if exclusive_start_key.is_some() && sk_info_val.is_none() {
-            // PK-only table with start key — no more items for this PK
+        // For index queries, fetch the base table's sort key info. This is needed
+        // for both ORDER BY (sub-sort by base SK when index SKs are equal) and
+        // pagination (compound ExclusiveStartKey condition).
+        let base_sk_info: Option<(String, ScalarAttributeType)> = if index_name.is_some() {
+            self.fetch_base_table_sk_info(&key_info.table_id).await?
+        } else {
+            None
+        };
+
+        if exclusive_start_key.is_some() && sk_info_val.is_none() && index_name.is_none() {
+            // PK-only base table with start key — no more items for this PK
             return Ok((Vec::new(), None));
+        }
+
+        if exclusive_start_key.is_some() {
+            let pagination_sql = build_pagination_where(
+                param_idx,
+                sk_info_val,
+                &base_sk_info,
+                index_name.is_some(),
+                is_lsi,
+                forward,
+            );
+            sql.push_str(&pagination_sql);
         }
 
         // ORDER BY — use COLLATE "C" for string sort keys to match DynamoDB
@@ -141,12 +222,97 @@ impl PostgresEngine {
                 ""
             };
             let dir = if forward { "ASC" } else { "DESC" };
-            let _ = write!(sql, " ORDER BY {sk_col}{collate} {dir}");
+            if let Some((_, base_sk_type)) = &base_sk_info {
+                // Index queries sub-sort by base table SK when index sort keys are equal.
+                // LSI: base SK follows ScanIndexForward (same partition, composite sort).
+                // GSI: base SK is always ASC (just a uniqueness tie-breaker).
+                let base_col = format!("base_{}", sk_column(*base_sk_type));
+                let base_collate = if *base_sk_type == ScalarAttributeType::S {
+                    " COLLATE \"C\""
+                } else {
+                    ""
+                };
+                let base_dir = if is_lsi { dir } else { "ASC" };
+                let _ = write!(
+                    sql,
+                    " ORDER BY {sk_col}{collate} {dir}, {base_col}{base_collate} {base_dir}"
+                );
+            } else if index_name.is_some() {
+                // Index with SK but no base SK: use base_pk as secondary sort
+                let _ = write!(
+                    sql,
+                    " ORDER BY {sk_col}{collate} {dir}, base_pk COLLATE \"C\" ASC"
+                );
+            } else {
+                let _ = write!(sql, " ORDER BY {sk_col}{collate} {dir}");
+            }
+        } else if index_name.is_some() {
+            // Hash-only index: order by base table PK for deterministic pagination.
+            let dir = if forward { "ASC" } else { "DESC" };
+            if let Some((_, base_sk_type)) = &base_sk_info {
+                let base_sk_col = format!("base_{}", sk_column(*base_sk_type));
+                let base_sk_collate = if *base_sk_type == ScalarAttributeType::S {
+                    " COLLATE \"C\""
+                } else {
+                    ""
+                };
+                let _ = write!(
+                    sql,
+                    " ORDER BY base_pk COLLATE \"C\" {dir}, {base_sk_col}{base_sk_collate} {dir}"
+                );
+            } else {
+                let _ = write!(sql, " ORDER BY base_pk COLLATE \"C\" {dir}");
+            }
         }
 
         // LIMIT — fetch one extra to detect pagination
         let fetch_limit = limit.map_or(1_000_001, |l| l + 1);
         let _ = write!(sql, " LIMIT {fetch_limit}");
+
+        // Build pagination bind values in the same place as the SQL placeholders.
+        // The enum variant determines exactly which values are bound and in what order,
+        // preventing bind-order divergence between SQL generation and execution.
+        let pagination_binds = if let Some(start_key) = exclusive_start_key {
+            if let Some((ref base_sk_name, base_sk_type)) = base_sk_info {
+                // Index with base SK tie-breaker (SQL has $N for base_sk)
+                if let Some(base_sk_val) = start_key.get(base_sk_name.as_str()) {
+                    let sk = parse_sk(base_sk_val, base_sk_type)?;
+                    PaginationBinds::BaseSkOnly { sk }
+                } else {
+                    PaginationBinds::None
+                }
+            } else if index_name.is_some() && sk_info_val.is_some() {
+                // Index with SK but no base SK — SQL has $N for base_pk
+                match self
+                    .resolve_base_pk_from_start_key(&key_info.table_id, start_key)
+                    .await?
+                {
+                    Some(pk_text) => PaginationBinds::BasePkOnly { pk_text },
+                    None => PaginationBinds::None,
+                }
+            } else if index_name.is_some() && sk_info_val.is_none() {
+                // Hash-only index — SQL may have $N for base_pk and $N+1 for base_sk
+                let base_pk = self
+                    .resolve_base_pk_from_start_key(&key_info.table_id, start_key)
+                    .await?;
+                match (base_pk, &base_sk_info) {
+                    (Some(pk_text), Some((sk_name, sk_type))) => {
+                        if let Some(sk_val) = start_key.get(sk_name.as_str()) {
+                            let sk = parse_sk(sk_val, *sk_type)?;
+                            PaginationBinds::BasePkAndSk { pk_text, sk }
+                        } else {
+                            PaginationBinds::BasePkOnly { pk_text }
+                        }
+                    }
+                    (Some(pk_text), None) => PaginationBinds::BasePkOnly { pk_text },
+                    _ => PaginationBinds::None,
+                }
+            } else {
+                PaginationBinds::None
+            }
+        } else {
+            PaginationBinds::None
+        };
 
         // Execute with dynamic bindings
         let rows = execute_query_sql(
@@ -157,6 +323,7 @@ impl PostgresEngine {
             sk_info_val,
             &extra_sk_col_indices,
             exclusive_start_key,
+            &pagination_binds,
             &self.data_pool,
         )
         .await?;
@@ -203,6 +370,13 @@ impl PostgresEngine {
         };
         let sk_info_val = sk_info(&key_info.key_schema, &key_info.attribute_definitions);
 
+        // For index scans, fetch base table SK info for compound pagination.
+        let base_sk_info: Option<(String, ScalarAttributeType)> = if index_name.is_some() {
+            self.fetch_base_table_sk_info(&key_info.table_id).await?
+        } else {
+            None
+        };
+
         let mut sql = format!("SELECT item_data FROM {ddb_table}");
         let mut conditions: Vec<String> = Vec::new();
         let param_idx: u32 = 1;
@@ -226,19 +400,59 @@ impl PostgresEngine {
             }
             // Actual PK/SK binding happens in execute_scan_sql.
 
-            if let Some((_, sk_type)) = sk_info_val {
-                let sk_col = sk_column(sk_type);
-                let collate = if sk_type == ScalarAttributeType::S {
-                    " COLLATE \"C\""
+            if index_name.is_some() {
+                // Index scan: use compound condition including base table key
+                // to handle duplicate (pk, sk) pairs on GSIs.
+                if let Some((_, sk_type)) = sk_info_val {
+                    let sk_col = sk_column(sk_type);
+                    let collate = if sk_type == ScalarAttributeType::S {
+                        " COLLATE \"C\""
+                    } else {
+                        ""
+                    };
+                    if let Some((_, base_sk_type)) = &base_sk_info {
+                        let base_sk_col = format!("base_{}", sk_column(*base_sk_type));
+                        let base_collate = if *base_sk_type == ScalarAttributeType::S {
+                            " COLLATE \"C\""
+                        } else {
+                            ""
+                        };
+                        conditions.push(format!(
+                            "(pk, {sk_col}{collate}, base_pk COLLATE \"C\", {base_sk_col}{base_collate}) > \
+                             (${p1}, ${p2}, ${p3}, ${p4})",
+                            p1 = param_idx, p2 = param_idx + 1,
+                            p3 = param_idx + 2, p4 = param_idx + 3
+                        ));
+                    } else {
+                        conditions.push(format!(
+                            "(pk, {sk_col}{collate}, base_pk COLLATE \"C\") > (${p1}, ${p2}, ${p3})",
+                            p1 = param_idx, p2 = param_idx + 1, p3 = param_idx + 2
+                        ));
+                    }
                 } else {
-                    ""
-                };
-                conditions.push(format!(
-                    "(pk, {sk_col}{collate}) > (${param_idx}, ${next})",
-                    next = param_idx + 1
-                ));
+                    // Hash-only index scan
+                    conditions.push(format!(
+                        "(pk, base_pk COLLATE \"C\") > (${p1}, ${p2})",
+                        p1 = param_idx,
+                        p2 = param_idx + 1
+                    ));
+                }
             } else {
-                conditions.push(format!("pk > ${param_idx}"));
+                // Base table scan: standard row-value comparison
+                if let Some((_, sk_type)) = sk_info_val {
+                    let sk_col = sk_column(sk_type);
+                    let collate = if sk_type == ScalarAttributeType::S {
+                        " COLLATE \"C\""
+                    } else {
+                        ""
+                    };
+                    conditions.push(format!(
+                        "(pk, {sk_col}{collate}) > (${param_idx}, ${next})",
+                        next = param_idx + 1
+                    ));
+                } else {
+                    conditions.push(format!("pk > ${param_idx}"));
+                }
             }
         }
 
@@ -247,22 +461,61 @@ impl PostgresEngine {
             sql.push_str(&conditions.join(" AND "));
         }
 
-        // Deterministic ordering for pagination — COLLATE "C" for string
-        // sort keys to match DynamoDB UTF-8 byte order.
-        if let Some((_, sk_type)) = sk_info_val {
-            let sk_col = sk_column(sk_type);
-            let collate = if sk_type == ScalarAttributeType::S {
-                " COLLATE \"C\""
+        // Deterministic ordering for pagination.
+        if index_name.is_some() {
+            // Index scan: include base table key columns for deterministic ordering.
+            if let Some((_, sk_type)) = sk_info_val {
+                let sk_col = sk_column(sk_type);
+                let collate = if sk_type == ScalarAttributeType::S {
+                    " COLLATE \"C\""
+                } else {
+                    ""
+                };
+                if let Some((_, base_sk_type)) = &base_sk_info {
+                    let base_sk_col = format!("base_{}", sk_column(*base_sk_type));
+                    let base_collate = if *base_sk_type == ScalarAttributeType::S {
+                        " COLLATE \"C\""
+                    } else {
+                        ""
+                    };
+                    let _ = write!(
+                        sql,
+                        " ORDER BY pk, {sk_col}{collate}, base_pk COLLATE \"C\", {base_sk_col}{base_collate}"
+                    );
+                } else {
+                    let _ = write!(
+                        sql,
+                        " ORDER BY pk, {sk_col}{collate}, base_pk COLLATE \"C\""
+                    );
+                }
             } else {
-                ""
-            };
-            let _ = write!(sql, " ORDER BY pk, {sk_col}{collate}");
+                let _ = write!(sql, " ORDER BY pk, base_pk COLLATE \"C\"");
+            }
         } else {
-            sql.push_str(" ORDER BY pk");
+            // Base table scan: standard ordering.
+            if let Some((_, sk_type)) = sk_info_val {
+                let sk_col = sk_column(sk_type);
+                let collate = if sk_type == ScalarAttributeType::S {
+                    " COLLATE \"C\""
+                } else {
+                    ""
+                };
+                let _ = write!(sql, " ORDER BY pk, {sk_col}{collate}");
+            } else {
+                sql.push_str(" ORDER BY pk");
+            }
         }
 
         let fetch_limit = limit.map_or(1_000_001, |l| l + 1);
         let _ = write!(sql, " LIMIT {fetch_limit}");
+
+        // Resolve base table PK attribute name for index scan binding.
+        let base_pk_attr_name: Option<String> =
+            if index_name.is_some() && exclusive_start_key.is_some() {
+                self.resolve_base_pk_attr_name(&key_info.table_id).await?
+            } else {
+                None
+            };
 
         // Execute
         let rows = execute_scan_sql(
@@ -270,6 +523,8 @@ impl PostgresEngine {
             exclusive_start_key,
             &key_info.key_schema,
             &key_info.attribute_definitions,
+            base_sk_info.as_ref(),
+            base_pk_attr_name.as_deref(),
             &self.data_pool,
         )
         .await?;
@@ -292,5 +547,92 @@ impl PostgresEngine {
         };
 
         Ok((items, last_key))
+    }
+
+    /// Fetch and cache the base table's key info for a given `table_id`.
+    /// Returns both PK attribute name and optional SK info.
+    async fn get_base_key_info(&self, table_id: &str) -> Result<crate::BaseKeyInfo, StorageError> {
+        // Check cache first
+        {
+            let cache = self.base_key_cache.read().await;
+            if let Some(info) = cache.get(table_id) {
+                return Ok(info.clone());
+            }
+        }
+
+        // Cache miss — query catalog
+        let row: Option<(serde_json::Value, serde_json::Value)> = sqlx::query_as(
+            "SELECT key_schema, attribute_definitions FROM tables WHERE table_id = $1",
+        )
+        .bind(table_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let Some((ks_json, ad_json)) = row else {
+            return Err(StorageError::Internal(format!(
+                "base table not found for table_id: {table_id}"
+            )));
+        };
+
+        let key_schema: Vec<KeySchemaElement> =
+            serde_json::from_value(ks_json).map_err(|e| StorageError::Internal(e.to_string()))?;
+        let attr_defs: Vec<extenddb_core::types::AttributeDefinition> =
+            serde_json::from_value(ad_json).map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let pk_attr_name = key_schema
+            .iter()
+            .find(|ks| ks.key_type == extenddb_core::types::KeyType::Hash)
+            .map(|ks| ks.attribute_name.clone())
+            .unwrap_or_default();
+
+        let sk = sk_info(&key_schema, &attr_defs).map(|(name, ty)| (name.to_owned(), ty));
+
+        let info = crate::BaseKeyInfo {
+            pk_attr_name,
+            sk_info: sk,
+        };
+
+        // Store in cache (bounded to prevent unbounded growth from deleted tables)
+        {
+            let mut cache = self.base_key_cache.write().await;
+            if cache.len() >= crate::BASE_KEY_CACHE_MAX_ENTRIES {
+                cache.clear();
+            }
+            cache.insert(table_id.to_owned(), info.clone());
+        }
+
+        Ok(info)
+    }
+
+    /// Fetch the base table's sort key attribute name and type for a given `table_id`.
+    async fn fetch_base_table_sk_info(
+        &self,
+        table_id: &str,
+    ) -> Result<Option<(String, ScalarAttributeType)>, StorageError> {
+        Ok(self.get_base_key_info(table_id).await?.sk_info)
+    }
+
+    /// Resolve the base table PK value from an `ExclusiveStartKey` for hash-only index pagination.
+    async fn resolve_base_pk_from_start_key(
+        &self,
+        table_id: &str,
+        start_key: &Item,
+    ) -> Result<Option<String>, StorageError> {
+        let info = self.get_base_key_info(table_id).await?;
+        let Some(pk_val) = start_key.get(&info.pk_attr_name) else {
+            return Ok(None);
+        };
+        let pk_text = pk_to_text(pk_val)?.into_owned();
+        Ok(Some(pk_text))
+    }
+
+    /// Resolve the base table PK attribute name for a given `table_id`.
+    async fn resolve_base_pk_attr_name(
+        &self,
+        table_id: &str,
+    ) -> Result<Option<String>, StorageError> {
+        let info = self.get_base_key_info(table_id).await?;
+        Ok(Some(info.pk_attr_name))
     }
 }

--- a/crates/storage-postgres/src/data/query_scan.rs
+++ b/crates/storage-postgres/src/data/query_scan.rs
@@ -4,7 +4,7 @@
 //! `query` and `scan` implementations for the `PostgreSQL` backend.
 
 use extenddb_core::expression::{ExpressionMaps, KeyCondition};
-use extenddb_core::types::{Item, KeySchemaElement, ScalarAttributeType, TableKeyInfo};
+use extenddb_core::types::{Item, ScalarAttributeType, TableKeyInfo};
 use extenddb_storage::error::StorageError;
 use extenddb_storage::util::{
     encode_netstring_composite, parse_sk, pk_to_text, sk_column, sk_column_n, sk_info,
@@ -186,11 +186,12 @@ impl PostgresEngine {
             }
         }
 
-        // For index queries, fetch the base table's sort key info. This is needed
-        // for both ORDER BY (sub-sort by base SK when index SKs are equal) and
-        // pagination (compound ExclusiveStartKey condition).
+        // For index queries, derive the base table's sort key info from
+        // base_key_schema. Needed for ORDER BY (sub-sort by base SK when index
+        // SKs are equal) and pagination (compound ExclusiveStartKey condition).
         let base_sk_info: Option<(String, ScalarAttributeType)> = if index_name.is_some() {
-            self.fetch_base_table_sk_info(&key_info.table_id).await?
+            sk_info(&key_info.base_key_schema, &key_info.attribute_definitions)
+                .map(|(name, ty)| (name.to_owned(), ty))
         } else {
             None
         };
@@ -283,18 +284,22 @@ impl PostgresEngine {
                 }
             } else if index_name.is_some() && sk_info_val.is_some() {
                 // Index with SK but no base SK — SQL has $N for base_pk
-                match self
-                    .resolve_base_pk_from_start_key(&key_info.table_id, start_key)
-                    .await?
-                {
-                    Some(pk_text) => PaginationBinds::BasePkOnly { pk_text },
+                let base_pk_attr = &key_info.base_key_schema[0].attribute_name;
+                match start_key.get(base_pk_attr.as_str()) {
+                    Some(pk_val) => {
+                        let pk_text = pk_to_text(pk_val)?.into_owned();
+                        PaginationBinds::BasePkOnly { pk_text }
+                    }
                     None => PaginationBinds::None,
                 }
             } else if index_name.is_some() && sk_info_val.is_none() {
                 // Hash-only index — SQL may have $N for base_pk and $N+1 for base_sk
-                let base_pk = self
-                    .resolve_base_pk_from_start_key(&key_info.table_id, start_key)
-                    .await?;
+                let base_pk_attr = &key_info.base_key_schema[0].attribute_name;
+                let base_pk = start_key
+                    .get(base_pk_attr.as_str())
+                    .map(|v| pk_to_text(v))
+                    .transpose()?
+                    .map(|c| c.into_owned());
                 match (base_pk, &base_sk_info) {
                     (Some(pk_text), Some((sk_name, sk_type))) => {
                         if let Some(sk_val) = start_key.get(sk_name.as_str()) {
@@ -370,9 +375,10 @@ impl PostgresEngine {
         };
         let sk_info_val = sk_info(&key_info.key_schema, &key_info.attribute_definitions);
 
-        // For index scans, fetch base table SK info for compound pagination.
+        // For index scans, derive base table SK info for compound pagination.
         let base_sk_info: Option<(String, ScalarAttributeType)> = if index_name.is_some() {
-            self.fetch_base_table_sk_info(&key_info.table_id).await?
+            sk_info(&key_info.base_key_schema, &key_info.attribute_definitions)
+                .map(|(name, ty)| (name.to_owned(), ty))
         } else {
             None
         };
@@ -509,10 +515,10 @@ impl PostgresEngine {
         let fetch_limit = limit.map_or(1_000_001, |l| l + 1);
         let _ = write!(sql, " LIMIT {fetch_limit}");
 
-        // Resolve base table PK attribute name for index scan binding.
-        let base_pk_attr_name: Option<String> =
+        // Derive base table PK attribute name for index scan binding.
+        let base_pk_attr_name: Option<&str> =
             if index_name.is_some() && exclusive_start_key.is_some() {
-                self.resolve_base_pk_attr_name(&key_info.table_id).await?
+                Some(key_info.base_key_schema[0].attribute_name.as_str())
             } else {
                 None
             };
@@ -524,7 +530,7 @@ impl PostgresEngine {
             &key_info.key_schema,
             &key_info.attribute_definitions,
             base_sk_info.as_ref(),
-            base_pk_attr_name.as_deref(),
+            base_pk_attr_name,
             &self.data_pool,
         )
         .await?;
@@ -547,92 +553,5 @@ impl PostgresEngine {
         };
 
         Ok((items, last_key))
-    }
-
-    /// Fetch and cache the base table's key info for a given `table_id`.
-    /// Returns both PK attribute name and optional SK info.
-    async fn get_base_key_info(&self, table_id: &str) -> Result<crate::BaseKeyInfo, StorageError> {
-        // Check cache first
-        {
-            let cache = self.base_key_cache.read().await;
-            if let Some(info) = cache.get(table_id) {
-                return Ok(info.clone());
-            }
-        }
-
-        // Cache miss — query catalog
-        let row: Option<(serde_json::Value, serde_json::Value)> = sqlx::query_as(
-            "SELECT key_schema, attribute_definitions FROM tables WHERE table_id = $1",
-        )
-        .bind(table_id)
-        .fetch_optional(&self.pool)
-        .await
-        .map_err(|e| StorageError::Internal(e.to_string()))?;
-
-        let Some((ks_json, ad_json)) = row else {
-            return Err(StorageError::Internal(format!(
-                "base table not found for table_id: {table_id}"
-            )));
-        };
-
-        let key_schema: Vec<KeySchemaElement> =
-            serde_json::from_value(ks_json).map_err(|e| StorageError::Internal(e.to_string()))?;
-        let attr_defs: Vec<extenddb_core::types::AttributeDefinition> =
-            serde_json::from_value(ad_json).map_err(|e| StorageError::Internal(e.to_string()))?;
-
-        let pk_attr_name = key_schema
-            .iter()
-            .find(|ks| ks.key_type == extenddb_core::types::KeyType::Hash)
-            .map(|ks| ks.attribute_name.clone())
-            .unwrap_or_default();
-
-        let sk = sk_info(&key_schema, &attr_defs).map(|(name, ty)| (name.to_owned(), ty));
-
-        let info = crate::BaseKeyInfo {
-            pk_attr_name,
-            sk_info: sk,
-        };
-
-        // Store in cache (bounded to prevent unbounded growth from deleted tables)
-        {
-            let mut cache = self.base_key_cache.write().await;
-            if cache.len() >= crate::BASE_KEY_CACHE_MAX_ENTRIES {
-                cache.clear();
-            }
-            cache.insert(table_id.to_owned(), info.clone());
-        }
-
-        Ok(info)
-    }
-
-    /// Fetch the base table's sort key attribute name and type for a given `table_id`.
-    async fn fetch_base_table_sk_info(
-        &self,
-        table_id: &str,
-    ) -> Result<Option<(String, ScalarAttributeType)>, StorageError> {
-        Ok(self.get_base_key_info(table_id).await?.sk_info)
-    }
-
-    /// Resolve the base table PK value from an `ExclusiveStartKey` for hash-only index pagination.
-    async fn resolve_base_pk_from_start_key(
-        &self,
-        table_id: &str,
-        start_key: &Item,
-    ) -> Result<Option<String>, StorageError> {
-        let info = self.get_base_key_info(table_id).await?;
-        let Some(pk_val) = start_key.get(&info.pk_attr_name) else {
-            return Ok(None);
-        };
-        let pk_text = pk_to_text(pk_val)?.into_owned();
-        Ok(Some(pk_text))
-    }
-
-    /// Resolve the base table PK attribute name for a given `table_id`.
-    async fn resolve_base_pk_attr_name(
-        &self,
-        table_id: &str,
-    ) -> Result<Option<String>, StorageError> {
-        let info = self.get_base_key_info(table_id).await?;
-        Ok(Some(info.pk_attr_name))
     }
 }

--- a/crates/storage-postgres/src/lib.rs
+++ b/crates/storage-postgres/src/lib.rs
@@ -155,24 +155,6 @@ pub struct PostgresEngine {
     /// P119: Cached GSI default propagation delay (milliseconds). Updated by
     /// background poller every 30s. Avoids per-request DB query on write path.
     pub gsi_default_delay_ms: Arc<std::sync::atomic::AtomicU64>,
-    /// Cache for base table key schema info, keyed by table_id.
-    /// Avoids per-request catalog queries during index pagination.
-    /// Entries are never invalidated because key schemas are immutable for a
-    /// table's lifetime and table_ids are never reused. The cache is bounded
-    /// to prevent unbounded memory growth from deleted tables.
-    pub(crate) base_key_cache: tokio::sync::RwLock<std::collections::HashMap<String, BaseKeyInfo>>,
-}
-
-/// Maximum cached base key info entries. Realistic deployments have 10-200 tables
-/// with indexes; 500 provides headroom while bounding memory (~100 KB typical,
-/// ~65 MB worst case with max-length attribute names).
-const BASE_KEY_CACHE_MAX_ENTRIES: usize = 500;
-
-/// Cached base table key information for index pagination.
-#[derive(Clone)]
-pub(crate) struct BaseKeyInfo {
-    pub pk_attr_name: String,
-    pub sk_info: Option<(String, extenddb_core::types::ScalarAttributeType)>,
 }
 
 impl PostgresEngine {
@@ -243,7 +225,6 @@ impl PostgresEngine {
             control_plane_notify: Arc::new(tokio::sync::Notify::new()),
             gsi_queue: None,
             gsi_default_delay_ms: Arc::new(std::sync::atomic::AtomicU64::new(initial_gsi_delay)),
-            base_key_cache: tokio::sync::RwLock::new(std::collections::HashMap::new()),
         })
     }
 

--- a/crates/storage-postgres/src/lib.rs
+++ b/crates/storage-postgres/src/lib.rs
@@ -155,6 +155,24 @@ pub struct PostgresEngine {
     /// P119: Cached GSI default propagation delay (milliseconds). Updated by
     /// background poller every 30s. Avoids per-request DB query on write path.
     pub gsi_default_delay_ms: Arc<std::sync::atomic::AtomicU64>,
+    /// Cache for base table key schema info, keyed by table_id.
+    /// Avoids per-request catalog queries during index pagination.
+    /// Entries are never invalidated because key schemas are immutable for a
+    /// table's lifetime and table_ids are never reused. The cache is bounded
+    /// to prevent unbounded memory growth from deleted tables.
+    pub(crate) base_key_cache: tokio::sync::RwLock<std::collections::HashMap<String, BaseKeyInfo>>,
+}
+
+/// Maximum cached base key info entries. Realistic deployments have 10-200 tables
+/// with indexes; 500 provides headroom while bounding memory (~100 KB typical,
+/// ~65 MB worst case with max-length attribute names).
+const BASE_KEY_CACHE_MAX_ENTRIES: usize = 500;
+
+/// Cached base table key information for index pagination.
+#[derive(Clone)]
+pub(crate) struct BaseKeyInfo {
+    pub pk_attr_name: String,
+    pub sk_info: Option<(String, extenddb_core::types::ScalarAttributeType)>,
 }
 
 impl PostgresEngine {
@@ -225,6 +243,7 @@ impl PostgresEngine {
             control_plane_notify: Arc::new(tokio::sync::Notify::new()),
             gsi_queue: None,
             gsi_default_delay_ms: Arc::new(std::sync::atomic::AtomicU64::new(initial_gsi_delay)),
+            base_key_cache: tokio::sync::RwLock::new(std::collections::HashMap::new()),
         })
     }
 

--- a/tests/rust/src/lsi.rs
+++ b/tests/rust/src/lsi.rs
@@ -1,0 +1,530 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! LSI (Local Secondary Index) pagination tests — regression for issue #145.
+//!
+//! Verifies that ExclusiveStartKey pagination works correctly when multiple
+//! items share the same index sort key value.
+
+use crate::test_base::*;
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition, AttributeValue, BillingMode, KeySchemaElement, KeyType,
+    LocalSecondaryIndex, Projection, ProjectionType, ScalarAttributeType,
+};
+use std::collections::HashMap;
+
+const LSI_NAME: &str = "TaskTypeLSI";
+const LSI_SK_ATTR: &str = "taskType";
+
+/// Create a table with an LSI for pagination tests.
+async fn create_lsi_table(name: &str) {
+    let c = client();
+    let attr_defs = vec![
+        AttributeDefinition::builder()
+            .attribute_name(HASH_KEY_S)
+            .attribute_type(ScalarAttributeType::S)
+            .build()
+            .unwrap(),
+        AttributeDefinition::builder()
+            .attribute_name(RANGE_KEY_S)
+            .attribute_type(ScalarAttributeType::S)
+            .build()
+            .unwrap(),
+        AttributeDefinition::builder()
+            .attribute_name(LSI_SK_ATTR)
+            .attribute_type(ScalarAttributeType::S)
+            .build()
+            .unwrap(),
+    ];
+
+    let key_schema = vec![
+        KeySchemaElement::builder()
+            .attribute_name(HASH_KEY_S)
+            .key_type(KeyType::Hash)
+            .build()
+            .unwrap(),
+        KeySchemaElement::builder()
+            .attribute_name(RANGE_KEY_S)
+            .key_type(KeyType::Range)
+            .build()
+            .unwrap(),
+    ];
+
+    let lsi = LocalSecondaryIndex::builder()
+        .index_name(LSI_NAME)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name(HASH_KEY_S)
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name(LSI_SK_ATTR)
+                .key_type(KeyType::Range)
+                .build()
+                .unwrap(),
+        )
+        .projection(
+            Projection::builder()
+                .projection_type(ProjectionType::All)
+                .build(),
+        )
+        .build()
+        .unwrap();
+
+    match c
+        .create_table()
+        .table_name(name)
+        .billing_mode(BillingMode::PayPerRequest)
+        .set_key_schema(Some(key_schema))
+        .set_attribute_definitions(Some(attr_defs))
+        .local_secondary_indexes(lsi)
+        .send()
+        .await
+    {
+        Ok(_) => {}
+        Err(e) => {
+            if err_code(&e) != Some("ResourceInUseException") {
+                panic!("Failed to create LSI table {name}: {e:?}");
+            }
+        }
+    }
+    wait_for_active(&c, name).await;
+}
+
+/// Seed items that share the same LSI sort key value.
+async fn seed_lsi_items(table: &str, pk: &str, count: usize) {
+    let c = client();
+    for i in 1..=count {
+        let mut item = HashMap::new();
+        item.insert(HASH_KEY_S.into(), s(pk));
+        item.insert(RANGE_KEY_S.into(), s(&format!("task{i}")));
+        item.insert(LSI_SK_ATTR.into(), s("EXPORT"));
+        item.insert("data".into(), s(&format!("payload-{i}")));
+        c.put_item()
+            .table_name(table)
+            .set_item(Some(item))
+            .send()
+            .await
+            .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn lsi_pagination_duplicate_sort_keys() {
+    let table = format!("LSIPagination_{}", ts());
+    let pk = format!("lsi_pag_{}", ts());
+    create_lsi_table(&table).await;
+    seed_lsi_items(&table, &pk, 5).await;
+
+    let c = client();
+    let mut all_items: Vec<HashMap<String, AttributeValue>> = Vec::new();
+    let mut exclusive_start_key: Option<HashMap<String, AttributeValue>> = None;
+
+    loop {
+        let mut req = c
+            .query()
+            .table_name(&table)
+            .index_name(LSI_NAME)
+            .key_condition_expression("#pk = :pk")
+            .expression_attribute_names("#pk", HASH_KEY_S)
+            .expression_attribute_values(":pk", s(&pk))
+            .limit(2);
+
+        if let Some(ref lek) = exclusive_start_key {
+            req = req.set_exclusive_start_key(Some(lek.clone()));
+        }
+
+        let resp = req.send().await.unwrap();
+        all_items.extend(resp.items().to_vec());
+
+        match resp.last_evaluated_key() {
+            Some(lek) => exclusive_start_key = Some(lek.to_owned()),
+            None => break,
+        }
+    }
+
+    assert_eq!(
+        all_items.len(),
+        5,
+        "All 5 items must be returned through pagination with duplicate LSI sort keys"
+    );
+
+    let mut sks: Vec<String> = all_items
+        .iter()
+        .map(|item| match item.get(RANGE_KEY_S).unwrap() {
+            AttributeValue::S(v) => v.clone(),
+            _ => panic!("unexpected type"),
+        })
+        .collect();
+    sks.sort();
+    assert_eq!(sks, vec!["task1", "task2", "task3", "task4", "task5"]);
+}
+
+#[tokio::test]
+async fn lsi_pagination_reverse_order() {
+    let table = format!("LSIPagRev_{}", ts());
+    let pk = format!("lsi_rev_{}", ts());
+    create_lsi_table(&table).await;
+    seed_lsi_items(&table, &pk, 5).await;
+
+    let c = client();
+    let mut all_items: Vec<HashMap<String, AttributeValue>> = Vec::new();
+    let mut exclusive_start_key: Option<HashMap<String, AttributeValue>> = None;
+
+    loop {
+        let mut req = c
+            .query()
+            .table_name(&table)
+            .index_name(LSI_NAME)
+            .key_condition_expression("#pk = :pk")
+            .expression_attribute_names("#pk", HASH_KEY_S)
+            .expression_attribute_values(":pk", s(&pk))
+            .scan_index_forward(false)
+            .limit(2);
+
+        if let Some(ref lek) = exclusive_start_key {
+            req = req.set_exclusive_start_key(Some(lek.clone()));
+        }
+
+        let resp = req.send().await.unwrap();
+        all_items.extend(resp.items().to_vec());
+
+        match resp.last_evaluated_key() {
+            Some(lek) => exclusive_start_key = Some(lek.to_owned()),
+            None => break,
+        }
+    }
+
+    assert_eq!(all_items.len(), 5);
+
+    // With ScanIndexForward=false and equal index sort keys, items should be
+    // sub-sorted by base table sort key in descending order.
+    let sks: Vec<String> = all_items
+        .iter()
+        .map(|item| match item.get(RANGE_KEY_S).unwrap() {
+            AttributeValue::S(v) => v.clone(),
+            _ => panic!("unexpected type"),
+        })
+        .collect();
+    assert_eq!(sks, vec!["task5", "task4", "task3", "task2", "task1"]);
+}
+
+#[tokio::test]
+async fn lsi_page_two_returns_items() {
+    let table = format!("LSIPagTwo_{}", ts());
+    let pk = format!("lsi_p2_{}", ts());
+    create_lsi_table(&table).await;
+    seed_lsi_items(&table, &pk, 5).await;
+
+    let c = client();
+
+    // Page 1
+    let resp1 = c
+        .query()
+        .table_name(&table)
+        .index_name(LSI_NAME)
+        .key_condition_expression("#pk = :pk")
+        .expression_attribute_names("#pk", HASH_KEY_S)
+        .expression_attribute_values(":pk", s(&pk))
+        .limit(2)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp1.items().len(), 2);
+    let lek = resp1
+        .last_evaluated_key()
+        .expect("Page 1 must have LastEvaluatedKey")
+        .to_owned();
+
+    // Page 2 — core regression test for issue #145
+    let resp2 = c
+        .query()
+        .table_name(&table)
+        .index_name(LSI_NAME)
+        .key_condition_expression("#pk = :pk")
+        .expression_attribute_names("#pk", HASH_KEY_S)
+        .expression_attribute_values(":pk", s(&pk))
+        .set_exclusive_start_key(Some(lek))
+        .limit(2)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp2.items().len(),
+        2,
+        "Page 2 must return items when index sort keys are duplicated"
+    );
+}
+
+#[tokio::test]
+async fn lsi_last_evaluated_key_contains_all_keys() {
+    let table = format!("LSILek_{}", ts());
+    let pk = format!("lsi_lek_{}", ts());
+    create_lsi_table(&table).await;
+    seed_lsi_items(&table, &pk, 5).await;
+
+    let c = client();
+
+    let resp = c
+        .query()
+        .table_name(&table)
+        .index_name(LSI_NAME)
+        .key_condition_expression("#pk = :pk")
+        .expression_attribute_names("#pk", HASH_KEY_S)
+        .expression_attribute_values(":pk", s(&pk))
+        .limit(2)
+        .send()
+        .await
+        .unwrap();
+
+    let lek = resp
+        .last_evaluated_key()
+        .expect("Must have LastEvaluatedKey");
+
+    assert!(
+        lek.contains_key(HASH_KEY_S),
+        "LEK must contain partition key"
+    );
+    assert!(
+        lek.contains_key(RANGE_KEY_S),
+        "LEK must contain base table sort key"
+    );
+    assert!(
+        lek.contains_key(LSI_SK_ATTR),
+        "LEK must contain index sort key"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Hash-only GSI pagination tests
+// ---------------------------------------------------------------------------
+
+/// Create a table with a hash-only GSI for pagination tests.
+async fn create_hash_only_gsi_table(name: &str) {
+    let c = client();
+    let attr_defs = vec![
+        AttributeDefinition::builder()
+            .attribute_name("instanceId")
+            .attribute_type(ScalarAttributeType::S)
+            .build()
+            .unwrap(),
+        AttributeDefinition::builder()
+            .attribute_name("nodeStatus")
+            .attribute_type(ScalarAttributeType::S)
+            .build()
+            .unwrap(),
+    ];
+
+    let key_schema = vec![KeySchemaElement::builder()
+        .attribute_name("instanceId")
+        .key_type(KeyType::Hash)
+        .build()
+        .unwrap()];
+
+    let gsi = aws_sdk_dynamodb::types::GlobalSecondaryIndex::builder()
+        .index_name("StatusGSI")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("nodeStatus")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .projection(
+            Projection::builder()
+                .projection_type(ProjectionType::All)
+                .build(),
+        )
+        .build()
+        .unwrap();
+
+    match c
+        .create_table()
+        .table_name(name)
+        .billing_mode(BillingMode::PayPerRequest)
+        .set_key_schema(Some(key_schema))
+        .set_attribute_definitions(Some(attr_defs))
+        .global_secondary_indexes(gsi)
+        .send()
+        .await
+    {
+        Ok(_) => {}
+        Err(e) => {
+            if err_code(&e) != Some("ResourceInUseException") {
+                panic!("Failed to create GSI table {name}: {e:?}");
+            }
+        }
+    }
+    wait_for_active(&c, name).await;
+}
+
+/// Seed items that share the same GSI hash key.
+async fn seed_gsi_items(table: &str, count: usize) {
+    let c = client();
+    for i in 1..=count {
+        let mut item = HashMap::new();
+        item.insert("instanceId".into(), s(&format!("node-{i}")));
+        item.insert("nodeStatus".into(), s("ACTIVE"));
+        item.insert("data".into(), s(&format!("payload-{i}")));
+        c.put_item()
+            .table_name(table)
+            .set_item(Some(item))
+            .send()
+            .await
+            .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn gsi_hash_only_pagination() {
+    let table = format!("GSIHashPag_{}", ts());
+    create_hash_only_gsi_table(&table).await;
+    seed_gsi_items(&table, 10).await;
+
+    // Allow GSI propagation
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let c = client();
+    let mut all_items: Vec<HashMap<String, AttributeValue>> = Vec::new();
+    let mut exclusive_start_key: Option<HashMap<String, AttributeValue>> = None;
+
+    loop {
+        let mut req = c
+            .query()
+            .table_name(&table)
+            .index_name("StatusGSI")
+            .key_condition_expression("nodeStatus = :s")
+            .expression_attribute_values(":s", s("ACTIVE"))
+            .limit(3);
+
+        if let Some(ref lek) = exclusive_start_key {
+            req = req.set_exclusive_start_key(Some(lek.clone()));
+        }
+
+        let resp = req.send().await.unwrap();
+        all_items.extend(resp.items().to_vec());
+
+        match resp.last_evaluated_key() {
+            Some(lek) => exclusive_start_key = Some(lek.to_owned()),
+            None => break,
+        }
+    }
+
+    assert_eq!(
+        all_items.len(),
+        10,
+        "All 10 items must be returned through hash-only GSI pagination"
+    );
+
+    let mut ids: Vec<String> = all_items
+        .iter()
+        .map(|item| match item.get("instanceId").unwrap() {
+            AttributeValue::S(v) => v.clone(),
+            _ => panic!("unexpected type"),
+        })
+        .collect();
+    ids.sort();
+    let expected: Vec<String> = (1..=10).map(|i| format!("node-{i}")).collect();
+    assert_eq!(ids, expected);
+}
+
+#[tokio::test]
+async fn gsi_hash_only_page_two_returns_items() {
+    let table = format!("GSIHashP2_{}", ts());
+    create_hash_only_gsi_table(&table).await;
+    seed_gsi_items(&table, 10).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let c = client();
+
+    let resp1 = c
+        .query()
+        .table_name(&table)
+        .index_name("StatusGSI")
+        .key_condition_expression("nodeStatus = :s")
+        .expression_attribute_values(":s", s("ACTIVE"))
+        .limit(3)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp1.items().len(), 3);
+    let lek = resp1
+        .last_evaluated_key()
+        .expect("Page 1 must have LastEvaluatedKey")
+        .to_owned();
+
+    let resp2 = c
+        .query()
+        .table_name(&table)
+        .index_name("StatusGSI")
+        .key_condition_expression("nodeStatus = :s")
+        .expression_attribute_values(":s", s("ACTIVE"))
+        .set_exclusive_start_key(Some(lek))
+        .limit(3)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp2.items().len(),
+        3,
+        "Page 2 must return items for hash-only GSI pagination"
+    );
+}
+
+#[tokio::test]
+async fn gsi_hash_only_no_duplicates() {
+    let table = format!("GSIHashNoDup_{}", ts());
+    create_hash_only_gsi_table(&table).await;
+    seed_gsi_items(&table, 10).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let c = client();
+    let mut all_ids: Vec<String> = Vec::new();
+    let mut exclusive_start_key: Option<HashMap<String, AttributeValue>> = None;
+
+    loop {
+        let mut req = c
+            .query()
+            .table_name(&table)
+            .index_name("StatusGSI")
+            .key_condition_expression("nodeStatus = :s")
+            .expression_attribute_values(":s", s("ACTIVE"))
+            .limit(2);
+
+        if let Some(ref lek) = exclusive_start_key {
+            req = req.set_exclusive_start_key(Some(lek.clone()));
+        }
+
+        let resp = req.send().await.unwrap();
+        for item in resp.items() {
+            if let Some(AttributeValue::S(id)) = item.get("instanceId") {
+                all_ids.push(id.clone());
+            }
+        }
+
+        match resp.last_evaluated_key() {
+            Some(lek) => exclusive_start_key = Some(lek.to_owned()),
+            None => break,
+        }
+    }
+
+    let unique_count = all_ids
+        .iter()
+        .collect::<std::collections::HashSet<_>>()
+        .len();
+    assert_eq!(
+        all_ids.len(),
+        unique_count,
+        "No duplicate items across pages"
+    );
+    assert_eq!(all_ids.len(), 10);
+}

--- a/tests/rust/src/main.rs
+++ b/tests/rust/src/main.rs
@@ -42,6 +42,8 @@ mod gsi;
 #[cfg(test)]
 mod gsi_more;
 #[cfg(test)]
+mod lsi;
+#[cfg(test)]
 mod misc_control_plane;
 #[cfg(test)]
 mod put_item;

--- a/tests/test_query_scan.py
+++ b/tests/test_query_scan.py
@@ -1186,3 +1186,129 @@ class TestGSIOnHashOnlyBaseTable:
             assert len(all_items) == 7, (
                 f"Run {run+1}: expected 7 items but got {len(all_items)}"
             )
+
+
+@pytest.fixture(scope="class")
+def base_key_schema_table(dynamodb_client):
+    """Table with GSI for testing base_key_schema propagation.
+
+    Base table: pk (HASH, S) + sk (RANGE, N)
+    GSI: gsi_pk (HASH, S) + gsi_sk (RANGE, S)
+
+    This verifies that the storage layer receives correct base table key
+    schema for both base table queries and index queries.
+    """
+    with scoped_table(
+        dynamodb_client,
+        attribute_definitions=[
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "sk", "AttributeType": "N"},
+            {"AttributeName": "gsi_pk", "AttributeType": "S"},
+            {"AttributeName": "gsi_sk", "AttributeType": "S"},
+        ],
+        key_schema=[
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"},
+        ],
+        GlobalSecondaryIndexes=[{
+            "IndexName": "TestGSI",
+            "KeySchema": [
+                {"AttributeName": "gsi_pk", "KeyType": "HASH"},
+                {"AttributeName": "gsi_sk", "KeyType": "RANGE"},
+            ],
+            "Projection": {"ProjectionType": "ALL"},
+        }],
+    ) as table_name:
+        items = [
+            {"pk": {"S": f"user#{i % 3}"}, "sk": {"N": str(i)},
+             "gsi_pk": {"S": "shared"}, "gsi_sk": {"S": f"sort#{i:03d}"},
+             "data": {"S": f"item-{i}"}}
+            for i in range(12)
+        ]
+        for item in items:
+            dynamodb_client.put_item(TableName=table_name, Item=item)
+        yield table_name
+
+
+class TestBaseKeySchemaFlow:
+    """Verify base_key_schema is available for both base table and index queries.
+
+    These tests confirm pagination works correctly when the storage layer
+    derives base PK/SK info from the base_key_schema field on TableKeyInfo.
+    """
+
+    def test_base_table_pagination_uses_own_key_schema(
+        self, dynamodb_client, base_key_schema_table
+    ):
+        """Base table query: base_key_schema == key_schema, pagination works."""
+        all_items = []
+        exclusive_start_key = None
+        while True:
+            kwargs = {
+                "TableName": base_key_schema_table,
+                "KeyConditionExpression": "pk = :pk",
+                "ExpressionAttributeValues": {":pk": {"S": "user#0"}},
+                "Limit": 2,
+            }
+            if exclusive_start_key:
+                kwargs["ExclusiveStartKey"] = exclusive_start_key
+            resp = dynamodb_client.query(**kwargs)
+            all_items.extend(resp["Items"])
+            if "LastEvaluatedKey" not in resp:
+                break
+            exclusive_start_key = resp["LastEvaluatedKey"]
+
+        assert len(all_items) == 4
+        sks = [int(item["sk"]["N"]) for item in all_items]
+        assert sks == sorted(sks)
+
+    def test_index_pagination_uses_base_key_schema_for_tiebreaker(
+        self, dynamodb_client, base_key_schema_table
+    ):
+        """GSI query: base_key_schema differs from key_schema, used for tie-breaking."""
+        all_items = []
+        exclusive_start_key = None
+        while True:
+            kwargs = {
+                "TableName": base_key_schema_table,
+                "IndexName": "TestGSI",
+                "KeyConditionExpression": "gsi_pk = :gpk",
+                "ExpressionAttributeValues": {":gpk": {"S": "shared"}},
+                "Limit": 3,
+            }
+            if exclusive_start_key:
+                kwargs["ExclusiveStartKey"] = exclusive_start_key
+            resp = dynamodb_client.query(**kwargs)
+            all_items.extend(resp["Items"])
+            if "LastEvaluatedKey" not in resp:
+                break
+            exclusive_start_key = resp["LastEvaluatedKey"]
+
+        assert len(all_items) == 12
+        # No duplicates across pages
+        item_keys = [(i["pk"]["S"], i["sk"]["N"]) for i in all_items]
+        assert len(item_keys) == len(set(item_keys))
+
+    def test_index_scan_pagination_uses_base_key_schema(
+        self, dynamodb_client, base_key_schema_table
+    ):
+        """GSI scan: base_key_schema provides base PK/SK for compound pagination."""
+        all_items = []
+        exclusive_start_key = None
+        while True:
+            kwargs = {
+                "TableName": base_key_schema_table,
+                "IndexName": "TestGSI",
+                "Limit": 4,
+            }
+            if exclusive_start_key:
+                kwargs["ExclusiveStartKey"] = exclusive_start_key
+            resp = dynamodb_client.scan(**kwargs)
+            all_items.extend(resp["Items"])
+            if "LastEvaluatedKey" not in resp:
+                break
+            exclusive_start_key = resp["LastEvaluatedKey"]
+
+        assert len(all_items) == 12
+        item_keys = [(i["pk"]["S"], i["sk"]["N"]) for i in all_items]
+        assert len(item_keys) == len(set(item_keys))

--- a/tests/test_query_scan.py
+++ b/tests/test_query_scan.py
@@ -791,3 +791,398 @@ class TestQueryLSI:
         )
         assert resp["Count"] == 1
         assert resp["Items"][0]["data"]["S"] == "hello"
+
+
+# ---------------------------------------------------------------------------
+# LSI pagination with duplicate index sort keys (issue #145)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="class")
+def lsi_pagination_table(dynamodb_client):
+    """Table with LSI and items sharing the same index sort key value."""
+    with scoped_table(
+        dynamodb_client,
+        attribute_definitions=[
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "sk", "AttributeType": "S"},
+            {"AttributeName": "taskType", "AttributeType": "S"},
+        ],
+        key_schema=[
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"},
+        ],
+        LocalSecondaryIndexes=[
+            {
+                "IndexName": "TaskTypeLSI",
+                "KeySchema": [
+                    {"AttributeName": "pk", "KeyType": "HASH"},
+                    {"AttributeName": "taskType", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+    ) as name:
+        # Insert 5 items with same pk and same LSI sort key, different base SK
+        for i in range(1, 6):
+            dynamodb_client.put_item(
+                TableName=name,
+                Item={
+                    "pk": {"S": "user1"},
+                    "sk": {"S": f"task{i}"},
+                    "taskType": {"S": "EXPORT"},
+                    "data": {"S": f"payload-{i}"},
+                },
+            )
+        yield name
+
+
+class TestLSIPaginationDuplicateSortKeys:
+    """LSI pagination must work when multiple items share the same index sort key."""
+
+    def test_paginate_all_items_with_limit(self, dynamodb_client, lsi_pagination_table):
+        """Paginating through all items with Limit returns all 5 items across pages."""
+        all_items = []
+        exclusive_start_key = None
+
+        while True:
+            kwargs = {
+                "TableName": lsi_pagination_table,
+                "IndexName": "TaskTypeLSI",
+                "KeyConditionExpression": "pk = :pk",
+                "ExpressionAttributeValues": {":pk": {"S": "user1"}},
+                "Limit": 2,
+            }
+            if exclusive_start_key:
+                kwargs["ExclusiveStartKey"] = exclusive_start_key
+
+            resp = dynamodb_client.query(**kwargs)
+            all_items.extend(resp["Items"])
+
+            if "LastEvaluatedKey" not in resp:
+                break
+            exclusive_start_key = resp["LastEvaluatedKey"]
+
+        assert len(all_items) == 5
+        # Verify all items are present
+        sks = sorted(item["sk"]["S"] for item in all_items)
+        assert sks == ["task1", "task2", "task3", "task4", "task5"]
+
+    def test_paginate_reverse_order(self, dynamodb_client, lsi_pagination_table):
+        """ScanIndexForward=False with pagination returns all items in reverse."""
+        all_items = []
+        exclusive_start_key = None
+
+        while True:
+            kwargs = {
+                "TableName": lsi_pagination_table,
+                "IndexName": "TaskTypeLSI",
+                "KeyConditionExpression": "pk = :pk",
+                "ExpressionAttributeValues": {":pk": {"S": "user1"}},
+                "Limit": 2,
+                "ScanIndexForward": False,
+            }
+            if exclusive_start_key:
+                kwargs["ExclusiveStartKey"] = exclusive_start_key
+
+            resp = dynamodb_client.query(**kwargs)
+            all_items.extend(resp["Items"])
+
+            if "LastEvaluatedKey" not in resp:
+                break
+            exclusive_start_key = resp["LastEvaluatedKey"]
+
+        assert len(all_items) == 5
+        # Verify reverse order by base table sort key
+        sks = [item["sk"]["S"] for item in all_items]
+        assert sks == ["task5", "task4", "task3", "task2", "task1"]
+
+    def test_page_two_returns_items(self, dynamodb_client, lsi_pagination_table):
+        """Second page of LSI query with duplicate sort keys returns items (not 0)."""
+        # First page
+        resp1 = dynamodb_client.query(
+            TableName=lsi_pagination_table,
+            IndexName="TaskTypeLSI",
+            KeyConditionExpression="pk = :pk",
+            ExpressionAttributeValues={":pk": {"S": "user1"}},
+            Limit=2,
+        )
+        assert resp1["Count"] == 2
+        assert "LastEvaluatedKey" in resp1
+
+        # Second page — this is the core regression test for issue #145
+        resp2 = dynamodb_client.query(
+            TableName=lsi_pagination_table,
+            IndexName="TaskTypeLSI",
+            KeyConditionExpression="pk = :pk",
+            ExpressionAttributeValues={":pk": {"S": "user1"}},
+            Limit=2,
+            ExclusiveStartKey=resp1["LastEvaluatedKey"],
+        )
+        assert resp2["Count"] == 2, (
+            f"Page 2 should return 2 items but got {resp2['Count']}. "
+            "ExclusiveStartKey pagination with duplicate index sort keys is broken."
+        )
+
+    def test_last_evaluated_key_contains_all_keys(self, dynamodb_client, lsi_pagination_table):
+        """LastEvaluatedKey for LSI query contains pk, sk (base), and taskType (index)."""
+        resp = dynamodb_client.query(
+            TableName=lsi_pagination_table,
+            IndexName="TaskTypeLSI",
+            KeyConditionExpression="pk = :pk",
+            ExpressionAttributeValues={":pk": {"S": "user1"}},
+            Limit=2,
+        )
+        lek = resp["LastEvaluatedKey"]
+        assert "pk" in lek, "LastEvaluatedKey must contain partition key"
+        assert "sk" in lek, "LastEvaluatedKey must contain base table sort key"
+        assert "taskType" in lek, "LastEvaluatedKey must contain index sort key"
+
+
+# ---------------------------------------------------------------------------
+# Hash-only GSI pagination (related to issue #145)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="class")
+def gsi_hash_only_table(dynamodb_client):
+    """Table with a hash-only GSI for pagination tests."""
+    with scoped_table(
+        dynamodb_client,
+        attribute_definitions=[
+            {"AttributeName": "instanceId", "AttributeType": "S"},
+            {"AttributeName": "nodeStatus", "AttributeType": "S"},
+        ],
+        key_schema=[
+            {"AttributeName": "instanceId", "KeyType": "HASH"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "StatusGSI",
+                "KeySchema": [
+                    {"AttributeName": "nodeStatus", "KeyType": "HASH"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+    ) as name:
+        # Insert 10 items with same GSI hash key
+        for i in range(1, 11):
+            dynamodb_client.put_item(
+                TableName=name,
+                Item={
+                    "instanceId": {"S": f"node-{i}"},
+                    "nodeStatus": {"S": "ACTIVE"},
+                    "data": {"S": f"payload-{i}"},
+                },
+            )
+        yield name
+
+
+class TestHashOnlyGSIPagination:
+    """Hash-only GSI pagination must work with ExclusiveStartKey."""
+
+    def test_paginate_all_items_with_limit(self, dynamodb_client, gsi_hash_only_table):
+        """Paginating through all items on a hash-only GSI returns all 10 items."""
+        all_items = []
+        exclusive_start_key = None
+
+        while True:
+            kwargs = {
+                "TableName": gsi_hash_only_table,
+                "IndexName": "StatusGSI",
+                "KeyConditionExpression": "nodeStatus = :s",
+                "ExpressionAttributeValues": {":s": {"S": "ACTIVE"}},
+                "Limit": 3,
+            }
+            if exclusive_start_key:
+                kwargs["ExclusiveStartKey"] = exclusive_start_key
+
+            resp = dynamodb_client.query(**kwargs)
+            all_items.extend(resp["Items"])
+
+            if "LastEvaluatedKey" not in resp:
+                break
+            exclusive_start_key = resp["LastEvaluatedKey"]
+
+        assert len(all_items) == 10
+        ids = sorted(item["instanceId"]["S"] for item in all_items)
+        expected = sorted(f"node-{i}" for i in range(1, 11))
+        assert ids == expected
+
+    def test_page_two_returns_items(self, dynamodb_client, gsi_hash_only_table):
+        """Second page of hash-only GSI query returns items (not 0)."""
+        resp1 = dynamodb_client.query(
+            TableName=gsi_hash_only_table,
+            IndexName="StatusGSI",
+            KeyConditionExpression="nodeStatus = :s",
+            ExpressionAttributeValues={":s": {"S": "ACTIVE"}},
+            Limit=3,
+        )
+        assert resp1["Count"] == 3
+        assert "LastEvaluatedKey" in resp1
+
+        resp2 = dynamodb_client.query(
+            TableName=gsi_hash_only_table,
+            IndexName="StatusGSI",
+            KeyConditionExpression="nodeStatus = :s",
+            ExpressionAttributeValues={":s": {"S": "ACTIVE"}},
+            Limit=3,
+            ExclusiveStartKey=resp1["LastEvaluatedKey"],
+        )
+        assert resp2["Count"] == 3, (
+            f"Page 2 should return 3 items but got {resp2['Count']}. "
+            "Hash-only GSI pagination with ExclusiveStartKey is broken."
+        )
+
+    def test_no_duplicates_across_pages(self, dynamodb_client, gsi_hash_only_table):
+        """Pagination does not return duplicate items across pages."""
+        all_ids = []
+        exclusive_start_key = None
+
+        while True:
+            kwargs = {
+                "TableName": gsi_hash_only_table,
+                "IndexName": "StatusGSI",
+                "KeyConditionExpression": "nodeStatus = :s",
+                "ExpressionAttributeValues": {":s": {"S": "ACTIVE"}},
+                "Limit": 2,
+            }
+            if exclusive_start_key:
+                kwargs["ExclusiveStartKey"] = exclusive_start_key
+
+            resp = dynamodb_client.query(**kwargs)
+            all_ids.extend(item["instanceId"]["S"] for item in resp["Items"])
+
+            if "LastEvaluatedKey" not in resp:
+                break
+            exclusive_start_key = resp["LastEvaluatedKey"]
+
+        assert len(all_ids) == len(set(all_ids)), "Duplicate items found across pages"
+
+
+# ---------------------------------------------------------------------------
+# GSI pagination on hash-only base table (reviewer comment #4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="class")
+def gsi_on_hash_only_base_table(dynamodb_client):
+    """Table with hash-only PK (no range key) and a GSI with a sort key."""
+    with scoped_table(
+        dynamodb_client,
+        attribute_definitions=[
+            {"AttributeName": "itemId", "AttributeType": "S"},
+            {"AttributeName": "category", "AttributeType": "S"},
+            {"AttributeName": "priority", "AttributeType": "N"},
+        ],
+        key_schema=[
+            {"AttributeName": "itemId", "KeyType": "HASH"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "CategoryPriorityGSI",
+                "KeySchema": [
+                    {"AttributeName": "category", "KeyType": "HASH"},
+                    {"AttributeName": "priority", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+    ) as name:
+        # Insert items with duplicate GSI sort keys (same priority)
+        for i in range(1, 8):
+            dynamodb_client.put_item(
+                TableName=name,
+                Item={
+                    "itemId": {"S": f"item-{i}"},
+                    "category": {"S": "urgent"},
+                    "priority": {"N": "1"},
+                    "data": {"S": f"payload-{i}"},
+                },
+            )
+        yield name
+
+
+class TestGSIOnHashOnlyBaseTable:
+    """GSI pagination works when the base table has no range key."""
+
+    def test_paginate_duplicate_gsi_sort_keys(self, dynamodb_client, gsi_on_hash_only_base_table):
+        """All 7 items with same GSI sort key are returned through pagination."""
+        all_items = []
+        exclusive_start_key = None
+
+        while True:
+            kwargs = {
+                "TableName": gsi_on_hash_only_base_table,
+                "IndexName": "CategoryPriorityGSI",
+                "KeyConditionExpression": "category = :c",
+                "ExpressionAttributeValues": {":c": {"S": "urgent"}},
+                "Limit": 2,
+            }
+            if exclusive_start_key:
+                kwargs["ExclusiveStartKey"] = exclusive_start_key
+
+            resp = dynamodb_client.query(**kwargs)
+            all_items.extend(resp["Items"])
+
+            if "LastEvaluatedKey" not in resp:
+                break
+            exclusive_start_key = resp["LastEvaluatedKey"]
+
+        assert len(all_items) == 7
+        ids = sorted(item["itemId"]["S"] for item in all_items)
+        assert ids == sorted(f"item-{i}" for i in range(1, 8))
+
+    def test_scan_pagination_on_gsi(self, dynamodb_client, gsi_on_hash_only_base_table):
+        """Scan on GSI with Limit paginates correctly over hash-only base table."""
+        all_items = []
+        exclusive_start_key = None
+
+        while True:
+            kwargs = {
+                "TableName": gsi_on_hash_only_base_table,
+                "IndexName": "CategoryPriorityGSI",
+                "Limit": 3,
+            }
+            if exclusive_start_key:
+                kwargs["ExclusiveStartKey"] = exclusive_start_key
+
+            resp = dynamodb_client.scan(**kwargs)
+            all_items.extend(resp["Items"])
+
+            if "LastEvaluatedKey" not in resp:
+                break
+            exclusive_start_key = resp["LastEvaluatedKey"]
+
+        assert len(all_items) == 7
+        ids = sorted(item["itemId"]["S"] for item in all_items)
+        assert ids == sorted(f"item-{i}" for i in range(1, 8))
+
+    def test_repeated_pagination_consistent(self, dynamodb_client, gsi_on_hash_only_base_table):
+        """Multiple paginated queries produce consistent results (exercises cache path).
+
+        The first query populates the internal base_key_cache. Subsequent queries
+        hit the cache. Any cache corruption would cause pagination to break.
+        """
+        for run in range(5):
+            all_items = []
+            exclusive_start_key = None
+            while True:
+                kwargs = {
+                    "TableName": gsi_on_hash_only_base_table,
+                    "IndexName": "CategoryPriorityGSI",
+                    "KeyConditionExpression": "category = :c",
+                    "ExpressionAttributeValues": {":c": {"S": "urgent"}},
+                    "Limit": 3,
+                }
+                if exclusive_start_key:
+                    kwargs["ExclusiveStartKey"] = exclusive_start_key
+                resp = dynamodb_client.query(**kwargs)
+                all_items.extend(resp["Items"])
+                if "LastEvaluatedKey" not in resp:
+                    break
+                exclusive_start_key = resp["LastEvaluatedKey"]
+            assert len(all_items) == 7, (
+                f"Run {run+1}: expected 7 items but got {len(all_items)}"
+            )

--- a/tests/test_query_scan.py
+++ b/tests/test_query_scan.py
@@ -1187,6 +1187,41 @@ class TestGSIOnHashOnlyBaseTable:
                 f"Run {run+1}: expected 7 items but got {len(all_items)}"
             )
 
+    def test_paginate_reverse_gsi_with_tied_sort_keys(
+        self, dynamodb_client, gsi_on_hash_only_base_table
+    ):
+        """Reverse GSI pagination (ScanIndexForward=False) with tied sort keys.
+
+        All 7 items share the same GSI sort key (priority=1). The tie-breaker
+        for GSI uses base_pk in ascending order regardless of ScanIndexForward.
+        If the tie-breaker accidentally followed ScanIndexForward, reverse
+        pagination would skip items or loop.
+        """
+        all_items = []
+        exclusive_start_key = None
+        while True:
+            kwargs = {
+                "TableName": gsi_on_hash_only_base_table,
+                "IndexName": "CategoryPriorityGSI",
+                "KeyConditionExpression": "category = :c",
+                "ExpressionAttributeValues": {":c": {"S": "urgent"}},
+                "ScanIndexForward": False,
+                "Limit": 3,
+            }
+            if exclusive_start_key:
+                kwargs["ExclusiveStartKey"] = exclusive_start_key
+            resp = dynamodb_client.query(**kwargs)
+            all_items.extend(resp["Items"])
+            if "LastEvaluatedKey" not in resp:
+                break
+            exclusive_start_key = resp["LastEvaluatedKey"]
+
+        assert len(all_items) == 7, (
+            f"Reverse GSI pagination: expected 7 items but got {len(all_items)}"
+        )
+        ids = [item["itemId"]["S"] for item in all_items]
+        assert len(ids) == len(set(ids)), "Duplicate items in reverse GSI pagination"
+
 
 @pytest.fixture(scope="class")
 def base_key_schema_table(dynamodb_client):


### PR DESCRIPTION
## What

Fix index (LSI/GSI) pagination when items share the same index sort key value. Extends the fix to cover all index types, scan operations, and addresses all review feedback.

1. **Query pagination compound condition** — use base table key as tie-breaker when index sort keys are equal
2. **Scan pagination for indexes** — same compound condition for index Scan operations
3. **Hash-only GSI pagination** — use `base_pk` for positioning when index has no sort key
4. **GSI on hash-only base table** — use `base_pk` as tie-breaker when base table has no range key
5. **LSI vs GSI ordering** — LSI base SK follows ScanIndexForward; GSI base SK always ASC
6. **Cache base table key info** — `RwLock<HashMap>` cache on `PostgresEngine`, bounded to 500 entries, avoids per-request catalog queries
7. **`PaginationBinds` enum** — bind values are built in the same code branch that generates SQL placeholders, consumed via `match` in `execute_query_sql`, preventing bind-order divergence
8. **`build_pagination_where()` helper** — self-contained SQL generation function, eliminates `let _ = param_idx`

## Why

Closes #145

PR #66 fixed the *output* side (`LastEvaluatedKey` includes base table keys). This PR fixes the *input* side — consuming `ExclusiveStartKey` correctly for pagination.

## Testing done

- `cargo check --workspace` — clean
- `cargo fmt --check` — clean
- `cargo test --workspace --lib` — 489 passed
- Python integration tests — **55 passed**, 0 failed
- Covers: LSI pagination (forward/reverse), hash-only GSI, GSI on hash-only base table, scan pagination, repeated pagination (cache path)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.