### PR TITLE
refactor: single-pass check_redundant_parens with Vec<bool> stack

### DIFF
--- a/crates/core/src/expression/parser.rs
+++ b/crates/core/src/expression/parser.rs
@@ -473,6 +473,7 @@ mod tests {
             "(((a = :v)))",
             "((a = :v AND b = :v2))",
             "((NOT (a = :v)))",
+            "(a = :v) AND ((b = :v2))",
         ];
         for expr in cases {
             let tokens = tokenize(expr).unwrap();

--- a/crates/core/src/expression/parser_common.rs
+++ b/crates/core/src/expression/parser_common.rs
@@ -81,38 +81,28 @@ pub fn expect_token(
     Ok(())
 }
 
-/// Reject redundant parentheses, matching DynamoDB: a parenthesised group whose
+/// Reject redundant parentheses: a parenthesised group whose
 /// entire content is itself a single parenthesised group, such as `((x))`.
 /// Returns the bare error body so each parser can prefix its own expression type.
 pub fn check_redundant_parens(tokens: &[Token]) -> Result<(), String> {
-    // First pass: map each '(' to the index of its matching ')'. Unbalanced
-    // parentheses stay `None` and are left for the grammar parser to report.
-    let mut match_of: Vec<Option<usize>> = vec![None; tokens.len()];
-    let mut stack: Vec<usize> = Vec::new();
+    // Single-pass stack: one bool per unmatched '('.
+    // true = the preceding token was also '(' (double-open).
+    // On ')', if popped is true AND the next token is ')', the group is redundant.
+    let mut stack: Vec<bool> = Vec::new();
+
     for (i, token) in tokens.iter().enumerate() {
         match token {
-            Token::LParen => stack.push(i),
+            Token::LParen => {
+                stack.push(i > 0 && tokens[i - 1] == Token::LParen);
+            }
             Token::RParen => {
-                if let Some(open) = stack.pop() {
-                    match_of[open] = Some(i);
+                if let Some(true) = stack.pop()
+                    && tokens.get(i + 1) == Some(&Token::RParen)
+                {
+                    return Err("The expression has redundant parentheses;".to_owned());
                 }
             }
             _ => {}
-        }
-    }
-
-    // Second pass: flag any group whose entire body is a single nested group,
-    // such as `((x))`. `match_of[i]` is `Some` only for matched '(' tokens.
-    for i in 0..tokens.len() {
-        let Some(close) = match_of[i] else {
-            continue;
-        };
-        // A matched close always sits after `i`, so `tokens[i + 1]` is already
-        // in bounds. `i + 1 < close` is a non-empty-group guard, not bounds
-        // protection: it skips empty `()`, which the LParen check below would
-        // reject anyway.
-        if i + 1 < close && tokens[i + 1] == Token::LParen && match_of[i + 1] == Some(close - 1) {
-            return Err("The expression has redundant parentheses;".to_owned());
         }
     }
     Ok(())


### PR DESCRIPTION
Replace the two-pass approach (match_of[] array + second scan) with a
single-pass algorithm using a Vec<bool> as a stack. Each '(' pushes
whether the preceding token was also '('; each ')' pops and checks
whether the next token is also ')'. Together these detect ((…)) groups
in O(n) time with no second pass or mutation after push.

## What

<!-- Describe what this PR changes. -->

## Why

<!-- Link the issue this addresses. Explain the motivation. -->

Closes #

## Testing done

<!-- How did you verify this change works? Include test commands or output. -->

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a

no breaking changes, no doc changes needed
---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
