### PR TITLE
ci: bump MSRV to 1.88, add MSRV CI check

### DIFF
--- a/.agents/skills/extenddb/references/setup/02-dependency-checks.md
+++ b/.agents/skills/extenddb/references/setup/02-dependency-checks.md
@@ -8,7 +8,7 @@ This file lists the dependency checks the `extenddb-setup` skill runs before pro
 
 | Dependency | Check command | Minimum version | Rationale |
 |---|---|---|---|
-| Rust toolchain | `cargo --version` and `rustc --version` | 1.85 | extenddb is a Rust workspace; older toolchains fail `cargo build --release`. |
+| Rust toolchain | `cargo --version` and `rustc --version` | 1.88 | extenddb is a Rust workspace; older toolchains fail `cargo build --release`. |
 | PostgreSQL client | `psql --version` | 14 | extenddb speaks the Postgres protocol at init and runtime; older clients may lack required features. |
 | PostgreSQL server readiness | `pg_isready` | n/a (server-side check) | Confirms the server is reachable before `extenddb init`. |
 | Python 3 | `python3 --version` | 3.10 | Required by the sample apps and the docs build pipeline. |
@@ -29,7 +29,7 @@ If `which cargo` exits nonzero, Rust is not installed. Install:
 - Linux (Fedora/RHEL): `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
 - macOS: `brew install rustup-init && rustup-init`
 
-If Rust is installed but `rustc --version` reports older than 1.85:
+If Rust is installed but `rustc --version` reports older than 1.88:
 
 ```bash
 rustup update
@@ -84,7 +84,7 @@ If `python3 --version` reports older than 3.10, upgrade via the same package man
 
 ## Version parsing
 
-`rustc --version` prints `rustc 1.85.0 (abcdef0 2025-01-01)`. Extract the version field with `awk`:
+`rustc --version` prints `rustc 1.88.0 (abcdef0 2025-01-01)`. Extract the version field with `awk`:
 
 ```bash
 rustc --version | awk '{print $2}'
@@ -96,11 +96,11 @@ rustc --version | awk '{print $2}'
 psql --version | awk '{print $3}'
 ```
 
-Compare the extracted version against the minimum (1.85 for Rust, 14 for Postgres) by splitting on `.` and comparing numerically. For skill-level checks, a string prefix comparison (`[[ "$PG_VER" < "14" ]]`) is adequate because major versions are single or double digits.
+Compare the extracted version against the minimum (1.88 for Rust, 14 for Postgres) by splitting on `.` and comparing numerically. For skill-level checks, a string prefix comparison (`[[ "$PG_VER" < "14" ]]`) is adequate because major versions are single or double digits.
 
 ## Rust version upgrade path
 
-If Rust is installed via rustup and `rustc --version` reports older than 1.85, the fix is:
+If Rust is installed via rustup and `rustc --version` reports older than 1.88, the fix is:
 
 ```bash
 rustup update

--- a/.agents/skills/extenddb/references/setup/03-build-stage.md
+++ b/.agents/skills/extenddb/references/setup/03-build-stage.md
@@ -59,4 +59,4 @@ This should print the extenddb version string. If it does not, the build failed 
 cargo build --release --verbose
 ```
 
-Common causes of silent build failure are a missing system library (for example, `libpq-dev` or `openssl-dev` on Linux), a Rust toolchain older than 1.85, or a disk full condition under `target/`. The verbose output names the failing crate and the missing dependency.
+Common causes of silent build failure are a missing system library (for example, `libpq-dev` or `openssl-dev` on Linux), a Rust toolchain older than 1.88, or a disk full condition under `target/`. The verbose output names the failing crate and the missing dependency.

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -8,7 +8,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -8,7 +8,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,25 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  run-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain: [stable, "1.88.0"]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
+
+  test:
+    runs-on: ubuntu-latest
+    needs: run-tests
+    if: always()
+    steps:
+      - run: |
+          if [ "${{ needs.run-tests.result }}" != "success" ]; then
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ License. ExtendDB is a clean-room implementation of the DynamoDB wire protocol, 
 by AWS engineers. It is not a fork of DynamoDB and contains no DynamoDB source code. ExtendDB speaks the DynamoDB wire
 protocol: any AWS SDK, CLI, or tool that works with DynamoDB works with ExtendDB, unchanged.
 
-- **Language:** Rust (edition 2024, MSRV 1.85+)
+- **Language:** Rust (edition 2024, MSRV 1.88+)
 - **Storage backend:** PostgreSQL 14+
 - **Architecture:** Async (tokio), trait-based storage abstraction
 - **Authentication:** Mandatory SigV4 with built-in IAM (users, groups, roles, policies)
@@ -81,7 +81,7 @@ extenddb (bin)
 
 ### Prerequisites
 
-- Rust 1.85+ (`rustup update`)
+- Rust 1.88+ (`rustup update`)
 - PostgreSQL 14+ running locally (see `docs/local-postgres-setup.md`)
 - Python 3.10+ for tests (`python3 -m venv ~/venvs/extenddb-venv && source ~/venvs/extenddb-venv/bin/activate && pip install -r requirements.txt`)
 
@@ -369,7 +369,7 @@ python3 docs/build-docs.py
 ## Code Style and Conventions
 
 - **Rust edition:** 2024
-- **MSRV:** 1.85
+- **MSRV:** 1.88
 - **Async:** tokio, no `#[async_trait]` (use RPITIT)
 - **Error handling:** `thiserror` for library errors, `anyhow` for application errors
 - **Serialization:** `serde` + `serde_json`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to ExtendDB!
 
 ### Prerequisites
 
-- Rust 1.85+ (stable)
+- Rust 1.88+ (stable)
 - PostgreSQL 14+
 - Python 3.10+ (for integration tests)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "Apache-2.0"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ scripts/install-macos.sh   # macOS
 
 ## Prerequisites
 
-- Rust 1.85+ (`rustup update`)
+- Rust 1.88+ (`rustup update`)
 - PostgreSQL 14+ (see `docs/local-postgres-setup.md`)
 - Python 3.10+ (for test suites and documentation)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,7 +30,7 @@ software on your behalf. After the script completes, continue from
 ## Prerequisites
 
 - PostgreSQL 14+ running locally (see `docs/local-postgres-setup.md`)
-- Rust toolchain (1.85+)
+- Rust toolchain (1.88+)
 - AWS CLI v2 (for testing)
 - Python 3.10+ with virtual environment (see [Python Environment Setup](../README.md#python-environment-setup) in the README)
 

--- a/docs/manuals/04-quickstart-setup-guide.md
+++ b/docs/manuals/04-quickstart-setup-guide.md
@@ -9,7 +9,7 @@ This section gets you from zero to a working extenddb instance as fast as possib
 ### Prerequisites
 
 - PostgreSQL 14+ running locally
-- Rust toolchain 1.85+
+- Rust toolchain 1.88+
 - AWS CLI v2
 
 ### Steps

--- a/docs/manuals/08-install-linux.md
+++ b/docs/manuals/08-install-linux.md
@@ -26,7 +26,7 @@ If you prefer to run each step yourself, follow the sections below.
 
 ## Prerequisites
 
-- Rust 1.85+ (`rustup update`)
+- Rust 1.88+ (`rustup update`)
 - PostgreSQL 14+
 - Python 3.10+ (for test suites)
 - AWS CLI v2 (for testing)

--- a/docs/manuals/09-install-macos.md
+++ b/docs/manuals/09-install-macos.md
@@ -26,7 +26,7 @@ If you prefer to run each step yourself, follow the sections below.
 
 ## Prerequisites
 
-- Rust 1.85+ (`rustup update`)
+- Rust 1.88+ (`rustup update`)
 - PostgreSQL 14+ via Homebrew (`brew install postgresql@17`)
 - Python 3.10+ (for test suites)
 - AWS CLI v2 (for testing)

--- a/docs/manuals/11-deployment-guide.md
+++ b/docs/manuals/11-deployment-guide.md
@@ -84,7 +84,7 @@ Example Dockerfile:
 
 ```dockerfile
 # Match rust-version in Cargo.toml
-FROM rust:1.85 AS builder
+FROM rust:1.95 AS builder
 WORKDIR /src
 COPY . .
 RUN cargo build --release


### PR DESCRIPTION
- Add matrix strategy to test workflow (stable + 1.88.0)
- Update rust-version in Cargo.toml to 1.88
- Update all docs referencing minimum Rust version
- Update actions/checkout to @v6 in GitHub workflows
- 
## What

Update minimum Rust version to 1.88. Update Rust version in Docker example to next-to-latest version.

## Why

We accidentally took dependencies on package versions that require 1.86+ or 1.88+. This adjusts the documentation to reflect that, and adds enforcement to make it unlikely we'll do this again without noticing.

## Testing done

Cargo test against 1.85.1, 1.88.0, and stable.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a

## Breaking changes

Well, it was already broken, this just cleans up documentation to match.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
