### PR TITLE
Fix clippy::collapsible_if warnings

### DIFF
--- a/crates/auth/src/cache_registry.rs
+++ b/crates/auth/src/cache_registry.rs
@@ -277,14 +277,14 @@ impl AuthCacheRegistry {
         // Best-effort credential fanout; failures are logged-but-not-fatal
         // because the credential cache's negative TTL bounds the worst-case
         // exposure window if invalidation fails.
-        if let Some(c) = &self.credential {
-            if let Err(e) = c.invalidate_account(account_id) {
-                tracing::warn!(
-                    account_id = account_id,
-                    error = ?e,
-                    "credential cache invalidate_account failed; relying on TTL"
-                );
-            }
+        if let Some(c) = &self.credential
+            && let Err(e) = c.invalidate_account(account_id)
+        {
+            tracing::warn!(
+                account_id = account_id,
+                error = ?e,
+                "credential cache invalidate_account failed; relying on TTL"
+            );
         }
     }
 
@@ -310,15 +310,15 @@ impl AuthCacheRegistry {
     /// `account_id`. Called when a user or role is deleted. No-op when
     /// caches are disabled.
     pub async fn invalidate_principal_credentials(&self, account_id: &str, principal_name: &str) {
-        if let Some(c) = &self.credential {
-            if let Err(e) = c.invalidate_principal(account_id, principal_name) {
-                tracing::warn!(
-                    account_id = account_id,
-                    principal = principal_name,
-                    error = ?e,
-                    "credential cache invalidate_principal failed; relying on TTL"
-                );
-            }
+        if let Some(c) = &self.credential
+            && let Err(e) = c.invalidate_principal(account_id, principal_name)
+        {
+            tracing::warn!(
+                account_id = account_id,
+                principal = principal_name,
+                error = ?e,
+                "credential cache invalidate_principal failed; relying on TTL"
+            );
         }
     }
 }

--- a/crates/auth/src/credential_cache.rs
+++ b/crates/auth/src/credential_cache.rs
@@ -179,21 +179,19 @@ impl CredentialStore for CachedCredentialStore {
         // the cache cannot extend a session past its issued lifetime.
         // Mirror the storage-layer error so the cache is transparent to the
         // auth provider.
-        if let Some(ref cred) = result {
-            if cred.is_session {
-                if let Some(expires_at) = cred.expires_at {
-                    if expires_at < time::OffsetDateTime::now_utc() {
-                        // Drop the stale entry so the next lookup goes
-                        // straight to the storage layer (which will raise
-                        // ExpiredTokenException itself, or return the
-                        // post-rotation credential if one exists).
-                        self.cache.invalidate(&access_key_id.to_owned()).await;
-                        return Err(DynamoDbError::ExpiredTokenException(
-                            "The security token included in the request is expired".to_owned(),
-                        ));
-                    }
-                }
-            }
+        if let Some(ref cred) = result
+            && cred.is_session
+            && let Some(expires_at) = cred.expires_at
+            && expires_at < time::OffsetDateTime::now_utc()
+        {
+            // Drop the stale entry so the next lookup goes
+            // straight to the storage layer (which will raise
+            // ExpiredTokenException itself, or return the
+            // post-rotation credential if one exists).
+            self.cache.invalidate(&access_key_id.to_owned()).await;
+            return Err(DynamoDbError::ExpiredTokenException(
+                "The security token included in the request is expired".to_owned(),
+            ));
         }
         Ok(result)
     }

--- a/crates/auth/src/policy/condition.rs
+++ b/crates/auth/src/policy/condition.rs
@@ -281,17 +281,18 @@ fn compare_dates(a: &str, b: &str, cmp: impl FnOnce(i128, i128) -> bool) -> bool
 /// Also accepts epoch seconds as a plain number.
 fn parse_epoch_millis(s: &str) -> Option<i128> {
     // Try epoch seconds first (plain number)
-    if let Ok(n) = s.parse::<f64>() {
-        if !s.contains('T') && !s.contains('-') {
-            // Reject NaN/Infinity — they are not valid epoch timestamps.
-            if !n.is_finite() {
-                return None;
-            }
-            // f64 → i128 via `as` is saturating (Rust ≥1.45). Epoch millis
-            // for any realistic date fits in i128 with no precision loss.
-            #[allow(clippy::cast_possible_truncation)]
-            return Some((n * 1000.0) as i128);
+    if let Ok(n) = s.parse::<f64>()
+        && !s.contains('T')
+        && !s.contains('-')
+    {
+        // Reject NaN/Infinity — they are not valid epoch timestamps.
+        if !n.is_finite() {
+            return None;
         }
+        // f64 → i128 via `as` is saturating (Rust ≥1.45). Epoch millis
+        // for any realistic date fits in i128 with no precision loss.
+        #[allow(clippy::cast_possible_truncation)]
+        return Some((n * 1000.0) as i128);
     }
 
     // Try ISO 8601 with time crate

--- a/crates/auth/src/sigv4/verify.rs
+++ b/crates/auth/src/sigv4/verify.rs
@@ -64,12 +64,12 @@ pub fn verify_signature(
 
     // Reject UNSIGNED-PAYLOAD: real DynamoDB requires a computed body hash
     // for all API calls. UNSIGNED-PAYLOAD is only valid for S3.
-    if let Some(content_sha) = headers.get("x-amz-content-sha256") {
-        if content_sha.as_bytes() == b"UNSIGNED-PAYLOAD" {
-            return Err(DynamoDbError::InvalidSignatureException(
-                "UNSIGNED-PAYLOAD is not supported for DynamoDB operations.".to_owned(),
-            ));
-        }
+    if let Some(content_sha) = headers.get("x-amz-content-sha256")
+        && content_sha.as_bytes() == b"UNSIGNED-PAYLOAD"
+    {
+        return Err(DynamoDbError::InvalidSignatureException(
+            "UNSIGNED-PAYLOAD is not supported for DynamoDB operations.".to_owned(),
+        ));
     }
 
     // Build canonical request

--- a/crates/bin/src/cmd_catalog_check.rs
+++ b/crates/bin/src/cmd_catalog_check.rs
@@ -48,15 +48,14 @@ pub async fn run(args: CatalogCheckArgs) -> anyhow::Result<()> {
 
     // Refuse to run while server is up.
     let pid_path = crate::serve_helpers::pid_file_path(&run_dir, port);
-    if let Ok(contents) = std::fs::read_to_string(&pid_path) {
-        if let Ok(pid) = contents.trim().parse::<i32>() {
-            if crate::util::is_process_alive(pid) {
-                anyhow::bail!(
-                    "Server is running (PID {pid}). Stop it with `extenddb stop` before \
+    if let Ok(contents) = std::fs::read_to_string(&pid_path)
+        && let Ok(pid) = contents.trim().parse::<i32>()
+        && crate::util::is_process_alive(pid)
+    {
+        anyhow::bail!(
+            "Server is running (PID {pid}). Stop it with `extenddb stop` before \
                      running catalog-check."
-                );
-            }
-        }
+        );
     }
 
     println!("=== extenddb catalog-check ===");

--- a/crates/bin/src/cmd_init.rs
+++ b/crates/bin/src/cmd_init.rs
@@ -81,13 +81,13 @@ fn discover_docs_dir() -> Option<String> {
     let candidates: Vec<std::path::PathBuf> = {
         let mut v = Vec::new();
         // Relative to the binary.
-        if let Ok(exe) = std::env::current_exe() {
-            if let Some(dir) = exe.parent() {
-                v.push(dir.join("docs/rendered"));
-                // Also check one level up (binary in target/release/).
-                if let Some(parent) = dir.parent() {
-                    v.push(parent.join("docs/rendered"));
-                }
+        if let Ok(exe) = std::env::current_exe()
+            && let Some(dir) = exe.parent()
+        {
+            v.push(dir.join("docs/rendered"));
+            // Also check one level up (binary in target/release/).
+            if let Some(parent) = dir.parent() {
+                v.push(parent.join("docs/rendered"));
             }
         }
         // Relative to cwd.

--- a/crates/bin/src/config.rs
+++ b/crates/bin/src/config.rs
@@ -307,12 +307,11 @@ fn default_run_dir() -> String {
 /// Expand a leading `~` in a path to `$HOME`. Returns the input unchanged
 /// if `$HOME` is unset or the path does not start with `~`.
 pub fn expand_tilde(path: &str) -> String {
-    if let Some(rest) = path.strip_prefix('~') {
-        if rest.is_empty() || rest.starts_with('/') {
-            if let Ok(home) = std::env::var("HOME") {
-                return format!("{home}{rest}");
-            }
-        }
+    if let Some(rest) = path.strip_prefix('~')
+        && (rest.is_empty() || rest.starts_with('/'))
+        && let Ok(home) = std::env::var("HOME")
+    {
+        return format!("{home}{rest}");
     }
     path.to_owned()
 }

--- a/crates/bin/src/manage_http.rs
+++ b/crates/bin/src/manage_http.rs
@@ -279,11 +279,10 @@ pub fn dispatch(
             let r = c.req("POST", "/management/accounts", Some(&body))?;
             if (200..300).contains(&r.0) {
                 // Read server-generated account_id from response body.
-                if let Ok(resp) = serde_json::from_str::<serde_json::Value>(&r.1) {
-                    if let Some(id) = resp.get("account_id").and_then(|v| v.as_str()) {
+                if let Ok(resp) = serde_json::from_str::<serde_json::Value>(&r.1)
+                    && let Some(id) = resp.get("account_id").and_then(|v| v.as_str()) {
                         eprintln!("Account ID: {id}");
                     }
-                }
             }
             Ok(r)
         }

--- a/crates/bin/src/serve_helpers.rs
+++ b/crates/bin/src/serve_helpers.rs
@@ -48,10 +48,10 @@ pub fn verify_daemon_started(pid_file: &PathBuf, bind_addr: &str) -> anyhow::Res
     // empty or partially written, so we retry both read and parse.
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
     let pid: u32 = loop {
-        if let Ok(content) = std::fs::read_to_string(pid_file) {
-            if let Ok(p) = content.trim().parse::<u32>() {
-                break p;
-            }
+        if let Ok(content) = std::fs::read_to_string(pid_file)
+            && let Ok(p) = content.trim().parse::<u32>()
+        {
+            break p;
         }
         if std::time::Instant::now() >= deadline {
             eprintln!("Server failed to start: PID file not created within 5 seconds.\n{hint}");

--- a/crates/core/src/expression/evaluator.rs
+++ b/crates/core/src/expression/evaluator.rs
@@ -56,26 +56,25 @@ pub fn evaluate_condition(
             // DynamoDB validates bounds when both are literal placeholders
             if matches!(low.as_ref(), Expr::Placeholder(_))
                 && matches!(high.as_ref(), Expr::Placeholder(_))
+                && let (Some(l), Some(h)) = (lo.as_deref(), hi.as_deref())
             {
-                if let (Some(l), Some(h)) = (lo.as_deref(), hi.as_deref()) {
-                    let l_type = attribute_type_code(l);
-                    let h_type = attribute_type_code(h);
-                    if l_type != h_type {
-                        return Err(DynamoDbError::ValidationException(format!(
-                            "Invalid ConditionExpression: The BETWEEN operator requires same data type for lower and upper bounds; lower bound operand: AttributeValue: {{{}}}, upper bound operand: AttributeValue: {{{}}}",
-                            format_attribute_value(l),
-                            format_attribute_value(h)
-                        )));
-                    }
-                    let lpn = placeholder_numeric(low, maps);
-                    let hpn = placeholder_numeric(high, maps);
-                    if compare_values(l, h, CompareOp::Gt, lpn, hpn) {
-                        return Err(DynamoDbError::ValidationException(format!(
-                            "Invalid ConditionExpression: The BETWEEN operator requires upper bound to be greater than or equal to lower bound; lower bound operand: AttributeValue: {{{}}}, upper bound operand: AttributeValue: {{{}}}",
-                            format_attribute_value(l),
-                            format_attribute_value(h)
-                        )));
-                    }
+                let l_type = attribute_type_code(l);
+                let h_type = attribute_type_code(h);
+                if l_type != h_type {
+                    return Err(DynamoDbError::ValidationException(format!(
+                        "Invalid ConditionExpression: The BETWEEN operator requires same data type for lower and upper bounds; lower bound operand: AttributeValue: {{{}}}, upper bound operand: AttributeValue: {{{}}}",
+                        format_attribute_value(l),
+                        format_attribute_value(h)
+                    )));
+                }
+                let lpn = placeholder_numeric(low, maps);
+                let hpn = placeholder_numeric(high, maps);
+                if compare_values(l, h, CompareOp::Gt, lpn, hpn) {
+                    return Err(DynamoDbError::ValidationException(format!(
+                        "Invalid ConditionExpression: The BETWEEN operator requires upper bound to be greater than or equal to lower bound; lower bound operand: AttributeValue: {{{}}}, upper bound operand: AttributeValue: {{{}}}",
+                        format_attribute_value(l),
+                        format_attribute_value(h)
+                    )));
                 }
             }
             match (&val, &lo, &hi) {
@@ -268,13 +267,13 @@ fn evaluate_function(
             let val = resolve_to_value(&args[0], item, maps)?;
             let prefix = resolve_to_value(&args[1], item, maps)?;
             // Reject invalid operand types — only S and B are allowed
-            if let Some(ref p) = prefix.as_deref() {
-                if !matches!(p, AttributeValue::S(_) | AttributeValue::B(_)) {
-                    let type_code = attribute_type_code(p);
-                    return Err(DynamoDbError::ValidationException(format!(
-                        "Invalid ConditionExpression: Incorrect operand type for operator or function; operator or function: begins_with, operand type: {type_code}"
-                    )));
-                }
+            if let Some(ref p) = prefix.as_deref()
+                && !matches!(p, AttributeValue::S(_) | AttributeValue::B(_))
+            {
+                let type_code = attribute_type_code(p);
+                return Err(DynamoDbError::ValidationException(format!(
+                    "Invalid ConditionExpression: Incorrect operand type for operator or function; operator or function: begins_with, operand type: {type_code}"
+                )));
             }
             match (val.as_deref(), prefix.as_deref()) {
                 (Some(AttributeValue::S(s)), Some(AttributeValue::S(p))) => {

--- a/crates/core/src/expression/key_condition.rs
+++ b/crates/core/src/expression/key_condition.rs
@@ -449,31 +449,18 @@ fn parse_key_clause_inner(tokens: &[Token], pos: &mut usize) -> Result<RawClause
     }
 
     // begins_with(path, :val)
-    if let Token::Ident(name) = &tokens[*pos] {
-        if name.eq_ignore_ascii_case("begins_with")
-            && *pos + 1 < tokens.len()
-            && tokens[*pos + 1] == Token::LParen
-        {
-            *pos += 1; // skip function name
-            parser_common::expect_token(
-                tokens,
-                pos,
-                &Token::LParen,
-                "(",
-                "KeyConditionExpression",
-            )?;
-            let path = parse_key_operand_path(tokens, pos)?;
-            parser_common::expect_token(tokens, pos, &Token::Comma, ",", "KeyConditionExpression")?;
-            let prefix = parse_key_value(tokens, pos)?;
-            parser_common::expect_token(
-                tokens,
-                pos,
-                &Token::RParen,
-                ")",
-                "KeyConditionExpression",
-            )?;
-            return Ok(RawClause::BeginsWith(path, prefix));
-        }
+    if let Token::Ident(name) = &tokens[*pos]
+        && name.eq_ignore_ascii_case("begins_with")
+        && *pos + 1 < tokens.len()
+        && tokens[*pos + 1] == Token::LParen
+    {
+        *pos += 1; // skip function name
+        parser_common::expect_token(tokens, pos, &Token::LParen, "(", "KeyConditionExpression")?;
+        let path = parse_key_operand_path(tokens, pos)?;
+        parser_common::expect_token(tokens, pos, &Token::Comma, ",", "KeyConditionExpression")?;
+        let prefix = parse_key_value(tokens, pos)?;
+        parser_common::expect_token(tokens, pos, &Token::RParen, ")", "KeyConditionExpression")?;
+        return Ok(RawClause::BeginsWith(path, prefix));
     }
 
     // path op :value | :value op path | path BETWEEN :lo AND :hi

--- a/crates/core/src/expression/resolver.rs
+++ b/crates/core/src/expression/resolver.rs
@@ -94,10 +94,10 @@ impl ExpressionMaps {
     /// existing behavior.
     pub fn pre_parse_numerics(&mut self) {
         for (key, value) in &self.values {
-            if let AttributeValue::N(n) = value {
-                if let Ok(d) = n.parse::<bigdecimal::BigDecimal>() {
-                    self.parsed_numerics.insert(key.clone(), d);
-                }
+            if let AttributeValue::N(n) = value
+                && let Ok(d) = n.parse::<bigdecimal::BigDecimal>()
+            {
+                self.parsed_numerics.insert(key.clone(), d);
             }
         }
     }
@@ -347,10 +347,10 @@ fn collect_action_refs(
 
 fn collect_path_refs(elements: &[PathElement], names: &mut std::collections::HashSet<String>) {
     for el in elements {
-        if let PathElement::Attribute(name) = el {
-            if let Some(ref_name) = name.strip_prefix('#') {
-                names.insert(ref_name.to_owned());
-            }
+        if let PathElement::Attribute(name) = el
+            && let Some(ref_name) = name.strip_prefix('#')
+        {
+            names.insert(ref_name.to_owned());
         }
     }
 }
@@ -415,27 +415,25 @@ pub fn validate_begins_with_operands(
 ) -> Result<(), DynamoDbError> {
     match expr {
         Expr::Function { name, args } if name == "begins_with" => {
-            if args.len() == 2 {
-                if let Expr::Placeholder(ref placeholder) = args[1] {
-                    if let Some(val) = maps.values.get(placeholder) {
-                        if !matches!(val, AttributeValue::S(_) | AttributeValue::B(_)) {
-                            let type_code = match val {
-                                AttributeValue::N(_) => "N",
-                                AttributeValue::Bool(_) => "BOOL",
-                                AttributeValue::Null => "NULL",
-                                AttributeValue::L(_) => "L",
-                                AttributeValue::M(_) => "M",
-                                AttributeValue::SS(_) => "SS",
-                                AttributeValue::NS(_) => "NS",
-                                AttributeValue::BS(_) => "BS",
-                                _ => "UNKNOWN",
-                            };
-                            return Err(DynamoDbError::ValidationException(format!(
-                                "Incorrect operand type for operator or function; operator or function: begins_with, operand type: {type_code}"
-                            )));
-                        }
-                    }
-                }
+            if args.len() == 2
+                && let Expr::Placeholder(ref placeholder) = args[1]
+                && let Some(val) = maps.values.get(placeholder)
+                && !matches!(val, AttributeValue::S(_) | AttributeValue::B(_))
+            {
+                let type_code = match val {
+                    AttributeValue::N(_) => "N",
+                    AttributeValue::Bool(_) => "BOOL",
+                    AttributeValue::Null => "NULL",
+                    AttributeValue::L(_) => "L",
+                    AttributeValue::M(_) => "M",
+                    AttributeValue::SS(_) => "SS",
+                    AttributeValue::NS(_) => "NS",
+                    AttributeValue::BS(_) => "BS",
+                    _ => "UNKNOWN",
+                };
+                return Err(DynamoDbError::ValidationException(format!(
+                    "Incorrect operand type for operator or function; operator or function: begins_with, operand type: {type_code}"
+                )));
             }
             Ok(())
         }

--- a/crates/core/src/expression/update_evaluator.rs
+++ b/crates/core/src/expression/update_evaluator.rs
@@ -135,10 +135,10 @@ fn evaluate_set_function(
                 ));
             }
             // If the path exists, return its value; otherwise return the default
-            if let Expr::Path(elements) = &args[0] {
-                if let Some(existing) = resolve_path_to_value(elements, item, maps)? {
-                    return Ok(existing.clone());
-                }
+            if let Expr::Path(elements) = &args[0]
+                && let Some(existing) = resolve_path_to_value(elements, item, maps)?
+            {
+                return Ok(existing.clone());
             }
             evaluate_set_value(&args[1], item, maps)
         }

--- a/crates/core/src/metrics/collector_query.rs
+++ b/crates/core/src/metrics/collector_query.rs
@@ -30,16 +30,16 @@ impl MetricsCollector {
         let mut results = Vec::new();
         for (key, acc) in map.iter() {
             // Filter by table name if specified.
-            if let Some(ref tn) = params.table_name {
-                if key.table_name.as_deref() != Some(tn.as_str()) {
-                    continue;
-                }
+            if let Some(ref tn) = params.table_name
+                && key.table_name.as_deref() != Some(tn.as_str())
+            {
+                continue;
             }
             // Filter by metric name if specified.
-            if let Some(ref m) = params.metric {
-                if key.metric != *m {
-                    continue;
-                }
+            if let Some(ref m) = params.metric
+                && key.metric != *m
+            {
+                continue;
             }
 
             let Some(snap) = acc.snapshot(window, now) else {
@@ -167,10 +167,10 @@ impl MetricsCollector {
         };
         let mut by_op: HashMap<String, SegmentAccum> = HashMap::new();
         for p in vec.iter() {
-            if let Some(c) = cutoff {
-                if p.timestamp < c {
-                    continue;
-                }
+            if let Some(c) = cutoff
+                && p.timestamp < c
+            {
+                continue;
             }
             let e = by_op.entry(p.operation.clone()).or_default();
             e.0 += p.segments.auth_us;

--- a/crates/core/src/throttle.rs
+++ b/crates/core/src/throttle.rs
@@ -314,23 +314,23 @@ impl ThrottleManager {
         }
 
         // Check per-partition bucket (1000 WCU/s, 3000 RCU/s per partition).
-        if let Some(pv) = partition_value {
-            if let Ok(mut partitions) = self.partitions.write() {
-                let pk = PartitionKey {
-                    account_id: account_id.to_owned(),
-                    table_name: table_name.to_owned(),
-                    partition_value: pv.to_owned(),
-                };
-                let buckets = partitions.entry(pk).or_insert_with(|| TableBuckets {
-                    read: TokenBucket::new(PARTITION_RCU_LIMIT),
-                    write: TokenBucket::new(PARTITION_WCU_LIMIT),
-                });
-                if is_read && !buckets.read.has_capacity(now) {
-                    return ThrottleResult::ThrottledRead;
-                }
-                if is_write && !buckets.write.has_capacity(now) {
-                    return ThrottleResult::ThrottledWrite;
-                }
+        if let Some(pv) = partition_value
+            && let Ok(mut partitions) = self.partitions.write()
+        {
+            let pk = PartitionKey {
+                account_id: account_id.to_owned(),
+                table_name: table_name.to_owned(),
+                partition_value: pv.to_owned(),
+            };
+            let buckets = partitions.entry(pk).or_insert_with(|| TableBuckets {
+                read: TokenBucket::new(PARTITION_RCU_LIMIT),
+                write: TokenBucket::new(PARTITION_WCU_LIMIT),
+            });
+            if is_read && !buckets.read.has_capacity(now) {
+                return ThrottleResult::ThrottledRead;
+            }
+            if is_write && !buckets.write.has_capacity(now) {
+                return ThrottleResult::ThrottledWrite;
             }
         }
 
@@ -391,23 +391,23 @@ impl ThrottleManager {
         }
 
         // Consume from per-partition bucket if partition value is known.
-        if let Some(pv) = partition_value {
-            if let Ok(mut partitions) = self.partitions.write() {
-                let pk = PartitionKey {
-                    account_id: account_id.to_owned(),
-                    table_name: table_name.to_owned(),
-                    partition_value: pv.to_owned(),
-                };
-                let buckets = partitions.entry(pk).or_insert_with(|| TableBuckets {
-                    read: TokenBucket::new(PARTITION_RCU_LIMIT),
-                    write: TokenBucket::new(PARTITION_WCU_LIMIT),
-                });
-                if read_units > 0.0 {
-                    buckets.read.consume(read_units, now);
-                }
-                if write_units > 0.0 {
-                    buckets.write.consume(write_units, now);
-                }
+        if let Some(pv) = partition_value
+            && let Ok(mut partitions) = self.partitions.write()
+        {
+            let pk = PartitionKey {
+                account_id: account_id.to_owned(),
+                table_name: table_name.to_owned(),
+                partition_value: pv.to_owned(),
+            };
+            let buckets = partitions.entry(pk).or_insert_with(|| TableBuckets {
+                read: TokenBucket::new(PARTITION_RCU_LIMIT),
+                write: TokenBucket::new(PARTITION_WCU_LIMIT),
+            });
+            if read_units > 0.0 {
+                buckets.read.consume(read_units, now);
+            }
+            if write_units > 0.0 {
+                buckets.write.consume(write_units, now);
             }
         }
 

--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -405,13 +405,13 @@ fn validate_gsi_count(
     input: &CreateTableInput,
     limits: &LimitsConfig,
 ) -> Result<(), DynamoDbError> {
-    if let Some(gsis) = &input.global_secondary_indexes {
-        if gsis.len() > limits.max_gsis_per_table {
-            return Err(DynamoDbError::ValidationException(format!(
-                "One or more parameter values were invalid: GlobalSecondaryIndexes count exceeds limit of {}",
-                limits.max_gsis_per_table
-            )));
-        }
+    if let Some(gsis) = &input.global_secondary_indexes
+        && gsis.len() > limits.max_gsis_per_table
+    {
+        return Err(DynamoDbError::ValidationException(format!(
+            "One or more parameter values were invalid: GlobalSecondaryIndexes count exceeds limit of {}",
+            limits.max_gsis_per_table
+        )));
     }
     Ok(())
 }
@@ -420,13 +420,13 @@ fn validate_lsi_count(
     input: &CreateTableInput,
     limits: &LimitsConfig,
 ) -> Result<(), DynamoDbError> {
-    if let Some(lsis) = &input.local_secondary_indexes {
-        if lsis.len() > limits.max_lsis_per_table {
-            return Err(DynamoDbError::ValidationException(format!(
-                "One or more parameter values were invalid: LocalSecondaryIndexes count exceeds limit of {}",
-                limits.max_lsis_per_table
-            )));
-        }
+    if let Some(lsis) = &input.local_secondary_indexes
+        && lsis.len() > limits.max_lsis_per_table
+    {
+        return Err(DynamoDbError::ValidationException(format!(
+            "One or more parameter values were invalid: LocalSecondaryIndexes count exceeds limit of {}",
+            limits.max_lsis_per_table
+        )));
     }
     Ok(())
 }

--- a/crates/engine/src/expected.rs
+++ b/crates/engine/src/expected.rs
@@ -80,16 +80,14 @@ fn desugar_one(
             ));
         }
         // Exists: true + Value → EQ comparison (legacy shorthand)
-        if exists {
-            if let Some(val) = &expected.value {
-                let placeholder = next_placeholder(counter);
-                values.insert(placeholder.clone(), val.clone());
-                return Ok(Expr::Compare {
-                    left: Box::new(path.clone()),
-                    op: CompareOp::Eq,
-                    right: Box::new(Expr::Placeholder(placeholder)),
-                });
-            }
+        if exists && let Some(val) = &expected.value {
+            let placeholder = next_placeholder(counter);
+            values.insert(placeholder.clone(), val.clone());
+            return Ok(Expr::Compare {
+                left: Box::new(path.clone()),
+                op: CompareOp::Eq,
+                right: Box::new(Expr::Placeholder(placeholder)),
+            });
         }
         let fn_name = if exists {
             "attribute_exists"

--- a/crates/engine/src/import_export_io.rs
+++ b/crates/engine/src/import_export_io.rs
@@ -120,10 +120,10 @@ fn read_csv(
         let values = split_csv_line(trimmed, delim_byte);
         let mut item = Item::new();
         for (i, header) in headers.iter().enumerate() {
-            if let Some(val) = values.get(i) {
-                if !val.is_empty() {
-                    item.insert(header.clone(), AttributeValue::S(val.clone()));
-                }
+            if let Some(val) = values.get(i)
+                && !val.is_empty()
+            {
+                item.insert(header.clone(), AttributeValue::S(val.clone()));
             }
         }
         if !item.is_empty() {

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -177,16 +177,15 @@ pub(crate) fn validate_enum_fields(
     };
     let mut errors: Vec<String> = Vec::new();
     for &(json_name, api_name, valid) in fields {
-        if let Some(val) = obj.get(json_name) {
-            if let Some(s) = val.as_str() {
-                if !valid.contains(&s) {
-                    errors.push(format!(
-                        "Value '{s}' at '{api_name}' failed to satisfy constraint: \
+        if let Some(val) = obj.get(json_name)
+            && let Some(s) = val.as_str()
+            && !valid.contains(&s)
+        {
+            errors.push(format!(
+                "Value '{s}' at '{api_name}' failed to satisfy constraint: \
                          Member must satisfy enum value set: [{}]",
-                        valid.join(", ")
-                    ));
-                }
-            }
+                valid.join(", ")
+            ));
         }
     }
     if errors.is_empty() {
@@ -284,10 +283,11 @@ impl OperationContext {
         &self,
         table_name: &str,
     ) -> Result<extenddb_core::types::TableKeyInfo, extenddb_storage::error::StorageError> {
-        if let Some(ref ki) = self.pre_fetched_key_info {
-            if ki.table_name == table_name && *ki.account_id == *self.account_id {
-                return Ok(ki.clone());
-            }
+        if let Some(ref ki) = self.pre_fetched_key_info
+            && ki.table_name == table_name
+            && *ki.account_id == *self.account_id
+        {
+            return Ok(ki.clone());
         }
         if let Some(ref lookup) = self.table_key_info_lookup {
             return lookup.lookup(&self.account_id, table_name).await;

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -62,23 +62,22 @@ pub async fn handle_query(
     };
 
     // ConsistentRead is not supported on GSI queries (tenet 1: fidelity).
-    if input.consistent_read == Some(true) {
-        if let Some(ref idx) = index_info {
-            if idx.index_type == IndexType::Gsi {
-                return Err(DynamoDbError::ValidationException(
-                    "Consistent reads are not supported on global secondary indexes".to_owned(),
-                ));
-            }
-        }
+    if input.consistent_read == Some(true)
+        && let Some(ref idx) = index_info
+        && idx.index_type == IndexType::Gsi
+    {
+        return Err(DynamoDbError::ValidationException(
+            "Consistent reads are not supported on global secondary indexes".to_owned(),
+        ));
     }
 
     // Validate Limit >= 1 (REQ-QUERY-001)
-    if let Some(limit) = input.limit {
-        if limit < 1 {
-            return Err(DynamoDbError::ValidationException(
+    if let Some(limit) = input.limit
+        && limit < 1
+    {
+        return Err(DynamoDbError::ValidationException(
                 "1 validation error detected: Value at 'Limit' failed to satisfy constraint: Member must have value greater than or equal to 1".to_owned(),
             ));
-        }
     }
 
     // For index queries, build a key_info that reflects the index's key schema
@@ -284,10 +283,10 @@ pub async fn handle_query(
         if let Some(ref proj) = projection {
             for path in proj {
                 for el in path {
-                    if let PathElement::Attribute(name) = el {
-                        if let Some(ref_name) = name.strip_prefix('#') {
-                            kc_names.insert(ref_name.to_owned());
-                        }
+                    if let PathElement::Attribute(name) = el
+                        && let Some(ref_name) = name.strip_prefix('#')
+                    {
+                        kc_names.insert(ref_name.to_owned());
                     }
                 }
             }
@@ -303,26 +302,26 @@ pub async fn handle_query(
     }
 
     // Validate Select vs ProjectionExpression and index requirements
-    if let Some(Select::SpecificAttributes) = input.select {
-        if effective_projection_str.is_none() {
-            return Err(DynamoDbError::ValidationException(
+    if let Some(Select::SpecificAttributes) = input.select
+        && effective_projection_str.is_none()
+    {
+        return Err(DynamoDbError::ValidationException(
                 "1 validation error detected: Must specify the AttributesToGet or ProjectionExpression when choosing to get SPECIFIC_ATTRIBUTES".to_owned(),
             ));
-        }
     }
-    if let Some(Select::AllProjectedAttributes) = input.select {
-        if index_info.is_none() {
-            return Err(DynamoDbError::ValidationException(
-                "ALL_PROJECTED_ATTRIBUTES can be used only when querying an index".to_owned(),
-            ));
-        }
+    if let Some(Select::AllProjectedAttributes) = input.select
+        && index_info.is_none()
+    {
+        return Err(DynamoDbError::ValidationException(
+            "ALL_PROJECTED_ATTRIBUTES can be used only when querying an index".to_owned(),
+        ));
     }
-    if let Some(Select::Count) = input.select {
-        if effective_projection_str.is_some() {
-            return Err(DynamoDbError::ValidationException(
-                "Cannot specify the ProjectionExpression when Select is COUNT".to_owned(),
-            ));
-        }
+    if let Some(Select::Count) = input.select
+        && effective_projection_str.is_some()
+    {
+        return Err(DynamoDbError::ValidationException(
+            "Cannot specify the ProjectionExpression when Select is COUNT".to_owned(),
+        ));
     }
 
     // When Select=ALL_PROJECTED_ATTRIBUTES, capture the index info for post-read filtering.
@@ -465,17 +464,17 @@ fn validate_name_refs_in_expr(
     match expr {
         Expr::Path(elements) => {
             for el in elements {
-                if let PathElement::Attribute(name) = el {
-                    if let Some(ref_name) = name.strip_prefix('#') {
-                        let key_with_hash = format!("#{ref_name}");
-                        let defined = names.as_ref().is_some_and(|m| {
-                            m.contains_key(ref_name) || m.contains_key(key_with_hash.as_str())
-                        });
-                        if !defined {
-                            return Err(DynamoDbError::ValidationException(format!(
-                                "Invalid {expr_type}: An expression attribute name used in the document path is not defined; attribute name: #{ref_name}"
-                            )));
-                        }
+                if let PathElement::Attribute(name) = el
+                    && let Some(ref_name) = name.strip_prefix('#')
+                {
+                    let key_with_hash = format!("#{ref_name}");
+                    let defined = names.as_ref().is_some_and(|m| {
+                        m.contains_key(ref_name) || m.contains_key(key_with_hash.as_str())
+                    });
+                    if !defined {
+                        return Err(DynamoDbError::ValidationException(format!(
+                            "Invalid {expr_type}: An expression attribute name used in the document path is not defined; attribute name: #{ref_name}"
+                        )));
                     }
                 }
             }

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -58,14 +58,13 @@ pub async fn handle_scan(
     };
 
     // ConsistentRead is not supported on GSI scans (tenet 1: fidelity).
-    if input.consistent_read == Some(true) {
-        if let Some(ref idx) = index_info {
-            if idx.index_type == IndexType::Gsi {
-                return Err(DynamoDbError::ValidationException(
-                    "Consistent reads are not supported on global secondary indexes".to_owned(),
-                ));
-            }
-        }
+    if input.consistent_read == Some(true)
+        && let Some(ref idx) = index_info
+        && idx.index_type == IndexType::Gsi
+    {
+        return Err(DynamoDbError::ValidationException(
+            "Consistent reads are not supported on global secondary indexes".to_owned(),
+        ));
     }
 
     // Validate Segment/TotalSegments — DynamoDB returns different messages per direction
@@ -104,12 +103,12 @@ pub async fn handle_scan(
     }
 
     // Validate Limit >= 1
-    if let Some(limit) = input.limit {
-        if limit < 1 {
-            return Err(DynamoDbError::ValidationException(format!(
-                "1 validation error detected: Value '{limit}' at 'limit' failed to satisfy constraint: Member must have value greater than or equal to 1"
-            )));
-        }
+    if let Some(limit) = input.limit
+        && limit < 1
+    {
+        return Err(DynamoDbError::ValidationException(format!(
+            "1 validation error detected: Value '{limit}' at 'limit' failed to satisfy constraint: Member must have value greater than or equal to 1"
+        )));
     }
 
     // For index scans, build a key_info that reflects the index's key schema.
@@ -210,10 +209,10 @@ pub async fn handle_scan(
         if let Some(ref proj) = projection {
             for path in proj {
                 for el in path {
-                    if let extenddb_core::expression::PathElement::Attribute(name) = el {
-                        if let Some(ref_name) = name.strip_prefix('#') {
-                            extra_names.insert(ref_name.to_owned());
-                        }
+                    if let extenddb_core::expression::PathElement::Attribute(name) = el
+                        && let Some(ref_name) = name.strip_prefix('#')
+                    {
+                        extra_names.insert(ref_name.to_owned());
                     }
                 }
             }
@@ -229,19 +228,19 @@ pub async fn handle_scan(
     }
 
     // Validate Select vs ProjectionExpression and index requirements
-    if let Some(Select::AllProjectedAttributes) = input.select {
-        if index_info.is_none() {
-            return Err(DynamoDbError::ValidationException(
-                "ALL_PROJECTED_ATTRIBUTES can be used only when scanning an index".to_owned(),
-            ));
-        }
+    if let Some(Select::AllProjectedAttributes) = input.select
+        && index_info.is_none()
+    {
+        return Err(DynamoDbError::ValidationException(
+            "ALL_PROJECTED_ATTRIBUTES can be used only when scanning an index".to_owned(),
+        ));
     }
-    if let Some(Select::Count) = input.select {
-        if effective_projection_str.is_some() {
-            return Err(DynamoDbError::ValidationException(
-                "Cannot specify the ProjectionExpression when Select is COUNT".to_owned(),
-            ));
-        }
+    if let Some(Select::Count) = input.select
+        && effective_projection_str.is_some()
+    {
+        return Err(DynamoDbError::ValidationException(
+            "Cannot specify the ProjectionExpression when Select is COUNT".to_owned(),
+        ));
     }
 
     let index_proj = if matches!(input.select, Some(Select::AllProjectedAttributes)) {

--- a/crates/engine/src/streams.rs
+++ b/crates/engine/src/streams.rs
@@ -198,20 +198,20 @@ pub async fn handle_get_records(
     let seq = if parts.len() >= 3 { parts[2] } else { "" };
 
     // Check iterator expiration (15 minutes).
-    if parts.len() >= 4 {
-        if let Ok(created_at) = parts[3].parse::<u64>() {
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-            if now.saturating_sub(created_at) > SHARD_ITERATOR_EXPIRY_SECS {
-                return Err(DynamoDbError::ExpiredIteratorException(
-                    "The shard iterator has expired and can no longer be \
+    if parts.len() >= 4
+        && let Ok(created_at) = parts[3].parse::<u64>()
+    {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        if now.saturating_sub(created_at) > SHARD_ITERATOR_EXPIRY_SECS {
+            return Err(DynamoDbError::ExpiredIteratorException(
+                "The shard iterator has expired and can no longer be \
                      used to retrieve stream records. A new shard iterator \
                      must be obtained by calling GetShardIterator."
-                        .to_owned(),
-                ));
-            }
+                    .to_owned(),
+            ));
         }
     }
 

--- a/crates/engine/src/tagging.rs
+++ b/crates/engine/src/tagging.rs
@@ -40,12 +40,12 @@ async fn validate_resource_arn(arn: &str, ctx: &OperationContext) -> Result<(), 
     })?;
 
     // Check the ARN's account matches the caller's account.
-    if let Some(arn_account) = extract_account_from_arn(arn) {
-        if arn_account != ctx.account_id.as_ref() {
-            return Err(DynamoDbError::AccessDeniedException(
-                "Access is denied".to_owned(),
-            ));
-        }
+    if let Some(arn_account) = extract_account_from_arn(arn)
+        && arn_account != ctx.account_id.as_ref()
+    {
+        return Err(DynamoDbError::AccessDeniedException(
+            "Access is denied".to_owned(),
+        ));
     }
 
     // Verify the table exists via table_key_info (lightweight check).

--- a/crates/engine/src/transact_get_items.rs
+++ b/crates/engine/src/transact_get_items.rs
@@ -140,10 +140,10 @@ pub async fn handle_transact_get_items(
                 let mut extra_names = std::collections::HashSet::new();
                 for path in &projection {
                     for el in path {
-                        if let extenddb_core::expression::PathElement::Attribute(name) = el {
-                            if let Some(ref_name) = name.strip_prefix('#') {
-                                extra_names.insert(ref_name.to_owned());
-                            }
+                        if let extenddb_core::expression::PathElement::Attribute(name) = el
+                            && let Some(ref_name) = name.strip_prefix('#')
+                        {
+                            extra_names.insert(ref_name.to_owned());
                         }
                     }
                 }

--- a/crates/engine/src/update_table.rs
+++ b/crates/engine/src/update_table.rs
@@ -53,12 +53,13 @@ pub async fn handle_update_table(
     }
 
     // Validate: enabling streams requires a view type.
-    if let Some(spec) = &input.stream_specification {
-        if spec.stream_enabled && spec.stream_view_type.is_none() {
-            return Err(DynamoDbError::ValidationException(
-                "StreamViewType must be specified when StreamEnabled is true".to_owned(),
-            ));
-        }
+    if let Some(spec) = &input.stream_specification
+        && spec.stream_enabled
+        && spec.stream_view_type.is_none()
+    {
+        return Err(DynamoDbError::ValidationException(
+            "StreamViewType must be specified when StreamEnabled is true".to_owned(),
+        ));
     }
 
     // Switching to PROVISIONED requires explicit throughput values.
@@ -80,12 +81,12 @@ pub async fn handle_update_table(
     }
 
     // Validate throughput values (must be > 0).
-    if let Some(ref tp) = input.provisioned_throughput {
-        if tp.read_capacity_units < 1 || tp.write_capacity_units < 1 {
-            return Err(DynamoDbError::ValidationException(
+    if let Some(ref tp) = input.provisioned_throughput
+        && (tp.read_capacity_units < 1 || tp.write_capacity_units < 1)
+    {
+        return Err(DynamoDbError::ValidationException(
                 "One or more parameter values were invalid: ReadCapacityUnits and WriteCapacityUnits must each be at least 1".to_owned(),
             ));
-        }
     }
 
     // Validate GSI updates: each entry must have exactly one of Create, Update, or Delete.

--- a/crates/server/src/console/pages/mod.rs
+++ b/crates/server/src/console/pages/mod.rs
@@ -110,10 +110,10 @@ fn extract_session_token(headers: &HeaderMap) -> Option<String> {
     let cookie_header = headers.get("cookie")?.to_str().ok()?;
     for part in cookie_header.split(';') {
         let part = part.trim();
-        if let Some(value) = part.strip_prefix("extenddb_session=") {
-            if !value.is_empty() {
-                return Some(value.to_owned());
-            }
+        if let Some(value) = part.strip_prefix("extenddb_session=")
+            && !value.is_empty()
+        {
+            return Some(value.to_owned());
         }
     }
     None

--- a/crates/server/src/console/pages/user_pages.rs
+++ b/crates/server/src/console/pages/user_pages.rs
@@ -111,21 +111,21 @@ pub async fn create_user(
 
     let pw = form.password.as_deref().filter(|p| !p.is_empty());
 
-    if let Some(p) = pw {
-        if p.len() > 72 {
-            let nav = html::nav_bar(&identity_label(&session.identity));
-            let content = format!(
-                "<h1>Create User</h1>{}",
-                html::alert_error("password must not exceed 72 bytes (bcrypt limit)")
-            );
-            return Html(html::layout_csrf(
-                "New User",
-                &nav,
-                &content,
-                &session.csrf_token,
-            ))
-            .into_response();
-        }
+    if let Some(p) = pw
+        && p.len() > 72
+    {
+        let nav = html::nav_bar(&identity_label(&session.identity));
+        let content = format!(
+            "<h1>Create User</h1>{}",
+            html::alert_error("password must not exceed 72 bytes (bcrypt limit)")
+        );
+        return Html(html::layout_csrf(
+            "New User",
+            &nav,
+            &content,
+            &session.csrf_token,
+        ))
+        .into_response();
     }
 
     let password_hash = match pw {

--- a/crates/server/src/handler.rs
+++ b/crates/server/src/handler.rs
@@ -39,12 +39,11 @@ pub(crate) async fn handle_request(
 
     // HTTP/2 uses :authority instead of Host. Ensure the Host header is
     // populated so SigV4 verification can find it in the canonical request.
-    if !headers.contains_key("host") {
-        if let Some(authority) = uri.authority() {
-            if let Ok(val) = authority.as_str().parse() {
-                headers.insert("host", val);
-            }
-        }
+    if !headers.contains_key("host")
+        && let Some(authority) = uri.authority()
+        && let Ok(val) = authority.as_str().parse()
+    {
+        headers.insert("host", val);
     }
     let request_id = uuid::Uuid::new_v4().to_string();
 
@@ -147,59 +146,58 @@ pub(crate) async fn handle_request(
     let throttle_start = std::time::Instant::now();
     let (is_read_op, is_write_op) = classify_data_operation(&operation);
     let partition_value = extract_partition_value(&input, &operation);
-    if let Some(ref tn) = table_name {
-        if is_read_op || is_write_op {
-            if !state.throttle.is_registered(&ctx.account_id, tn) {
-                if let Ok(desc) = ctx
-                    .storage
-                    .describe_table(
-                        &ctx.account_id,
-                        extenddb_core::types::DescribeTableInput {
-                            table_name: tn.clone(),
-                        },
-                    )
-                    .await
-                {
-                    let throughput = table_description_to_throughput(&desc);
-                    state
-                        .throttle
-                        .register_table(&ctx.account_id, tn, throughput);
-                }
-            }
+    if let Some(ref tn) = table_name
+        && (is_read_op || is_write_op)
+    {
+        if !state.throttle.is_registered(&ctx.account_id, tn)
+            && let Ok(desc) = ctx
+                .storage
+                .describe_table(
+                    &ctx.account_id,
+                    extenddb_core::types::DescribeTableInput {
+                        table_name: tn.clone(),
+                    },
+                )
+                .await
+        {
+            let throughput = table_description_to_throughput(&desc);
+            state
+                .throttle
+                .register_table(&ctx.account_id, tn, throughput);
+        }
 
-            let result = state.throttle.check_capacity_with_partition(
-                &ctx.account_id,
-                tn,
-                is_read_op,
-                is_write_op,
-                partition_value.as_deref(),
+        let result = state.throttle.check_capacity_with_partition(
+            &ctx.account_id,
+            tn,
+            is_read_op,
+            is_write_op,
+            partition_value.as_deref(),
+        );
+        if result != extenddb_core::throttle::ThrottleResult::Allowed {
+            let metric = if result == extenddb_core::throttle::ThrottleResult::ThrottledRead {
+                extenddb_core::metrics::MetricName::ReadThrottleEvents
+            } else {
+                extenddb_core::metrics::MetricName::WriteThrottleEvents
+            };
+            state
+                .metrics
+                .record(metric, 1.0, Some(tn), None, Some(&operation));
+            state.metrics.record(
+                extenddb_core::metrics::MetricName::ThrottledRequests,
+                1.0,
+                Some(tn),
+                None,
+                Some(&operation),
             );
-            if result != extenddb_core::throttle::ThrottleResult::Allowed {
-                let metric = if result == extenddb_core::throttle::ThrottleResult::ThrottledRead {
-                    extenddb_core::metrics::MetricName::ReadThrottleEvents
-                } else {
-                    extenddb_core::metrics::MetricName::WriteThrottleEvents
-                };
-                state
-                    .metrics
-                    .record(metric, 1.0, Some(tn), None, Some(&operation));
-                state.metrics.record(
-                    extenddb_core::metrics::MetricName::ThrottledRequests,
-                    1.0,
-                    Some(tn),
-                    None,
-                    Some(&operation),
-                );
-                return error_response(
-                    &DynamoDbError::ProvisionedThroughputExceededException(
-                        "The level of configured provisioned throughput for the table \
+            return error_response(
+                &DynamoDbError::ProvisionedThroughputExceededException(
+                    "The level of configured provisioned throughput for the table \
                          was exceeded. Consider increasing your provisioning level \
                          with the UpdateTable API."
-                            .to_owned(),
-                    ),
-                    &request_id,
-                );
-            }
+                        .to_owned(),
+                ),
+                &request_id,
+            );
         }
     }
     #[allow(clippy::cast_precision_loss)]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -277,12 +277,11 @@ async fn graceful_shutdown(pid_file: Option<PathBuf>) {
 
 /// Remove the PID file if it exists. Best-effort — log but don't fail.
 fn cleanup_pid_file(pid_file: Option<&std::path::Path>) {
-    if let Some(path) = pid_file {
-        if let Err(e) = std::fs::remove_file(path) {
-            if e.kind() != std::io::ErrorKind::NotFound {
-                tracing::warn!("Failed to remove PID file {}: {e}", path.display());
-            }
-        }
+    if let Some(path) = pid_file
+        && let Err(e) = std::fs::remove_file(path)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::warn!("Failed to remove PID file {}: {e}", path.display());
     }
 }
 

--- a/crates/server/src/management/assume_role.rs
+++ b/crates/server/src/management/assume_role.rs
@@ -119,14 +119,14 @@ pub async fn assume_role(
     }
 
     // Validate session policy if provided.
-    if let Some(ref sp) = request.session_policy {
-        if sp.get("Version").is_none() || sp.get("Statement").is_none() {
-            return (
-                StatusCode::BAD_REQUEST,
-                "Session policy must contain Version and Statement",
-            )
-                .into_response();
-        }
+    if let Some(ref sp) = request.session_policy
+        && (sp.get("Version").is_none() || sp.get("Statement").is_none())
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            "Session policy must contain Version and Statement",
+        )
+            .into_response();
     }
 
     // Load the role and its trust policy.

--- a/crates/storage-postgres/src/bootstrapper.rs
+++ b/crates/storage-postgres/src/bootstrapper.rs
@@ -509,13 +509,13 @@ impl PostgresBootstrapper {
             check_conflict(extenddb_user.as_ref(), &parts.user, "--extenddb-user")?;
             check_conflict(extenddb_pass.as_ref(), &parts.password, "--extenddb-pass")?;
 
-            if let Some(ref cli_catalog) = catalog_db {
-                if cli_catalog != &parts.database {
-                    return Err(StorageError::Internal(format!(
-                        "--catalog-db '{}' conflicts with config file catalog database '{}'",
-                        cli_catalog, parts.database
-                    )));
-                }
+            if let Some(ref cli_catalog) = catalog_db
+                && cli_catalog != &parts.database
+            {
+                return Err(StorageError::Internal(format!(
+                    "--catalog-db '{}' conflicts with config file catalog database '{}'",
+                    cli_catalog, parts.database
+                )));
             }
 
             (

--- a/crates/storage-postgres/src/data/index.rs
+++ b/crates/storage-postgres/src/data/index.rs
@@ -145,31 +145,31 @@ pub(crate) async fn sync_indexes(
         let base_sks = all_sort_key_info(base_key_schema, attr_defs);
 
         // Delete old index row if the old item had index keys
-        if let Some(old) = old_item {
-            if item_has_index_keys(old, &idx.key_schema) {
-                delete_index_row_multi(tx, &idx_table, old, base_key_schema, attr_defs, &base_sks)
-                    .await?;
-            }
+        if let Some(old) = old_item
+            && item_has_index_keys(old, &idx.key_schema)
+        {
+            delete_index_row_multi(tx, &idx_table, old, base_key_schema, attr_defs, &base_sks)
+                .await?;
         }
 
         // Insert new index row if the new item has index keys
-        if let Some(new) = new_item {
-            if item_has_index_keys(new, &idx.key_schema) {
-                let projected =
-                    project_item_for_index(new, &idx.key_schema, base_key_schema, &idx.projection);
-                insert_index_row_multi(
-                    tx,
-                    &idx_table,
-                    new,
-                    &projected,
-                    &idx.key_schema,
-                    base_key_schema,
-                    attr_defs,
-                    &idx_sks,
-                    &base_sks,
-                )
-                .await?;
-            }
+        if let Some(new) = new_item
+            && item_has_index_keys(new, &idx.key_schema)
+        {
+            let projected =
+                project_item_for_index(new, &idx.key_schema, base_key_schema, &idx.projection);
+            insert_index_row_multi(
+                tx,
+                &idx_table,
+                new,
+                &projected,
+                &idx.key_schema,
+                base_key_schema,
+                attr_defs,
+                &idx_sks,
+                &base_sks,
+            )
+            .await?;
         }
     }
     Ok(())

--- a/crates/storage-postgres/src/data/query.rs
+++ b/crates/storage-postgres/src/data/query.rs
@@ -151,11 +151,11 @@ pub(crate) async fn execute_query_sql(
     }
 
     // Bind exclusive start key SK value
-    if let (Some(start_key), Some((sk_name, sk_type))) = (exclusive_start_key, sk_info) {
-        if let Some(sk_val) = start_key.get(sk_name) {
-            let sk = parse_sk(sk_val, sk_type)?;
-            query = bind_sk_value(query, &sk);
-        }
+    if let (Some(start_key), Some((sk_name, sk_type))) = (exclusive_start_key, sk_info)
+        && let Some(sk_val) = start_key.get(sk_name)
+    {
+        let sk = parse_sk(sk_val, sk_type)?;
+        query = bind_sk_value(query, &sk);
     }
 
     let rows: Vec<(serde_json::Value,)> = query
@@ -266,11 +266,11 @@ pub(crate) async fn execute_scan_sql(
         let pk_text = pk_to_text(pk_val)?;
         query = query.bind(pk_text.into_owned());
 
-        if let Some((sk_name, sk_type)) = sk_info(key_schema, attr_defs) {
-            if let Some(sk_val) = start_key.get(sk_name) {
-                let sk = parse_sk(sk_val, sk_type)?;
-                query = bind_sk_value(query, &sk);
-            }
+        if let Some((sk_name, sk_type)) = sk_info(key_schema, attr_defs)
+            && let Some(sk_val) = start_key.get(sk_name)
+        {
+            let sk = parse_sk(sk_val, sk_type)?;
+            query = bind_sk_value(query, &sk);
         }
     }
 

--- a/crates/storage-postgres/src/gsi_queue.rs
+++ b/crates/storage-postgres/src/gsi_queue.rs
@@ -201,42 +201,42 @@ async fn apply_gsi_update(pool: &PgPool, update: &GsiUpdate) -> Result<(), Stora
         .map_err(|e| StorageError::Internal(e.to_string()))?;
 
     // Delete old index row if the old item had index keys.
-    if let Some(ref old) = update.old_item {
-        if item_has_index_keys(old, &update.index_key_schema) {
-            delete_index_row_multi(
-                &mut tx,
-                &idx_table,
-                old,
-                &update.base_key_schema,
-                &update.attr_defs,
-                &base_sks,
-            )
-            .await?;
-        }
+    if let Some(ref old) = update.old_item
+        && item_has_index_keys(old, &update.index_key_schema)
+    {
+        delete_index_row_multi(
+            &mut tx,
+            &idx_table,
+            old,
+            &update.base_key_schema,
+            &update.attr_defs,
+            &base_sks,
+        )
+        .await?;
     }
 
     // Insert new index row if the new item has index keys.
-    if let Some(ref new) = update.new_item {
-        if item_has_index_keys(new, &update.index_key_schema) {
-            let projected = project_item_for_index(
-                new,
-                &update.index_key_schema,
-                &update.base_key_schema,
-                &update.index_projection,
-            );
-            insert_index_row_multi(
-                &mut tx,
-                &idx_table,
-                new,
-                &projected,
-                &update.index_key_schema,
-                &update.base_key_schema,
-                &update.attr_defs,
-                &idx_sks,
-                &base_sks,
-            )
-            .await?;
-        }
+    if let Some(ref new) = update.new_item
+        && item_has_index_keys(new, &update.index_key_schema)
+    {
+        let projected = project_item_for_index(
+            new,
+            &update.index_key_schema,
+            &update.base_key_schema,
+            &update.index_projection,
+        );
+        insert_index_row_multi(
+            &mut tx,
+            &idx_table,
+            new,
+            &projected,
+            &update.index_key_schema,
+            &update.base_key_schema,
+            &update.attr_defs,
+            &idx_sks,
+            &base_sks,
+        )
+        .await?;
     }
 
     tx.commit()

--- a/crates/storage-postgres/src/operations.rs
+++ b/crates/storage-postgres/src/operations.rs
@@ -26,12 +26,12 @@ impl OperationsEngine for PostgresOperationsEngine {
 
     fn redact_connection_string(&self, s: &str) -> String {
         // Redact password from postgresql://user:password@host:port/database
-        if let Some(at) = s.find('@') {
-            if let Some(colon) = s[..at].rfind(':') {
-                let scheme_end = s.find("://").map_or(0, |i| i + 3);
-                if colon >= scheme_end {
-                    return format!("{}:***@{}", &s[..colon], &s[at + 1..]);
-                }
+        if let Some(at) = s.find('@')
+            && let Some(colon) = s[..at].rfind(':')
+        {
+            let scheme_end = s.find("://").map_or(0, |i| i + 3);
+            if colon >= scheme_end {
+                return format!("{}:***@{}", &s[..colon], &s[at + 1..]);
             }
         }
         s.to_owned()

--- a/crates/storage-postgres/src/update_table.rs
+++ b/crates/storage-postgres/src/update_table.rs
@@ -44,52 +44,48 @@ impl PostgresEngine {
         // throughput values is rejected by DynamoDB. This check runs under the
         // FOR UPDATE lock to eliminate the TOCTOU race that existed when the
         // check was in the engine layer.
-        if matches!(input.billing_mode, Some(BillingMode::Provisioned)) {
-            if let Some(ref pt) = input.provisioned_throughput {
-                let current_row: Option<(Option<String>, Option<serde_json::Value>)> =
-                    sqlx::query_as(
-                        "SELECT billing_mode, provisioned_throughput FROM tables \
+        if matches!(input.billing_mode, Some(BillingMode::Provisioned))
+            && let Some(ref pt) = input.provisioned_throughput
+        {
+            let current_row: Option<(Option<String>, Option<serde_json::Value>)> = sqlx::query_as(
+                "SELECT billing_mode, provisioned_throughput FROM tables \
                      WHERE account_id = $1 AND table_name = $2",
-                    )
-                    .bind(account_id)
-                    .bind(&input.table_name)
-                    .fetch_optional(&mut *tx)
-                    .await
-                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            )
+            .bind(account_id)
+            .bind(&input.table_name)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
 
-                if let Some((current_bm, current_pt_opt)) = current_row {
-                    let current_pt =
-                        current_pt_opt.unwrap_or(serde_json::Value::Object(Default::default()));
-                    let is_provisioned =
-                        current_bm.as_deref() == Some("PROVISIONED") || current_bm.is_none();
-                    let current_rcu = current_pt
-                        .get("ReadCapacityUnits")
-                        .or_else(|| current_pt.get("read_capacity_units"))
-                        .and_then(|v| v.as_i64())
-                        .unwrap_or(0);
-                    let current_wcu = current_pt
-                        .get("WriteCapacityUnits")
-                        .or_else(|| current_pt.get("write_capacity_units"))
-                        .and_then(|v| v.as_i64())
-                        .unwrap_or(0);
+            if let Some((current_bm, current_pt_opt)) = current_row {
+                let current_pt =
+                    current_pt_opt.unwrap_or(serde_json::Value::Object(Default::default()));
+                let is_provisioned =
+                    current_bm.as_deref() == Some("PROVISIONED") || current_bm.is_none();
+                let current_rcu = current_pt
+                    .get("ReadCapacityUnits")
+                    .or_else(|| current_pt.get("read_capacity_units"))
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+                let current_wcu = current_pt
+                    .get("WriteCapacityUnits")
+                    .or_else(|| current_pt.get("write_capacity_units"))
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
 
-                    if is_provisioned
-                        && current_rcu == pt.read_capacity_units
-                        && current_wcu == pt.write_capacity_units
-                    {
-                        return Err(StorageError::NoOpUpdate(format!(
-                            "The provisioned throughput for the table will not change. \
+                if is_provisioned
+                    && current_rcu == pt.read_capacity_units
+                    && current_wcu == pt.write_capacity_units
+                {
+                    return Err(StorageError::NoOpUpdate(format!(
+                        "The provisioned throughput for the table will not change. \
                              The requested value equals the current value. \
                              Current ReadCapacityUnits provisioned for the table: {}. \
                              Requested ReadCapacityUnits: {}. \
                              Current WriteCapacityUnits provisioned for the table: {}. \
                              Requested WriteCapacityUnits: {}.",
-                            current_rcu,
-                            pt.read_capacity_units,
-                            current_wcu,
-                            pt.write_capacity_units
-                        )));
-                    }
+                        current_rcu, pt.read_capacity_units, current_wcu, pt.write_capacity_units
+                    )));
                 }
             }
         }

--- a/crates/storage/src/bootstrapper.rs
+++ b/crates/storage/src/bootstrapper.rs
@@ -241,13 +241,13 @@ pub mod helpers {
         config_val: &T,
         flag: &str,
     ) -> Result<(), crate::error::StorageError> {
-        if let Some(v) = cli_val {
-            if v != config_val {
-                return Err(crate::error::StorageError::Internal(format!(
-                    "{} value '{}' conflicts with config file value '{}'",
-                    flag, v, config_val
-                )));
-            }
+        if let Some(v) = cli_val
+            && v != config_val
+        {
+            return Err(crate::error::StorageError::Internal(format!(
+                "{} value '{}' conflicts with config file value '{}'",
+                flag, v, config_val
+            )));
         }
         Ok(())
     }


### PR DESCRIPTION
Collapse nested if/else-if blocks across crates/.

## What

Rerun clippy/fmt due to changed clippy behavior for chained if-let.

## Why

Ensures GitHub clippy workflow continues to succeed

## Testing done

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
