### PR TITLE
fix: always emit empty UnprocessedKeys/UnprocessedItems on batch get/write success

### DIFF
--- a/crates/core/src/types/batch.rs
+++ b/crates/core/src/types/batch.rs
@@ -48,7 +48,9 @@ pub struct BatchGetItemInput {
 pub struct BatchGetItemOutput {
     #[serde(rename = "Responses")]
     pub responses: HashMap<String, Vec<Item>>,
-    #[serde(rename = "UnprocessedKeys", skip_serializing_if = "HashMap::is_empty")]
+    /// Always serialized, even when empty: Amazon DynamoDB returns
+    /// `"UnprocessedKeys": {}` when all keys are processed rather than omitting it.
+    #[serde(rename = "UnprocessedKeys")]
     pub unprocessed_keys: HashMap<String, KeysAndAttributes>,
     /// Per-table consumed capacity (present when requested).
     #[serde(rename = "ConsumedCapacity", skip_serializing_if = "Option::is_none")]
@@ -116,7 +118,9 @@ pub struct BatchWriteItemInput {
 /// `BatchWriteItem` response body.
 #[derive(Debug, Clone, Serialize)]
 pub struct BatchWriteItemOutput {
-    #[serde(rename = "UnprocessedItems", skip_serializing_if = "HashMap::is_empty")]
+    /// Always serialized, even when empty: Amazon DynamoDB returns
+    /// `"UnprocessedItems": {}` on full success rather than omitting the field.
+    #[serde(rename = "UnprocessedItems")]
     pub unprocessed_items: HashMap<String, Vec<WriteRequest>>,
     /// Per-table consumed capacity (present when requested).
     #[serde(rename = "ConsumedCapacity", skip_serializing_if = "Option::is_none")]

--- a/tests/test_batch_operations.py
+++ b/tests/test_batch_operations.py
@@ -178,6 +178,30 @@ class TestBatchGetItem:
         # UnprocessedKeys should be empty (or absent)
         unprocessed = resp.get("UnprocessedKeys", {})
         assert len(unprocessed) == 0
+
+    def test_batch_get_unprocessed_keys_always_present(
+        self, dynamodb_client, hash_table
+    ):
+        """BatchGetItem always includes UnprocessedKeys, even when all keys processed.
+
+        Amazon DynamoDB returns ``"UnprocessedKeys": {}`` on the wire when every
+        key is processed; the field is never omitted. A response that drops the
+        field entirely is non-conformant.
+        """
+        dynamodb_client.put_item(
+            TableName=hash_table,
+            Item={"pk": {"S": "present"}},
+        )
+
+        resp = dynamodb_client.batch_get_item(
+            RequestItems={hash_table: {"Keys": [{"pk": {"S": "present"}}]}}
+        )
+
+        assert "UnprocessedKeys" in resp, (
+            "UnprocessedKeys must always be present in the BatchGetItem "
+            "response, even when empty"
+        )
+        assert resp["UnprocessedKeys"] == {}
 # ── BatchWriteItem ────────────────────────────────────────────────────
 class TestBatchWriteItem:
     """Tests for the BatchWriteItem operation."""
@@ -313,6 +337,29 @@ class TestBatchWriteItem:
 
         unprocessed = resp.get("UnprocessedItems", {})
         assert len(unprocessed) == 0
+
+    def test_batch_write_unprocessed_items_always_present(
+        self, dynamodb_client, hash_table
+    ):
+        """BatchWriteItem always includes UnprocessedItems, even on full success.
+
+        Amazon DynamoDB returns ``"UnprocessedItems": {}`` on the wire when every
+        write succeeds; the field is never omitted. A response that drops the
+        field entirely is non-conformant.
+        """
+        resp = dynamodb_client.batch_write_item(
+            RequestItems={
+                hash_table: [
+                    {"PutRequest": {"Item": {"pk": {"S": "always-present"}}}},
+                ]
+            }
+        )
+
+        assert "UnprocessedItems" in resp, (
+            "UnprocessedItems must always be present in the BatchWriteItem "
+            "response, even when empty"
+        )
+        assert resp["UnprocessedItems"] == {}
 
     def test_batch_write_put_wrong_key_type(self, dynamodb_client, hash_table):
         """BatchWriteItem PutRequest with wrong key type returns ValidationException."""


### PR DESCRIPTION
## What

`BatchGetItem` and `BatchWriteItem` now always serialize the unprocessed-work field on the wire, even when it is empty:

- `BatchGetItem`: response always includes `"UnprocessedKeys": {}` when every requested key is processed (was: field omitted on full success).
- `BatchWriteItem`: response always includes `"UnprocessedItems": {}` when every write succeeds (was: field omitted on full success).

## Why

Amazon DynamoDB always returns `UnprocessedKeys` / `UnprocessedItems` in the response body, set to `{}` when there is no unprocessed work.

## Testing done

Confirmed against Amazon DynamoDB that both fields are present (`{}`) on full success, then verified the fix against ExtendDB end-to-end.

New pytest cases in `tests/test_batch_operations.py`.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy --all-targets --workspace -- -D warnings`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

## Breaking changes
None.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
