### PR TITLE
fix: broken integ tests and UPDATED_NEW/OLD multiple subpaths

### DIFF
--- a/crates/core/src/expression/evaluator.rs
+++ b/crates/core/src/expression/evaluator.rs
@@ -298,7 +298,16 @@ fn evaluate_function(
                         let parts: Vec<String> = p
                             .iter()
                             .map(|e| match e {
-                                PathElement::Attribute(a) => a.clone(),
+                                PathElement::Attribute(a) => {
+                                    if let Some(ref_name) = a.strip_prefix('#') {
+                                        maps.names
+                                            .get(ref_name)
+                                            .cloned()
+                                            .unwrap_or_else(|| a.clone())
+                                    } else {
+                                        a.clone()
+                                    }
+                                }
                                 PathElement::Index(i) => format!("[{i}]"),
                             })
                             .collect();

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -88,9 +88,10 @@ pub async fn handle_scan(
                 ));
             }
             if seg < 0 {
-                return Err(DynamoDbError::ValidationException(
-                    "The parameter Segment should be greater than or equal to 0".to_owned(),
-                ));
+                return Err(DynamoDbError::ValidationException(format!(
+                    "1 validation error detected: Value '{}' at 'segment' failed to satisfy constraint: Member must have value greater than or equal to 0",
+                    seg
+                )));
             }
             if seg >= total {
                 return Err(DynamoDbError::ValidationException(format!(

--- a/crates/engine/src/transact_write_items.rs
+++ b/crates/engine/src/transact_write_items.rs
@@ -157,7 +157,7 @@ pub async fn handle_transact_write_items(
     let wcu: f64 = prepared
         .iter()
         .map(|op| {
-            let item_wcu = capacity_helpers::write_capacity_units(op.write_bytes());
+            let item_wcu = capacity_helpers::write_capacity_units(op.write_bytes()) * 2.0; // transactions cost 2x
             *per_table_wcu.entry(op.table_name().to_owned()).or_default() += item_wcu;
             item_wcu
         })

--- a/crates/engine/src/update_item.rs
+++ b/crates/engine/src/update_item.rs
@@ -325,7 +325,17 @@ fn filter_to_updated_attrs(item: &Item, actions: &[UpdateAction], maps: &Express
         };
         if let Some(leaf) = resolve_path_value(top_val, &path[1..], maps) {
             let wrapped = wrap_leaf_in_path(&path[1..], &leaf, maps);
-            result.insert(top_name, wrapped);
+            // Merge into existing top-level entry if multiple subpaths target
+            // the same attribute (e.g., SET a.b = :x, a.c = :y).
+            if let Some(existing) = result.get(&top_name) {
+                if let Some(merged) = merge_maps(existing, &wrapped) {
+                    result.insert(top_name, merged);
+                } else {
+                    result.insert(top_name, wrapped);
+                }
+            } else {
+                result.insert(top_name, wrapped);
+            }
         }
     }
     result
@@ -377,6 +387,28 @@ fn wrap_leaf_in_path(
             AttributeValue::M(map)
         }
         PathElement::Index(_) => AttributeValue::L(vec![inner]),
+    }
+}
+
+/// Recursively merge two Map AttributeValues. Returns None if either isn't a Map.
+fn merge_maps(a: &AttributeValue, b: &AttributeValue) -> Option<AttributeValue> {
+    match (a, b) {
+        (AttributeValue::M(ma), AttributeValue::M(mb)) => {
+            let mut merged = ma.clone();
+            for (k, v) in mb {
+                if let Some(existing) = merged.get(k) {
+                    if let Some(deep) = merge_maps(existing, v) {
+                        merged.insert(k.clone(), deep);
+                    } else {
+                        merged.insert(k.clone(), v.clone());
+                    }
+                } else {
+                    merged.insert(k.clone(), v.clone());
+                }
+            }
+            Some(AttributeValue::M(merged))
+        }
+        _ => None,
     }
 }
 

--- a/crates/engine/src/update_table.rs
+++ b/crates/engine/src/update_table.rs
@@ -164,7 +164,8 @@ pub async fn handle_update_table(
             }
             extenddb_storage::error::StorageError::IndexNotFound(name) => {
                 DynamoDbError::ResourceNotFoundException(format!(
-                    "One or more parameter values were invalid: Index not found: {name}"
+                    "Requested resource not found: Index {name} for table {}",
+                    table_name
                 ))
             }
             extenddb_storage::error::StorageError::NoOpUpdate(msg) => {

--- a/tests/python/test_expressions.py
+++ b/tests/python/test_expressions.py
@@ -95,7 +95,8 @@ class TestConditionExpressions:
         dynamodb_client.delete_item(
             TableName=name,
             Key={"pk": {"S": "k1"}},
-            ConditionExpression="status IN (:a, :b)",
+            ConditionExpression="#s IN (:a, :b)",
+            ExpressionAttributeNames={"#s": "status"},
             ExpressionAttributeValues={
                 ":a": {"S": "active"},
                 ":b": {"S": "pending"},
@@ -278,7 +279,8 @@ class TestUpdateExpressions:
         dynamodb_client.update_item(
             TableName=name,
             Key={"pk": {"S": "k1"}},
-            UpdateExpression="SET items = list_append(items, :new)",
+            UpdateExpression="SET #i = list_append(#i, :new)",
+            ExpressionAttributeNames={"#i": "items"},
             ExpressionAttributeValues={":new": {"L": [{"S": "b"}, {"S": "c"}]}},
         )
         resp = dynamodb_client.get_item(TableName=name, Key={"pk": {"S": "k1"}})
@@ -316,7 +318,8 @@ class TestUpdateExpressions:
         dynamodb_client.update_item(
             TableName=name,
             Key={"pk": {"S": "k1"}},
-            UpdateExpression="SET added = :v REMOVE drop",
+            UpdateExpression="SET added = :v REMOVE #d",
+            ExpressionAttributeNames={"#d": "drop"},
             ExpressionAttributeValues={":v": {"S": "new"}},
         )
         resp = dynamodb_client.get_item(TableName=name, Key={"pk": {"S": "k1"}})

--- a/tests/python/test_item_edge_cases.py
+++ b/tests/python/test_item_edge_cases.py
@@ -282,22 +282,20 @@ class TestGetItemEdgeCases:
         assert set(resp["Item"]["ss"]["SS"]) == {"alpha", "beta", "gamma"}
 
     def test_batch_get_item_same_key_twice(self, table_factory, dynamodb_client):
-        """BatchGetItem with same key twice returns it once."""
+        """BatchGetItem with same key twice is rejected."""
         name = table_factory()
         dynamodb_client.put_item(
             TableName=name, Item={"pk": {"S": "k1"}, "v": {"S": "val"}}
         )
-        resp = dynamodb_client.batch_get_item(
-            RequestItems={
-                name: {
-                    "Keys": [{"pk": {"S": "k1"}}, {"pk": {"S": "k1"}}],
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.batch_get_item(
+                RequestItems={
+                    name: {
+                        "Keys": [{"pk": {"S": "k1"}}, {"pk": {"S": "k1"}}],
+                    }
                 }
-            }
-        )
-        # DynamoDB deduplicates or returns duplicates — verify at least one
-        items = resp["Responses"][name]
-        assert len(items) >= 1
-        assert items[0]["v"]["S"] == "val"
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
 
 
 class TestDeleteItemEdgeCases:
@@ -417,7 +415,8 @@ class TestUpdateItemEdgeCases:
         dynamodb_client.update_item(
             TableName=name,
             Key={"pk": {"S": "k1"}},
-            UpdateExpression="SET items[1] = :v",
+            UpdateExpression="SET #i[1] = :v",
+            ExpressionAttributeNames={"#i": "items"},
             ExpressionAttributeValues={":v": {"S": "B"}},
         )
         resp = dynamodb_client.get_item(TableName=name, Key={"pk": {"S": "k1"}})
@@ -525,7 +524,8 @@ class TestUpdateItemEdgeCases:
         dynamodb_client.update_item(
             TableName=name,
             Key={"pk": {"S": "k1"}},
-            UpdateExpression="ADD counter :v",
+            UpdateExpression="ADD #c :v",
+            ExpressionAttributeNames={"#c": "counter"},
             ExpressionAttributeValues={":v": {"N": "1"}},
         )
         resp = dynamodb_client.get_item(TableName=name, Key={"pk": {"S": "k1"}})

--- a/tests/python/test_items.py
+++ b/tests/python/test_items.py
@@ -392,7 +392,8 @@ class TestUpdateItem:
         dynamodb_client.update_item(
             TableName=name,
             Key={"pk": {"S": "key1"}},
-            UpdateExpression="ADD counter :inc",
+            UpdateExpression="ADD #c :inc",
+            ExpressionAttributeNames={"#c": "counter"},
             ExpressionAttributeValues={":inc": {"N": "5"}},
         )
         resp = dynamodb_client.get_item(TableName=name, Key={"pk": {"S": "key1"}})
@@ -533,7 +534,8 @@ class TestUpdateItem:
         dynamodb_client.update_item(
             TableName=name,
             Key={"pk": {"S": "key1"}},
-            UpdateExpression="SET items = list_append(items, :new)",
+            UpdateExpression="SET #i = list_append(#i, :new)",
+            ExpressionAttributeNames={"#i": "items"},
             ExpressionAttributeValues={":new": {"L": [{"S": "b"}]}},
         )
         resp = dynamodb_client.get_item(TableName=name, Key={"pk": {"S": "key1"}})

--- a/tests/python/test_scan_edge_cases.py
+++ b/tests/python/test_scan_edge_cases.py
@@ -452,3 +452,29 @@ class TestScanEdgeCases:
             ExclusiveStartKey={"pk": {"S": "P"}, "sk": {"S": "S"}},
         )
         assert "Items" in resp
+
+
+    def test_scan_rejects_negative_segment(self, table_factory, dynamodb_client):
+        """Scan with negative Segment returns ValidationException."""
+        import os
+        import boto3
+        import botocore.config
+
+        name = table_factory()
+        # Create a client without parameter validation to bypass boto3 client-side checks
+        endpoint = os.environ.get("DYNAMODB_ENDPOINT")
+        kwargs = {
+            "service_name": "dynamodb",
+            "region_name": os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
+            "config": botocore.config.Config(parameter_validation=False),
+        }
+        if endpoint:
+            kwargs["endpoint_url"] = endpoint
+            if endpoint.startswith("https://"):
+                kwargs["verify"] = False
+        raw_client = boto3.client(**kwargs)
+        with pytest.raises(ClientError) as exc:
+            raw_client.scan(TableName=name, Segment=-1, TotalSegments=4)
+        err = exc.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert "greater than or equal to 0" in err["Message"]

--- a/tests/python/test_streams.py
+++ b/tests/python/test_streams.py
@@ -377,7 +377,8 @@ class TestInOrderDelivery:
                 dynamodb_client.update_item(
                     TableName=name,
                     Key={"pk": {"S": "ordered-key"}},
-                    UpdateExpression="SET counter = :c",
+                    UpdateExpression="SET #c = :c",
+                    ExpressionAttributeNames={"#c": "counter"},
                     ExpressionAttributeValues={":c": {"N": str(i)}},
                 )
             time.sleep(2)

--- a/tests/python/test_tables.py
+++ b/tests/python/test_tables.py
@@ -96,7 +96,7 @@ class TestCreateTable:
                 BillingMode="PAY_PER_REQUEST",
             )
         err = exc_info.value.response["Error"]
-        assert err["Code"] == "SerializationException"
+        assert err["Code"] == "ValidationException"
 
     def test_create_missing_attribute_definition(self, dynamodb_client):
         """KeySchema references an attribute not in AttributeDefinitions."""

--- a/tests/python/test_tagging.py
+++ b/tests/python/test_tagging.py
@@ -77,18 +77,24 @@ class TestTagging:
         resp = dynamodb_client.list_tags_of_resource(ResourceArn=arn)
         assert resp["Tags"] == []
 
-    def test_tag_nonexistent_resource(self, dynamodb_client):
+    def test_tag_nonexistent_resource(self, table_factory, dynamodb_client):
         """Tagging a nonexistent resource fails."""
-        fake_arn = "arn:aws:dynamodb:us-east-1:000000000000:table/nonexistent-xyz"
+        # Use a real table's ARN to extract the correct account/region prefix,
+        # then reference a table that doesn't exist.
+        name = table_factory()
+        real_arn = self._get_table_arn(dynamodb_client, name)
+        fake_arn = real_arn.rsplit("/", 1)[0] + "/nonexistent-xyz-99"
         with pytest.raises(ClientError) as exc:
             dynamodb_client.tag_resource(
                 ResourceArn=fake_arn, Tags=[{"Key": "k", "Value": "v"}]
             )
         assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
 
-    def test_list_tags_nonexistent_resource(self, dynamodb_client):
+    def test_list_tags_nonexistent_resource(self, table_factory, dynamodb_client):
         """ListTagsOfResource on a nonexistent resource fails."""
-        fake_arn = "arn:aws:dynamodb:us-east-1:000000000000:table/nonexistent-xyz"
+        name = table_factory()
+        real_arn = self._get_table_arn(dynamodb_client, name)
+        fake_arn = real_arn.rsplit("/", 1)[0] + "/nonexistent-xyz-99"
         with pytest.raises(ClientError) as exc:
             dynamodb_client.list_tags_of_resource(ResourceArn=fake_arn)
         assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"

--- a/tests/test_table_operations.py
+++ b/tests/test_table_operations.py
@@ -359,3 +359,50 @@ class TestUpdateTable:
         )
         # Should succeed — the table transitions billing mode.
         assert resp["TableDescription"]["TableName"] == unique_table_name
+
+
+
+class TestUpdateTableGsiDeletion:
+    """UpdateTable GSI deletion error handling."""
+
+    def test_delete_nonexistent_gsi_returns_resource_not_found(
+        self, dynamodb_client, create_and_cleanup_table
+    ):
+        """Deleting a non-existent GSI returns ResourceNotFoundException."""
+        resp = create_and_cleanup_table()
+        name = resp["TableDescription"]["TableName"]
+        with pytest.raises(ClientError) as exc:
+            dynamodb_client.update_table(
+                TableName=name,
+                GlobalSecondaryIndexUpdates=[
+                    {"Delete": {"IndexName": "does_not_exist"}}
+                ],
+            )
+        err = exc.value.response["Error"]
+        assert err["Code"] == "ResourceNotFoundException"
+        assert "Requested resource not found" in err["Message"]
+
+
+class TestContainsDuplicateOperand:
+    """contains() with duplicate operand error message."""
+
+    def test_contains_duplicate_path_error_message(
+        self, dynamodb_client, create_and_cleanup_table
+    ):
+        """contains(#a, #a) with same path reports correct error with resolved name."""
+        resp = create_and_cleanup_table()
+        name = resp["TableDescription"]["TableName"]
+        dynamodb_client.put_item(
+            TableName=name, Item={"pk": {"S": "k1"}, "val": {"S": "hello"}}
+        )
+        with pytest.raises(ClientError) as exc:
+            dynamodb_client.put_item(
+                TableName=name,
+                Item={"pk": {"S": "k2"}},
+                ConditionExpression="contains(#a, #a)",
+                ExpressionAttributeNames={"#a": "val"},
+            )
+        err = exc.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert "first operand must be distinct" in err["Message"]
+        assert "[val]" in err["Message"]

--- a/tests/test_transaction_operations.py
+++ b/tests/test_transaction_operations.py
@@ -510,3 +510,17 @@ def test_transact_get_indexes_capacity_has_rcu_field(dynamodb_client, hash_table
     assert table_cap.get("ReadCapacityUnits") == 2.0
     # WriteCapacityUnits should not be present for reads
     assert table_cap.get("WriteCapacityUnits") is None
+
+
+def test_transact_write_charges_2x_wcu(dynamodb_client, hash_table):
+    """TransactWriteItems charges 2 WCU per item (transaction cost)."""
+    resp = dynamodb_client.transact_write_items(
+        ReturnConsumedCapacity="TOTAL",
+        TransactItems=[
+            {"Put": {"TableName": hash_table, "Item": {"pk": {"S": "tw-cap-1"}}}},
+            {"Put": {"TableName": hash_table, "Item": {"pk": {"S": "tw-cap-2"}}}},
+        ],
+    )
+    # 2 items × 1 WCU each × 2 (transaction) = 4.0
+    total = sum(c["CapacityUnits"] for c in resp["ConsumedCapacity"])
+    assert total == 4.0


### PR DESCRIPTION
## What
  

1. **Fix 11 broken integration tests** that were failing on both real DynamoDB and ExtendDB due to test bugs (reserved keywords used without `#name` placeholders, wrong error code assertions, wrong account in ARN).

2. **Fix UPDATED_NEW/OLD with multiple subpaths** under the same top-level attribute (e.g., `SET a.b = :x, a.c = :y` now returns both `a.b` and `a.c` instead of only the last one).

3. **Fix 4 additional engine bugs** found during investigation:
   - TransactWriteItems now charges 2x WCU (transaction cost), matching DynamoDB
   - Scan with negative Segment returns the correct DynamoDB-format ValidationException
   - UpdateTable deleting a non-existent GSI returns ResourceNotFoundException with correct message
   - `contains(#a, #a)` error message now resolves `#name` placeholders to the actual attribute name

4. **Add 4 new integration tests** for the engine fixes above so they don't regress.

## Why

Closes #98 (the remaining edge case from #105)

The 11 test failures were masking real progress, they failed on real DynamoDB too, meaning the tests themselves were wrong, not the engine. Fixing them gives us a clean signal: 771/776 pytest passing.

## Testing done

- All 11 fixed tests verified against **real DynamoDB** first (all pass)
- Then verified against ExtendDB (all pass)
- 4 new tests verified against ExtendDB (all pass)
- Error messages for scan segment, UpdateTable GSI, and contains() verified against real DynamoDB for exact match
- `cargo test --workspace` — all pass
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- Full pytest: 771 passed, 5 failed (import/export disabled in config only)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.