### PR TITLE
ci: add integration test workflow with PostgreSQL

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,82 @@
+name: Integration Tests
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  run-integration:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: devpass
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Build release
+        run: cargo build --release
+
+      - name: Initialize ExtendDB
+        id: init
+        run: |
+          output=$(./target/release/extenddb init --config extenddb.toml \
+            --pg-host 127.0.0.1 --pg-port 5432 --pg-user postgres --pg-pass devpass 2>&1)
+          echo "$output"
+          password=$(echo "$output" | grep -oP 'Password: \K\S+')
+          echo "admin_password=$password" >> "$GITHUB_OUTPUT"
+
+      - name: Start ExtendDB
+        run: |
+          ./target/release/extenddb serve --config extenddb.toml --foreground &
+          for i in $(seq 1 30); do
+            if curl -sk https://127.0.0.1:8000/health | grep -q healthy; then
+              echo "Server ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server failed to start"
+          exit 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run integration tests
+        env:
+          EXTENDDB_TEST_ENDPOINT: https://127.0.0.1:8000
+          EXTENDDB_ADMIN_USER: admin
+          EXTENDDB_ADMIN_PASSWORD: ${{ steps.init.outputs.admin_password }}
+        run: devtools/run-tests --extenddb --pytest --comprehensive --parallel --filter "not import_export"
+
+  integration:
+    runs-on: ubuntu-latest
+    needs: run-integration
+    if: always()
+    steps:
+      - run: |
+          if [ "${{ needs.run-integration.result }}" != "success" ]; then
+            exit 1
+          fi

--- a/devtools/run-tests
+++ b/devtools/run-tests
@@ -459,6 +459,7 @@ if $RUN_EXTERNAL; then
             echo "  ✓ External tests passed"
         else
             echo "  ✗ External tests had failures (check output for details)"
+            PASS=false
         fi
     else
         export EXTENDDB_ENDPOINT="${EXTENDDB_TEST_ENDPOINT}"
@@ -467,6 +468,7 @@ if $RUN_EXTERNAL; then
             echo "  ✓ External tests passed"
         else
             echo "  ✗ External tests had failures (check output for details)"
+            PASS=false
         fi
     fi
     echo ""
@@ -500,6 +502,7 @@ if $RUN_COMPREHENSIVE; then
         echo "  ✓ Comprehensive tests passed"
     else
         echo "  ✗ Comprehensive tests had failures (check output for details)"
+        PASS=false
     fi
     echo ""
 fi


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that runs the full Python integration test suite against a live ExtendDB instance backed by PostgreSQL on every PR and push to main.

The workflow:
1. Starts PostgreSQL 16 as a service container
2. Builds ExtendDB in release mode (with Rust caching)
3. Runs `extenddb init` and `extenddb serve --foreground`
4. Delegates to `devtools/run-tests --extenddb --pytest` which handles credential provisioning, runtime settings, health checks, and test execution
5. Excludes `test_import_export.py` (pre-existing path resolution bug, tracked separately)

## Why

We have 450+ integration tests but no CI runs them — test regressions are only caught manually. This workflow gates PRs on the integration suite passing.

## Dependencies

This PR should be merged **after** the following PRs land (they fix test failures that would otherwise block CI):

- #153 — fix broken integ tests and UPDATED_NEW/OLD multiple subpaths
- #152 — refactor serde_helpers (no test impact, but avoids merge conflicts)

## Testing done

- Ran `devtools/run-tests --extenddb --pytest --filter "not import_export"` locally against a fresh init — all tests pass after dependent PRs
- Verified the `--filter` correctly deselects 5 import/export tests (446/452 collected)
- Verified the script exits non-zero on test failure (gates the job correctly)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [ ] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.