### PR TITLE
ci: add merge_group trigger to all workflows

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,6 +1,7 @@
 name: Clippy
 on:
   pull_request:
+  merge_group:
   push:
     branches: [main]
 

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,6 +1,7 @@
 name: Format
 on:
   pull_request:
+  merge_group:
   push:
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test
 on:
   pull_request:
+  merge_group:
   push:
     branches: [main]
 


### PR DESCRIPTION
Enable GitHub merge queue support. All CI checks (test, clippy, fmt)
now run on merge_group events in addition to pull_request and push.

## What

This adds workflow triggers for merge queues, which we haven't enabled yet but likely will shortly.

## Why

Merge queues mean less manual work for us.

## Testing done

Workflows will be checked when PR is created.

## Checklist

nonstandard checklist because we're changing GitHub configuration, not the real code

- Workflow still succeeds

GitHub will check this for us. We need to check that it actually ran as expected for this PR before approving/merging.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
