### PR TITLE
fix: enforce Scan Segment/TotalSegments bounds

### DIFF
--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -313,7 +313,7 @@ pub async fn handle_query(
         && index_info.is_none()
     {
         return Err(DynamoDbError::ValidationException(
-            "ALL_PROJECTED_ATTRIBUTES can be used only when querying an index".to_owned(),
+            "ALL_PROJECTED_ATTRIBUTES can be used only when Querying using an IndexName".to_owned(),
         ));
     }
     if let Some(Select::Count) = input.select

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -87,10 +87,20 @@ pub async fn handle_scan(
                     "The parameter TotalSegments should be greater than or equal to 1".to_owned(),
                 ));
             }
+            if total > 1_000_000 {
+                return Err(DynamoDbError::ValidationException(format!(
+                    "1 validation error detected: Value '{total}' at 'totalSegments' failed to satisfy constraint: Member must have value less than or equal to 1000000"
+                )));
+            }
             if seg < 0 {
                 return Err(DynamoDbError::ValidationException(format!(
                     "1 validation error detected: Value '{}' at 'segment' failed to satisfy constraint: Member must have value greater than or equal to 0",
                     seg
+                )));
+            }
+            if seg > 999_999 {
+                return Err(DynamoDbError::ValidationException(format!(
+                    "1 validation error detected: Value '{seg}' at 'segment' failed to satisfy constraint: Member must have value less than or equal to 999999"
                 )));
             }
             if seg >= total {
@@ -233,7 +243,7 @@ pub async fn handle_scan(
         && index_info.is_none()
     {
         return Err(DynamoDbError::ValidationException(
-            "ALL_PROJECTED_ATTRIBUTES can be used only when scanning an index".to_owned(),
+            "ALL_PROJECTED_ATTRIBUTES can be used only when Querying using an IndexName".to_owned(),
         ));
     }
     if let Some(Select::Count) = input.select

--- a/tests/test_query_scan.py
+++ b/tests/test_query_scan.py
@@ -471,6 +471,24 @@ class TestQueryValidation:
             )
         assert exc_info.value.response["Error"]["Code"] == "ValidationException"
 
+    def test_query_all_projected_attributes_without_index_rejected(
+        self, dynamodb_client, query_table
+    ):
+        """Select=ALL_PROJECTED_ATTRIBUTES on the base table is rejected."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.query(
+                TableName=query_table,
+                KeyConditionExpression="pk = :pk",
+                ExpressionAttributeValues={":pk": {"S": "user-1"}},
+                Select="ALL_PROJECTED_ATTRIBUTES",
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert (
+            "ALL_PROJECTED_ATTRIBUTES can be used only when Querying using an IndexName"
+            in err["Message"]
+        )
+
 
 class TestScanValidation:
     """Scan validation edge cases from recent fixes."""
@@ -505,6 +523,63 @@ class TestScanValidation:
                 ExpressionAttributeValues={":cat": {"S": "a"}, ":extra": {"N": "1"}},
             )
         assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_scan_segment_at_max_accepted(self, dynamodb_client, scan_table):
+        """Segment=999999 with TotalSegments=1000000 is at the documented bound."""
+        dynamodb_client.scan(
+            TableName=scan_table, Segment=999_999, TotalSegments=1_000_000
+        )
+
+    def test_scan_segment_one_over_max_rejected(
+        self, dynamodb_client_no_validation, scan_table
+    ):
+        """Segment > 999999 returns the Coral-format ValidationException."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client_no_validation.scan(
+                TableName=scan_table, Segment=1_000_000, TotalSegments=1_000_000
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        msg = err["Message"]
+        assert "1 validation error detected" in msg
+        assert "'1000000' at 'segment'" in msg
+        assert "Member must have value less than or equal to 999999" in msg
+
+    def test_scan_total_segments_at_max_accepted(self, dynamodb_client, scan_table):
+        """TotalSegments=1000000 with Segment=0 is at the documented bound."""
+        dynamodb_client.scan(
+            TableName=scan_table, Segment=0, TotalSegments=1_000_000
+        )
+
+    def test_scan_total_segments_one_over_max_rejected(
+        self, dynamodb_client_no_validation, scan_table
+    ):
+        """TotalSegments > 1000000 returns the Coral-format ValidationException."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client_no_validation.scan(
+                TableName=scan_table, Segment=0, TotalSegments=1_000_001
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        msg = err["Message"]
+        assert "1 validation error detected" in msg
+        assert "'1000001' at 'totalSegments'" in msg
+        assert "Member must have value less than or equal to 1000000" in msg
+
+    def test_scan_all_projected_attributes_without_index_rejected(
+        self, dynamodb_client, scan_table
+    ):
+        """Select=ALL_PROJECTED_ATTRIBUTES on a base-table scan is rejected."""
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.scan(
+                TableName=scan_table, Select="ALL_PROJECTED_ATTRIBUTES"
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert (
+            "ALL_PROJECTED_ATTRIBUTES can be used only when Querying using an IndexName"
+            in err["Message"]
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Addresses several Scan/Query validation gaps:
    
- Enforcing Segment <= 999999 and TotalSegments <= 1000000
- Adjusting validation exception messaging for use of `Select=ALL_PROJECTED_ATTRIBUTES`

## Why

Parity with DynamoDB

## Testing done

- Existing and new cargo unit tests
- Existing and newly added python integration tests
- Server side DynamoDB functional tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
