### PR TITLE
fix: validate expression attributes and label parse errors per parameter

### DIFF
--- a/crates/core/src/expression/kind.rs
+++ b/crates/core/src/expression/kind.rs
@@ -1,0 +1,40 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Expression parameter kinds.
+
+use std::fmt;
+
+/// A DynamoDB expression parameter.
+///
+/// The string form is the exact wire-format parameter name DynamoDB uses in
+/// error messages (`Invalid <Kind>: ...`). Centralizing it here keeps those
+/// labels typo-safe instead of repeating string literals at each call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExpressionKind {
+    Projection,
+    Condition,
+    Filter,
+    KeyCondition,
+    Update,
+}
+
+impl ExpressionKind {
+    /// The canonical DynamoDB parameter name.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Projection => "ProjectionExpression",
+            Self::Condition => "ConditionExpression",
+            Self::Filter => "FilterExpression",
+            Self::KeyCondition => "KeyConditionExpression",
+            Self::Update => "UpdateExpression",
+        }
+    }
+}
+
+impl fmt::Display for ExpressionKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}

--- a/crates/core/src/expression/mod.rs
+++ b/crates/core/src/expression/mod.rs
@@ -28,7 +28,8 @@ pub use projection::{apply_projection, parse_projection};
 pub use reserved_words::validate_no_reserved_words;
 pub use resolver::{
     ExpressionMaps, collect_key_condition_refs, collect_value_placeholders, resolve_element_name,
-    resolve_name_ref, resolve_path, validate_begins_with_operands, validate_unused_attributes,
+    resolve_name_ref, resolve_path, validate_begins_with_operands, validate_expression_param_usage,
+    validate_unused_attributes,
 };
 pub use tokenizer::{Token, tokenize, tokenize_for, tokenize_with_limit};
 pub use update_evaluator::apply_update;

--- a/crates/core/src/expression/mod.rs
+++ b/crates/core/src/expression/mod.rs
@@ -11,6 +11,7 @@
 mod ast;
 mod evaluator;
 mod key_condition;
+mod kind;
 mod parser;
 mod parser_common;
 mod projection;
@@ -23,6 +24,7 @@ mod update_parser;
 pub use ast::{ArithOp, CompareOp, Expr, PathElement, UpdateAction};
 pub use evaluator::evaluate_condition;
 pub use key_condition::{KeyCondition, SortKeyCondition, parse_key_condition};
+pub use kind::ExpressionKind;
 pub use parser::{parse_condition, parse_condition_with_depth_limit};
 pub use projection::{apply_projection, parse_projection};
 pub use reserved_words::validate_no_reserved_words;

--- a/crates/core/src/expression/resolver.rs
+++ b/crates/core/src/expression/resolver.rs
@@ -200,6 +200,51 @@ pub fn resolve_element_name<'a>(
     }
 }
 
+/// Reject `ExpressionAttributeNames`/`Values` supplied with no expression that
+/// can reference them. Matches Amazon DynamoDB:
+///
+/// - names: `ExpressionAttributeNames can only be specified when using expressions`
+///   (no suffix), for every API.
+/// - values: `ExpressionAttributeValues can only be specified when using
+///   expressions: <params> is/are null`, listing the value-capable expression
+///   parameter(s) of the API.
+///
+/// `name_expr_present` is true when any expression that can carry a `#name` is
+/// present (projection, condition, filter, key condition, update).
+/// `value_expr_present` is true when any expression that can carry a `:value` is
+/// present (condition, filter, key condition, update; not projection).
+/// `value_expr_params` is the API's static list of value-capable expression
+/// parameter names, used to build the values suffix.
+///
+/// # Errors
+///
+/// Returns `DynamoDbError::ValidationException` when a map is supplied with no
+/// referencing expression.
+pub fn validate_expression_param_usage(
+    names: Option<&HashMap<String, String>>,
+    name_expr_present: bool,
+    values: Option<&HashMap<String, AttributeValue>>,
+    value_expr_present: bool,
+    value_expr_params: &[&str],
+) -> Result<(), DynamoDbError> {
+    if !name_expr_present && names.is_some_and(|m| !m.is_empty()) {
+        return Err(DynamoDbError::ValidationException(
+            "ExpressionAttributeNames can only be specified when using expressions".to_owned(),
+        ));
+    }
+    if !value_expr_present && values.is_some_and(|m| !m.is_empty()) {
+        let suffix = match value_expr_params {
+            [] => String::new(),
+            [one] => format!("{one} is null"),
+            many => format!("{} are null", many.join(" and ")),
+        };
+        return Err(DynamoDbError::ValidationException(format!(
+            "ExpressionAttributeValues can only be specified when using expressions: {suffix}"
+        )));
+    }
+    Ok(())
+}
+
 /// Validate that all provided ExpressionAttributeNames/Values were used.
 ///
 /// Collects `#name` and `:value` references from the given expressions,

--- a/crates/core/src/expression/resolver.rs
+++ b/crates/core/src/expression/resolver.rs
@@ -214,7 +214,8 @@ pub fn resolve_element_name<'a>(
 /// `value_expr_present` is true when any expression that can carry a `:value` is
 /// present (condition, filter, key condition, update; not projection).
 /// `value_expr_params` is the API's static list of value-capable expression
-/// parameter names, used to build the values suffix.
+/// parameter kinds, used to build the values suffix. An empty list yields no
+/// suffix (matching Query).
 ///
 /// # Errors
 ///
@@ -225,7 +226,7 @@ pub fn validate_expression_param_usage(
     name_expr_present: bool,
     values: Option<&HashMap<String, AttributeValue>>,
     value_expr_present: bool,
-    value_expr_params: &[&str],
+    value_expr_params: &[super::ExpressionKind],
 ) -> Result<(), DynamoDbError> {
     if !name_expr_present && names.is_some_and(|m| !m.is_empty()) {
         return Err(DynamoDbError::ValidationException(
@@ -233,14 +234,20 @@ pub fn validate_expression_param_usage(
         ));
     }
     if !value_expr_present && values.is_some_and(|m| !m.is_empty()) {
-        let suffix = match value_expr_params {
-            [] => String::new(),
-            [one] => format!("{one} is null"),
-            many => format!("{} are null", many.join(" and ")),
+        let base = "ExpressionAttributeValues can only be specified when using expressions";
+        let msg = match value_expr_params {
+            [] => base.to_owned(),
+            [one] => format!("{base}: {one} is null"),
+            many => {
+                let joined = many
+                    .iter()
+                    .map(|k| k.as_str())
+                    .collect::<Vec<_>>()
+                    .join(" and ");
+                format!("{base}: {joined} are null")
+            }
         };
-        return Err(DynamoDbError::ValidationException(format!(
-            "ExpressionAttributeValues can only be specified when using expressions: {suffix}"
-        )));
+        return Err(DynamoDbError::ValidationException(msg));
     }
     Ok(())
 }

--- a/crates/core/src/expression/tokenizer.rs
+++ b/crates/core/src/expression/tokenizer.rs
@@ -200,11 +200,11 @@ pub fn tokenize_with_limit(input: &str, max_tokens: usize) -> Result<Vec<Token>,
 pub fn tokenize_for(
     input: &str,
     max_tokens: usize,
-    expr_type: &str,
+    kind: super::ExpressionKind,
 ) -> Result<Vec<Token>, DynamoDbError> {
     if input.is_empty() {
         return Err(DynamoDbError::ValidationException(format!(
-            "Invalid {expr_type}: The expression can not be empty;"
+            "Invalid {kind}: The expression can not be empty;"
         )));
     }
     let mut tokens = Vec::new();
@@ -279,7 +279,7 @@ pub fn tokenize_for(
                 }
                 if i == start {
                     return Err(DynamoDbError::ValidationException(format!(
-                        "Invalid {expr_type}: Syntax error; token: \"#\", near: \"#\""
+                        "Invalid {kind}: Syntax error; token: \"#\", near: \"#\""
                     )));
                 }
                 push_token(
@@ -296,7 +296,7 @@ pub fn tokenize_for(
                 }
                 if i == start {
                     return Err(DynamoDbError::ValidationException(format!(
-                        "Invalid {expr_type}: Syntax error; token: \":\", near: \":\""
+                        "Invalid {kind}: Syntax error; token: \":\", near: \":\""
                     )));
                 }
                 push_token(
@@ -342,7 +342,7 @@ pub fn tokenize_for(
                 };
                 let near = &input[i..near_end];
                 return Err(DynamoDbError::ValidationException(format!(
-                    "Invalid {expr_type}: Syntax error; token: \"{ch}\", near: \"{near}\""
+                    "Invalid {kind}: Syntax error; token: \"{ch}\", near: \"{near}\""
                 )));
             }
         }
@@ -568,19 +568,20 @@ mod tests {
     #[test]
     fn tokenize_for_multibyte_utf8_does_not_panic() {
         // Emoji (4-byte UTF-8) should produce a validation error, not a panic.
-        let err = tokenize_for("a = 😀", 4096, "ConditionExpression").unwrap_err();
+        let err =
+            tokenize_for("a = 😀", 4096, super::super::ExpressionKind::Condition).unwrap_err();
         assert!(
             matches!(err, DynamoDbError::ValidationException(ref msg) if msg.contains("Syntax error"))
         );
 
         // Accented character (2-byte UTF-8)
-        let err = tokenize_for("café", 4096, "FilterExpression").unwrap_err();
+        let err = tokenize_for("café", 4096, super::super::ExpressionKind::Filter).unwrap_err();
         assert!(
             matches!(err, DynamoDbError::ValidationException(ref msg) if msg.contains("Syntax error"))
         );
 
         // Multi-byte at the very end
-        let err = tokenize_for("x + ñ", 4096, "UpdateExpression").unwrap_err();
+        let err = tokenize_for("x + ñ", 4096, super::super::ExpressionKind::Update).unwrap_err();
         assert!(
             matches!(err, DynamoDbError::ValidationException(ref msg) if msg.contains("Syntax error"))
         );

--- a/crates/engine/src/batch_get_item.rs
+++ b/crates/engine/src/batch_get_item.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use serde_json::Value;
 
 use extenddb_core::error::DynamoDbError;
-use extenddb_core::expression::{apply_projection, parse_projection};
+use extenddb_core::expression::apply_projection;
 use extenddb_core::types::{BatchGetItemInput, BatchGetItemOutput, Item, item_size_bytes};
 use extenddb_core::validation::validate_batch_key_only;
 
@@ -97,6 +97,16 @@ pub async fn handle_batch_get_item(
             ));
         }
 
+        extenddb_core::expression::validate_expression_param_usage(
+            ka.expression_attribute_names.as_ref(),
+            ka.projection_expression
+                .as_ref()
+                .is_some_and(|s| !s.is_empty()),
+            None,
+            true,
+            &[],
+        )?;
+
         let (effective_proj_str, extra_proj_names) = if ka.projection_expression.is_some() {
             (ka.projection_expression.clone(), HashMap::new())
         } else if let Some(attrs) = &ka.attributes_to_get {
@@ -116,12 +126,24 @@ pub async fn handle_batch_get_item(
         };
 
         let projection = if let Some(ref proj_str) = effective_proj_str {
-            let proj_tokens =
-                crate::expression_helpers::tokenize_expression(proj_str, &ctx.limits)?;
-            Some(parse_projection(&proj_tokens)?)
+            Some(crate::expression_helpers::parse_projection_expr(
+                proj_str,
+                &ctx.limits,
+            )?)
         } else {
             None
         };
+        // Reject ExpressionAttributeNames entries the projection never
+        // references, matching Amazon DynamoDB. Scoped to a user-supplied
+        // ProjectionExpression; desugared AttributesToGet uses synthetic names.
+        if ka.projection_expression.is_some()
+            && let Some(ref paths) = projection
+        {
+            crate::read_helpers::validate_projection_unused_names(
+                ka.expression_attribute_names.as_ref(),
+                paths,
+            )?;
+        }
         let ean = if extra_proj_names.is_empty() {
             ka.expression_attribute_names.as_ref()
         } else {

--- a/crates/engine/src/delete_item.rs
+++ b/crates/engine/src/delete_item.rs
@@ -63,7 +63,7 @@ pub async fn handle_delete_item(
         has_condition,
         input.expression_attribute_values.as_ref(),
         has_condition,
-        &["ConditionExpression"],
+        &[extenddb_core::expression::ExpressionKind::Condition],
     )?;
 
     let (condition, maps) = resolve_condition(

--- a/crates/engine/src/delete_item.rs
+++ b/crates/engine/src/delete_item.rs
@@ -54,6 +54,18 @@ pub async fn handle_delete_item(
         &key_info.attribute_definitions,
     )?;
 
+    let has_condition = input
+        .condition_expression
+        .as_ref()
+        .is_some_and(|s| !s.is_empty());
+    extenddb_core::expression::validate_expression_param_usage(
+        input.expression_attribute_names.as_ref(),
+        has_condition,
+        input.expression_attribute_values.as_ref(),
+        has_condition,
+        &["ConditionExpression"],
+    )?;
+
     let (condition, maps) = resolve_condition(
         input.condition_expression.as_deref(),
         input.expression_attribute_names.as_ref(),

--- a/crates/engine/src/expression_helpers.rs
+++ b/crates/engine/src/expression_helpers.rs
@@ -7,8 +7,8 @@ use std::collections::HashMap;
 
 use extenddb_core::error::DynamoDbError;
 use extenddb_core::expression::{
-    Expr, ExpressionMaps, PathElement, Token, parse_condition_with_depth_limit, parse_projection,
-    tokenize_for, tokenize_with_limit, validate_no_reserved_words,
+    Expr, ExpressionKind, ExpressionMaps, PathElement, Token, parse_condition_with_depth_limit,
+    parse_projection, tokenize_for, tokenize_with_limit, validate_no_reserved_words,
 };
 use extenddb_core::limits::LimitsConfig;
 use extenddb_core::types::{AttributeValue, ConditionalOperator, ExpectedAttributeValue};
@@ -72,7 +72,7 @@ pub fn parse_optional_condition(
             });
             parsed
                 .map(Some)
-                .map_err(|e| prefix_expression_error(e, "ConditionExpression"))
+                .map_err(|e| prefix_expression_error(e, ExpressionKind::Condition))
         }
         _ => Ok(None),
     }
@@ -91,7 +91,7 @@ pub fn parse_optional_filter(
     limits: &LimitsConfig,
 ) -> Result<Option<Expr>, DynamoDbError> {
     parse_optional_condition(expr, limits)
-        .map_err(|e| prefix_expression_error(e, "FilterExpression"))
+        .map_err(|e| prefix_expression_error(e, ExpressionKind::Filter))
 }
 
 /// Resolve a condition from either `ConditionExpression` or legacy `Expected`.
@@ -164,7 +164,7 @@ pub fn parse_projection_expr(
     let result = tokenize_for(
         proj_str,
         limits.max_expression_tokens,
-        "ProjectionExpression",
+        ExpressionKind::Projection,
     )
     .and_then(|tokens| {
         if limits.enforce_reserved_keywords {
@@ -172,7 +172,7 @@ pub fn parse_projection_expr(
         }
         parse_projection(&tokens)
     });
-    result.map_err(|e| prefix_expression_error(e, "ProjectionExpression"))
+    result.map_err(|e| prefix_expression_error(e, ExpressionKind::Projection))
 }
 
 /// Prefix an expression error with the expression type, matching DynamoDB's format.
@@ -181,17 +181,17 @@ pub fn parse_projection_expr(
 /// `ConditionExpression`; those are relabelled to `expr_type`. Errors already
 /// labelled with another expression type, or non-expression validation errors,
 /// are returned unchanged.
-pub fn prefix_expression_error(err: DynamoDbError, expr_type: &str) -> DynamoDbError {
+pub fn prefix_expression_error(err: DynamoDbError, kind: ExpressionKind) -> DynamoDbError {
     match err {
         DynamoDbError::ValidationException(msg) => {
             if let Some(rest) = msg.strip_prefix("Invalid ConditionExpression:") {
-                DynamoDbError::ValidationException(format!("Invalid {expr_type}:{rest}"))
+                DynamoDbError::ValidationException(format!("Invalid {kind}:{rest}"))
             } else if let Some(rest) = msg.strip_prefix("Invalid expression:") {
-                DynamoDbError::ValidationException(format!("Invalid {expr_type}:{rest}"))
+                DynamoDbError::ValidationException(format!("Invalid {kind}:{rest}"))
             } else if msg.starts_with("Invalid ") || msg.starts_with("1 validation") {
                 DynamoDbError::ValidationException(msg)
             } else {
-                DynamoDbError::ValidationException(format!("Invalid {expr_type}: {msg}"))
+                DynamoDbError::ValidationException(format!("Invalid {kind}: {msg}"))
             }
         }
         other => other,

--- a/crates/engine/src/expression_helpers.rs
+++ b/crates/engine/src/expression_helpers.rs
@@ -7,8 +7,8 @@ use std::collections::HashMap;
 
 use extenddb_core::error::DynamoDbError;
 use extenddb_core::expression::{
-    Expr, ExpressionMaps, Token, parse_condition_with_depth_limit, tokenize_with_limit,
-    validate_no_reserved_words,
+    Expr, ExpressionMaps, PathElement, Token, parse_condition_with_depth_limit, parse_projection,
+    tokenize_for, tokenize_with_limit, validate_no_reserved_words,
 };
 use extenddb_core::limits::LimitsConfig;
 use extenddb_core::types::{AttributeValue, ConditionalOperator, ExpectedAttributeValue};
@@ -67,9 +67,12 @@ pub fn parse_optional_condition(
 ) -> Result<Option<Expr>, DynamoDbError> {
     match expr {
         Some(s) if !s.is_empty() => {
-            let tokens = tokenize_expression(s, limits)?;
-            let ast = parse_condition_with_depth_limit(&tokens, limits.max_expression_depth)?;
-            Ok(Some(ast))
+            let parsed = tokenize_expression(s, limits).and_then(|tokens| {
+                parse_condition_with_depth_limit(&tokens, limits.max_expression_depth)
+            });
+            parsed
+                .map(Some)
+                .map_err(|e| prefix_expression_error(e, "ConditionExpression"))
         }
         _ => Ok(None),
     }
@@ -147,6 +150,31 @@ pub fn resolve_condition(
     Ok((condition, maps))
 }
 
+/// Tokenize, reserved-word check, and parse a `ProjectionExpression`.
+///
+/// Errors carry the `ProjectionExpression` prefix, matching Amazon DynamoDB.
+///
+/// # Errors
+///
+/// Returns `DynamoDbError::ValidationException` for syntax or reserved-word errors.
+pub fn parse_projection_expr(
+    proj_str: &str,
+    limits: &LimitsConfig,
+) -> Result<Vec<Vec<PathElement>>, DynamoDbError> {
+    let result = tokenize_for(
+        proj_str,
+        limits.max_expression_tokens,
+        "ProjectionExpression",
+    )
+    .and_then(|tokens| {
+        if limits.enforce_reserved_keywords {
+            validate_no_reserved_words(&tokens)?;
+        }
+        parse_projection(&tokens)
+    });
+    result.map_err(|e| prefix_expression_error(e, "ProjectionExpression"))
+}
+
 /// Prefix an expression error with the expression type, matching DynamoDB's format.
 ///
 /// `FilterExpression` shares the condition parser, so its errors arrive labelled
@@ -157,6 +185,8 @@ pub fn prefix_expression_error(err: DynamoDbError, expr_type: &str) -> DynamoDbE
     match err {
         DynamoDbError::ValidationException(msg) => {
             if let Some(rest) = msg.strip_prefix("Invalid ConditionExpression:") {
+                DynamoDbError::ValidationException(format!("Invalid {expr_type}:{rest}"))
+            } else if let Some(rest) = msg.strip_prefix("Invalid expression:") {
                 DynamoDbError::ValidationException(format!("Invalid {expr_type}:{rest}"))
             } else if msg.starts_with("Invalid ") || msg.starts_with("1 validation") {
                 DynamoDbError::ValidationException(msg)

--- a/crates/engine/src/get_item.rs
+++ b/crates/engine/src/get_item.rs
@@ -10,9 +10,7 @@ use std::collections::HashMap;
 use serde_json::Value;
 
 use extenddb_core::error::DynamoDbError;
-use extenddb_core::expression::{
-    apply_projection, parse_projection, tokenize_for, validate_no_reserved_words,
-};
+use extenddb_core::expression::apply_projection;
 use extenddb_core::types::GetItemInput;
 use extenddb_core::types::GetItemOutput;
 use extenddb_core::types::item_size_bytes;
@@ -48,6 +46,19 @@ pub async fn handle_get_item(
         &ctx.limits,
         &key_info.key_schema,
         &key_info.attribute_definitions,
+    )?;
+
+    // Reject ExpressionAttributeNames supplied with no ProjectionExpression
+    // (legacy AttributesToGet does not count as an expression).
+    extenddb_core::expression::validate_expression_param_usage(
+        input.expression_attribute_names.as_ref(),
+        input
+            .projection_expression
+            .as_ref()
+            .is_some_and(|s| !s.is_empty()),
+        None,
+        true,
+        &[],
     )?;
 
     let item = ctx
@@ -104,28 +115,29 @@ pub async fn handle_get_item(
         Some(merged)
     };
 
-    // Validate projection expression upfront (before item fetch result matters)
-    if let Some(ref proj_str) = effective_projection {
-        let proj_tokens = tokenize_for(
-            proj_str,
-            ctx.limits.max_expression_tokens,
-            "ProjectionExpression",
-        )?;
-        if ctx.limits.enforce_reserved_keywords {
-            validate_no_reserved_words(&proj_tokens)?;
+    // Parse and validate the projection once, before the item fetch result
+    // matters, so the unused-name check runs whether or not the item exists.
+    let projection = match effective_projection {
+        Some(ref proj_str) => {
+            let parsed = crate::expression_helpers::parse_projection_expr(proj_str, &ctx.limits)?;
+            // Reject ExpressionAttributeNames entries the projection never
+            // references. Scoped to a user-supplied ProjectionExpression;
+            // desugared AttributesToGet uses synthetic placeholders.
+            if input.projection_expression.is_some() {
+                crate::read_helpers::validate_projection_unused_names(
+                    input.expression_attribute_names.as_ref(),
+                    &parsed,
+                )?;
+            }
+            Some(parsed)
         }
-    }
+        None => None,
+    };
 
-    let item = match (&effective_projection, item) {
-        (Some(proj_str), Some(fetched)) => {
-            let proj_tokens = tokenize_for(
-                proj_str,
-                ctx.limits.max_expression_tokens,
-                "ProjectionExpression",
-            )?;
-            let projection = parse_projection(&proj_tokens)?;
+    let item = match (projection, item) {
+        (Some(paths), Some(fetched)) => {
             let maps = build_expression_maps(effective_proj_names.as_ref(), None);
-            Some(apply_projection(&fetched, &projection, &maps)?)
+            Some(apply_projection(&fetched, &paths, &maps)?)
         }
         (_, item) => item,
     };

--- a/crates/engine/src/put_item.rs
+++ b/crates/engine/src/put_item.rs
@@ -87,7 +87,7 @@ pub async fn handle_put_item(
         has_expression,
         input.expression_attribute_values.as_ref(),
         has_expression,
-        &["ConditionExpression"],
+        &[extenddb_core::expression::ExpressionKind::Condition],
     )?;
 
     extenddb_core::validation::validate_table_name(&input.table_name, &ctx.limits)?;

--- a/crates/engine/src/put_item.rs
+++ b/crates/engine/src/put_item.rs
@@ -77,31 +77,18 @@ pub async fn handle_put_item(
         }
     })?;
 
-    // Reject EAV/EAN without an expression
+    // Reject EAN/EAV supplied without a referencing expression.
     let has_expression = input
         .condition_expression
         .as_ref()
         .is_some_and(|s| !s.is_empty());
-    if !has_expression
-        && input
-            .expression_attribute_values
-            .as_ref()
-            .is_some_and(|m| !m.is_empty())
-    {
-        return Err(DynamoDbError::ValidationException(
-            "ExpressionAttributeValues can only be specified when using expressions: ConditionExpression is null".to_owned(),
-        ));
-    }
-    if !has_expression
-        && input
-            .expression_attribute_names
-            .as_ref()
-            .is_some_and(|m| !m.is_empty())
-    {
-        return Err(DynamoDbError::ValidationException(
-            "ExpressionAttributeNames can only be specified when using expressions: ConditionExpression is null".to_owned(),
-        ));
-    }
+    extenddb_core::expression::validate_expression_param_usage(
+        input.expression_attribute_names.as_ref(),
+        has_expression,
+        input.expression_attribute_values.as_ref(),
+        has_expression,
+        &["ConditionExpression"],
+    )?;
 
     extenddb_core::validation::validate_table_name(&input.table_name, &ctx.limits)?;
 

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -9,9 +9,7 @@ use serde_json::Value;
 
 use extenddb_core::error::DynamoDbError;
 use extenddb_core::expression::PathElement;
-use extenddb_core::expression::{
-    ExpressionMaps, parse_key_condition, parse_projection, tokenize_for,
-};
+use extenddb_core::expression::{ExpressionMaps, parse_key_condition, tokenize_for};
 use extenddb_core::types::{
     IndexType, KeyType, QueryInput, QueryOutput, Select, TableKeyInfo, extract_key, item_size_bytes,
 };
@@ -143,12 +141,21 @@ pub async fn handle_query(
     let (mut key_condition, legacy_kc_maps) = if let Some(kce_str) =
         input.key_condition_expression.as_deref()
     {
-        let tokens = tokenize_for(
+        let parsed = tokenize_for(
             kce_str,
             ctx.limits.max_expression_tokens,
             "KeyConditionExpression",
-        )?;
-        (parse_key_condition(&tokens)?, None)
+        )
+        .and_then(|tokens| {
+            if ctx.limits.enforce_reserved_keywords {
+                extenddb_core::expression::validate_no_reserved_words(&tokens)?;
+            }
+            parse_key_condition(&tokens)
+        })
+        .map_err(|e| {
+            crate::expression_helpers::prefix_expression_error(e, "KeyConditionExpression")
+        })?;
+        (parsed, None)
     } else if let Some(ref kc) = input.key_conditions {
         let key_schema_pairs: Vec<(String, bool)> = query_key_info
             .key_schema
@@ -264,12 +271,10 @@ pub async fn handle_query(
     };
 
     let projection = if let Some(ref proj_str) = effective_projection_str {
-        let proj_tokens = tokenize_for(
+        Some(crate::expression_helpers::parse_projection_expr(
             proj_str,
-            ctx.limits.max_expression_tokens,
-            "ProjectionExpression",
-        )?;
-        Some(parse_projection(&proj_tokens)?)
+            &ctx.limits,
+        )?)
     } else {
         None
     };

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -9,7 +9,9 @@ use serde_json::Value;
 
 use extenddb_core::error::DynamoDbError;
 use extenddb_core::expression::PathElement;
-use extenddb_core::expression::{ExpressionMaps, parse_key_condition, tokenize_for};
+use extenddb_core::expression::{
+    ExpressionKind, ExpressionMaps, parse_key_condition, tokenize_for,
+};
 use extenddb_core::types::{
     IndexType, KeyType, QueryInput, QueryOutput, Select, TableKeyInfo, extract_key, item_size_bytes,
 };
@@ -137,6 +139,28 @@ pub async fn handle_query(
         input.expression_attribute_values.as_ref(),
     );
 
+    // Reject EAN/EAV supplied with no expression that references them. Legacy
+    // KeyConditions does not count as an expression. Query emits no values suffix.
+    let has_kce = input
+        .key_condition_expression
+        .as_ref()
+        .is_some_and(|s| !s.is_empty());
+    let has_filter_expr = input
+        .filter_expression
+        .as_ref()
+        .is_some_and(|s| !s.is_empty());
+    let has_proj_expr = input
+        .projection_expression
+        .as_ref()
+        .is_some_and(|s| !s.is_empty());
+    extenddb_core::expression::validate_expression_param_usage(
+        input.expression_attribute_names.as_ref(),
+        has_kce || has_filter_expr || has_proj_expr,
+        input.expression_attribute_values.as_ref(),
+        has_kce || has_filter_expr,
+        &[],
+    )?;
+
     // Parse KeyConditionExpression or desugar legacy KeyConditions
     let (mut key_condition, legacy_kc_maps) = if let Some(kce_str) =
         input.key_condition_expression.as_deref()
@@ -144,7 +168,7 @@ pub async fn handle_query(
         let parsed = tokenize_for(
             kce_str,
             ctx.limits.max_expression_tokens,
-            "KeyConditionExpression",
+            ExpressionKind::KeyCondition,
         )
         .and_then(|tokens| {
             if ctx.limits.enforce_reserved_keywords {
@@ -153,7 +177,7 @@ pub async fn handle_query(
             parse_key_condition(&tokens)
         })
         .map_err(|e| {
-            crate::expression_helpers::prefix_expression_error(e, "KeyConditionExpression")
+            crate::expression_helpers::prefix_expression_error(e, ExpressionKind::KeyCondition)
         })?;
         (parsed, None)
     } else if let Some(ref kc) = input.key_conditions {
@@ -248,7 +272,7 @@ pub async fn handle_query(
     // Validate #name references in filter are defined in ExpressionAttributeNames
     if let Some(ref filter_expr) = filter {
         let names = input.expression_attribute_names.as_ref();
-        validate_name_refs_in_expr(filter_expr, names, "FilterExpression")?;
+        validate_name_refs_in_expr(filter_expr, names, ExpressionKind::Filter)?;
     }
 
     // Parse ProjectionExpression or desugar legacy AttributesToGet
@@ -360,7 +384,7 @@ pub async fn handle_query(
     // Validate begins_with operand types upfront (before any rows are read).
     if let Some(ref f) = filter {
         extenddb_core::expression::validate_begins_with_operands(f, &combined_maps).map_err(
-            |e| crate::expression_helpers::prefix_expression_error(e, "FilterExpression"),
+            |e| crate::expression_helpers::prefix_expression_error(e, ExpressionKind::Filter),
         )?;
     }
 
@@ -463,7 +487,7 @@ fn resolve_path_attr_name(
 fn validate_name_refs_in_expr(
     expr: &extenddb_core::expression::Expr,
     names: Option<&HashMap<String, String>>,
-    expr_type: &str,
+    expr_type: ExpressionKind,
 ) -> Result<(), DynamoDbError> {
     use extenddb_core::expression::Expr;
     match expr {

--- a/crates/engine/src/read_helpers.rs
+++ b/crates/engine/src/read_helpers.rs
@@ -7,15 +7,57 @@
 //! after fetching raw items from storage. This module extracts that shared
 //! logic to avoid duplication.
 
+use std::collections::{HashMap, HashSet};
+
 use extenddb_core::error::DynamoDbError;
 use extenddb_core::expression::{
     Expr, ExpressionMaps, PathElement, apply_projection, evaluate_condition,
+    validate_unused_attributes,
 };
 use extenddb_core::types::{
     IndexInfo, Item, KeySchemaElement, Select, extract_key, item_size_bytes,
 };
 
 use crate::index_helpers::apply_index_projection;
+
+/// Reject `ExpressionAttributeNames` entries the projection never references.
+///
+/// Mirrors the unused-attribute check Query and Scan run via
+/// `validate_unused_attributes`, narrowed to read handlers that accept only a
+/// projection (GetItem, BatchGetItem). `names` is the raw request map with
+/// keys still carrying their `#` prefix. The caller passes this only for a
+/// user-supplied `ProjectionExpression`; desugared `AttributesToGet` uses
+/// synthetic placeholders and is governed by a separate rule.
+///
+/// # Errors
+///
+/// Returns `DynamoDbError::ValidationException` when a declared name is unused.
+pub fn validate_projection_unused_names(
+    names: Option<&HashMap<String, String>>,
+    projection: &[Vec<PathElement>],
+) -> Result<(), DynamoDbError> {
+    let Some(names) = names.filter(|m| !m.is_empty()) else {
+        return Ok(());
+    };
+    let mut used_names: HashSet<String> = HashSet::new();
+    for path in projection {
+        for el in path {
+            if let PathElement::Attribute(name) = el
+                && let Some(stripped) = name.strip_prefix('#')
+            {
+                used_names.insert(stripped.to_owned());
+            }
+        }
+    }
+    validate_unused_attributes(
+        names,
+        &HashMap::new(),
+        &[],
+        &[],
+        &used_names,
+        &HashSet::new(),
+    )
+}
 
 /// Result of the post-read processing pipeline.
 pub struct PostReadResult {

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use serde_json::Value;
 
 use extenddb_core::error::DynamoDbError;
-use extenddb_core::expression::{ExpressionMaps, parse_projection, tokenize_with_limit};
+use extenddb_core::expression::ExpressionMaps;
 use extenddb_core::types::{
     IndexType, ScanInput, ScanOutput, Select, TableKeyInfo, extract_key, item_size_bytes,
 };
@@ -158,6 +158,22 @@ pub async fn handle_scan(
         input.expression_attribute_values.as_ref(),
     );
 
+    let has_filter_expr = input
+        .filter_expression
+        .as_ref()
+        .is_some_and(|s| !s.is_empty());
+    let has_proj_expr = input
+        .projection_expression
+        .as_ref()
+        .is_some_and(|s| !s.is_empty());
+    extenddb_core::expression::validate_expression_param_usage(
+        input.expression_attribute_names.as_ref(),
+        has_proj_expr || has_filter_expr,
+        input.expression_attribute_values.as_ref(),
+        has_filter_expr,
+        &["FilterExpression"],
+    )?;
+
     // Parse FilterExpression or desugar legacy ScanFilter
     let (filter, filter_maps) = if let Some(ref sf) = input.scan_filter {
         if !sf.is_empty() {
@@ -197,8 +213,10 @@ pub async fn handle_scan(
     };
 
     let projection = if let Some(ref proj_str) = effective_projection_str {
-        let proj_tokens = tokenize_with_limit(proj_str, ctx.limits.max_expression_tokens)?;
-        Some(parse_projection(&proj_tokens)?)
+        Some(crate::expression_helpers::parse_projection_expr(
+            proj_str,
+            &ctx.limits,
+        )?)
     } else {
         None
     };

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use serde_json::Value;
 
 use extenddb_core::error::DynamoDbError;
-use extenddb_core::expression::ExpressionMaps;
+use extenddb_core::expression::{ExpressionKind, ExpressionMaps};
 use extenddb_core::types::{
     IndexType, ScanInput, ScanOutput, Select, TableKeyInfo, extract_key, item_size_bytes,
 };
@@ -171,7 +171,7 @@ pub async fn handle_scan(
         has_proj_expr || has_filter_expr,
         input.expression_attribute_values.as_ref(),
         has_filter_expr,
-        &["FilterExpression"],
+        &[ExpressionKind::Filter],
     )?;
 
     // Parse FilterExpression or desugar legacy ScanFilter
@@ -293,7 +293,7 @@ pub async fn handle_scan(
     // Validate begins_with operand types upfront (before any rows are scanned).
     if let Some(ref f) = filter {
         extenddb_core::expression::validate_begins_with_operands(f, &combined_maps).map_err(
-            |e| crate::expression_helpers::prefix_expression_error(e, "FilterExpression"),
+            |e| crate::expression_helpers::prefix_expression_error(e, ExpressionKind::Filter),
         )?;
     }
 

--- a/crates/engine/src/transact_get_items.rs
+++ b/crates/engine/src/transact_get_items.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 use serde_json::Value;
 
 use extenddb_core::error::DynamoDbError;
-use extenddb_core::expression::{apply_projection, parse_projection, tokenize_for};
+use extenddb_core::expression::{ExpressionKind, apply_projection, parse_projection, tokenize_for};
 use extenddb_core::types::{
     ItemResponse, TransactGetItemsInput, TransactGetItemsOutput, item_size_bytes,
 };
@@ -134,7 +134,7 @@ pub async fn handle_transact_get_items(
                 let proj_tokens = tokenize_for(
                     proj_str,
                     ctx.limits.max_expression_tokens,
-                    "ProjectionExpression",
+                    ExpressionKind::Projection,
                 )?;
                 let projection = parse_projection(&proj_tokens)?;
                 let mut extra_names = std::collections::HashSet::new();

--- a/crates/engine/src/update_item.rs
+++ b/crates/engine/src/update_item.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 
 use extenddb_core::error::DynamoDbError;
 use extenddb_core::expression::{
-    ExpressionMaps, PathElement, UpdateAction, parse_update_from, tokenize_for,
+    ExpressionKind, ExpressionMaps, PathElement, UpdateAction, parse_update_from, tokenize_for,
     validate_no_reserved_words,
 };
 use extenddb_core::types::{
@@ -126,7 +126,7 @@ pub async fn handle_update_item(
         has_expr,
         input.expression_attribute_values.as_ref(),
         has_expr,
-        &["UpdateExpression", "ConditionExpression"],
+        &[ExpressionKind::Update, ExpressionKind::Condition],
     )?;
 
     let (condition, maps) = resolve_condition(
@@ -144,7 +144,7 @@ pub async fn handle_update_item(
         tokenize_for(
             update_expr,
             ctx.limits.max_expression_tokens,
-            "UpdateExpression",
+            ExpressionKind::Update,
         )
         .and_then(|update_tokens| {
             if ctx.limits.enforce_reserved_keywords {
@@ -152,7 +152,9 @@ pub async fn handle_update_item(
             }
             parse_update_from(&update_tokens, update_expr)
         })
-        .map_err(|e| crate::expression_helpers::prefix_expression_error(e, "UpdateExpression"))?
+        .map_err(|e| {
+            crate::expression_helpers::prefix_expression_error(e, ExpressionKind::Update)
+        })?
     } else {
         Vec::new()
     };

--- a/crates/engine/src/update_item.rs
+++ b/crates/engine/src/update_item.rs
@@ -112,6 +112,23 @@ pub async fn handle_update_item(
         &key_info.attribute_definitions,
     )?;
 
+    let has_update_expr = input
+        .update_expression
+        .as_ref()
+        .is_some_and(|s| !s.is_empty());
+    let has_condition = input
+        .condition_expression
+        .as_ref()
+        .is_some_and(|s| !s.is_empty());
+    let has_expr = has_update_expr || has_condition;
+    extenddb_core::expression::validate_expression_param_usage(
+        input.expression_attribute_names.as_ref(),
+        has_expr,
+        input.expression_attribute_values.as_ref(),
+        has_expr,
+        &["UpdateExpression", "ConditionExpression"],
+    )?;
+
     let (condition, maps) = resolve_condition(
         input.condition_expression.as_deref(),
         effective_expr_names.as_ref(),
@@ -124,15 +141,18 @@ pub async fn handle_update_item(
     // No UpdateExpression and no AttributeUpdates: no-op upsert.
     // Some("") still errors via tokenize_for.
     let actions = if let Some(update_expr) = effective_update_expr.as_deref() {
-        let update_tokens = tokenize_for(
+        tokenize_for(
             update_expr,
             ctx.limits.max_expression_tokens,
             "UpdateExpression",
-        )?;
-        if ctx.limits.enforce_reserved_keywords {
-            validate_no_reserved_words(&update_tokens)?;
-        }
-        parse_update_from(&update_tokens, update_expr)?
+        )
+        .and_then(|update_tokens| {
+            if ctx.limits.enforce_reserved_keywords {
+                validate_no_reserved_words(&update_tokens)?;
+            }
+            parse_update_from(&update_tokens, update_expr)
+        })
+        .map_err(|e| crate::expression_helpers::prefix_expression_error(e, "UpdateExpression"))?
     } else {
         Vec::new()
     };

--- a/tests/test_expression_error_prefix.py
+++ b/tests/test_expression_error_prefix.py
@@ -1,0 +1,94 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Expression parse errors must carry the expression-parameter-specific prefix.
+
+Amazon DynamoDB prefixes expression parse errors with the specific parameter
+name (Invalid ProjectionExpression / ConditionExpression / FilterExpression /
+KeyConditionExpression / UpdateExpression), not a generic "Invalid expression".
+
+Dual-target against Amazon DynamoDB and extenddb.
+"""
+
+from __future__ import annotations
+
+import pytest
+from botocore.exceptions import ClientError
+
+from conftest import scoped_table
+
+RESERVED = "Attribute name is a reserved keyword; reserved keyword: status"
+
+
+@pytest.fixture(scope="class")
+def hash_table(dynamodb_client):
+    with scoped_table(dynamodb_client) as name:
+        dynamodb_client.put_item(TableName=name, Item={"pk": {"S": "k1"}})
+        yield name
+
+
+def _msg(func) -> str:
+    with pytest.raises(ClientError) as exc_info:
+        func()
+    err = exc_info.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    return err["Message"]
+
+
+class TestExpressionErrorPrefix:
+    """Reserved-keyword parse errors carry the per-parameter prefix."""
+
+    def test_projection_prefix(self, dynamodb_client, hash_table):
+        msg = _msg(lambda: dynamodb_client.get_item(
+            TableName=hash_table, Key={"pk": {"S": "k1"}},
+            ProjectionExpression="status",
+        ))
+        assert msg == f"Invalid ProjectionExpression: {RESERVED}"
+
+    def test_filter_prefix(self, dynamodb_client, hash_table):
+        msg = _msg(lambda: dynamodb_client.scan(
+            TableName=hash_table,
+            FilterExpression="status = :v",
+            ExpressionAttributeValues={":v": {"S": "x"}},
+        ))
+        assert msg == f"Invalid FilterExpression: {RESERVED}"
+
+    def test_condition_prefix_put(self, dynamodb_client, hash_table):
+        msg = _msg(lambda: dynamodb_client.put_item(
+            TableName=hash_table, Item={"pk": {"S": "k9"}},
+            ConditionExpression="status = :v",
+            ExpressionAttributeValues={":v": {"S": "x"}},
+        ))
+        assert msg == f"Invalid ConditionExpression: {RESERVED}"
+
+    def test_condition_prefix_delete(self, dynamodb_client, hash_table):
+        msg = _msg(lambda: dynamodb_client.delete_item(
+            TableName=hash_table, Key={"pk": {"S": "k1"}},
+            ConditionExpression="status = :v",
+            ExpressionAttributeValues={":v": {"S": "x"}},
+        ))
+        assert msg == f"Invalid ConditionExpression: {RESERVED}"
+
+    def test_update_prefix(self, dynamodb_client, hash_table):
+        msg = _msg(lambda: dynamodb_client.update_item(
+            TableName=hash_table, Key={"pk": {"S": "k1"}},
+            UpdateExpression="SET status = :v",
+            ExpressionAttributeValues={":v": {"S": "x"}},
+        ))
+        assert msg == f"Invalid UpdateExpression: {RESERVED}"
+
+    def test_key_condition_prefix(self, dynamodb_client, hash_table):
+        msg = _msg(lambda: dynamodb_client.query(
+            TableName=hash_table,
+            KeyConditionExpression="status = :v",
+            ExpressionAttributeValues={":v": {"S": "x"}},
+        ))
+        assert msg == f"Invalid KeyConditionExpression: {RESERVED}"
+
+    def test_projection_syntax_prefix(self, dynamodb_client, hash_table):
+        # Syntax error also carries the ProjectionExpression prefix.
+        msg = _msg(lambda: dynamodb_client.get_item(
+            TableName=hash_table, Key={"pk": {"S": "k1"}},
+            ProjectionExpression="a..b",
+        ))
+        assert msg.startswith("Invalid ProjectionExpression:")

--- a/tests/test_expression_param_usage.py
+++ b/tests/test_expression_param_usage.py
@@ -144,3 +144,35 @@ class TestExpressionParamsWithoutExpression:
             ),
             f"{VALUES_PREFIX}: ConditionExpression is null",
         )
+
+    def test_query_names_no_expression(self, dynamodb_client, hash_table):
+        # Legacy KeyConditions is not an expression; stray names are rejected.
+        _expect_validation(
+            lambda: dynamodb_client.query(
+                TableName=hash_table,
+                KeyConditions={
+                    "pk": {
+                        "AttributeValueList": [{"S": "k1"}],
+                        "ComparisonOperator": "EQ",
+                    }
+                },
+                ExpressionAttributeNames={"#a": "pk"},
+            ),
+            NAMES_MSG,
+        )
+
+    def test_query_values_no_expression(self, dynamodb_client, hash_table):
+        # Query emits no values suffix, unlike Scan/Delete/Update.
+        _expect_validation(
+            lambda: dynamodb_client.query(
+                TableName=hash_table,
+                KeyConditions={
+                    "pk": {
+                        "AttributeValueList": [{"S": "k1"}],
+                        "ComparisonOperator": "EQ",
+                    }
+                },
+                ExpressionAttributeValues={":v": {"S": "x"}},
+            ),
+            VALUES_PREFIX,
+        )

--- a/tests/test_expression_param_usage.py
+++ b/tests/test_expression_param_usage.py
@@ -1,0 +1,146 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""ExpressionAttributeNames/Values supplied with no expression that uses them.
+
+Amazon DynamoDB rejects a request that provides ExpressionAttributeNames or
+ExpressionAttributeValues when there is no expression parameter that could
+reference them. The names message is always suffix-free; the values message
+names the null value-capable expression parameter(s) for that API.
+
+Dual-target against Amazon DynamoDB and extenddb.
+"""
+
+from __future__ import annotations
+
+import pytest
+from botocore.exceptions import ClientError
+
+from conftest import scoped_table
+
+NAMES_MSG = "ExpressionAttributeNames can only be specified when using expressions"
+VALUES_PREFIX = "ExpressionAttributeValues can only be specified when using expressions"
+
+
+@pytest.fixture(scope="class")
+def hash_table(dynamodb_client):
+    """Hash-only table for the class, with one item, deleted on teardown."""
+    with scoped_table(dynamodb_client) as name:
+        dynamodb_client.put_item(
+            TableName=name,
+            Item={"pk": {"S": "k1"}, "foo": {"S": "a"}},
+        )
+        yield name
+
+
+def _expect_validation(func, expected_message: str):
+    with pytest.raises(ClientError) as exc_info:
+        func()
+    err = exc_info.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert err["Message"] == expected_message
+
+
+class TestExpressionParamsWithoutExpression:
+    """Names/values with no referencing expression must be rejected."""
+
+    def test_get_item_names_no_expression(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.get_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ExpressionAttributeNames={"#a": "foo"},
+            ),
+            NAMES_MSG,
+        )
+
+    def test_batch_get_item_names_no_expression(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.batch_get_item(
+                RequestItems={
+                    hash_table: {
+                        "Keys": [{"pk": {"S": "k1"}}],
+                        "ExpressionAttributeNames": {"#a": "foo"},
+                    }
+                }
+            ),
+            NAMES_MSG,
+        )
+
+    def test_scan_names_no_expression(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.scan(
+                TableName=hash_table,
+                ExpressionAttributeNames={"#a": "foo"},
+            ),
+            NAMES_MSG,
+        )
+
+    def test_scan_values_no_expression(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.scan(
+                TableName=hash_table,
+                ExpressionAttributeValues={":v": {"S": "x"}},
+            ),
+            f"{VALUES_PREFIX}: FilterExpression is null",
+        )
+
+    def test_delete_item_names_no_expression(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.delete_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ExpressionAttributeNames={"#a": "foo"},
+            ),
+            NAMES_MSG,
+        )
+
+    def test_delete_item_values_no_expression(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.delete_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ExpressionAttributeValues={":v": {"S": "x"}},
+            ),
+            f"{VALUES_PREFIX}: ConditionExpression is null",
+        )
+
+    def test_update_item_names_no_expression(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.update_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ExpressionAttributeNames={"#a": "foo"},
+            ),
+            NAMES_MSG,
+        )
+
+    def test_update_item_values_no_expression(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.update_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ExpressionAttributeValues={":v": {"S": "x"}},
+            ),
+            f"{VALUES_PREFIX}: UpdateExpression and ConditionExpression are null",
+        )
+
+    def test_put_item_names_no_expression(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.put_item(
+                TableName=hash_table,
+                Item={"pk": {"S": "k2"}},
+                ExpressionAttributeNames={"#a": "foo"},
+            ),
+            NAMES_MSG,
+        )
+
+    def test_put_item_values_no_expression(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.put_item(
+                TableName=hash_table,
+                Item={"pk": {"S": "k2"}},
+                ExpressionAttributeValues={":v": {"S": "x"}},
+            ),
+            f"{VALUES_PREFIX}: ConditionExpression is null",
+        )

--- a/tests/test_unused_expression_attribute_names.py
+++ b/tests/test_unused_expression_attribute_names.py
@@ -1,0 +1,97 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unused ExpressionAttributeNames validation on the read path.
+
+Amazon DynamoDB rejects a request that declares an entry in
+ExpressionAttributeNames which is never referenced by any expression
+(here, the ProjectionExpression). GetItem and BatchGetItem must enforce
+this the same way Query, Scan, PutItem, DeleteItem, and UpdateItem do.
+
+Dual-target against Amazon DynamoDB and extenddb.
+"""
+
+from __future__ import annotations
+
+import pytest
+from botocore.exceptions import ClientError
+
+from conftest import scoped_table
+
+
+@pytest.fixture(scope="class")
+def hash_table(dynamodb_client):
+    """Hash-only table for the class, deleted on teardown."""
+    with scoped_table(dynamodb_client) as name:
+        dynamodb_client.put_item(
+            TableName=name,
+            Item={"pk": {"S": "k1"}, "foo": {"S": "a"}, "bar": {"S": "b"}},
+        )
+        yield name
+
+
+class TestUnusedExpressionAttributeNames:
+    """ExpressionAttributeNames entries must be referenced by an expression."""
+
+    def test_get_item_unused_name_existing_item(self, dynamodb_client, hash_table):
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.get_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ProjectionExpression="pk",
+                ExpressionAttributeNames={"#abc": "foo"},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert "unused in expressions" in err["Message"]
+        assert "#abc" in err["Message"]
+
+    def test_get_item_unused_name_missing_item(self, dynamodb_client, hash_table):
+        # Validation must fire even when the key does not exist.
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.get_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "does-not-exist"}},
+                ProjectionExpression="pk",
+                ExpressionAttributeNames={"#abc": "foo"},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert "unused in expressions" in err["Message"]
+
+    def test_get_item_used_name_succeeds(self, dynamodb_client, hash_table):
+        # Positive control: a referenced name is fine and projection narrows.
+        resp = dynamodb_client.get_item(
+            TableName=hash_table,
+            Key={"pk": {"S": "k1"}},
+            ProjectionExpression="#abc",
+            ExpressionAttributeNames={"#abc": "foo"},
+        )
+        assert resp["Item"] == {"foo": {"S": "a"}}
+
+    def test_batch_get_item_unused_name(self, dynamodb_client, hash_table):
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.batch_get_item(
+                RequestItems={
+                    hash_table: {
+                        "Keys": [{"pk": {"S": "k1"}}],
+                        "ProjectionExpression": "pk",
+                        "ExpressionAttributeNames": {"#abc": "foo"},
+                    }
+                }
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert "unused in expressions" in err["Message"]
+
+    def test_batch_get_item_used_name_succeeds(self, dynamodb_client, hash_table):
+        resp = dynamodb_client.batch_get_item(
+            RequestItems={
+                hash_table: {
+                    "Keys": [{"pk": {"S": "k1"}}],
+                    "ProjectionExpression": "#abc",
+                    "ExpressionAttributeNames": {"#abc": "foo"},
+                }
+            }
+        )
+        assert resp["Responses"][hash_table] == [{"foo": {"S": "a"}}]


### PR DESCRIPTION
## What

This makes expression-attribute validation and expression parse-error messages match Amazon DynamoDB across the single-item and query/scan APIs. Three related gaps:

1. `GetItem` and `BatchGetItem` did not reject `ExpressionAttributeNames` entries that the projection never references. Every other handler (Query, Scan, PutItem, UpdateItem, DeleteItem) already did.
2. No handler rejected `ExpressionAttributeNames`/`ExpressionAttributeValues` supplied when there is no expression that could reference them. `PutItem` had a partial check, but it appended a suffix to the names message that Amazon DynamoDB does not emit.
3. Expression parse errors used a generic `Invalid expression:` prefix instead of the parameter-specific `Invalid ProjectionExpression:` / `Invalid ConditionExpression:` / `Invalid FilterExpression:` / `Invalid KeyConditionExpression:` / `Invalid UpdateExpression:`.

I also added an `ExpressionKind` enum in `extenddb-core` so the parameter label that drives both the error prefix and the value-suffix is defined once and is typo-safe, instead of being repeated as string literals at each call site.

## Behavior: today vs Amazon DynamoDB

The table shows what ExtendDB returns before this PR and what Amazon DynamoDB returns. I captured every Amazon DynamoDB message directly via the AWS CLI.

| Scenario | ExtendDB (before this PR) | Amazon DynamoDB |
|---|---|---|
| GetItem with `ProjectionExpression="id"` and `ExpressionAttributeNames={"#abc":"foo"}` (declared, never referenced) | Returns the item, no error | `ValidationException: Value provided in ExpressionAttributeNames unused in expressions: keys: {#abc}` |
| GetItem / BatchGetItem / Scan / Query with `ExpressionAttributeNames` but no expression that uses a name | Returns the item, no error | `ValidationException: ExpressionAttributeNames can only be specified when using expressions` |
| PutItem with `ExpressionAttributeNames` and no `ConditionExpression` | `ValidationException: ExpressionAttributeNames can only be specified when using expressions: ConditionExpression is null` (extra suffix) | `ValidationException: ExpressionAttributeNames can only be specified when using expressions` (no suffix) |
| Scan with `ExpressionAttributeValues` and no `FilterExpression` | Runs the scan, no error | `ValidationException: ExpressionAttributeValues can only be specified when using expressions: FilterExpression is null` |
| DeleteItem with `ExpressionAttributeValues` and no `ConditionExpression` | Deletes, no error | `ValidationException: ExpressionAttributeValues can only be specified when using expressions: ConditionExpression is null` |
| UpdateItem with `ExpressionAttributeValues` and no `UpdateExpression`/`ConditionExpression` | Runs the update, no error | `ValidationException: ExpressionAttributeValues can only be specified when using expressions: UpdateExpression and ConditionExpression are null` |
| Query with legacy `KeyConditions` and a stray `ExpressionAttributeValues` | Runs the query, no error | `ValidationException: ExpressionAttributeValues can only be specified when using expressions` (Query emits no suffix) |
| GetItem with `ProjectionExpression="status"` (a reserved word) | `ValidationException: Invalid expression: Attribute name is a reserved keyword; reserved keyword: status` | `ValidationException: Invalid ProjectionExpression: Attribute name is a reserved keyword; reserved keyword: status` |
| PutItem/DeleteItem `ConditionExpression`, Scan/Query `FilterExpression`, Query `KeyConditionExpression`, UpdateItem `UpdateExpression` with a reserved word | `Invalid expression: ...` | `Invalid <that parameter>: ...` |

## Out of scope

I kept this PR focused on the single-item and query/scan validation and the error prefix. The following gaps will be addressed in separate PRs:

- `TransactWriteItems` and `TransactGetItems` are not wired into this validation yet. Their expression parse errors and "can only be specified" handling are unchanged. This needs its own message capture pass because transactions can format errors by item index.
- Only the error prefix is corrected, not the full syntax-error body text. For example a negative list index in a projection gets the right `Invalid ProjectionExpression:` prefix but not yet the exact token/near wording Amazon DynamoDB includes.
- Nested projection correctness (for example dropping a `NULL` marker inside a list, or list-element projection) is unchanged.
- Validation of the `ExpressionAttributeNames` map entries themselves (empty key, over-long key, duplicate, over-long or empty mapped value, too many names) is unchanged.
- Expression size-limit validation is unchanged.
- Rejecting a mix of `AttributesToGet` and expression parameters inside `BatchGetItem` is unchanged.

## Why

These are conformance gaps found by comparing ExtendDB against Amazon DynamoDB with the AWS CLI.

## Testing done

Added three pytest modules; every expected message was captured from Amazon DynamoDB:

- `tests/test_unused_expression_attribute_names.py` (5 cases): unused names on GetItem/BatchGetItem, including the missing-item case that proves validation runs before the lookup, plus positive controls.
- `tests/test_expression_param_usage.py` (12 cases): names and values with no referencing expression across GetItem, BatchGetItem, Scan, DeleteItem, UpdateItem, PutItem, and Query, asserting the exact per-API suffix.
- `tests/test_expression_error_prefix.py` (7 cases): the per-parameter prefix for all five expression kinds, for both reserved-word and syntax errors.

Results:

- New tests: 24 pass against ExtendDB; the same cases pass against Amazon DynamoDB.
- Regression: `tests/` item, batch, query/scan, conditional-write, transaction, and expression suites pass (325 cases), no new failures.
- `cargo test --workspace` passes; `cargo fmt --check` clean; `cargo clippy -- -D warnings` clean for the touched crates.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface, an RFC has been accepted or is linked below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a.

## Breaking changes

n/a

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.