### PR TITLE
refactor: enable downcasting of StorageConfig to engine-specific configurations

### DIFF
--- a/crates/bin/src/cmd_serve.rs
+++ b/crates/bin/src/cmd_serve.rs
@@ -79,19 +79,9 @@ pub fn run(args: &ServeArgs) -> anyhow::Result<()> {
         );
     }
 
-    // Check backend is supported by this build
+    // Validate backend is supported and get catalog version (fail fast before binding port)
     let backend = &app_config.storage._backend;
-    #[cfg(not(feature = "postgres"))]
-    if backend == "postgres" {
-        anyhow::bail!("PostgreSQL backend not enabled. Rebuild with --features postgres");
-    }
-    #[cfg(feature = "postgres")]
-    if backend != "postgres" {
-        anyhow::bail!(
-            "Unknown backend '{}'. This build only supports 'postgres'.",
-            backend
-        );
-    }
+    let catalog_version = extenddb_storage::operations::catalog_version(backend)?;
 
     let port = args.port.unwrap_or(app_config.server.port);
     let bind_addr = format!("{}:{}", app_config.server.bind_addr, port);
@@ -112,9 +102,6 @@ pub fn run(args: &ServeArgs) -> anyhow::Result<()> {
     // it to stderr so a process supervisor receives banner and tracing logs
     // on the same stream — mixing stdout and stderr makes container log
     // capture noisier than necessary.
-    let backend = &app_config.storage._backend;
-    let catalog_version = extenddb_storage::operations::catalog_version(backend)
-        .unwrap_or_else(|_| "unknown".to_string());
     let banner_line1 = format!(
         "extenddb {} (catalog {}) starting on {}",
         env!("CARGO_PKG_VERSION"),

--- a/crates/storage-postgres/src/config.rs
+++ b/crates/storage-postgres/src/config.rs
@@ -108,4 +108,8 @@ impl extenddb_storage::config::StorageConfig for PostgresStorageConfig {
     fn clone_box(&self) -> Box<dyn extenddb_storage::config::StorageConfig> {
         Box::new(self.clone())
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }

--- a/crates/storage/src/config.rs
+++ b/crates/storage/src/config.rs
@@ -26,7 +26,9 @@ pub trait StorageConfig: Send + Sync + std::fmt::Debug {
     /// Enable downcasting to specific storage engine config types to allow
     /// access to engine-specific configuration (e.g. `keyspace_prefix` for
     /// the Cassandra backend).
-    fn as_any(&self) -> &dyn std::any::Any where Self: 'static;
+    fn as_any(&self) -> &dyn std::any::Any
+    where
+        Self: 'static;
 }
 
 impl Clone for Box<dyn StorageConfig> {

--- a/crates/storage/src/config.rs
+++ b/crates/storage/src/config.rs
@@ -22,6 +22,11 @@ pub trait StorageConfig: Send + Sync + std::fmt::Debug {
 
     /// Clone this config into a boxed trait object.
     fn clone_box(&self) -> Box<dyn StorageConfig>;
+
+    /// Enable downcasting to specific storage engine config types to allow
+    /// access to engine-specific configuration (e.g. `keyspace_prefix` for
+    /// the Cassandra backend).
+    fn as_any(&self) -> &dyn std::any::Any where Self: 'static;
 }
 
 impl Clone for Box<dyn StorageConfig> {


### PR DESCRIPTION
## What

This (primarily) enables downcasting of StorageConfig implementations to engine-specific configurations. This eliminates the need to clutter StorageConfig with config parameters for every engine ExtendDB supports. Also removed overzealous backend check in cmd_serve and instead allowing the command to fail "naturally" if it doesn't know how to handle the configured backend.

## Why

Different db engines need different configuration (e.g. Cassandra needs keyspace configuration). We don't want all that configuration to have to be declared in StorageConfig and overridden by every engine-specific config. Making as_any() public enables downcasting of StorageConfig to the type the engine needs to initialize.

## Testing done

cargo test, pytests, manual testing

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] All tests pass (`cargo test --workspace`)
- [X] Code is formatted (`cargo fmt --check`)
- [X] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [X] I have added or updated tests for new functionality
- [N/A] I have updated documentation if behavior changed
- [X] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

## Breaking changes

DB backend crates need to implement StorageConfig::as_any() to avoid build breakage. E.g.:
```
    fn as_any(&self) -> &dyn std::any::Any {
        self
    }
```
(storage-postgres updated in this PR)

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
