### PR TITLE
fix(ci): make integration job fail on CLI lifecycle errors, add psycopg2, use a PG admin role

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -70,6 +70,7 @@ jobs:
           EXTENDDB_TEST_ENDPOINT: https://127.0.0.1:8000
           EXTENDDB_ADMIN_USER: admin
           EXTENDDB_ADMIN_PASSWORD: ${{ steps.init.outputs.admin_password }}
+          EXTENDDB_TEST_PG_ADMIN_CONNECTION_STRING: postgresql://postgres:devpass@127.0.0.1:5432
         run: devtools/run-tests --extenddb --pytest --comprehensive --parallel --filter "not import_export"
 
   integration:

--- a/devtools/run-tests
+++ b/devtools/run-tests
@@ -519,6 +519,7 @@ if $RUN_PYTEST && [[ "$TARGET" != "real-dynamodb" && -n "${EXTENDDB_TEST_PG_CONN
         echo "  ✓ CLI lifecycle tests passed"
     else
         echo "  ✗ CLI lifecycle tests failed"
+        PASS=false
     fi
     echo ""
 fi

--- a/devtools/run-tests
+++ b/devtools/run-tests
@@ -441,6 +441,7 @@ if $RUN_PYTEST; then
         echo "  ✓ Pytest passed"
     else
         echo "  ✗ Pytest failed (check output for details)"
+        PASS=false
     fi
     echo ""
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 
 # Testing
 boto3==1.43.14
+psycopg2-binary==2.9.12
 pytest==9.0.3
 pytest-cov==7.1.0
 pytest-xdist==3.8.0

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -46,17 +46,22 @@ EXTENDDB_BINARY = os.environ.get(
 # PostgreSQL connection string for creating test databases.
 PG_CONN = os.environ.get("EXTENDDB_TEST_PG_CONNECTION_STRING", "")
 
+# Admin connection for privileged ops (CREATE/DROP DATABASE, CREATE ROLE).
+# PG_CONN is the unprivileged app role; falls back to it for local superuser setups.
+PG_ADMIN_CONN = os.environ.get("EXTENDDB_TEST_PG_ADMIN_CONNECTION_STRING", "") or PG_CONN
 
-def _parse_pg_credentials():
-    """Extract user and password from PG_CONN (postgresql://user:pass@host:port)."""
-    if not PG_CONN:
+
+def _parse_pg_credentials(conn):
+    """Extract user and password from a connection string (postgresql://user:pass@host:port)."""
+    if not conn:
         return None, None
     from urllib.parse import urlparse
-    parsed = urlparse(PG_CONN)
+    parsed = urlparse(conn)
     return parsed.username, parsed.password
 
 
-PG_USER, PG_PASS = _parse_pg_credentials()
+PG_USER, PG_PASS = _parse_pg_credentials(PG_CONN)
+PG_ADMIN_USER, PG_ADMIN_PASS = _parse_pg_credentials(PG_ADMIN_CONN)
 
 
 def _fail_if_no_pg():
@@ -78,12 +83,13 @@ def _fail_if_no_binary():
 
 
 def _pg_args():
-    """Return --pg-user and --pg-pass args for commands that connect as admin."""
+    """Return --pg-user and --pg-pass args for commands that connect as the
+    PostgreSQL admin (catalog database and application-role creation)."""
     args = []
-    if PG_USER:
-        args.extend(["--pg-user", PG_USER])
-    if PG_PASS:
-        args.extend(["--pg-pass", PG_PASS])
+    if PG_ADMIN_USER:
+        args.extend(["--pg-user", PG_ADMIN_USER])
+    if PG_ADMIN_PASS:
+        args.extend(["--pg-pass", PG_ADMIN_PASS])
     return args
 
 
@@ -212,7 +218,7 @@ def _drop_database(db_name):
     import psycopg2
 
     try:
-        conn = psycopg2.connect(PG_CONN + "/postgres")
+        conn = psycopg2.connect(PG_ADMIN_CONN + "/postgres")
         conn.autocommit = True
         with conn.cursor() as cur:
             # Terminate existing connections
@@ -388,8 +394,8 @@ class TestCliLifecycle:
             # Connect using Unix socket to discover the socket directory
             conn = psycopg2.connect(
                 dbname="postgres",
-                user=PG_USER,
-                password=PG_PASS,
+                user=PG_ADMIN_USER,
+                password=PG_ADMIN_PASS,
             )
             # Query the socket directory from PostgreSQL
             with conn.cursor() as cur:


### PR DESCRIPTION
## What

Makes the integration `run-integration` job fail when the CLI lifecycle suite fails, and fixes the two underlying failures that the broken gate was hiding.

Three changes:

1. `devtools/run-tests`: add `PASS=false` to the CLI lifecycle else-branch so a failing suite propagates to a non-zero exit.
2. `requirements.txt`: add `psycopg2-binary==2.9.12` (the test module imports it but it was never declared).
3. `tests/test_cli_lifecycle.py` and `.github/workflows/integration.yml`: run privileged database and role operations through a dedicated `EXTENDDB_TEST_PG_ADMIN_CONNECTION_STRING` instead of the unprivileged application role.

example run: https://github.com/ExtendDB/extenddb/actions/runs/26965818125/job/79568039469

## Why

The `run-integration` job reports success even when the CLI lifecycle suite fail.

`devtools/run-tests` propagates failures inconsistently. The rust, rust-integration, comprehensive, external, and catalog-check blocks all set `PASS=false` on failure. The CLI lifecycle block did not: it printed the failure line and moved on, so the script exited 0 and the job went green.

### unprivileged application role
Each CLI lifecycle test ran extenddb init as the extenddb app role, and the init subprocess exited non-zero. The error:
```
Error: Internal("Create database 'extenddb_test_6043a472_catalog':
        error returned from database: permission denied to create database")
```

## Testing done

Validated on a full run of the integration workflow before opening this PR.

Before (the failing state above): `8 failed, 2 passed, 8 errors`, job still green.

After:

```
tests/test_cli_lifecycle.py::TestCliLifecycle::test_version                 PASSED
tests/test_cli_lifecycle.py::TestCliLifecycle::test_init_creates_schema     PASSED
tests/test_cli_lifecycle.py::TestCliLifecycle::test_init_serve_status_stop  PASSED
tests/test_cli_lifecycle.py::TestCliLifecycle::test_init_serve_stop_destroy PASSED
tests/test_cli_lifecycle.py::TestCliLifecycle::test_serve_without_init_fails PASSED
tests/test_cli_lifecycle.py::TestCliLifecycle::test_destroy_without_yes_fails PASSED
tests/test_cli_lifecycle.py::TestCliLifecycle::test_double_init_fails        PASSED
tests/test_cli_lifecycle.py::TestCliLifecycle::test_stop_when_not_running    PASSED
tests/test_cli_lifecycle.py::TestCliLifecycle::test_init_with_unix_socket    SKIPPED
tests/test_cli_lifecycle.py::TestCliMultiInstance::test_two_instances_isolated PASSED
======================== 9 passed, 1 skipped in 19.78s =========================
  ✓ CLI lifecycle tests passed
=== All requested test suites completed ===
```

`test_init_with_unix_socket` now skips instead of failing. That is correct: it previously failed only because `import psycopg2` raised before its own skip logic ran. With psycopg2 installed it reaches its designed skip path when the CI Postgres is not reachable over a Unix socket.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] All tests pass (`cargo test --workspace`)
- [ ] Code is formatted (`cargo fmt --check`)
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [ ] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

