### PR TITLE
refactor: decouple StorageConfig from postgres feature

### DIFF
--- a/crates/bin/src/config.rs
+++ b/crates/bin/src/config.rs
@@ -6,12 +6,11 @@
 use extenddb_core::limits::LimitsConfig;
 use serde::Deserialize;
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AppConfig {
     #[serde(default)]
     pub server: ServerConfig,
-    #[serde(default)]
     pub storage: StorageConfig,
     /// Auth provider configuration. `provider = "builtin"` for `SigV4` with
     /// local credential store. The server refuses to start with `provider = "none"`.
@@ -180,6 +179,7 @@ impl<'de> serde::Deserialize<'de> for StorageConfig {
     }
 }
 
+#[cfg(feature = "postgres")]
 impl Default for StorageConfig {
     fn default() -> Self {
         Self {
@@ -315,6 +315,7 @@ pub fn expand_tilde(path: &str) -> String {
     }
     path.to_owned()
 }
+#[cfg(feature = "postgres")]
 fn default_backend() -> String {
     "postgres".to_owned()
 }

--- a/crates/bin/src/serve_helpers.rs
+++ b/crates/bin/src/serve_helpers.rs
@@ -92,7 +92,7 @@ pub fn pid_file_path(run_dir: &str, port: u16) -> PathBuf {
 /// PID file path using the default run directory. Used by `status` when
 /// no config file is loaded.
 pub fn pid_file_path_default(port: u16) -> PathBuf {
-    let run_dir = config::AppConfig::default().server.run_dir;
+    let run_dir = config::ServerConfig::default().run_dir;
     pid_file_path(&run_dir, port)
 }
 


### PR DESCRIPTION
## What

Gate `StorageConfig`'s `Default` impl and the `default_backend()` function behind `#[cfg(feature = "postgres")]`. Remove `#[serde(default)]` from the `storage` field on `AppConfig` and drop the `Default` derive from `AppConfig`.

## Why

The binary fails to compile with `--no-default-features` because `StorageConfig::default()` unconditionally references `extenddb_storage_postgres::PostgresStorageConfig`. This blocks building backend-specific binaries (e.g. `--no-default-features --features memory`) which is a prerequisite for per-backend Docker images and the multi-backend distribution strategy.

The `#[serde(default)]` fallback was never exercised in practice — `extenddb init` always generates a config with an explicit `[storage]` section. Removing it makes the contract clear: every config must declare its backend.

## Testing done

- `cargo build` (default features) — compiles ✓
- `cargo build --no-default-features` — compiles ✓ (previously failed)
- `cargo clippy --all-targets -- -D warnings` — clean for both feature sets
- `cargo test --workspace` — all pass
- Full integration pytest (945 passed, 0 failed)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [ ] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a

## Breaking changes

Config files without a `[storage]` section will now fail to parse instead of silently defaulting to postgres. This only affects hand-written configs that omit the section — `extenddb init` has always generated it.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.