### PR TITLE
fix: validate transaction expression attributes and label parse errors per parameter

### DIFF
--- a/crates/engine/src/expression_helpers.rs
+++ b/crates/engine/src/expression_helpers.rs
@@ -7,8 +7,9 @@ use std::collections::HashMap;
 
 use extenddb_core::error::DynamoDbError;
 use extenddb_core::expression::{
-    Expr, ExpressionKind, ExpressionMaps, PathElement, Token, parse_condition_with_depth_limit,
-    parse_projection, tokenize_for, tokenize_with_limit, validate_no_reserved_words,
+    Expr, ExpressionKind, ExpressionMaps, PathElement, Token, UpdateAction,
+    parse_condition_with_depth_limit, parse_projection, parse_update_from, tokenize_for,
+    tokenize_with_limit, validate_no_reserved_words,
 };
 use extenddb_core::limits::LimitsConfig;
 use extenddb_core::types::{AttributeValue, ConditionalOperator, ExpectedAttributeValue};
@@ -54,6 +55,44 @@ pub fn build_expression_maps(
     )
 }
 
+/// Tokenize, reserved-word check, and parse a required `ConditionExpression`.
+///
+/// Errors carry the `ConditionExpression` prefix, matching Amazon DynamoDB.
+///
+/// # Errors
+///
+/// Returns `DynamoDbError::ValidationException` for syntax or reserved-word errors.
+pub fn parse_condition_expr(expr: &str, limits: &LimitsConfig) -> Result<Expr, DynamoDbError> {
+    tokenize_expression(expr, limits)
+        .and_then(|tokens| parse_condition_with_depth_limit(&tokens, limits.max_expression_depth))
+        .map_err(|e| prefix_expression_error(e, ExpressionKind::Condition))
+}
+
+/// Tokenize, reserved-word check, and parse an `UpdateExpression`.
+///
+/// Errors carry the `UpdateExpression` prefix, matching Amazon DynamoDB.
+///
+/// # Errors
+///
+/// Returns `DynamoDbError::ValidationException` for syntax or reserved-word errors.
+pub fn parse_update_expr(
+    update_expr: &str,
+    limits: &LimitsConfig,
+) -> Result<Vec<UpdateAction>, DynamoDbError> {
+    tokenize_for(
+        update_expr,
+        limits.max_expression_tokens,
+        ExpressionKind::Update,
+    )
+    .and_then(|update_tokens| {
+        if limits.enforce_reserved_keywords {
+            validate_no_reserved_words(&update_tokens)?;
+        }
+        parse_update_from(&update_tokens, update_expr)
+    })
+    .map_err(|e| prefix_expression_error(e, ExpressionKind::Update))
+}
+
 /// Parse an optional condition expression string into an AST.
 ///
 /// Returns `None` if the input is `None` or empty.
@@ -66,14 +105,7 @@ pub fn parse_optional_condition(
     limits: &LimitsConfig,
 ) -> Result<Option<Expr>, DynamoDbError> {
     match expr {
-        Some(s) if !s.is_empty() => {
-            let parsed = tokenize_expression(s, limits).and_then(|tokens| {
-                parse_condition_with_depth_limit(&tokens, limits.max_expression_depth)
-            });
-            parsed
-                .map(Some)
-                .map_err(|e| prefix_expression_error(e, ExpressionKind::Condition))
-        }
+        Some(s) if !s.is_empty() => parse_condition_expr(s, limits).map(Some),
         _ => Ok(None),
     }
 }

--- a/crates/engine/src/transact_get_items.rs
+++ b/crates/engine/src/transact_get_items.rs
@@ -161,14 +161,7 @@ pub async fn handle_transact_get_items(
                     .filter(|i| !i.is_empty());
                 Ok(ItemResponse { item })
             } else {
-                extenddb_core::expression::validate_unused_attributes(
-                    &maps.names,
-                    &maps.values,
-                    &[],
-                    &[],
-                    &std::collections::HashSet::new(),
-                    &std::collections::HashSet::new(),
-                )?;
+                // No projection: transactions accept names with no expression.
                 Ok(ItemResponse { item: opt })
             }
         })

--- a/crates/engine/src/transact_write_helpers.rs
+++ b/crates/engine/src/transact_write_helpers.rs
@@ -207,24 +207,6 @@ impl PreparedOp {
     }
 }
 
-/// Parse an optional condition expression string.
-pub(crate) fn parse_optional_condition(
-    expr: Option<&str>,
-    limits: &extenddb_core::limits::LimitsConfig,
-) -> Result<Option<extenddb_core::expression::Expr>, DynamoDbError> {
-    match expr {
-        Some(s) if !s.is_empty() => {
-            let tokens = crate::expression_helpers::tokenize_expression(s, limits)?;
-            let ast = extenddb_core::expression::parse_condition_with_depth_limit(
-                &tokens,
-                limits.max_expression_depth,
-            )?;
-            Ok(Some(ast))
-        }
-        _ => Ok(None),
-    }
-}
-
 /// Validate `ClientRequestToken` format.
 ///
 /// Real `DynamoDB` requires 1–36 characters, alphanumeric plus hyphens.
@@ -307,17 +289,6 @@ pub(crate) fn validate_no_key_updates(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn transact_condition_redundant_parens_rejected_with_canonical_message() {
-        let limits = extenddb_core::limits::LimitsConfig::default();
-        let err = parse_optional_condition(Some("((a = :v))"), &limits).unwrap_err();
-        assert!(
-            matches!(&err, DynamoDbError::ValidationException(msg)
-                if msg == "Invalid ConditionExpression: The expression has redundant parentheses;"),
-            "got {err:?}"
-        );
-    }
 
     #[test]
     fn validate_token_valid() {

--- a/crates/engine/src/transact_write_items.rs
+++ b/crates/engine/src/transact_write_items.rs
@@ -18,9 +18,6 @@ use crate::transact_write_helpers::{
 };
 use crate::{DispatchMetrics, DispatchResult};
 use extenddb_core::error::DynamoDbError;
-use extenddb_core::expression::{
-    ExpressionKind, parse_update_from, tokenize_for, validate_no_reserved_words,
-};
 use extenddb_core::types::{TransactWriteItem, TransactWriteItemsInput, TransactWriteItemsOutput};
 use extenddb_core::validation::{
     validate_attribute_name_sizes, validate_attribute_values_nesting_depth,
@@ -296,20 +293,8 @@ async fn prepare_write_op(
             upd.expression_attribute_names.as_ref(),
             upd.expression_attribute_values.as_ref(),
         );
-        let actions = tokenize_for(
-            &upd.update_expression,
-            ctx.limits.max_expression_tokens,
-            ExpressionKind::Update,
-        )
-        .and_then(|update_tokens| {
-            if ctx.limits.enforce_reserved_keywords {
-                validate_no_reserved_words(&update_tokens)?;
-            }
-            parse_update_from(&update_tokens, &upd.update_expression)
-        })
-        .map_err(|e| {
-            crate::expression_helpers::prefix_expression_error(e, ExpressionKind::Update)
-        })?;
+        let actions =
+            crate::expression_helpers::parse_update_expr(&upd.update_expression, &ctx.limits)?;
         validate_no_key_updates(&actions, &key_info, &maps)?;
 
         // Validate nesting depth of EAV values that get stored via SET actions.
@@ -366,16 +351,7 @@ async fn prepare_write_op(
             cc.expression_attribute_values.as_ref(),
         );
         let condition =
-            crate::expression_helpers::tokenize_expression(&cc.condition_expression, &ctx.limits)
-                .and_then(|tokens| {
-                    extenddb_core::expression::parse_condition_with_depth_limit(
-                        &tokens,
-                        ctx.limits.max_expression_depth,
-                    )
-                })
-                .map_err(|e| {
-                    crate::expression_helpers::prefix_expression_error(e, ExpressionKind::Condition)
-                })?;
+            crate::expression_helpers::parse_condition_expr(&cc.condition_expression, &ctx.limits)?;
         {
             let exprs: Vec<&extenddb_core::expression::Expr> = vec![&condition];
             extenddb_core::expression::validate_unused_attributes(

--- a/crates/engine/src/transact_write_items.rs
+++ b/crates/engine/src/transact_write_items.rs
@@ -10,16 +10,17 @@ use serde_json::Value;
 use crate::OperationContext;
 use crate::capacity_helpers;
 use crate::create_table::storage_err_to_dynamo;
-use crate::expression_helpers::build_expression_maps;
+use crate::expression_helpers::{build_expression_maps, parse_optional_condition};
 use crate::serialize_output;
 use crate::stream_capture;
 use crate::transact_write_helpers::{
-    PreparedOp, compute_fingerprint, parse_optional_condition, validate_client_request_token,
-    validate_no_key_updates,
+    PreparedOp, compute_fingerprint, validate_client_request_token, validate_no_key_updates,
 };
 use crate::{DispatchMetrics, DispatchResult};
 use extenddb_core::error::DynamoDbError;
-use extenddb_core::expression::parse_update;
+use extenddb_core::expression::{
+    ExpressionKind, parse_update_from, tokenize_for, validate_no_reserved_words,
+};
 use extenddb_core::types::{TransactWriteItem, TransactWriteItemsInput, TransactWriteItemsOutput};
 use extenddb_core::validation::{
     validate_attribute_name_sizes, validate_attribute_values_nesting_depth,
@@ -218,7 +219,9 @@ async fn prepare_write_op(
             put.expression_attribute_values.as_ref(),
         );
         let condition = parse_optional_condition(put.condition_expression.as_deref(), &ctx.limits)?;
-        {
+        // Transactions accept names/values with no expression (unlike single-item
+        // APIs); only check for unused refs when a condition is present.
+        if condition.is_some() {
             let exprs: Vec<&extenddb_core::expression::Expr> = condition.iter().collect();
             extenddb_core::expression::validate_unused_attributes(
                 &maps.names,
@@ -256,7 +259,7 @@ async fn prepare_write_op(
             del.expression_attribute_values.as_ref(),
         );
         let condition = parse_optional_condition(del.condition_expression.as_deref(), &ctx.limits)?;
-        {
+        if condition.is_some() {
             let exprs: Vec<&extenddb_core::expression::Expr> = condition.iter().collect();
             extenddb_core::expression::validate_unused_attributes(
                 &maps.names,
@@ -293,9 +296,20 @@ async fn prepare_write_op(
             upd.expression_attribute_names.as_ref(),
             upd.expression_attribute_values.as_ref(),
         );
-        let update_tokens =
-            crate::expression_helpers::tokenize_expression(&upd.update_expression, &ctx.limits)?;
-        let actions = parse_update(&update_tokens)?;
+        let actions = tokenize_for(
+            &upd.update_expression,
+            ctx.limits.max_expression_tokens,
+            ExpressionKind::Update,
+        )
+        .and_then(|update_tokens| {
+            if ctx.limits.enforce_reserved_keywords {
+                validate_no_reserved_words(&update_tokens)?;
+            }
+            parse_update_from(&update_tokens, &upd.update_expression)
+        })
+        .map_err(|e| {
+            crate::expression_helpers::prefix_expression_error(e, ExpressionKind::Update)
+        })?;
         validate_no_key_updates(&actions, &key_info, &maps)?;
 
         // Validate nesting depth of EAV values that get stored via SET actions.
@@ -351,12 +365,17 @@ async fn prepare_write_op(
             cc.expression_attribute_names.as_ref(),
             cc.expression_attribute_values.as_ref(),
         );
-        let tokens =
-            crate::expression_helpers::tokenize_expression(&cc.condition_expression, &ctx.limits)?;
-        let condition = extenddb_core::expression::parse_condition_with_depth_limit(
-            &tokens,
-            ctx.limits.max_expression_depth,
-        )?;
+        let condition =
+            crate::expression_helpers::tokenize_expression(&cc.condition_expression, &ctx.limits)
+                .and_then(|tokens| {
+                    extenddb_core::expression::parse_condition_with_depth_limit(
+                        &tokens,
+                        ctx.limits.max_expression_depth,
+                    )
+                })
+                .map_err(|e| {
+                    crate::expression_helpers::prefix_expression_error(e, ExpressionKind::Condition)
+                })?;
         {
             let exprs: Vec<&extenddb_core::expression::Expr> = vec![&condition];
             extenddb_core::expression::validate_unused_attributes(

--- a/crates/engine/src/update_item.rs
+++ b/crates/engine/src/update_item.rs
@@ -11,10 +11,7 @@ use std::collections::HashMap;
 use serde_json::Value;
 
 use extenddb_core::error::DynamoDbError;
-use extenddb_core::expression::{
-    ExpressionKind, ExpressionMaps, PathElement, UpdateAction, parse_update_from, tokenize_for,
-    validate_no_reserved_words,
-};
+use extenddb_core::expression::{ExpressionKind, ExpressionMaps, PathElement, UpdateAction};
 use extenddb_core::types::{
     AttributeValue, Item, ReturnValues, TableKeyInfo, UpdateItemInput, UpdateItemOutput,
     item_size_bytes,
@@ -139,22 +136,9 @@ pub async fn handle_update_item(
     )?;
 
     // No UpdateExpression and no AttributeUpdates: no-op upsert.
-    // Some("") still errors via tokenize_for.
+    // Some("") still errors via parse_update_expr.
     let actions = if let Some(update_expr) = effective_update_expr.as_deref() {
-        tokenize_for(
-            update_expr,
-            ctx.limits.max_expression_tokens,
-            ExpressionKind::Update,
-        )
-        .and_then(|update_tokens| {
-            if ctx.limits.enforce_reserved_keywords {
-                validate_no_reserved_words(&update_tokens)?;
-            }
-            parse_update_from(&update_tokens, update_expr)
-        })
-        .map_err(|e| {
-            crate::expression_helpers::prefix_expression_error(e, ExpressionKind::Update)
-        })?
+        crate::expression_helpers::parse_update_expr(update_expr, &ctx.limits)?
     } else {
         Vec::new()
     };

--- a/tests/test_transact_expression_validation.py
+++ b/tests/test_transact_expression_validation.py
@@ -1,0 +1,251 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Expression-attribute validation and parse-error labeling for transactions.
+
+TransactWriteItems and TransactGetItems differ from the single-item APIs:
+
+  - They do NOT reject ExpressionAttributeNames/Values supplied with no
+    expression. Amazon DynamoDB accepts a Put/Delete/Get sub-operation that
+    declares names or values but has no condition/update/projection that
+    references them. (The single-item APIs reject this as
+    "can only be specified when using expressions"; transactions do not.)
+
+  - The "unused in expressions" rejection still applies when an expression IS
+    present and a name/value goes unreferenced.
+
+  - Parse errors carry the per-parameter prefix
+    (Invalid UpdateExpression: / Invalid ConditionExpression:), not the generic
+    Invalid expression:.
+
+Every expected message was captured from Amazon DynamoDB. Dual-target.
+"""
+
+from __future__ import annotations
+
+import pytest
+from botocore.exceptions import ClientError
+
+from conftest import scoped_table
+
+RESERVED_UPDATE = (
+    "Invalid UpdateExpression: Attribute name is a reserved keyword; "
+    "reserved keyword: status"
+)
+RESERVED_CONDITION = (
+    "Invalid ConditionExpression: Attribute name is a reserved keyword; "
+    "reserved keyword: status"
+)
+
+
+@pytest.fixture(scope="class")
+def hash_table(dynamodb_client):
+    """Hash-only table (pk) with one item, deleted on teardown."""
+    with scoped_table(dynamodb_client) as name:
+        dynamodb_client.put_item(
+            TableName=name,
+            Item={"pk": {"S": "k1"}, "foo": {"S": "a"}},
+        )
+        yield name
+
+
+def _expect_validation(func, expected_message: str):
+    with pytest.raises(ClientError) as exc_info:
+        func()
+    err = exc_info.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert err["Message"] == expected_message
+
+
+class TestTransactNamesValuesWithoutExpression:
+    """Transactions accept names/values that have no referencing expression."""
+
+    def test_twi_put_names_no_condition_accepted(self, dynamodb_client, hash_table):
+        dynamodb_client.transact_write_items(
+            TransactItems=[
+                {
+                    "Put": {
+                        "TableName": hash_table,
+                        "Item": {"pk": {"S": "p-names"}},
+                        "ExpressionAttributeNames": {"#n": "foo"},
+                    }
+                }
+            ]
+        )
+        got = dynamodb_client.get_item(TableName=hash_table, Key={"pk": {"S": "p-names"}})
+        assert got["Item"]["pk"]["S"] == "p-names"
+
+    def test_twi_put_values_no_condition_accepted(self, dynamodb_client, hash_table):
+        dynamodb_client.transact_write_items(
+            TransactItems=[
+                {
+                    "Put": {
+                        "TableName": hash_table,
+                        "Item": {"pk": {"S": "p-values"}},
+                        "ExpressionAttributeValues": {":v": {"N": "1"}},
+                    }
+                }
+            ]
+        )
+        got = dynamodb_client.get_item(TableName=hash_table, Key={"pk": {"S": "p-values"}})
+        assert got["Item"]["pk"]["S"] == "p-values"
+
+    def test_twi_delete_names_no_condition_accepted(self, dynamodb_client, hash_table):
+        dynamodb_client.put_item(TableName=hash_table, Item={"pk": {"S": "d-names"}})
+        dynamodb_client.transact_write_items(
+            TransactItems=[
+                {
+                    "Delete": {
+                        "TableName": hash_table,
+                        "Key": {"pk": {"S": "d-names"}},
+                        "ExpressionAttributeNames": {"#n": "foo"},
+                    }
+                }
+            ]
+        )
+        got = dynamodb_client.get_item(TableName=hash_table, Key={"pk": {"S": "d-names"}})
+        assert "Item" not in got
+
+    def test_twi_delete_values_no_condition_accepted(self, dynamodb_client, hash_table):
+        dynamodb_client.put_item(TableName=hash_table, Item={"pk": {"S": "d-values"}})
+        dynamodb_client.transact_write_items(
+            TransactItems=[
+                {
+                    "Delete": {
+                        "TableName": hash_table,
+                        "Key": {"pk": {"S": "d-values"}},
+                        "ExpressionAttributeValues": {":v": {"N": "1"}},
+                    }
+                }
+            ]
+        )
+        got = dynamodb_client.get_item(TableName=hash_table, Key={"pk": {"S": "d-values"}})
+        assert "Item" not in got
+
+    def test_tgi_get_names_no_projection_accepted(self, dynamodb_client, hash_table):
+        resp = dynamodb_client.transact_get_items(
+            TransactItems=[
+                {
+                    "Get": {
+                        "TableName": hash_table,
+                        "Key": {"pk": {"S": "k1"}},
+                        "ExpressionAttributeNames": {"#n": "foo"},
+                    }
+                }
+            ]
+        )
+        assert resp["Responses"][0]["Item"]["pk"]["S"] == "k1"
+
+
+class TestTransactUnusedWithExpression:
+    """With an expression present, unused names/values are still rejected."""
+
+    def test_twi_put_unused_name_with_condition_rejected(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.transact_write_items(
+                TransactItems=[
+                    {
+                        "Put": {
+                            "TableName": hash_table,
+                            "Item": {"pk": {"S": "p-unused"}},
+                            "ConditionExpression": "attribute_not_exists(pk)",
+                            "ExpressionAttributeNames": {"#n": "foo"},
+                        }
+                    }
+                ]
+            ),
+            "Value provided in ExpressionAttributeNames unused in expressions: keys: {#n}",
+        )
+
+    def test_tgi_get_unused_name_with_projection_rejected(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.transact_get_items(
+                TransactItems=[
+                    {
+                        "Get": {
+                            "TableName": hash_table,
+                            "Key": {"pk": {"S": "k1"}},
+                            "ProjectionExpression": "pk",
+                            "ExpressionAttributeNames": {"#n": "foo"},
+                        }
+                    }
+                ]
+            ),
+            "Value provided in ExpressionAttributeNames unused in expressions: keys: {#n}",
+        )
+
+
+class TestTransactParseErrorPrefix:
+    """Parse errors carry the per-parameter prefix, not Invalid expression:."""
+
+    def test_twi_update_reserved_word_prefix(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.transact_write_items(
+                TransactItems=[
+                    {
+                        "Update": {
+                            "TableName": hash_table,
+                            "Key": {"pk": {"S": "k1"}},
+                            "UpdateExpression": "SET status = :v",
+                            "ExpressionAttributeValues": {":v": {"N": "1"}},
+                        }
+                    }
+                ]
+            ),
+            RESERVED_UPDATE,
+        )
+
+    def test_twi_condition_check_reserved_word_prefix(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.transact_write_items(
+                TransactItems=[
+                    {
+                        "ConditionCheck": {
+                            "TableName": hash_table,
+                            "Key": {"pk": {"S": "k1"}},
+                            "ConditionExpression": "status > :v",
+                            "ExpressionAttributeValues": {":v": {"N": "0"}},
+                        }
+                    }
+                ]
+            ),
+            RESERVED_CONDITION,
+        )
+
+    def test_twi_put_condition_reserved_word_prefix(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.transact_write_items(
+                TransactItems=[
+                    {
+                        "Put": {
+                            "TableName": hash_table,
+                            "Item": {"pk": {"S": "p-cond"}},
+                            "ConditionExpression": "status = :v",
+                            "ExpressionAttributeValues": {":v": {"N": "1"}},
+                        }
+                    }
+                ]
+            ),
+            RESERVED_CONDITION,
+        )
+
+    def test_twi_delete_condition_reserved_word_prefix(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.transact_write_items(
+                TransactItems=[
+                    {
+                        "Delete": {
+                            "TableName": hash_table,
+                            "Key": {"pk": {"S": "k1"}},
+                            "ConditionExpression": "status = :v",
+                            "ExpressionAttributeValues": {":v": {"N": "1"}},
+                        }
+                    }
+                ]
+            ),
+            RESERVED_CONDITION,
+        )

--- a/tests/test_transact_expression_validation.py
+++ b/tests/test_transact_expression_validation.py
@@ -36,6 +36,15 @@ RESERVED_CONDITION = (
     "Invalid ConditionExpression: Attribute name is a reserved keyword; "
     "reserved keyword: status"
 )
+REDUNDANT_PARENS_CONDITION = (
+    "Invalid ConditionExpression: The expression has redundant parentheses;"
+)
+UNUSED_NAME_MSG = (
+    "Value provided in ExpressionAttributeNames unused in expressions: keys: {#n}"
+)
+UNUSED_VALUE_MSG = (
+    "Value provided in ExpressionAttributeValues unused in expressions: keys: {:v}"
+)
 
 
 @pytest.fixture(scope="class")
@@ -137,6 +146,44 @@ class TestTransactNamesValuesWithoutExpression:
         assert resp["Responses"][0]["Item"]["pk"]["S"] == "k1"
 
 
+class TestTransactReferencedExpressionAccepted:
+    """Names/values that ARE referenced by an expression are accepted."""
+
+    def test_twi_put_name_referenced_by_condition_accepted(
+        self, dynamodb_client, hash_table
+    ):
+        dynamodb_client.transact_write_items(
+            TransactItems=[
+                {
+                    "Put": {
+                        "TableName": hash_table,
+                        "Item": {"pk": {"S": "p-ref"}},
+                        "ConditionExpression": "attribute_not_exists(#n)",
+                        "ExpressionAttributeNames": {"#n": "pk"},
+                    }
+                }
+            ]
+        )
+        got = dynamodb_client.get_item(TableName=hash_table, Key={"pk": {"S": "p-ref"}})
+        assert got["Item"]["pk"]["S"] == "p-ref"
+
+    def test_twi_update_value_referenced_accepted(self, dynamodb_client, hash_table):
+        dynamodb_client.transact_write_items(
+            TransactItems=[
+                {
+                    "Update": {
+                        "TableName": hash_table,
+                        "Key": {"pk": {"S": "k1"}},
+                        "UpdateExpression": "SET foo = :v",
+                        "ExpressionAttributeValues": {":v": {"S": "set"}},
+                    }
+                }
+            ]
+        )
+        got = dynamodb_client.get_item(TableName=hash_table, Key={"pk": {"S": "k1"}})
+        assert got["Item"]["foo"]["S"] == "set"
+
+
 class TestTransactUnusedWithExpression:
     """With an expression present, unused names/values are still rejected."""
 
@@ -156,7 +203,45 @@ class TestTransactUnusedWithExpression:
                     }
                 ]
             ),
-            "Value provided in ExpressionAttributeNames unused in expressions: keys: {#n}",
+            UNUSED_NAME_MSG,
+        )
+
+    def test_twi_delete_unused_value_with_condition_rejected(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.transact_write_items(
+                TransactItems=[
+                    {
+                        "Delete": {
+                            "TableName": hash_table,
+                            "Key": {"pk": {"S": "k1"}},
+                            "ConditionExpression": "attribute_exists(pk)",
+                            "ExpressionAttributeValues": {":v": {"N": "1"}},
+                        }
+                    }
+                ]
+            ),
+            UNUSED_VALUE_MSG,
+        )
+
+    def test_twi_condition_check_unused_name_rejected(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.transact_write_items(
+                TransactItems=[
+                    {
+                        "ConditionCheck": {
+                            "TableName": hash_table,
+                            "Key": {"pk": {"S": "k1"}},
+                            "ConditionExpression": "attribute_exists(pk)",
+                            "ExpressionAttributeNames": {"#n": "foo"},
+                        }
+                    }
+                ]
+            ),
+            UNUSED_NAME_MSG,
         )
 
     def test_tgi_get_unused_name_with_projection_rejected(
@@ -175,7 +260,7 @@ class TestTransactUnusedWithExpression:
                     }
                 ]
             ),
-            "Value provided in ExpressionAttributeNames unused in expressions: keys: {#n}",
+            UNUSED_NAME_MSG,
         )
 
 
@@ -248,4 +333,42 @@ class TestTransactParseErrorPrefix:
                 ]
             ),
             RESERVED_CONDITION,
+        )
+
+    def test_twi_update_syntax_error_prefix(self, dynamodb_client, hash_table):
+        # Syntax error also carries the UpdateExpression prefix.
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.transact_write_items(
+                TransactItems=[
+                    {
+                        "Update": {
+                            "TableName": hash_table,
+                            "Key": {"pk": {"S": "k1"}},
+                            "UpdateExpression": "SET foo = ",
+                            "ExpressionAttributeValues": {":v": {"N": "1"}},
+                        }
+                    }
+                ]
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert err["Message"].startswith("Invalid UpdateExpression:")
+
+    def test_twi_condition_check_redundant_parens_prefix(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.transact_write_items(
+                TransactItems=[
+                    {
+                        "ConditionCheck": {
+                            "TableName": hash_table,
+                            "Key": {"pk": {"S": "k1"}},
+                            "ConditionExpression": "((pk = :v))",
+                            "ExpressionAttributeValues": {":v": {"S": "k1"}},
+                        }
+                    }
+                ]
+            ),
+            REDUNDANT_PARENS_CONDITION,
         )


### PR DESCRIPTION
## What

This makes `TransactWriteItems` and `TransactGetItems` match Amazon DynamoDB for expression-attribute validation and expression parse-error messages. It closes the transactions gap left out of #162, which fixed the single-item and query/scan APIs. Three related changes:

1. Transactions no longer reject `ExpressionAttributeNames`/`ExpressionAttributeValues` that are supplied with no expression to reference them. Amazon DynamoDB accepts a `Put`/`Delete`/`Get` sub-operation that declares names or values but has no condition, update, or projection. ExtendDB was rejecting these as unused.

2. Transactions did not relabel expression parse errors per parameter. An `UpdateExpression` error came back as `Invalid expression:` instead of `Invalid UpdateExpression:`, and a `ConditionExpression` error in `ConditionCheck`/`Put`/`Delete` came back as `Invalid expression:` instead of `Invalid ConditionExpression:`.

3. Consolidated expression parsing into shared `expression_helpers` (`parse_update_expr`, `parse_condition_expr`, and the existing `parse_optional_condition`), so the transaction handlers and the single-item `UpdateItem` handler go through one path each instead of hand-rolled copies.

## Behavior: today vs Amazon DynamoDB

The table shows what ExtendDB returns before this PR and what Amazon DynamoDB returns. I captured every Amazon DynamoDB message directly via the AWS CLI.

| Scenario | ExtendDB (before this PR) | Amazon DynamoDB |
|---|---|---|
| `TransactWriteItems` `Put` (or `Delete`) with `ExpressionAttributeNames` and no `ConditionExpression` | `ValidationException: Value provided in ExpressionAttributeNames unused in expressions: keys: {#n}` (rejected) | Accepts the operation (the same applies to `ExpressionAttributeValues`, where ExtendDB rejected with `... ExpressionAttributeValues unused in expressions: keys: {:v}`) |
| `TransactGetItems` `Get` with `ExpressionAttributeNames` and no `ProjectionExpression` | `ValidationException: Value provided in ExpressionAttributeNames unused in expressions: keys: {#n}` (rejected) | Accepts the operation, returns the item |
| `TransactWriteItems` `Update` with a reserved word in `UpdateExpression` (for example `SET status = :v`) | `ValidationException: Invalid expression: Attribute name is a reserved keyword; reserved keyword: status` | `ValidationException: Invalid UpdateExpression: Attribute name is a reserved keyword; reserved keyword: status` |
| `TransactWriteItems` `ConditionCheck`, `Put`, or `Delete` with a reserved word in `ConditionExpression` (for example `status > :v`) | `ValidationException: Invalid expression: Attribute name is a reserved keyword; reserved keyword: status` | `ValidationException: Invalid ConditionExpression: Attribute name is a reserved keyword; reserved keyword: status` |
| `TransactWriteItems` `Put` with an unused `ExpressionAttributeNames` entry while a `ConditionExpression` is present | `ValidationException: Value provided in ExpressionAttributeNames unused in expressions: keys: {#n}` | `ValidationException: Value provided in ExpressionAttributeNames unused in expressions: keys: {#n}` (already correct, kept as a control) |

## Why

These are conformance gaps found by comparing ExtendDB against Amazon DynamoDB. This is the transactions follow-up to #162, which corrected the same class of behavior on the single-item and query/scan APIs and explicitly deferred the transaction handlers.

## Testing done

Added `tests/test_transact_expression_validation.py` (17 cases). Every expected message was captured from Amazon DynamoDB.

## Out of scope

Consistent with #162, I corrected the error prefix but not the full syntax-error body text (the `near: "..."` token window), which is tracked separately.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -D warnings`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed (no docs change: this only makes ExtendDB more conformant)
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface, an RFC has been accepted or is linked below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
