### PR TITLE
fix: update stale license headers and resolve clippy pedantic warnings

### DIFF
--- a/crates/auth/src/credential_cache.rs
+++ b/crates/auth/src/credential_cache.rs
@@ -122,7 +122,7 @@ impl CachedCredentialStore {
     ) -> Result<(), extenddb_cache::PredicateError> {
         let acct = account_id.to_owned();
         self.cache
-            .invalidate_if_value(move |v| v.map(|cred| cred.account_id == acct).unwrap_or(false))
+            .invalidate_if_value(move |v| v.is_some_and(|cred| cred.account_id == acct))
     }
 
     /// Drop every cached credential for `principal_name` in `account_id`.
@@ -140,8 +140,7 @@ impl CachedCredentialStore {
         let acct = account_id.to_owned();
         let principal = principal_name.to_owned();
         self.cache.invalidate_if_value(move |v| {
-            v.map(|cred| cred.account_id == acct && cred.principal_name == principal)
-                .unwrap_or(false)
+            v.is_some_and(|cred| cred.account_id == acct && cred.principal_name == principal)
         })
     }
 

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -4,7 +4,7 @@
 //! Authentication and authorization for extenddb.
 //!
 //! Defines the `AuthProvider` trait for pluggable auth backends. Ships with
-//! `BuiltinAuthProvider` (full SigV4 verification with local credential store).
+//! `BuiltinAuthProvider` (full `SigV4` verification with local credential store).
 
 pub mod cache_registry;
 pub mod credential_cache;
@@ -20,7 +20,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Auth provider trait — pluggable authentication.
 ///
-/// `BuiltinAuthProvider` performs SigV4 verification.
+/// `BuiltinAuthProvider` performs `SigV4` verification.
 /// Fix #11: Accept `&HeaderMap` directly to avoid per-request `HashMap` allocation.
 #[async_trait::async_trait]
 pub trait AuthProvider: Send + Sync {
@@ -102,10 +102,10 @@ pub trait CredentialStore: Send + Sync {
     ) -> Result<Option<StoredCredential>, DynamoDbError>;
 }
 
-/// SigV4 auth provider with local credential store.
+/// `SigV4` auth provider with local credential store.
 ///
 /// Parses the `Authorization` header, looks up the access key, decrypts the
-/// secret, verifies the SigV4 signature, and validates the request timestamp.
+/// secret, verifies the `SigV4` signature, and validates the request timestamp.
 /// Handles both long-lived (AKIA*) and temporary (ASIA* + X-Amz-Security-Token)
 /// credentials.
 pub struct BuiltinAuthProvider<C: CredentialStore> {

--- a/crates/auth/src/policy/condition.rs
+++ b/crates/auth/src/policy/condition.rs
@@ -5,7 +5,7 @@
 //!
 //! Evaluates condition blocks against a `ConditionContext`. Supports all IAM
 //! condition operators: String*, Numeric*, Date*, Bool, Null, Arn*, and the
-//! set operators ForAllValues/ForAnyValue with optional IfExists suffix.
+//! set operators ForAllValues/ForAnyValue with optional `IfExists` suffix.
 
 use super::context::ConditionContext;
 use super::document::{Condition, ConditionOperator};
@@ -160,10 +160,10 @@ fn unwrap_if_exists(op: &ConditionOperator) -> (bool, &ConditionOperator) {
 /// For multi-valued keys (e.g., `dynamodb:LeadingKeys`), all context values
 /// must satisfy the condition (implicit AND).
 ///
-/// For positive operators (StringEquals, NumericEquals, etc.): each context
+/// For positive operators (`StringEquals`, `NumericEquals`, etc.): each context
 /// value must match at least one policy value (OR semantics — "value in set").
 ///
-/// For negative operators (StringNotEquals, NumericNotEquals, etc.): each
+/// For negative operators (`StringNotEquals`, `NumericNotEquals`, etc.): each
 /// context value must satisfy the negative comparison against ALL policy
 /// values (AND semantics — "value not in set"). This matches AWS IAM behavior
 /// where `StringNotEquals` with `["a", "b"]` means "value is neither a nor b".

--- a/crates/auth/src/policy/context.rs
+++ b/crates/auth/src/policy/context.rs
@@ -1,18 +1,18 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Condition context trait and DynamoDB request context.
+//! Condition context trait and `DynamoDB` request context.
 //!
 //! `ConditionContext` is the shared trait for resolving condition keys during
-//! policy evaluation. `RequestContext` implements it for DynamoDB operations;
+//! policy evaluation. `RequestContext` implements it for `DynamoDB` operations;
 //! `AssumeRoleContext` implements it for trust policy evaluation.
 
 use std::collections::HashMap;
 
 /// Trait for resolving condition keys during policy evaluation.
 ///
-/// Implemented by `RequestContext` (DynamoDB operations) and
-/// `AssumeRoleContext` (trust policy / AssumeRole).
+/// Implemented by `RequestContext` (`DynamoDB` operations) and
+/// `AssumeRoleContext` (trust policy / `AssumeRole`).
 pub trait ConditionContext {
     /// Resolve a condition key to its value(s).
     ///
@@ -21,29 +21,29 @@ pub trait ConditionContext {
     fn resolve_key(&self, key: &str) -> Option<Vec<&str>>;
 }
 
-/// Request parameters extracted from a DynamoDB operation for condition evaluation.
+/// Request parameters extracted from a `DynamoDB` operation for condition evaluation.
 #[derive(Debug, Default)]
 pub struct RequestParams {
     /// Partition key values being accessed (for `dynamodb:LeadingKeys`).
-    /// `None` for table-level operations (CreateTable, etc.).
+    /// `None` for table-level operations (`CreateTable`, etc.).
     pub leading_keys: Option<Vec<String>>,
     /// Attribute names being read/written (for `dynamodb:Attributes`).
     /// `None` when not applicable.
     pub attributes: Option<Vec<String>>,
     /// The Select parameter value (for `dynamodb:Select`).
     pub select: Option<String>,
-    /// The ReturnValues parameter value (for `dynamodb:ReturnValues`).
+    /// The `ReturnValues` parameter value (for `dynamodb:ReturnValues`).
     pub return_values: Option<String>,
-    /// The ReturnConsumedCapacity parameter value.
+    /// The `ReturnConsumedCapacity` parameter value.
     pub return_consumed_capacity: Option<String>,
     /// The enclosing operation for batch/transact sub-operations.
     pub enclosing_operation: Option<String>,
 }
 
-/// Context for evaluating conditions on DynamoDB operations.
+/// Context for evaluating conditions on `DynamoDB` operations.
 ///
 /// Built by the server middleware before policy evaluation. Contains all
-/// condition keys that IAM policies can reference for DynamoDB access control.
+/// condition keys that IAM policies can reference for `DynamoDB` access control.
 #[derive(Debug)]
 pub struct RequestContext {
     /// Tags on the authenticated principal (`aws:PrincipalTag/*`).
@@ -56,9 +56,9 @@ pub struct RequestContext {
     pub attributes: Option<Vec<String>>,
     /// The Select parameter value.
     pub select: Option<String>,
-    /// The ReturnValues parameter value.
+    /// The `ReturnValues` parameter value.
     pub return_values: Option<String>,
-    /// The ReturnConsumedCapacity parameter value.
+    /// The `ReturnConsumedCapacity` parameter value.
     pub return_consumed_capacity: Option<String>,
     /// Whether this is a Scan operation.
     pub full_table_scan: Option<bool>,
@@ -67,11 +67,12 @@ pub struct RequestContext {
 }
 
 impl RequestContext {
-    /// Build context for a DynamoDB operation.
+    /// Build context for a `DynamoDB` operation.
     ///
     /// `principal_tags` and `resource_tags` come from the identity and target
     /// table respectively. `is_scan` should be true for Scan operations.
     /// `params` carries operation-specific request parameters.
+    #[must_use]
     pub fn build(
         principal_tags: HashMap<String, String>,
         resource_tags: HashMap<String, String>,
@@ -103,11 +104,11 @@ impl ConditionContext for RequestContext {
                 "dynamodb:LeadingKeys" => self
                     .leading_keys
                     .as_ref()
-                    .map(|v| v.iter().map(|s| s.as_str()).collect()),
+                    .map(|v| v.iter().map(std::string::String::as_str).collect()),
                 "dynamodb:Attributes" => self
                     .attributes
                     .as_ref()
-                    .map(|v| v.iter().map(|s| s.as_str()).collect()),
+                    .map(|v| v.iter().map(std::string::String::as_str).collect()),
                 "dynamodb:Select" => self.select.as_deref().map(|v| vec![v]),
                 "dynamodb:ReturnValues" => self.return_values.as_deref().map(|v| vec![v]),
                 "dynamodb:ReturnConsumedCapacity" => {
@@ -125,7 +126,7 @@ impl ConditionContext for RequestContext {
     }
 }
 
-/// Context for evaluating trust policy conditions during AssumeRole.
+/// Context for evaluating trust policy conditions during `AssumeRole`.
 ///
 /// Trust policies can reference `aws:PrincipalTag/*` and `sts:ExternalId`.
 /// DynamoDB-specific keys are not applicable.
@@ -133,7 +134,7 @@ impl ConditionContext for RequestContext {
 pub struct AssumeRoleContext {
     /// Tags on the calling principal.
     pub principal_tags: HashMap<String, String>,
-    /// The external ID provided in the AssumeRole call (if any).
+    /// The external ID provided in the `AssumeRole` call (if any).
     pub external_id: Option<String>,
 }
 

--- a/crates/auth/src/policy/document.rs
+++ b/crates/auth/src/policy/document.rs
@@ -26,9 +26,9 @@ pub struct Statement {
     pub sid: Option<String>,
     /// Allow or Deny.
     pub effect: Effect,
-    /// Action or NotAction matching.
+    /// Action or `NotAction` matching.
     pub action_match: ActionMatch,
-    /// Resource or NotResource matching.
+    /// Resource or `NotResource` matching.
     pub resource_match: ResourceMatch,
     /// Conditions that must all be true for the statement to apply.
     pub conditions: Vec<Condition>,
@@ -43,7 +43,7 @@ pub enum Effect {
     Deny,
 }
 
-/// Action matching: either Action (include list) or NotAction (exclude list).
+/// Action matching: either Action (include list) or `NotAction` (exclude list).
 /// A statement uses exactly one — never both.
 #[derive(Debug, Clone)]
 pub enum ActionMatch {
@@ -53,7 +53,7 @@ pub enum ActionMatch {
     NotActions(Vec<String>),
 }
 
-/// Resource matching: either Resource (include list) or NotResource (exclude list).
+/// Resource matching: either Resource (include list) or `NotResource` (exclude list).
 #[derive(Debug, Clone)]
 pub enum ResourceMatch {
     /// Matches listed resources.
@@ -82,7 +82,7 @@ pub struct Condition {
     pub values: Vec<String>,
 }
 
-/// All IAM condition operators relevant to DynamoDB access control.
+/// All IAM condition operators relevant to `DynamoDB` access control.
 ///
 /// Set operators (`ForAllValues`, `ForAnyValue`) and `IfExists` wrap a base
 /// operator. Valid nestings: `ForAllValues(IfExists(base))`,
@@ -148,7 +148,7 @@ impl PolicyDocument {
     /// # Errors
     ///
     /// Returns `PolicyParseError` if the JSON is malformed or contains
-    /// invalid policy constructs (e.g., both Action and NotAction).
+    /// invalid policy constructs (e.g., both Action and `NotAction`).
     pub fn from_json(json: &str) -> Result<Self, PolicyParseError> {
         Self::from_json_with_size_limit(json, 6_144)
     }
@@ -214,7 +214,7 @@ fn parse_statement(value: &Value) -> Result<Statement, PolicyParseError> {
     })
 }
 
-/// Parse Action or NotAction (mutually exclusive).
+/// Parse Action or `NotAction` (mutually exclusive).
 fn parse_action_match(value: &Value) -> Result<ActionMatch, PolicyParseError> {
     let has_action = !value["Action"].is_null();
     let has_not_action = !value["NotAction"].is_null();
@@ -234,7 +234,7 @@ fn parse_action_match(value: &Value) -> Result<ActionMatch, PolicyParseError> {
     }
 }
 
-/// Parse Resource or NotResource (mutually exclusive).
+/// Parse Resource or `NotResource` (mutually exclusive).
 fn parse_resource_match(value: &Value) -> Result<ResourceMatch, PolicyParseError> {
     let has_resource = !value["Resource"].is_null();
     let has_not_resource = !value["NotResource"].is_null();
@@ -254,7 +254,7 @@ fn parse_resource_match(value: &Value) -> Result<ResourceMatch, PolicyParseError
     }
 }
 
-/// Parse Principal or NotPrincipal (optional, for trust policies).
+/// Parse Principal or `NotPrincipal` (optional, for trust policies).
 fn parse_principal_match(value: &Value) -> Result<Option<PrincipalMatch>, PolicyParseError> {
     let has_principal = !value["Principal"].is_null();
     let has_not_principal = !value["NotPrincipal"].is_null();

--- a/crates/auth/src/policy/evaluator.rs
+++ b/crates/auth/src/policy/evaluator.rs
@@ -33,8 +33,8 @@ pub enum AuthzDecision {
 ///
 /// - `identity_policies`: user + group policies, or role policies.
 /// - `permissions_boundary`: optional boundary policy on the user or role.
-/// - `session_policy`: optional inline policy from AssumeRole.
-/// - `action`: the DynamoDB action (e.g., "dynamodb:PutItem").
+/// - `session_policy`: optional inline policy from `AssumeRole`.
+/// - `action`: the `DynamoDB` action (e.g., "dynamodb:PutItem").
 /// - `resource_arn`: the target resource ARN.
 /// - `context`: condition context for evaluating condition blocks.
 pub fn evaluate_policies(

--- a/crates/auth/src/policy/matcher.rs
+++ b/crates/auth/src/policy/matcher.rs
@@ -23,6 +23,7 @@
 /// assert!(!wildcard_match("dynamodb:Get*", "dynamodb:PutItem"));
 /// assert!(wildcard_match("s?s", "sis"));
 /// ```
+#[must_use]
 pub fn wildcard_match(pattern: &str, value: &str) -> bool {
     wildcard_match_impl(pattern.as_bytes(), value.as_bytes(), false)
 }
@@ -40,6 +41,7 @@ pub fn wildcard_match(pattern: &str, value: &str) -> bool {
 /// assert!(wildcard_match_ignore_case("dynamodb:Get*", "dynamodb:getitem"));
 /// assert!(!wildcard_match_ignore_case("dynamodb:Get*", "dynamodb:PutItem"));
 /// ```
+#[must_use]
 pub fn wildcard_match_ignore_case(pattern: &str, value: &str) -> bool {
     wildcard_match_impl(pattern.as_bytes(), value.as_bytes(), true)
 }
@@ -104,6 +106,7 @@ fn wildcard_match_impl(p: &[u8], v: &[u8], ignore_case: bool) -> bool {
 ///     "arn:aws:dynamodb:us-east-1:123456789012:table/Users"
 /// ));
 /// ```
+#[must_use]
 pub fn arn_match(pattern: &str, value: &str) -> bool {
     // "*" as a pattern matches any ARN
     if pattern == "*" {

--- a/crates/auth/src/sigv4/canonical.rs
+++ b/crates/auth/src/sigv4/canonical.rs
@@ -1,10 +1,10 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Canonical request construction for SigV4 verification.
+//! Canonical request construction for `SigV4` verification.
 //!
 //! Builds the canonical request string from the HTTP method, URI path,
-//! query string, signed headers, and body hash per the AWS SigV4 spec.
+//! query string, signed headers, and body hash per the AWS `SigV4` spec.
 
 use axum::http::HeaderMap;
 use sha2::{Digest, Sha256};
@@ -21,7 +21,7 @@ use sha2::{Digest, Sha256};
 /// HashedPayload
 /// ```
 ///
-/// For DynamoDB, the URI is always `/` and there is no query string.
+/// For `DynamoDB`, the URI is always `/` and there is no query string.
 pub fn canonical_request(
     method: &str,
     uri_path: &str,
@@ -39,15 +39,14 @@ pub fn canonical_request(
     let payload_hash = headers
         .get("x-amz-content-sha256")
         .and_then(|v| v.to_str().ok())
-        .map(str::to_owned)
-        .unwrap_or_else(|| sha256_hex(body));
+        .map_or_else(|| sha256_hex(body), str::to_owned);
 
     format!(
         "{method}\n{uri_path}\n{query_string}\n{canonical_headers}\n{signed_lower}\n{payload_hash}"
     )
 }
 
-/// Build the string-to-sign for SigV4.
+/// Build the string-to-sign for `SigV4`.
 ///
 /// Format:
 /// ```text
@@ -56,6 +55,7 @@ pub fn canonical_request(
 /// <scope>\n
 /// Hex(SHA256(canonical_request))
 /// ```
+#[must_use]
 pub fn string_to_sign(timestamp: &str, scope: &str, canonical_request: &str) -> String {
     let hashed = sha256_hex(canonical_request.as_bytes());
     format!("AWS4-HMAC-SHA256\n{timestamp}\n{scope}\n{hashed}")

--- a/crates/auth/src/sigv4/mod.rs
+++ b/crates/auth/src/sigv4/mod.rs
@@ -3,7 +3,7 @@
 
 //! AWS Signature Version 4 verification.
 //!
-//! Implements server-side SigV4 verification: parsing the `Authorization` header,
+//! Implements server-side `SigV4` verification: parsing the `Authorization` header,
 //! reconstructing the canonical request, deriving the signing key, and performing
 //! constant-time signature comparison.
 

--- a/crates/auth/src/sigv4/parse.rs
+++ b/crates/auth/src/sigv4/parse.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Parse the AWS SigV4 `Authorization` header.
+//! Parse the AWS `SigV4` `Authorization` header.
 //!
 //! Format:
 //! ```text
@@ -12,7 +12,7 @@
 
 use extenddb_core::error::DynamoDbError;
 
-/// Parsed components of a SigV4 `Authorization` header.
+/// Parsed components of a `SigV4` `Authorization` header.
 #[derive(Debug, PartialEq)]
 pub struct ParsedAuthorization {
     /// The access key ID (e.g. `AKIAIOSFODNN7EXAMPLE`).
@@ -29,7 +29,7 @@ pub struct ParsedAuthorization {
     pub signature: String,
 }
 
-/// Parse a SigV4 `Authorization` header value.
+/// Parse a `SigV4` `Authorization` header value.
 ///
 /// Returns `IncompleteSignature` if the header is malformed.
 /// S-2: Rejects headers exceeding 8 KB to prevent heap abuse.

--- a/crates/auth/src/sigv4/signing_key.rs
+++ b/crates/auth/src/sigv4/signing_key.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! SigV4 signing key derivation.
+//! `SigV4` signing key derivation.
 //!
 //! Derives the signing key via the 4-step HMAC-SHA256 chain:
 //! ```text
@@ -16,7 +16,7 @@ use sha2::Sha256;
 
 type HmacSha256 = Hmac<Sha256>;
 
-/// Derive the SigV4 signing key from a secret access key.
+/// Derive the `SigV4` signing key from a secret access key.
 ///
 /// # Arguments
 /// * `secret` — The plaintext secret access key.
@@ -31,7 +31,7 @@ pub fn derive_signing_key(secret: &str, date: &str, region: &str, service: &str)
     hmac_sha256(&k_service, b"aws4_request")
 }
 
-/// Compute the final signature: HMAC-SHA256(signing_key, string_to_sign), hex-encoded.
+/// Compute the final signature: HMAC-SHA256(signing_key, `string_to_sign`), hex-encoded.
 #[must_use]
 pub fn compute_signature(signing_key: &[u8], string_to_sign: &str) -> String {
     hex::encode(hmac_sha256(signing_key, string_to_sign.as_bytes()))

--- a/crates/auth/src/sigv4/verify.rs
+++ b/crates/auth/src/sigv4/verify.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! SigV4 signature verification.
+//! `SigV4` signature verification.
 //!
 //! Reconstructs the expected signature from the request and compares it
 //! against the signature in the `Authorization` header using constant-time
@@ -17,14 +17,14 @@ use super::signing_key;
 /// Maximum allowed clock skew between client and server (±15 minutes).
 const MAX_CLOCK_SKEW_SECS: i64 = 15 * 60;
 
-/// Verify a SigV4 signature against the request.
+/// Verify a `SigV4` signature against the request.
 ///
 /// # Arguments
 /// * `parsed` — The parsed `Authorization` header.
 /// * `secret_key` — The plaintext secret access key.
 /// * `method` — HTTP method (e.g. `POST`).
 /// * `uri_path` — URI path (e.g. `/`).
-/// * `query_string` — Query string (empty for DynamoDB).
+/// * `query_string` — Query string (empty for `DynamoDB`).
 /// * `headers` — The full request headers.
 /// * `body` — The request body bytes.
 ///

--- a/crates/bin/build.rs
+++ b/crates/bin/build.rs
@@ -44,7 +44,7 @@ fn main() {
             let era = z.div_euclid(146_097);
             #[allow(clippy::cast_possible_truncation)]
             let doe = z.rem_euclid(146_097) as u64;
-            let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+            let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
             #[allow(clippy::cast_possible_wrap)]
             let y = (yoe as i64) + era * 400;
             let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);

--- a/crates/bin/src/cmd_destroy.rs
+++ b/crates/bin/src/cmd_destroy.rs
@@ -38,7 +38,7 @@ pub async fn run(args: DestroyArgs) -> anyhow::Result<()> {
         );
     }
     let app_config = config::load(&args.config)?;
-    let backend = &app_config.storage._backend;
+    let backend = &app_config.storage.backend;
 
     // Collect CLI args for backend-specific parsing
     let cli_args: Vec<String> = std::env::args().collect();

--- a/crates/bin/src/cmd_init.rs
+++ b/crates/bin/src/cmd_init.rs
@@ -119,7 +119,7 @@ pub async fn run(args: InitArgs) -> anyhow::Result<u8> {
         b.clone()
     } else if Path::new(&args.config).exists() {
         let app_config = config::load(&args.config)?;
-        app_config.storage._backend
+        app_config.storage.backend
     } else {
         "postgres".to_owned()
     };

--- a/crates/bin/src/cmd_migrate.rs
+++ b/crates/bin/src/cmd_migrate.rs
@@ -37,7 +37,7 @@ pub async fn run(args: MigrateArgs) -> anyhow::Result<()> {
         );
     }
     let app_config = config::load(&args.config)?;
-    let backend = &app_config.storage._backend;
+    let backend = &app_config.storage.backend;
 
     println!("=== extenddb migrate ===");
     println!("Config:           {}", args.config);

--- a/crates/bin/src/cmd_serve.rs
+++ b/crates/bin/src/cmd_serve.rs
@@ -80,7 +80,7 @@ pub fn run(args: &ServeArgs) -> anyhow::Result<()> {
     }
 
     // Validate backend is supported and get catalog version (fail fast before binding port)
-    let backend = &app_config.storage._backend;
+    let backend = &app_config.storage.backend;
     let catalog_version = extenddb_storage::operations::catalog_version(backend)?;
 
     let port = args.port.unwrap_or(app_config.server.port);
@@ -204,7 +204,7 @@ async fn serve(
     // server (e.g., Postgres connection failure). The PID file was already
     // written by Daemonize in run().
     let pid_path = pid_file_path(&run_dir, port);
-    let backend = app_config.storage._backend.clone();
+    let backend = app_config.storage.backend.clone();
     let result = serve_inner(app_config, std_listener, port, run_dir, backend, foreground).await;
     if let Err(ref e) = result {
         let _ = std::fs::remove_file(&pid_path);

--- a/crates/bin/src/cmd_settings.rs
+++ b/crates/bin/src/cmd_settings.rs
@@ -46,7 +46,7 @@ pub async fn run(args: SettingsArgs) -> anyhow::Result<()> {
         );
     }
     let app_config = config::load(&args.config)?;
-    let backend = &app_config.storage._backend;
+    let backend = &app_config.storage.backend;
     let store = extenddb_storage::settings_store::create_settings_store(
         backend,
         app_config.storage.connection_config(),

--- a/crates/bin/src/cmd_verify.rs
+++ b/crates/bin/src/cmd_verify.rs
@@ -31,7 +31,7 @@ pub async fn run(args: VerifyArgs) -> anyhow::Result<()> {
         );
     }
     let app_config = config::load(&args.config)?;
-    let backend = &app_config.storage._backend;
+    let backend = &app_config.storage.backend;
     let expected_version = extenddb_storage::operations::catalog_version(backend)
         .unwrap_or_else(|_| "unknown".to_string());
 

--- a/crates/bin/src/config.rs
+++ b/crates/bin/src/config.rs
@@ -113,7 +113,7 @@ impl Default for TlsConfig {
 #[derive(Debug, Clone)]
 pub struct StorageConfig {
     /// Storage backend selector (e.g. "postgres").
-    pub _backend: String,
+    pub backend: String,
     /// Backend-specific configuration (trait object).
     config: Box<dyn extenddb_storage::config::StorageConfig>,
 }
@@ -172,10 +172,7 @@ impl<'de> serde::Deserialize<'de> for StorageConfig {
         let config = extenddb_storage::config::deserialize_storage_config(&backend, backend_table)
             .map_err(D::Error::custom)?;
 
-        Ok(StorageConfig {
-            _backend: backend,
-            config,
-        })
+        Ok(StorageConfig { backend, config })
     }
 }
 
@@ -183,7 +180,7 @@ impl<'de> serde::Deserialize<'de> for StorageConfig {
 impl Default for StorageConfig {
     fn default() -> Self {
         Self {
-            _backend: default_backend(),
+            backend: default_backend(),
             config: Box::new(extenddb_storage_postgres::PostgresStorageConfig::default()),
         }
     }
@@ -414,7 +411,7 @@ fn redact_if_sensitive(key: &str, val: &str) -> String {
 /// sensitive values (connection strings, passwords, keys).
 pub fn build_config_entries(cfg: &AppConfig) -> Vec<(String, String)> {
     let r = redact_if_sensitive;
-    let backend = &cfg.storage._backend;
+    let backend = &cfg.storage.backend;
     let mut entries = vec![
         ("server.bind_addr".into(), cfg.server.bind_addr.clone()),
         ("server.port".into(), cfg.server.port.to_string()),

--- a/crates/bin/src/manage_types.rs
+++ b/crates/bin/src/manage_types.rs
@@ -452,7 +452,7 @@ pub enum CacheInvalidateScope {
         #[arg(long)]
         role_name: String,
     },
-    /// Invalidate the cached group_policies for a list of users (used
+    /// Invalidate the cached `group_policies` for a list of users (used
     /// after a group-membership change that the write-through hooks
     /// missed).
     GroupMembers {
@@ -462,14 +462,14 @@ pub enum CacheInvalidateScope {
         #[arg(long)]
         user_names: String,
     },
-    /// Invalidate the TableKeyInfo cache for a single table.
+    /// Invalidate the `TableKeyInfo` cache for a single table.
     TableKeyInfo {
         #[arg(long)]
         account_id: String,
         #[arg(long)]
         table_name: String,
     },
-    /// Invalidate the resource_tags cache for a resource ARN.
+    /// Invalidate the `resource_tags` cache for a resource ARN.
     ResourceTags {
         #[arg(long)]
         arn: String,

--- a/crates/core/src/error/messages.rs
+++ b/crates/core/src/error/messages.rs
@@ -1,10 +1,10 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Error message templates captured from real DynamoDB.
-//! These are the exact messages DynamoDB returns — tenet 4 (errors are contracts).
+//! Error message templates captured from real `DynamoDB`.
+//! These are the exact messages `DynamoDB` returns — tenet 4 (errors are contracts).
 
-/// Format a single validation constraint error in DynamoDB's exact format.
+/// Format a single validation constraint error in `DynamoDB`'s exact format.
 #[must_use]
 pub fn validation_error(value: &str, field: &str, constraint: &str) -> String {
     format!(
@@ -12,7 +12,7 @@ pub fn validation_error(value: &str, field: &str, constraint: &str) -> String {
     )
 }
 
-/// Format multiple validation constraint errors in DynamoDB's exact format.
+/// Format multiple validation constraint errors in `DynamoDB`'s exact format.
 #[must_use]
 pub fn validation_errors(errors: &[(&str, &str, &str)]) -> String {
     let count = errors.len();

--- a/crates/core/src/error/mod.rs
+++ b/crates/core/src/error/mod.rs
@@ -9,7 +9,7 @@ use crate::types::{CancellationReason, Item};
 /// All Virtual `DynamoDB` error types with HTTP status codes.
 ///
 /// REQ-ERR-001 through REQ-ERR-004: error JSON format, status codes, and SDK retry behavior.
-/// SP-ERR-002: HTTP status codes match the real DynamoDB error catalog exactly.
+/// SP-ERR-002: HTTP status codes match the real `DynamoDB` error catalog exactly.
 #[derive(Debug, Clone, thiserror::Error)]
 #[non_exhaustive]
 pub enum DynamoDbError {
@@ -84,7 +84,7 @@ pub enum DynamoDbError {
     /// SP-ERR-002: Per-request timeout. HTTP 408.
     #[error("{0}")]
     RequestTimeoutException(String),
-    /// SP-ERR-002: SigV4 signature mismatch. HTTP 403.
+    /// SP-ERR-002: `SigV4` signature mismatch. HTTP 403.
     #[error("{0}")]
     InvalidSignatureException(String),
 }
@@ -92,7 +92,7 @@ pub enum DynamoDbError {
 impl DynamoDbError {
     /// HTTP status code for this error.
     ///
-    /// SP-ERR-002: status codes match the real DynamoDB error catalog.
+    /// SP-ERR-002: status codes match the real `DynamoDB` error catalog.
     #[must_use]
     pub fn status_code(&self) -> u16 {
         match self {
@@ -180,7 +180,7 @@ impl DynamoDbError {
     ///   `InvalidSignatureException`)
     /// - All other `DynamoDB` errors → `com.amazonaws.dynamodb.v20120810#`
     ///
-    /// Verified against real DynamoDB 2026-05-04.
+    /// Verified against real `DynamoDB` 2026-05-04.
     #[must_use]
     pub fn full_error_type(&self) -> String {
         let prefix = match self {

--- a/crates/core/src/expression/evaluator.rs
+++ b/crates/core/src/expression/evaluator.rs
@@ -267,8 +267,8 @@ fn evaluate_function(
             let val = resolve_to_value(&args[0], item, maps)?;
             let prefix = resolve_to_value(&args[1], item, maps)?;
             // Reject invalid operand types — only S and B are allowed
-            if let Some(ref p) = prefix.as_deref()
-                && !matches!(p, AttributeValue::S(_) | AttributeValue::B(_))
+            if let Some(p) = prefix.as_deref()
+                && !matches!(&p, AttributeValue::S(_) | AttributeValue::B(_))
             {
                 let type_code = attribute_type_code(p);
                 return Err(DynamoDbError::ValidationException(format!(
@@ -343,7 +343,7 @@ fn evaluate_function(
 /// Evaluate the `size()` function, returning the size as a number `AttributeValue`.
 ///
 /// Returns `None` if the argument resolves to a missing attribute, matching
-/// DynamoDB's behavior where `size(nonexistent)` causes the enclosing
+/// `DynamoDB`'s behavior where `size(nonexistent)` causes the enclosing
 /// comparison to evaluate to false (the item is skipped).
 fn evaluate_size<'a>(
     args: &'a [Expr],

--- a/crates/core/src/expression/key_condition.rs
+++ b/crates/core/src/expression/key_condition.rs
@@ -196,7 +196,7 @@ impl KeyCondition {
         } else {
             self.sk_condition = None;
             self.extra_sk_conditions = Vec::new();
-        };
+        }
 
         Ok(())
     }

--- a/crates/core/src/expression/kind.rs
+++ b/crates/core/src/expression/kind.rs
@@ -5,9 +5,9 @@
 
 use std::fmt;
 
-/// A DynamoDB expression parameter.
+/// A `DynamoDB` expression parameter.
 ///
-/// The string form is the exact wire-format parameter name DynamoDB uses in
+/// The string form is the exact wire-format parameter name `DynamoDB` uses in
 /// error messages (`Invalid <Kind>: ...`). Centralizing it here keeps those
 /// labels typo-safe instead of repeating string literals at each call site.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -20,7 +20,7 @@ pub enum ExpressionKind {
 }
 
 impl ExpressionKind {
-    /// The canonical DynamoDB parameter name.
+    /// The canonical `DynamoDB` parameter name.
     #[must_use]
     pub fn as_str(self) -> &'static str {
         match self {

--- a/crates/core/src/expression/reserved_words.rs
+++ b/crates/core/src/expression/reserved_words.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! DynamoDB reserved word list.
+//! `DynamoDB` reserved word list.
 //!
 //! Bare identifiers matching these words are rejected in expressions unless
 //! aliased via `ExpressionAttributeNames`.

--- a/crates/core/src/expression/resolver.rs
+++ b/crates/core/src/expression/resolver.rs
@@ -201,7 +201,7 @@ pub fn resolve_element_name<'a>(
 }
 
 /// Reject `ExpressionAttributeNames`/`Values` supplied with no expression that
-/// can reference them. Matches Amazon DynamoDB:
+/// can reference them. Matches Amazon `DynamoDB`:
 ///
 /// - names: `ExpressionAttributeNames can only be specified when using expressions`
 ///   (no suffix), for every API.
@@ -411,6 +411,7 @@ fn collect_path_refs(elements: &[PathElement], names: &mut std::collections::Has
 ///
 /// Returns `(used_names, used_values)` sets suitable for passing to
 /// `validate_unused_attributes`.
+#[must_use]
 pub fn collect_key_condition_refs(
     kc: &super::key_condition::KeyCondition,
 ) -> (
@@ -455,7 +456,7 @@ pub fn collect_key_condition_refs(
 
 /// Validate `begins_with` operand types in a parsed expression.
 ///
-/// DynamoDB rejects `begins_with(path, value)` upfront when `value` is not
+/// `DynamoDB` rejects `begins_with(path, value)` upfront when `value` is not
 /// a string or binary type. This validation runs before evaluation so that
 /// empty scans/queries still reject invalid operand types.
 ///

--- a/crates/core/src/limits/mod.rs
+++ b/crates/core/src/limits/mod.rs
@@ -33,7 +33,7 @@ pub struct LimitsConfig {
     #[serde(default = "default_per_account_max_wcu")]
     pub per_account_max_wcu: u64,
     /// Preview extension: allow multi-part (composite) keys on base tables.
-    /// When `false` (default), base tables follow standard DynamoDB rules
+    /// When `false` (default), base tables follow standard `DynamoDB` rules
     /// (1 HASH + optional 1 RANGE). GSIs always allow multi-part keys.
     #[serde(default)]
     pub allow_multipart_table_keys: bool,

--- a/crates/core/src/serde_helpers.rs
+++ b/crates/core/src/serde_helpers.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Custom serde deserializers for DynamoDB input validation.
+//! Custom serde deserializers for `DynamoDB` input validation.
 
 use std::collections::HashMap;
 use std::fmt;

--- a/crates/core/src/types/backup.rs
+++ b/crates/core/src/types/backup.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Types for DynamoDB backup and point-in-time recovery operations.
+//! Types for `DynamoDB` backup and point-in-time recovery operations.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/core/src/types/batch.rs
+++ b/crates/core/src/types/batch.rs
@@ -48,7 +48,7 @@ pub struct BatchGetItemInput {
 pub struct BatchGetItemOutput {
     #[serde(rename = "Responses")]
     pub responses: HashMap<String, Vec<Item>>,
-    /// Always serialized, even when empty: Amazon DynamoDB returns
+    /// Always serialized, even when empty: Amazon `DynamoDB` returns
     /// `"UnprocessedKeys": {}` when all keys are processed rather than omitting it.
     #[serde(rename = "UnprocessedKeys")]
     pub unprocessed_keys: HashMap<String, KeysAndAttributes>,
@@ -118,7 +118,7 @@ pub struct BatchWriteItemInput {
 /// `BatchWriteItem` response body.
 #[derive(Debug, Clone, Serialize)]
 pub struct BatchWriteItemOutput {
-    /// Always serialized, even when empty: Amazon DynamoDB returns
+    /// Always serialized, even when empty: Amazon `DynamoDB` returns
     /// `"UnprocessedItems": {}` on full success rather than omitting the field.
     #[serde(rename = "UnprocessedItems")]
     pub unprocessed_items: HashMap<String, Vec<WriteRequest>>,

--- a/crates/core/src/types/import_export.rs
+++ b/crates/core/src/types/import_export.rs
@@ -13,7 +13,7 @@ use super::{AttributeDefinition, BillingMode, GsiInput, KeySchemaElement, Provis
 /// Input format for import operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum InputFormat {
-    /// DynamoDB JSON format (`{"Item": {"pk": {"S": "val"}, ...}}`).
+    /// `DynamoDB` JSON format (`{"Item": {"pk": {"S": "val"}, ...}}`).
     #[serde(rename = "DYNAMODB_JSON")]
     DynamoDbJson,
     /// Amazon Ion text format.
@@ -27,7 +27,7 @@ pub enum InputFormat {
 /// Export format (CSV is not supported for export).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ExportFormat {
-    /// DynamoDB JSON format.
+    /// `DynamoDB` JSON format.
     #[serde(rename = "DYNAMODB_JSON")]
     DynamoDbJson,
     /// Amazon Ion text format.
@@ -219,7 +219,7 @@ pub struct ExportTableToPointInTimeInput {
     /// Standard `DynamoDB` field — accepted but ignored.
     #[serde(rename = "IncrementalExportSpecification")]
     _incremental_export_spec: Option<serde_json::Value>,
-    /// Export format (default: DYNAMODB_JSON).
+    /// Export format (default: `DYNAMODB_JSON`).
     #[serde(rename = "ExportFormat")]
     pub export_format: Option<ExportFormat>,
 }

--- a/crates/core/src/types/item.rs
+++ b/crates/core/src/types/item.rs
@@ -379,9 +379,9 @@ pub fn attribute_value_size(value: &AttributeValue) -> usize {
     }
 }
 
-/// Calculate the DynamoDB size of a number in bytes.
+/// Calculate the `DynamoDB` size of a number in bytes.
 ///
-/// DynamoDB number sizing: approximately 1 byte per 2 significant digits + 1 byte.
+/// `DynamoDB` number sizing: approximately 1 byte per 2 significant digits + 1 byte.
 /// Zero is 1 byte. Negative numbers add 1 byte. Max 21 bytes.
 fn dynamodb_number_size(n: &str) -> usize {
     let s = n.trim_start_matches('-');

--- a/crates/core/src/types/key_schema.rs
+++ b/crates/core/src/types/key_schema.rs
@@ -93,6 +93,7 @@ pub struct TableKeyInfo {
 }
 
 /// Extract all HASH key elements from a key schema (preserving order).
+#[must_use]
 pub fn hash_key_elements(key_schema: &[KeySchemaElement]) -> Vec<&KeySchemaElement> {
     key_schema
         .iter()
@@ -101,6 +102,7 @@ pub fn hash_key_elements(key_schema: &[KeySchemaElement]) -> Vec<&KeySchemaEleme
 }
 
 /// Extract all RANGE key elements from a key schema (preserving order).
+#[must_use]
 pub fn range_key_elements(key_schema: &[KeySchemaElement]) -> Vec<&KeySchemaElement> {
     key_schema
         .iter()
@@ -109,6 +111,7 @@ pub fn range_key_elements(key_schema: &[KeySchemaElement]) -> Vec<&KeySchemaElem
 }
 
 /// Returns `true` if the key schema has more than one HASH or more than one RANGE element.
+#[must_use]
 pub fn is_multipart_key_schema(key_schema: &[KeySchemaElement]) -> bool {
     let hash_count = key_schema
         .iter()

--- a/crates/core/src/types/stream.rs
+++ b/crates/core/src/types/stream.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! DynamoDB Streams types — stream records, shard iterators, and API input/output.
+//! `DynamoDB` Streams types — stream records, shard iterators, and API input/output.
 
 use std::collections::BTreeMap;
 
@@ -60,7 +60,7 @@ pub struct StreamRecordData {
 
 /// Identity of the principal that triggered a stream record.
 ///
-/// For TTL-originated deletions, DynamoDB sets `Type` to `"Service"` and
+/// For TTL-originated deletions, `DynamoDB` sets `Type` to `"Service"` and
 /// `PrincipalId` to `"dynamodb.amazonaws.com"`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserIdentity {

--- a/crates/core/src/types/transaction.rs
+++ b/crates/core/src/types/transaction.rs
@@ -67,7 +67,7 @@ pub struct TransactGetItemsOutput {
 
 /// A single item response within `TransactGetItems` output.
 ///
-/// Real DynamoDB returns `{}` (no `Item` key) for missing items. When an item
+/// Real `DynamoDB` returns `{}` (no `Item` key) for missing items. When an item
 /// exists, it returns `{"Item": {...}}`. The AWS SDK API model marks `Item` as
 /// optional, and SDKs deserialize an absent `Item` key as `None`/`null`.
 #[derive(Debug, Clone, Serialize)]

--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -104,7 +104,7 @@ pub fn validate_create_table(
     Ok(())
 }
 
-/// Format KeySchema elements in DynamoDB's Java-toString style for error messages.
+/// Format `KeySchema` elements in `DynamoDB`'s Java-toString style for error messages.
 fn format_key_schema_value(ks: &[KeySchemaElement]) -> String {
     let elements: Vec<String> = ks
         .iter()
@@ -245,7 +245,7 @@ fn validate_gsi_key_schemas(input: &CreateTableInput) -> Result<(), DynamoDbErro
 
 /// Validate LSI key schemas: each must have exactly 2 elements, HASH key must match
 /// the table's HASH key, second element must be RANGE.
-/// LSIs do not support multi-part keys (same as real DynamoDB).
+/// LSIs do not support multi-part keys (same as real `DynamoDB`).
 fn validate_lsi_key_schemas(input: &CreateTableInput) -> Result<(), DynamoDbError> {
     let Some(lsis) = &input.local_secondary_indexes else {
         return Ok(());
@@ -378,9 +378,9 @@ fn validate_provisioned_throughput(input: &CreateTableInput) -> Result<(), Dynam
 }
 
 /// Reject `ProvisionedThroughput` on GSIs when the table uses `PayPerRequest`.
-/// Real DynamoDB returns: "One or more parameter values were invalid:
-/// ProvisionedThroughput should not be specified for index: <name> when
-/// BillingMode is PAY_PER_REQUEST"
+/// Real `DynamoDB` returns: "One or more parameter values were invalid:
+/// `ProvisionedThroughput` should not be specified for index: <name> when
+/// `BillingMode` is `PAY_PER_REQUEST`"
 fn validate_gsi_provisioned_throughput(input: &CreateTableInput) -> Result<(), DynamoDbError> {
     let billing = input.billing_mode.unwrap_or(BillingMode::Provisioned);
     if billing != BillingMode::PayPerRequest {
@@ -656,7 +656,7 @@ pub fn validate_batch_item_keys(
 
 /// Remap key type-mismatch errors to the batch/transaction-specific message.
 ///
-/// Real DynamoDB uses "The provided key element does not match the schema"
+/// Real `DynamoDB` uses "The provided key element does not match the schema"
 /// for batch and transaction operations, not the single-item "Type mismatch"
 /// message.
 fn remap_key_type_mismatch(err: DynamoDbError) -> DynamoDbError {
@@ -793,7 +793,7 @@ pub fn validate_item_size(item: &Item, max_bytes: usize) -> Result<(), DynamoDbE
     Ok(())
 }
 
-/// Validate all number values in an item are within DynamoDB limits.
+/// Validate all number values in an item are within `DynamoDB` limits.
 pub fn validate_item_numbers(item: &Item) -> Result<(), DynamoDbError> {
     for value in item.values() {
         validate_attribute_number(value)?;
@@ -843,7 +843,7 @@ fn validate_attribute_number(value: &AttributeValue) -> Result<(), DynamoDbError
     Ok(())
 }
 
-/// Maximum total nesting levels (M/L wrappers plus the leaf) DynamoDB allows.
+/// Maximum total nesting levels (M/L wrappers plus the leaf) `DynamoDB` allows.
 pub(crate) const MAX_ITEM_NESTING_DEPTH: usize = 32;
 
 /// Validate that no attribute value in `item` nests beyond `MAX_ITEM_NESTING_DEPTH`.

--- a/crates/core/src/validation/number.rs
+++ b/crates/core/src/validation/number.rs
@@ -7,7 +7,7 @@ const MAX_SIGNIFICANT_DIGITS: usize = 38;
 const MAX_EXPONENT: i32 = 125;
 const MIN_EXPONENT: i32 = -130;
 
-/// Validate and normalize a DynamoDB number string.
+/// Validate and normalize a `DynamoDB` number string.
 pub fn validate_and_normalize_number(s: &str) -> Result<String, DynamoDbError> {
     let s = s.trim();
     if s.is_empty() {

--- a/crates/engine/src/backup.rs
+++ b/crates/engine/src/backup.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Engine handlers for DynamoDB backup and point-in-time recovery operations.
+//! Engine handlers for `DynamoDB` backup and point-in-time recovery operations.
 
 use extenddb_core::error::DynamoDbError;
 use serde_json::{Value, json};
@@ -196,7 +196,7 @@ pub(crate) async fn handle_update_continuous_backups(
     let pitr_enabled = body
         .get("PointInTimeRecoverySpecification")
         .and_then(|v| v.get("PointInTimeRecoveryEnabled"))
-        .and_then(|v| v.as_bool())
+        .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
 
     let desc = ctx
@@ -227,7 +227,7 @@ pub(crate) async fn handle_restore_table_to_point_in_time(
     ))
 }
 
-/// Convert storage errors to DynamoDB errors.
+/// Convert storage errors to `DynamoDB` errors.
 fn storage_err_to_dynamo(e: extenddb_storage::error::StorageError) -> DynamoDbError {
     match e {
         extenddb_storage::error::StorageError::TableNotFound(msg) => {

--- a/crates/engine/src/batch_write_item.rs
+++ b/crates/engine/src/batch_write_item.rs
@@ -68,7 +68,7 @@ pub async fn handle_batch_write_item(
     }
 
     // Validate: total operations across all tables <= 25
-    let total_ops: usize = input.request_items.values().map(|r| r.len()).sum();
+    let total_ops: usize = input.request_items.values().map(std::vec::Vec::len).sum();
     if total_ops > MAX_BATCH_WRITE_ITEMS {
         return Err(DynamoDbError::ValidationException(
             "Too many items requested for the BatchWriteItem call".to_owned(),

--- a/crates/engine/src/delete_item.rs
+++ b/crates/engine/src/delete_item.rs
@@ -75,7 +75,12 @@ pub async fn handle_delete_item(
         &ctx.limits,
     )?;
 
-    if input.expected.is_none() || input.expected.as_ref().is_some_and(|m| m.is_empty()) {
+    if input.expected.is_none()
+        || input
+            .expected
+            .as_ref()
+            .is_some_and(std::collections::HashMap::is_empty)
+    {
         let exprs: Vec<&extenddb_core::expression::Expr> = condition.iter().collect();
         extenddb_core::expression::validate_unused_attributes(
             &maps.names,

--- a/crates/engine/src/describe_limits.rs
+++ b/crates/engine/src/describe_limits.rs
@@ -12,7 +12,7 @@ use crate::serialize_output;
 
 /// Handle `DescribeLimits` — return account-level throughput limits.
 ///
-/// REQ-CTRL-019: DescribeLimits returns configured account and table limits.
+/// REQ-CTRL-019: `DescribeLimits` returns configured account and table limits.
 ///
 /// # Errors
 ///

--- a/crates/engine/src/expression_helpers.rs
+++ b/crates/engine/src/expression_helpers.rs
@@ -184,7 +184,7 @@ pub fn resolve_condition(
 
 /// Tokenize, reserved-word check, and parse a `ProjectionExpression`.
 ///
-/// Errors carry the `ProjectionExpression` prefix, matching Amazon DynamoDB.
+/// Errors carry the `ProjectionExpression` prefix, matching Amazon `DynamoDB`.
 ///
 /// # Errors
 ///
@@ -207,7 +207,7 @@ pub fn parse_projection_expr(
     result.map_err(|e| prefix_expression_error(e, ExpressionKind::Projection))
 }
 
-/// Prefix an expression error with the expression type, matching DynamoDB's format.
+/// Prefix an expression error with the expression type, matching `DynamoDB`'s format.
 ///
 /// `FilterExpression` shares the condition parser, so its errors arrive labelled
 /// `ConditionExpression`; those are relabelled to `expr_type`. Errors already

--- a/crates/engine/src/import_export_io.rs
+++ b/crates/engine/src/import_export_io.rs
@@ -32,7 +32,7 @@ pub(crate) fn read_items(
     }
 }
 
-/// Read DynamoDB JSON format: one JSON object per line with `{"Item": {...}}` wrapper.
+/// Read `DynamoDB` JSON format: one JSON object per line with `{"Item": {...}}` wrapper.
 fn read_dynamodb_json(reader: impl BufRead, max_items: u64) -> Result<Vec<Item>, DynamoDbError> {
     let mut items = Vec::new();
     for (line_num, line) in reader.lines().enumerate() {
@@ -80,8 +80,7 @@ fn read_csv(
 ) -> Result<Vec<Item>, DynamoDbError> {
     let delimiter = options
         .and_then(|o| o.csv.as_ref())
-        .map(|c| c.delimiter.as_str())
-        .unwrap_or(",");
+        .map_or(",", |c| c.delimiter.as_str());
     let explicit_headers = options
         .and_then(|o| o.csv.as_ref())
         .and_then(|c| c.header_list.as_ref());

--- a/crates/engine/src/index_helpers.rs
+++ b/crates/engine/src/index_helpers.rs
@@ -65,7 +65,7 @@ pub fn apply_index_projection(
 }
 
 /// Validate `ExclusiveStartKey` against the (table or index) key schema for
-/// `Scan`. Base-table scans use the long DynamoDB error message; index scans
+/// `Scan`. Base-table scans use the long `DynamoDB` error message; index scans
 /// use the short one.
 ///
 /// # Errors
@@ -88,7 +88,7 @@ pub fn validate_scan_exclusive_start_key(
 }
 
 /// Validate `ExclusiveStartKey` for `Query`. Same rules as Scan; uses the
-/// short DynamoDB error message in all cases.
+/// short `DynamoDB` error message in all cases.
 ///
 /// # Errors
 ///

--- a/crates/engine/src/legacy_filter.rs
+++ b/crates/engine/src/legacy_filter.rs
@@ -3,7 +3,7 @@
 
 //! Legacy filter parameter desugaring.
 //!
-//! Converts pre-expression parameters (KeyConditions, QueryFilter, ScanFilter)
+//! Converts pre-expression parameters (`KeyConditions`, `QueryFilter`, `ScanFilter`)
 //! into expression-based equivalents.
 
 use std::collections::HashMap;
@@ -16,8 +16,8 @@ use extenddb_core::types::{AttributeValue, Condition, ConditionalOperator};
 
 /// Desugar legacy `KeyConditions` into a `KeyCondition` struct and expression maps.
 ///
-/// The hash key must have ComparisonOperator = "EQ".
-/// The optional range key supports: EQ, LE, LT, GE, GT, BEGINS_WITH, BETWEEN.
+/// The hash key must have `ComparisonOperator` = "EQ".
+/// The optional range key supports: EQ, LE, LT, GE, GT, `BEGINS_WITH`, BETWEEN.
 pub fn desugar_key_conditions(
     conditions: &HashMap<String, Condition>,
     key_schema: &[(String, bool)], // Vec of (attr_name, is_hash)
@@ -164,7 +164,7 @@ fn desugar_sk_condition(
 
 /// Desugar legacy `QueryFilter` or `ScanFilter` into a condition expression AST.
 ///
-/// Each entry maps an attribute name to a Condition with ComparisonOperator and values.
+/// Each entry maps an attribute name to a Condition with `ComparisonOperator` and values.
 /// Multiple entries are combined with the `ConditionalOperator` (default AND).
 pub fn desugar_filter(
     filter: &HashMap<String, Condition>,

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -71,7 +71,7 @@ use extenddb_core::limits::LimitsConfig;
 
 /// Check whether an operation name is recognized by the dispatch table.
 ///
-/// Real DynamoDB validates the operation name before checking authentication.
+/// Real `DynamoDB` validates the operation name before checking authentication.
 /// An unknown operation with no auth headers returns `UnknownOperationException`,
 /// not `MissingAuthenticationToken`. The server layer calls this before auth.
 #[must_use]
@@ -141,7 +141,7 @@ pub(crate) fn sanitize_storage_error(e: extenddb_storage::error::StorageError) -
     DynamoDbError::InternalServerError("Internal server error".to_owned())
 }
 
-/// Map a serde deserialization error to the appropriate DynamoDB error type.
+/// Map a serde deserialization error to the appropriate `DynamoDB` error type.
 ///
 /// Enum validation errors (produced by custom Deserialize impls) contain
 /// "validation error detected" and should be returned as `ValidationException`.
@@ -168,15 +168,14 @@ pub(crate) fn deserialize_error(e: serde_json::Error) -> DynamoDbError {
 
 /// Pre-validate enum fields in a JSON body and return a combined error if multiple are invalid.
 ///
-/// DynamoDB reports all invalid enum fields together rather than stopping at the first.
+/// `DynamoDB` reports all invalid enum fields together rather than stopping at the first.
 /// Each entry is `(json_field_name, api_field_name, valid_values)`.
 pub(crate) fn validate_enum_fields(
     body: &serde_json::Value,
     fields: &[(&str, &str, &[&str])],
 ) -> Result<(), DynamoDbError> {
-    let obj = match body.as_object() {
-        Some(o) => o,
-        None => return Ok(()),
+    let Some(obj) = body.as_object() else {
+        return Ok(());
     };
     let mut errors: Vec<String> = Vec::new();
     for &(json_name, api_name, valid) in fields {
@@ -215,7 +214,7 @@ pub struct DispatchMetrics {
     /// Number of items returned to the client.
     pub returned_item_count: u64,
     /// Total bytes of items returned to the client (pre-projection scanned size,
-    /// consistent with how DynamoDB charges capacity on scanned data).
+    /// consistent with how `DynamoDB` charges capacity on scanned data).
     pub returned_bytes: u64,
     /// GSI/LSI name when the operation targets a secondary index.
     /// Used to attribute metrics to the specific index.

--- a/crates/engine/src/put_item.rs
+++ b/crates/engine/src/put_item.rs
@@ -32,9 +32,15 @@ pub async fn handle_put_item(
     // Validate table name from raw body first (takes priority over enum errors)
     if let Some(table_name) = body.get("TableName").and_then(|v| v.as_str()) {
         extenddb_core::validation::validate_table_name(table_name, &ctx.limits)?;
-    } else if body.get("TableName").is_some_and(|v| v.is_string()) {
+    } else if body
+        .get("TableName")
+        .is_some_and(serde_json::Value::is_string)
+    {
         // empty string — caught by validate_table_name above
-    } else if body.get("TableName").is_none() || body.get("TableName").is_some_and(|v| v.is_null())
+    } else if body.get("TableName").is_none()
+        || body
+            .get("TableName")
+            .is_some_and(serde_json::Value::is_null)
     {
         return Err(DynamoDbError::ValidationException(
             "1 validation error detected: Value null at 'tableName' failed to satisfy constraint: Member must not be null".to_owned()
@@ -115,7 +121,12 @@ pub async fn handle_put_item(
         &ctx.limits,
     )?;
 
-    if input.expected.is_none() || input.expected.as_ref().is_some_and(|m| m.is_empty()) {
+    if input.expected.is_none()
+        || input
+            .expected
+            .as_ref()
+            .is_some_and(std::collections::HashMap::is_empty)
+    {
         let exprs: Vec<&extenddb_core::expression::Expr> = condition.iter().collect();
         extenddb_core::expression::validate_unused_attributes(
             &maps.names,

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -253,15 +253,15 @@ pub async fn handle_query(
 
     // Parse FilterExpression or desugar legacy QueryFilter
     let (filter, filter_maps) = if let Some(ref qf) = input.query_filter {
-        if !qf.is_empty() {
-            let cond_op = input.conditional_operator.unwrap_or_default();
-            let (expr, fmaps) = desugar_filter(qf, cond_op)?;
-            (Some(expr), Some(fmaps))
-        } else {
+        if qf.is_empty() {
             (
                 parse_optional_filter(input.filter_expression.as_deref(), &ctx.limits)?,
                 None,
             )
+        } else {
+            let cond_op = input.conditional_operator.unwrap_or_default();
+            let (expr, fmaps) = desugar_filter(qf, cond_op)?;
+            (Some(expr), Some(fmaps))
         }
     } else {
         (

--- a/crates/engine/src/read_helpers.rs
+++ b/crates/engine/src/read_helpers.rs
@@ -24,7 +24,7 @@ use crate::index_helpers::apply_index_projection;
 ///
 /// Mirrors the unused-attribute check Query and Scan run via
 /// `validate_unused_attributes`, narrowed to read handlers that accept only a
-/// projection (GetItem, BatchGetItem). `names` is the raw request map with
+/// projection (`GetItem`, `BatchGetItem`). `names` is the raw request map with
 /// keys still carrying their `#` prefix. The caller passes this only for a
 /// user-supplied `ProjectionExpression`; desugared `AttributesToGet` uses
 /// synthetic placeholders and is governed by a separate rule.
@@ -67,7 +67,7 @@ pub struct PostReadResult {
     pub last_evaluated_key: Option<Item>,
 }
 
-/// Apply FilterExpression, ProjectionExpression, and 1 MB response size limit
+/// Apply `FilterExpression`, `ProjectionExpression`, and 1 MB response size limit
 /// to raw items returned from storage.
 ///
 /// This is the shared pipeline used by both `Query` and `Scan`.

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -94,8 +94,7 @@ pub async fn handle_scan(
             }
             if seg < 0 {
                 return Err(DynamoDbError::ValidationException(format!(
-                    "1 validation error detected: Value '{}' at 'segment' failed to satisfy constraint: Member must have value greater than or equal to 0",
-                    seg
+                    "1 validation error detected: Value '{seg}' at 'segment' failed to satisfy constraint: Member must have value greater than or equal to 0"
                 )));
             }
             if seg > 999_999 {
@@ -187,15 +186,15 @@ pub async fn handle_scan(
 
     // Parse FilterExpression or desugar legacy ScanFilter
     let (filter, filter_maps) = if let Some(ref sf) = input.scan_filter {
-        if !sf.is_empty() {
-            let cond_op = input.conditional_operator.unwrap_or_default();
-            let (expr, fmaps) = desugar_filter(sf, cond_op)?;
-            (Some(expr), Some(fmaps))
-        } else {
+        if sf.is_empty() {
             (
                 parse_optional_filter(input.filter_expression.as_deref(), &ctx.limits)?,
                 None,
             )
+        } else {
+            let cond_op = input.conditional_operator.unwrap_or_default();
+            let (expr, fmaps) = desugar_filter(sf, cond_op)?;
+            (Some(expr), Some(fmaps))
         }
     } else {
         (

--- a/crates/engine/src/stream_capture.rs
+++ b/crates/engine/src/stream_capture.rs
@@ -3,8 +3,8 @@
 
 //! Stream record capture helpers for write operations.
 //!
-//! When a table has streams enabled, write operations (PutItem, DeleteItem,
-//! UpdateItem) generate stream records. This module provides the
+//! When a table has streams enabled, write operations (`PutItem`, `DeleteItem`,
+//! `UpdateItem`) generate stream records. This module provides the
 //! `stream_view_type` helper to check whether a table has streams enabled
 //! and determine the view type.
 
@@ -14,6 +14,7 @@ use extenddb_core::types::{StreamViewType, TableKeyInfo};
 ///
 /// Reads the stream specification from the cached `TableKeyInfo` — no extra
 /// SQL round-trip required.
+#[must_use]
 pub fn stream_view_type(key_info: &TableKeyInfo) -> Option<StreamViewType> {
     let spec = key_info.stream_specification.as_ref()?;
     if !spec.stream_enabled {

--- a/crates/engine/src/streams.rs
+++ b/crates/engine/src/streams.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! DynamoDB Streams operation handlers.
+//! `DynamoDB` Streams operation handlers.
 
 use extenddb_core::error::DynamoDbError;
 use extenddb_core::types::{
@@ -153,7 +153,7 @@ pub async fn handle_get_shard_iterator(
     serialize_output(&output)
 }
 
-/// Shard iterator expiration: 15 minutes (900 seconds), matching real DynamoDB.
+/// Shard iterator expiration: 15 minutes (900 seconds), matching real `DynamoDB`.
 const SHARD_ITERATOR_EXPIRY_SECS: u64 = 900;
 
 /// Handle `GetRecords`.

--- a/crates/engine/src/tagging.rs
+++ b/crates/engine/src/tagging.rs
@@ -23,7 +23,7 @@ fn extract_table_name_from_arn(arn: &str) -> Option<&str> {
     Some(table_name.split('/').next().unwrap_or(table_name))
 }
 
-/// Extract the account ID from a DynamoDB table ARN.
+/// Extract the account ID from a `DynamoDB` table ARN.
 fn extract_account_from_arn(arn: &str) -> Option<&str> {
     arn.strip_prefix("arn:aws:dynamodb:")?.split(':').nth(1)
 }

--- a/crates/engine/src/transact_write_helpers.rs
+++ b/crates/engine/src/transact_write_helpers.rs
@@ -69,8 +69,8 @@ impl PreparedOp {
     /// Approximate item size for transaction size limit enforcement.
     ///
     /// For Put operations, this returns the exact item size. For Update, Delete,
-    /// and ConditionCheck, the full item is not yet available at validation time
-    /// (it will be fetched during execution). DynamoDB's 4MB limit counts the
+    /// and `ConditionCheck`, the full item is not yet available at validation time
+    /// (it will be fetched during execution). `DynamoDB`'s 4MB limit counts the
     /// full item size as it exists or will exist post-mutation.
     ///
     /// To avoid bypassing the limit with updates that produce large items, we

--- a/crates/engine/src/transact_write_items.rs
+++ b/crates/engine/src/transact_write_items.rs
@@ -105,7 +105,10 @@ pub async fn handle_transact_write_items(
     }
 
     // Validate total transaction size <= 4MB
-    let total_size: usize = prepared.iter().map(|op| op.item_size()).sum();
+    let total_size: usize = prepared
+        .iter()
+        .map(super::transact_write_helpers::PreparedOp::item_size)
+        .sum();
     if total_size > 4 * 1024 * 1024 {
         return Err(DynamoDbError::ValidationException(
             "Transaction item size has exceeded the 4 MB limit".to_owned(),

--- a/crates/engine/src/update_item.rs
+++ b/crates/engine/src/update_item.rs
@@ -161,7 +161,12 @@ pub async fn handle_update_item(
         extenddb_core::validation::validate_attribute_values_nesting_depth(stored)?;
     }
 
-    if input.expected.is_none() || input.expected.as_ref().is_some_and(|m| m.is_empty()) {
+    if input.expected.is_none()
+        || input
+            .expected
+            .as_ref()
+            .is_some_and(std::collections::HashMap::is_empty)
+    {
         let exprs: Vec<&extenddb_core::expression::Expr> = condition.iter().collect();
         extenddb_core::expression::validate_unused_attributes(
             &maps.names,
@@ -347,7 +352,7 @@ fn filter_to_updated_attrs(item: &Item, actions: &[UpdateAction], maps: &Express
     result
 }
 
-/// Resolve a value at a nested path within an AttributeValue.
+/// Resolve a value at a nested path within an `AttributeValue`.
 fn resolve_path_value(
     val: &AttributeValue,
     path: &[PathElement],
@@ -396,7 +401,7 @@ fn wrap_leaf_in_path(
     }
 }
 
-/// Recursively merge two Map AttributeValues. Returns None if either isn't a Map.
+/// Recursively merge two Map `AttributeValues`. Returns None if either isn't a Map.
 fn merge_maps(a: &AttributeValue, b: &AttributeValue) -> Option<AttributeValue> {
     match (a, b) {
         (AttributeValue::M(ma), AttributeValue::M(mb)) => {

--- a/crates/engine/src/update_table.rs
+++ b/crates/engine/src/update_table.rs
@@ -166,8 +166,7 @@ pub async fn handle_update_table(
             }
             extenddb_storage::error::StorageError::IndexNotFound(name) => {
                 DynamoDbError::ResourceNotFoundException(format!(
-                    "Requested resource not found: Index {name} for table {}",
-                    table_name
+                    "Requested resource not found: Index {name} for table {table_name}"
                 ))
             }
             extenddb_storage::error::StorageError::NoOpUpdate(msg) => {

--- a/crates/server/src/authorization.rs
+++ b/crates/server/src/authorization.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Authorization layer for DynamoDB requests.
+//! Authorization layer for `DynamoDB` requests.
 //!
 //! After authentication resolves an `AuthIdentity`, this module fetches the
 //! applicable IAM policies, permissions boundary, and session policy via
@@ -25,7 +25,7 @@ use extenddb_storage::management_store::OpError;
 use crate::authz_cache::{CachedAuthzStore, PolicyList, TagMap};
 
 /// Evaluate whether the authenticated identity is authorized for the given
-/// DynamoDB operation on the given resource.
+/// `DynamoDB` operation on the given resource.
 ///
 /// For `AuthIdentity::User` and `AuthIdentity::RoleSession`, the full IAM
 /// evaluation algorithm runs: explicit deny → permissions boundary → session

--- a/crates/server/src/authz_cache.rs
+++ b/crates/server/src/authz_cache.rs
@@ -488,6 +488,7 @@ impl CachedAuthzStore {
     /// Snapshot per-sub-cache counters for export to `/auth-cache-metrics`.
     /// Returns `None` if metrics are unavailable for any reason (currently
     /// always returns `Some`).
+    #[must_use]
     pub fn metrics_snapshot(&self) -> Option<AuthzCacheMetricsSnapshot> {
         Some(AuthzCacheMetricsSnapshot {
             user_policies: self.user_policies.metrics().snapshot(),

--- a/crates/server/src/console/html.rs
+++ b/crates/server/src/console/html.rs
@@ -84,7 +84,7 @@ f.appendChild(i);
     };
     let tls_line = match listen_url {
         Some(url) => format!(
-            r#"Self-signed TLS certificate bound to <strong>{}</strong>"#,
+            r"Self-signed TLS certificate bound to <strong>{}</strong>",
             escape(url),
         ),
         None => String::new(),

--- a/crates/server/src/console/mod.rs
+++ b/crates/server/src/console/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! A server-rendered HTML interface for the management API. Provides login,
 //! account/user/group/role CRUD, policy editing, and IAM user self-service.
-//! Mounted at `/console/*` on the same server as the DynamoDB API.
+//! Mounted at `/console/*` on the same server as the `DynamoDB` API.
 //!
 //! Sessions are stored in-memory with random tokens in cookies. No external
 //! dependencies — all HTML is generated with Rust string formatting.
@@ -32,7 +32,7 @@ pub struct ConsoleState {
     pub sessions: SessionStore,
     /// Version string displayed in the console footer (e.g. "0.1.0 · catalog 2.1.0 · abc1234").
     pub version_info: Arc<str>,
-    /// The URL the server is listening on (e.g. "https://127.0.0.1:8000").
+    /// The URL the server is listening on (e.g. "<https://127.0.0.1:8000>").
     /// Displayed in the footer so users know which address the self-signed
     /// certificate is bound to.
     pub listen_url: String,

--- a/crates/server/src/console/pages/account_pages.rs
+++ b/crates/server/src/console/pages/account_pages.rs
@@ -81,7 +81,7 @@ pub async fn list_accounts(State(state): State<Arc<ConsoleState>>, headers: Head
     };
 
     let mut table = String::from(
-        r#"<table><thead><tr><th>Account ID</th><th>Name</th><th></th></tr></thead><tbody>"#,
+        r"<table><thead><tr><th>Account ID</th><th>Name</th><th></th></tr></thead><tbody>",
     );
     for (id, name) in &rows {
         let eid = html::escape(id);
@@ -302,7 +302,7 @@ pub async fn account_detail(
         );
     }
 
-    content.push_str(r#"<table><thead><tr><th>User Name</th></tr></thead><tbody>"#);
+    content.push_str(r"<table><thead><tr><th>User Name</th></tr></thead><tbody>");
     for name in &detail.users {
         let en = html::escape(name);
         let _ = write!(
@@ -320,7 +320,7 @@ pub async fn account_detail(
             r#"<a href="/console/accounts/{eid}/groups/new" class="btn btn-primary btn-sm" style="margin-bottom:0.5rem;display:inline-block">New Group</a>"#
         );
     }
-    content.push_str(r#"<table><thead><tr><th>Group Name</th></tr></thead><tbody>"#);
+    content.push_str(r"<table><thead><tr><th>Group Name</th></tr></thead><tbody>");
     for name in &detail.groups {
         let en = html::escape(name);
         let _ = write!(
@@ -338,7 +338,7 @@ pub async fn account_detail(
             r#"<a href="/console/accounts/{eid}/roles/new" class="btn btn-primary btn-sm" style="margin-bottom:0.5rem;display:inline-block">New Role</a>"#
         );
     }
-    content.push_str(r#"<table><thead><tr><th>Role Name</th></tr></thead><tbody>"#);
+    content.push_str(r"<table><thead><tr><th>Role Name</th></tr></thead><tbody>");
     for name in &detail.roles {
         let en = html::escape(name);
         let _ = write!(

--- a/crates/server/src/console/pages/auth_pages.rs
+++ b/crates/server/src/console/pages/auth_pages.rs
@@ -144,9 +144,8 @@ async fn try_admin_login(
     password: &str,
     store: &dyn extenddb_storage::management_store::AdminStore,
 ) -> AdminLoginResult {
-    let result = match store.verify_admin_password(username, password).await {
-        Ok(r) => r,
-        Err(_) => return AdminLoginResult::NotFound,
+    let Ok(result) = store.verify_admin_password(username, password).await else {
+        return AdminLoginResult::NotFound;
     };
     match result {
         Some(true) => AdminLoginResult::Authenticated(CallerIdentity::Admin(username.to_owned())),

--- a/crates/server/src/console/pages/group_pages.rs
+++ b/crates/server/src/console/pages/group_pages.rs
@@ -184,7 +184,7 @@ pub async fn group_detail(
         );
     }
 
-    content.push_str(r#"<table><thead><tr><th>User Name</th><th></th></tr></thead><tbody>"#);
+    content.push_str(r"<table><thead><tr><th>User Name</th><th></th></tr></thead><tbody>");
     for uname in &detail.members {
         let eu = html::escape(uname);
         let remove_btn = if is_admin(&session.identity) {
@@ -211,7 +211,7 @@ pub async fn group_detail(
             r#"<a href="/console/accounts/{eid}/groups/{egn}/policies/new" class="btn btn-primary btn-sm" style="margin-bottom:0.5rem;display:inline-block">Add Policy</a>"#
         );
     }
-    content.push_str(r#"<table><thead><tr><th>Policy Name</th><th></th></tr></thead><tbody>"#);
+    content.push_str(r"<table><thead><tr><th>Policy Name</th><th></th></tr></thead><tbody>");
     for pname in &detail.policies {
         let ep = html::escape(pname);
         let delete_btn = if is_admin(&session.identity) {

--- a/crates/server/src/console/pages/policy_pages.rs
+++ b/crates/server/src/console/pages/policy_pages.rs
@@ -268,22 +268,21 @@ async fn put_policy(
     }
 
     // Validate JSON.
-    let doc: serde_json::Value = match serde_json::from_str(&form.policy_document) {
-        Ok(v) => v,
-        Err(_) => {
-            let nav = html::nav_bar(&identity_label(&session.identity));
-            let content = format!(
-                "<h1>Add Policy</h1>{}",
-                html::alert_error("Policy document is not valid JSON")
-            );
-            return Html(html::layout_csrf(
-                "New Policy",
-                &nav,
-                &content,
-                &session.csrf_token,
-            ))
-            .into_response();
-        }
+    let doc: serde_json::Value = if let Ok(v) = serde_json::from_str(&form.policy_document) {
+        v
+    } else {
+        let nav = html::nav_bar(&identity_label(&session.identity));
+        let content = format!(
+            "<h1>Add Policy</h1>{}",
+            html::alert_error("Policy document is not valid JSON")
+        );
+        return Html(html::layout_csrf(
+            "New Policy",
+            &nav,
+            &content,
+            &session.csrf_token,
+        ))
+        .into_response();
     };
 
     match state

--- a/crates/server/src/console/pages/role_pages.rs
+++ b/crates/server/src/console/pages/role_pages.rs
@@ -210,7 +210,7 @@ pub async fn role_detail(
             r#"<a href="/console/accounts/{eid}/roles/{ern}/policies/new" class="btn btn-primary btn-sm" style="margin-bottom:0.5rem;display:inline-block">Add Policy</a>"#
         );
     }
-    content.push_str(r#"<table><thead><tr><th>Policy Name</th><th></th></tr></thead><tbody>"#);
+    content.push_str(r"<table><thead><tr><th>Policy Name</th><th></th></tr></thead><tbody>");
     for pname in &detail.policies {
         let ep = html::escape(pname);
         let delete_btn = if is_admin(&session.identity) {
@@ -229,7 +229,7 @@ pub async fn role_detail(
 
     // Tags section.
     let _ = write!(content, "<h2>Tags ({})</h2>", detail.tags.len());
-    content.push_str(r#"<table><thead><tr><th>Key</th><th>Value</th></tr></thead><tbody>"#);
+    content.push_str(r"<table><thead><tr><th>Key</th><th>Value</th></tr></thead><tbody>");
     for (k, v) in &detail.tags {
         let _ = write!(
             content,

--- a/crates/server/src/console/pages/user_pages.rs
+++ b/crates/server/src/console/pages/user_pages.rs
@@ -238,7 +238,7 @@ pub async fn user_detail(
 </form>"#
     );
     content.push_str(
-        r#"<table><thead><tr><th>Access Key ID</th><th>Status</th><th></th></tr></thead><tbody>"#,
+        r"<table><thead><tr><th>Access Key ID</th><th>Status</th><th></th></tr></thead><tbody>",
     );
     for (kid, is_active) in &detail.keys {
         let ekid = html::escape(kid);
@@ -262,7 +262,7 @@ pub async fn user_detail(
             r#"<a href="/console/accounts/{eid}/users/{eun}/policies/new" class="btn btn-primary btn-sm" style="margin-bottom:0.5rem;display:inline-block">Add Policy</a>"#
         );
     }
-    content.push_str(r#"<table><thead><tr><th>Policy Name</th><th></th></tr></thead><tbody>"#);
+    content.push_str(r"<table><thead><tr><th>Policy Name</th><th></th></tr></thead><tbody>");
     for pname in &detail.policies {
         let ep = html::escape(pname);
         let delete_btn = if is_admin(&session.identity) {
@@ -281,7 +281,7 @@ pub async fn user_detail(
 
     // Groups section.
     let _ = write!(content, "<h2>Groups ({})</h2>", detail.groups.len());
-    content.push_str(r#"<table><thead><tr><th>Group Name</th></tr></thead><tbody>"#);
+    content.push_str(r"<table><thead><tr><th>Group Name</th></tr></thead><tbody>");
     for gname in &detail.groups {
         let eg = html::escape(gname);
         let _ = write!(
@@ -293,7 +293,7 @@ pub async fn user_detail(
 
     // Tags section.
     let _ = write!(content, "<h2>Tags ({})</h2>", detail.tags.len());
-    content.push_str(r#"<table><thead><tr><th>Key</th><th>Value</th></tr></thead><tbody>"#);
+    content.push_str(r"<table><thead><tr><th>Key</th><th>Value</th></tr></thead><tbody>");
     for (k, v) in &detail.tags {
         let _ = write!(
             content,

--- a/crates/server/src/console/session.rs
+++ b/crates/server/src/console/session.rs
@@ -44,6 +44,7 @@ impl Default for SessionStore {
 
 impl SessionStore {
     /// Create an empty session store.
+    #[must_use]
     pub fn new() -> Self {
         Self {
             sessions: Mutex::new(HashMap::new()),

--- a/crates/server/src/handler.rs
+++ b/crates/server/src/handler.rs
@@ -116,7 +116,7 @@ pub(crate) async fn handle_request(
                 ),
                 &request_id,
             );
-        };
+        }
         match authorize_request(&state, &identity, &input, &operation, &account_id).await {
             Ok(ki) => pre_fetched_key_info = ki,
             Err(e) => return error_response(&e, &request_id),

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -287,7 +287,7 @@ fn cleanup_pid_file(pid_file: Option<&std::path::Path>) {
 
 /// AI-2: Acceptor that detects plain HTTP connections on the TLS port.
 ///
-/// Peeks the first byte of each connection. If it's `0x16` (TLS ClientHello),
+/// Peeks the first byte of each connection. If it's `0x16` (TLS `ClientHello`),
 /// the connection passes through to the TLS acceptor. If it's a plain HTTP
 /// verb, a 301 redirect to `https://` is written and the connection is
 /// rejected with an IO error (which `axum_server` handles by dropping it).

--- a/crates/server/src/management/cache_invalidate.rs
+++ b/crates/server/src/management/cache_invalidate.rs
@@ -49,7 +49,7 @@ pub enum Scope {
 }
 
 impl Scope {
-    /// Canonical snake_case name (matches the JSON wire format, the CLI
+    /// Canonical `snake_case` name (matches the JSON wire format, the CLI
     /// subcommand names, and the design doc table). Used in audit logs
     /// and the console success page so operators see the same
     /// identifier across every surface.

--- a/crates/server/src/management/mod.rs
+++ b/crates/server/src/management/mod.rs
@@ -46,7 +46,7 @@ pub struct ManagementState {
     /// endpoint to expose per-sub-cache counters. The same instance is held
     /// trait-object-style in `auth_cache.authz` for invalidation calls.
     pub authz_cache: Arc<crate::CachedAuthzStore>,
-    /// Concrete TableKeyInfo cache handle, used by the auth-cache-metrics
+    /// Concrete `TableKeyInfo` cache handle, used by the auth-cache-metrics
     /// endpoint. Same instance is held in `auth_cache.table_key_info`.
     pub table_key_info_cache: Arc<crate::CachedTableKeyInfoStore>,
 }

--- a/crates/server/src/rate_limit.rs
+++ b/crates/server/src/rate_limit.rs
@@ -4,7 +4,7 @@
 //! Login rate limiting and account lockout.
 //!
 //! All state lives in the storage backend (e.g. `login_attempts` table in
-//! PostgreSQL) so multiple ExtendDB instances sharing a catalog see a consistent
+//! `PostgreSQL`) so multiple `ExtendDB` instances sharing a catalog see a consistent
 //! view. No in-process caching.
 
 use extenddb_storage::management_store::RateLimitStore;

--- a/crates/server/src/response.rs
+++ b/crates/server/src/response.rs
@@ -34,7 +34,7 @@ pub(crate) fn success_response(body: &Value, request_id: &str) -> Response {
 }
 
 /// REQ-ERR-001: `__type` with prefix. REQ-ERR-002: message field.
-/// REQ-ERR-003: Omit `message` when empty (real DynamoDB behavior, verified 2026-05-04).
+/// REQ-ERR-003: Omit `message` when empty (real `DynamoDB` behavior, verified 2026-05-04).
 pub(crate) fn error_response(error: &DynamoDbError, request_id: &str) -> Response {
     // Fix #14: Use full_error_type() which includes the prefix
     let mut body = serde_json::json!({

--- a/crates/storage-postgres/src/admin_store.rs
+++ b/crates/storage-postgres/src/admin_store.rs
@@ -126,7 +126,7 @@ impl extenddb_storage::management_store::AdminStore for PostgresCatalogStore {
     }
 }
 
-/// Verify a bcrypt password on a blocking thread (same logic as server::password).
+/// Verify a bcrypt password on a blocking thread (same logic as `server::password`).
 async fn verify_bcrypt(password: String, hash: String) -> bool {
     tokio::task::spawn_blocking(move || bcrypt::verify(password, &hash).unwrap_or(false))
         .await

--- a/crates/storage-postgres/src/backup_engine.rs
+++ b/crates/storage-postgres/src/backup_engine.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Backup and point-in-time recovery implementation for PostgreSQL storage.
+//! Backup and point-in-time recovery implementation for `PostgreSQL` storage.
 
 use extenddb_core::types::{
     BackupDescription, BackupDetails, BackupSummary, ContinuousBackupsDescription,
@@ -23,7 +23,7 @@ fn epoch_millis() -> u128 {
         .as_millis()
 }
 
-/// Convert a PostgreSQL `TIMESTAMPTZ` to epoch seconds as `f64`.
+/// Convert a `PostgreSQL` `TIMESTAMPTZ` to epoch seconds as `f64`.
 #[allow(clippy::cast_precision_loss)]
 fn pg_timestamp_to_epoch(ts: time::OffsetDateTime) -> f64 {
     ts.unix_timestamp() as f64
@@ -168,7 +168,7 @@ impl BackupEngine for PostgresEngine {
 
             Ok(BackupDetails {
                 backup_arn,
-                backup_name: backup_name.to_owned(),
+                backup_name: backup_name.clone(),
                 backup_status: "AVAILABLE".to_owned(),
                 backup_type: "USER".to_owned(),
                 backup_size_bytes: size_bytes,
@@ -235,7 +235,7 @@ impl BackupEngine for PostgresEngine {
 
             Ok(BackupDescription {
                 backup_details: BackupDetails {
-                    backup_arn: backup_arn.to_owned(),
+                    backup_arn: backup_arn.clone(),
                     backup_name: name,
                     backup_status: status,
                     backup_type: "USER".to_owned(),
@@ -262,7 +262,7 @@ impl BackupEngine for PostgresEngine {
         table_name: Option<&str>,
     ) -> BoxFuture<'_, Result<Vec<BackupSummary>, StorageError>> {
         let account_id = account_id.to_string();
-        let table_name = table_name.map(|s| s.to_string());
+        let table_name = table_name.map(std::string::ToString::to_string);
         Box::pin(async move {
             let rows: Vec<(
                 String,
@@ -400,7 +400,7 @@ impl BackupEngine for PostgresEngine {
             };
 
             let create_input = extenddb_core::types::CreateTableInput {
-                table_name: target_table_name.to_owned(),
+                table_name: target_table_name.clone(),
                 key_schema,
                 attribute_definitions: attr_defs,
                 billing_mode,

--- a/crates/storage-postgres/src/bootstrapper.rs
+++ b/crates/storage-postgres/src/bootstrapper.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! PostgreSQL implementation of `Bootstrapper`.
+//! `PostgreSQL` implementation of `Bootstrapper`.
 //!
 //! Handles `CREATE DATABASE`, schema migrations, user provisioning, and
 //! teardown using PostgreSQL-specific DDL. Connection pools are created
@@ -23,7 +23,7 @@ use tokio::sync::OnceCell;
 use crate::CATALOG_VERSION;
 use crate::migrations;
 
-/// Utilities for bootstrapping a PostgreSQL backend store.
+/// Utilities for bootstrapping a `PostgreSQL` backend store.
 ///
 /// Holds the bootstrap configuration and lazily-created connection pools.
 /// The admin pool connects to the `postgres` database for DDL operations
@@ -37,6 +37,7 @@ pub struct PostgresBootstrapper {
 impl PostgresBootstrapper {
     /// Create a new bootstrapper. The admin pool is created lazily on
     /// first use, so this constructor never opens a database connection.
+    #[must_use]
     pub fn new(config: BootstrapConfig) -> Self {
         Self {
             config,
@@ -93,7 +94,7 @@ impl PostgresBootstrapper {
     /// - Passwords with special chars (e.g., `pass@word` → `pass%40word`)
     /// - Database names with special chars
     ///
-    /// PostgreSQL's libpq automatically decodes percent-encoded values per RFC 3986.
+    /// `PostgreSQL`'s libpq automatically decodes percent-encoded values per RFC 3986.
     fn app_connection_url(&self, database: &str) -> String {
         let host_encoded = urlencoding::encode(&self.config.host);
         let user_encoded = urlencoding::encode(&self.config.app_user);
@@ -348,9 +349,8 @@ impl Bootstrapper for PostgresBootstrapper {
     }
 
     async fn list_table_names(&self) -> OpResult<Vec<String>> {
-        let pool = match self.app_pool(&self.config.catalog_db).await {
-            Ok(p) => p,
-            Err(_) => return Ok(Vec::new()),
+        let Ok(pool) = self.app_pool(&self.config.catalog_db).await else {
+            return Ok(Vec::new());
         };
         let tables: Vec<(String,)> =
             sqlx::query_as("SELECT table_name FROM tables ORDER BY table_name")
@@ -361,9 +361,8 @@ impl Bootstrapper for PostgresBootstrapper {
     }
 
     async fn get_data_db_name(&self) -> OpResult<Option<String>> {
-        let pool = match self.app_pool(&self.config.catalog_db).await {
-            Ok(p) => p,
-            Err(_) => return Ok(None),
+        let Ok(pool) = self.app_pool(&self.config.catalog_db).await else {
+            return Ok(None);
         };
         let row = sqlx::query_as::<_, (String,)>(
             "SELECT value FROM settings WHERE key = 'data_database_name'",
@@ -491,7 +490,7 @@ impl PostgresBootstrapper {
         let (host, port, user, password, catalog_db_name) = if std::path::Path::new(config_path)
             .exists()
         {
-            println!("--- Loading defaults from {}", config_path);
+            println!("--- Loading defaults from {config_path}");
 
             // Parse connection string from config
             let config_content = std::fs::read_to_string(config_path)

--- a/crates/storage-postgres/src/catalog_store.rs
+++ b/crates/storage-postgres/src/catalog_store.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! PostgreSQL implementations of `SettingsStore`, `MetricsStore`, and
+//! `PostgreSQL` implementations of `SettingsStore`, `MetricsStore`, and
 //! `RateLimitStore`.
 //!
 //! `PostgresCatalogStore` wraps a `PgPool` connected to the catalog database
@@ -28,6 +28,7 @@ pub struct PostgresCatalogStore {
 
 impl PostgresCatalogStore {
     /// Create a new catalog store wrapping the given pool.
+    #[must_use]
     pub fn new(pool: PgPool) -> Self {
         Self {
             pool,
@@ -36,6 +37,7 @@ impl PostgresCatalogStore {
     }
 
     /// Create a new catalog store with a pre-loaded encryption key (P119).
+    #[must_use]
     pub fn with_encryption_key(pool: PgPool, encryption_key: String) -> Self {
         Self {
             pool,
@@ -44,11 +46,13 @@ impl PostgresCatalogStore {
     }
 
     /// Borrow the underlying pool (escape hatch for callers not yet migrated).
+    #[must_use]
     pub fn pool(&self) -> &PgPool {
         &self.pool
     }
 
     /// Get the cached encryption key. Returns `None` if not loaded at startup.
+    #[must_use]
     pub fn encryption_key(&self) -> Option<&Arc<str>> {
         self.encryption_key.as_ref()
     }
@@ -109,7 +113,9 @@ impl extenddb_storage::management_store::SettingsStore for PostgresCatalogStore 
     }
 
     fn cached_encryption_key(&self) -> Option<String> {
-        self.encryption_key.as_ref().map(|k| k.to_string())
+        self.encryption_key
+            .as_ref()
+            .map(std::string::ToString::to_string)
     }
 }
 
@@ -232,8 +238,8 @@ impl extenddb_storage::management_store::MetricsStore for PostgresCatalogStore {
         table_name: Option<&str>,
         metric: Option<&str>,
     ) -> BoxFuture<'_, OpResult<Vec<MetricsRow>>> {
-        let table_name = table_name.map(|s| s.to_owned());
-        let metric = metric.map(|s| s.to_owned());
+        let table_name = table_name.map(std::borrow::ToOwned::to_owned);
+        let metric = metric.map(std::borrow::ToOwned::to_owned);
         Box::pin(async move {
             use std::fmt::Write as _;
 
@@ -385,7 +391,7 @@ impl extenddb_storage::management_store::RateLimitStore for PostgresCatalogStore
 
     fn record_failed_login(&self, principal: &str, source_ip: Option<&str>) -> BoxFuture<'_, ()> {
         let principal = principal.to_owned();
-        let source_ip = source_ip.map(|s| s.to_owned());
+        let source_ip = source_ip.map(std::borrow::ToOwned::to_owned);
         Box::pin(async move {
             let result = sqlx::query(
                 "INSERT INTO login_attempts (principal, success, source_ip) VALUES ($1, false, $2)",
@@ -426,6 +432,8 @@ impl extenddb_storage::management_store::RateLimitStore for PostgresCatalogStore
 // Implement CatalogStore supertrait
 impl extenddb_storage::CatalogStore for PostgresCatalogStore {
     fn cached_encryption_key(&self) -> Option<String> {
-        self.encryption_key.as_ref().map(|arc| arc.to_string())
+        self.encryption_key
+            .as_ref()
+            .map(std::string::ToString::to_string)
     }
 }

--- a/crates/storage-postgres/src/config.rs
+++ b/crates/storage-postgres/src/config.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! PostgreSQL connection configuration.
+//! `PostgreSQL` connection configuration.
 
 use serde::Deserialize;
 

--- a/crates/storage-postgres/src/create_table.rs
+++ b/crates/storage-postgres/src/create_table.rs
@@ -45,7 +45,7 @@ impl PostgresEngine {
             .transpose()
             .map_err(|e| StorageError::Internal(e.to_string()))?;
         let deletion_protection = input.deletion_protection_enabled.unwrap_or(false);
-        let sse_spec_json = input.sse_specification.as_ref().cloned();
+        let sse_spec_json = input.sse_specification.clone();
         let on_demand_json = input
             .on_demand_throughput
             .as_ref()
@@ -400,7 +400,7 @@ impl PostgresEngine {
             sse_description: input.sse_specification.as_ref().and_then(|spec| {
                 let enabled = spec
                     .get("Enabled")
-                    .and_then(|v| v.as_bool())
+                    .and_then(serde_json::Value::as_bool)
                     .unwrap_or(false);
                 if enabled {
                     Some(SseDescription {

--- a/crates/storage-postgres/src/credential_store.rs
+++ b/crates/storage-postgres/src/credential_store.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Database-backed credential store for SigV4 authentication.
+//! Database-backed credential store for `SigV4` authentication.
 //!
 //! Implements `extenddb_auth::CredentialStore` by looking up access keys and
 //! session credentials from the catalog database, decrypting secrets with
@@ -57,7 +57,7 @@ fn decrypt_secret(encrypted: &[u8], key_b64: &str, aad: &str) -> Result<String, 
         .map_err(|e| format!("decrypted secret is not valid UTF-8: {e}"))
 }
 
-/// Credential store backed by the catalog PostgreSQL database.
+/// Credential store backed by the catalog `PostgreSQL` database.
 ///
 /// The `encryption_key` is zeroed from memory on drop.
 #[derive(Zeroize, ZeroizeOnDrop)]
@@ -72,6 +72,7 @@ impl DbCredentialStore {
     /// Create a new credential store.
     ///
     /// `encryption_key` is the base64-encoded 32-byte key from the `settings` table.
+    #[must_use]
     pub fn new(pool: PgPool, encryption_key: String) -> Self {
         Self {
             pool,

--- a/crates/storage-postgres/src/data/data_engine.rs
+++ b/crates/storage-postgres/src/data/data_engine.rs
@@ -122,7 +122,7 @@ impl DataEngine for PostgresEngine {
         let key_condition = key_condition.clone();
         let maps = maps.clone();
         let exclusive_start_key = exclusive_start_key.cloned();
-        let index_name = index_name.map(|s| s.to_string());
+        let index_name = index_name.map(std::string::ToString::to_string);
         Box::pin(async move {
             self.query_impl(
                 &key_info,
@@ -148,7 +148,7 @@ impl DataEngine for PostgresEngine {
     ) -> BoxFuture<'_, Result<(Vec<Item>, Option<Item>), StorageError>> {
         let key_info = key_info.clone();
         let exclusive_start_key = exclusive_start_key.cloned();
-        let index_name = index_name.map(|s| s.to_string());
+        let index_name = index_name.map(std::string::ToString::to_string);
         Box::pin(async move {
             self.scan_impl(
                 &key_info,

--- a/crates/storage-postgres/src/data/ddl.rs
+++ b/crates/storage-postgres/src/data/ddl.rs
@@ -13,7 +13,7 @@ use extenddb_storage::util::{sk_column, sk_column_n};
 use super::{all_sort_key_info, data_table_name, index_table_name};
 use crate::PostgresEngine;
 
-/// Row shape returned by the table-info query: (key_schema, attr_defs, status, table_id, stream_spec, has_lsi).
+/// Row shape returned by the table-info query: (`key_schema`, `attr_defs`, status, `table_id`, `stream_spec`, `has_lsi`).
 type TableInfoRow = (
     serde_json::Value,
     serde_json::Value,
@@ -123,7 +123,7 @@ impl PostgresEngine {
         Ok(())
     }
 
-    /// Create a GSI/LSI data table in PostgreSQL.
+    /// Create a GSI/LSI data table in `PostgreSQL`.
     ///
     /// GSI tables use the same `(pk, sk_*)` structure as base tables but add
     /// `base_pk` and `base_sk_*` columns for uniqueness (GSI keys are not unique).

--- a/crates/storage-postgres/src/data/delete_item.rs
+++ b/crates/storage-postgres/src/data/delete_item.rs
@@ -119,7 +119,9 @@ impl PostgresEngine {
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
 
                 // Sync GSI/LSI update within transaction (D-4).
-                let old_item_for_idx = if !indexes.is_empty() {
+                let old_item_for_idx = if indexes.is_empty() {
+                    None
+                } else {
                     let oi = old
                         .as_ref()
                         .map(|(v,)| json_to_item(v.clone()))
@@ -136,8 +138,6 @@ impl PostgresEngine {
                     )
                     .await?;
                     oi
-                } else {
-                    None
                 };
 
                 // Write stream record atomically within the transaction.
@@ -257,7 +257,9 @@ impl PostgresEngine {
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
 
                 // Sync GSI/LSI update within transaction (D-4).
-                let old_item_for_idx = if !indexes.is_empty() {
+                let old_item_for_idx = if indexes.is_empty() {
+                    None
+                } else {
                     let oi = old
                         .as_ref()
                         .map(|(v,)| json_to_item(v.clone()))
@@ -274,8 +276,6 @@ impl PostgresEngine {
                     )
                     .await?;
                     oi
-                } else {
-                    None
                 };
 
                 // Write stream record atomically within the transaction.

--- a/crates/storage-postgres/src/data/index.rs
+++ b/crates/storage-postgres/src/data/index.rs
@@ -222,7 +222,7 @@ pub(crate) async fn enqueue_async_indexes(
 }
 
 /// Compute a hash of the partition key text for queue partitioning.
-/// Uses crc32 for stability across Rust versions (DefaultHasher is not stable).
+/// Uses crc32 for stability across Rust versions (`DefaultHasher` is not stable).
 pub(crate) fn pk_hash(pk_text: &str) -> u64 {
     u64::from(crc32fast::hash(pk_text.as_bytes()))
 }

--- a/crates/storage-postgres/src/data/put_item.rs
+++ b/crates/storage-postgres/src/data/put_item.rs
@@ -110,7 +110,9 @@ impl PostgresEngine {
                 }
 
                 // Sync GSI/LSI update within transaction (D-4).
-                let old_item_for_idx = if !indexes.is_empty() {
+                let old_item_for_idx = if indexes.is_empty() {
+                    None
+                } else {
                     let oi = old
                         .as_ref()
                         .map(|(v,)| json_to_item(v.clone()))
@@ -127,8 +129,6 @@ impl PostgresEngine {
                     )
                     .await?;
                     oi
-                } else {
-                    None
                 };
 
                 // Write stream record atomically within the transaction.
@@ -255,7 +255,9 @@ impl PostgresEngine {
                 }
 
                 // Sync GSI/LSI update within transaction (D-4).
-                let old_item_for_idx = if !indexes.is_empty() {
+                let old_item_for_idx = if indexes.is_empty() {
+                    None
+                } else {
                     let oi = old
                         .as_ref()
                         .map(|(v,)| json_to_item(v.clone()))
@@ -272,8 +274,6 @@ impl PostgresEngine {
                     )
                     .await?;
                     oi
-                } else {
-                    None
                 };
 
                 // Write stream record atomically within the transaction.

--- a/crates/storage-postgres/src/data/query.rs
+++ b/crates/storage-postgres/src/data/query.rs
@@ -22,11 +22,11 @@ use extenddb_storage::util::{parse_sk, pk_to_text, sk_info};
 pub(crate) enum PaginationBinds {
     /// Base table query or index query with no extra pagination binds needed.
     None,
-    /// Index query where base table has no SK — only base_pk as tie-breaker.
+    /// Index query where base table has no SK — only `base_pk` as tie-breaker.
     BasePkOnly { pk_text: String },
-    /// Index query where base table has a SK — base_sk as tie-breaker.
+    /// Index query where base table has a SK — `base_sk` as tie-breaker.
     BaseSkOnly { sk: SortKeyValue },
-    /// Hash-only index where base table has a SK — both base_pk and base_sk.
+    /// Hash-only index where base table has a SK — both `base_pk` and `base_sk`.
     BasePkAndSk { pk_text: String, sk: SortKeyValue },
 }
 
@@ -72,9 +72,9 @@ pub(crate) struct SkSqlInfo {
 
 /// Build a SQL WHERE fragment for a sort key condition.
 ///
-/// DynamoDB sorts strings by UTF-8 byte order, not by locale. We use
+/// `DynamoDB` sorts strings by UTF-8 byte order, not by locale. We use
 /// `COLLATE "C"` on string columns to match this behavior regardless of
-/// the PostgreSQL database's `lc_collate` setting.
+/// the `PostgreSQL` database's `lc_collate` setting.
 pub(crate) fn build_sk_sql(
     sk_cond: &SortKeyCondition,
     sk_col: &str,
@@ -140,10 +140,10 @@ pub(crate) fn build_sk_sql(
 /// Execute a query SQL statement with dynamic parameter binding.
 ///
 /// # Parameter binding order:
-/// 1. pk_text (partition key)
+/// 1. `pk_text` (partition key)
 /// 2. SK condition params (from `build_sk_sql`)
 /// 3. Extra SK equality params (multi-range schemas)
-/// 4. ExclusiveStartKey index SK value (if paginating with sort key)
+/// 4. `ExclusiveStartKey` index SK value (if paginating with sort key)
 /// 5. Pagination extra binds (from `PaginationBinds` enum — built in `query_scan.rs`
 ///    in the same branch that generates the SQL, so order cannot diverge)
 #[allow(clippy::too_many_arguments)]
@@ -259,7 +259,7 @@ fn bind_sk_condition<'q>(
 ///
 /// Increments the last non-0xFF byte and truncates trailing 0xFF bytes.
 /// If the prefix is all 0xFF, returns a 1025-byte all-0xFF vector (longer
-/// than any valid DynamoDB sort key, so `< upper` is always true).
+/// than any valid `DynamoDB` sort key, so `< upper` is always true).
 fn increment_bytes(prefix: &[u8]) -> Vec<u8> {
     let mut result = prefix.to_vec();
     for i in (0..result.len()).rev() {
@@ -291,7 +291,7 @@ pub(crate) fn bind_sk_value<'q>(
 
 /// Execute a scan SQL statement with dynamic parameter binding.
 ///
-/// Bind order for index scans: pk, sk (if present), base_pk, base_sk (if present).
+/// Bind order for index scans: pk, sk (if present), `base_pk`, `base_sk` (if present).
 /// Bind order for base table scans: pk, sk (if present).
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_scan_sql(

--- a/crates/storage-postgres/src/data/query_scan.rs
+++ b/crates/storage-postgres/src/data/query_scan.rs
@@ -17,7 +17,7 @@ use super::query::{
 use super::{all_sort_key_info, data_table_name, index_table_name, json_to_item};
 use crate::PostgresEngine;
 
-/// Build the WHERE clause fragment for ExclusiveStartKey pagination.
+/// Build the WHERE clause fragment for `ExclusiveStartKey` pagination.
 ///
 /// Self-contained: takes `param_idx` (the next available placeholder number),
 /// returns a complete SQL fragment. No mutable state leaks out.
@@ -161,12 +161,11 @@ impl PostgresEngine {
             let attr_name = match path.first() {
                 Some(extenddb_core::expression::PathElement::Attribute(name)) => {
                     if let Some(ref_name) = name.strip_prefix('#') {
-                        match maps.names.get(ref_name) {
-                            Some(resolved) => resolved.clone(),
-                            None => {
-                                tracing::warn!(name_ref = %ref_name, "unresolved expression attribute name in extra SK condition, skipping");
-                                continue;
-                            }
+                        if let Some(resolved) = maps.names.get(ref_name) {
+                            resolved.clone()
+                        } else {
+                            tracing::warn!(name_ref = %ref_name, "unresolved expression attribute name in extra SK condition, skipping");
+                            continue;
                         }
                     } else {
                         name.clone()
@@ -303,7 +302,7 @@ impl PostgresEngine {
                     .get(base_pk_attr.as_str())
                     .map(pk_to_text)
                     .transpose()?
-                    .map(|c| c.into_owned());
+                    .map(std::borrow::Cow::into_owned);
                 match (base_pk, &base_sk_info) {
                     (Some(pk_text), Some((sk_name, sk_type))) => {
                         if let Some(sk_val) = start_key.get(sk_name.as_str()) {

--- a/crates/storage-postgres/src/data/transactions.rs
+++ b/crates/storage-postgres/src/data/transactions.rs
@@ -186,13 +186,11 @@ impl PostgresEngine {
                 // Derive pk_text from whichever item is available.
                 let pk_item = new_item.as_ref().or(old_item.as_ref());
                 let Some(pk_item) = pk_item else { continue }; // ConditionCheck — no index changes
-                let pk_value = match pk_item.get(pk_name) {
-                    Some(v) => v,
-                    None => continue,
+                let Some(pk_value) = pk_item.get(pk_name) else {
+                    continue;
                 };
-                let pk_text = match pk_to_text(pk_value) {
-                    Ok(t) => t,
-                    Err(_) => continue,
+                let Ok(pk_text) = pk_to_text(pk_value) else {
+                    continue;
                 };
                 enqueue_async_indexes(
                     q,
@@ -243,7 +241,7 @@ fn transact_op_table_name<'a>(op: &'a TransactWriteOp<'_>) -> &'a str {
     }
 }
 
-/// Extract the table_id from a transactional write operation.
+/// Extract the `table_id` from a transactional write operation.
 fn transact_op_table_id<'a>(op: &'a TransactWriteOp<'_>) -> &'a str {
     match op {
         TransactWriteOp::Put { key_info, .. }

--- a/crates/storage-postgres/src/gsi_queue.rs
+++ b/crates/storage-postgres/src/gsi_queue.rs
@@ -5,7 +5,7 @@
 //!
 //! Base table writes commit independently. For GSIs with a non-zero
 //! propagation delay, index updates are enqueued here and applied after a
-//! random delay, simulating real DynamoDB eventual consistency.
+//! random delay, simulating real `DynamoDB` eventual consistency.
 //!
 //! Each queue partition is consumed by a single worker task, guaranteeing
 //! per-key FIFO ordering. Workers are event-driven via `Notify` and sleep
@@ -27,7 +27,7 @@ use crate::data::{
 /// Number of queue partitions. Each partition has one consumer task.
 const NUM_PARTITIONS: usize = 4;
 
-/// PostgreSQL SQLSTATE code for "undefined_table" (relation does not exist).
+/// `PostgreSQL` SQLSTATE code for "`undefined_table`" (relation does not exist).
 const PG_UNDEFINED_TABLE: &str = "42P01";
 
 /// Check if a `StorageError` is caused by an undefined table (SQLSTATE 42P01).

--- a/crates/storage-postgres/src/lib.rs
+++ b/crates/storage-postgres/src/lib.rs
@@ -65,7 +65,7 @@ inventory::submit! {
         backend: "postgres",
         deserializer: |table| {
             let config: PostgresStorageConfig = table.clone().try_into()
-                .map_err(|e: toml::de::Error| format!("Failed to parse postgres config: {}", e))?;
+                .map_err(|e: toml::de::Error| format!("Failed to parse postgres config: {e}"))?;
             Ok(Box::new(config) as Box<dyn extenddb_storage::config::StorageConfig>)
         },
     }
@@ -118,7 +118,7 @@ pub const CATALOG_VERSION: CatalogVersion = CatalogVersion::new(0, 0, 2);
 
 /// Minimum number of connections allowed per pool.
 ///
-/// Each DynamoDB request triggers an auth/authz query fanout against the
+/// Each `DynamoDB` request triggers an auth/authz query fanout against the
 /// catalog pool. Pools smaller than this floor starve under concurrent load.
 /// Configured values below the floor are clamped at startup with a warning.
 const MIN_POOL_SIZE: u32 = 10;
@@ -140,7 +140,7 @@ pub struct PostgresConfig {
 /// Uses two connection pools: `pool` for catalog metadata (tables, indexes,
 /// settings, accounts, IAM) and `data_pool` for per-DynamoDB-table data
 /// (`_ddb_*` tables, GSI tables). This separation allows the catalog and
-/// data to live in different PostgreSQL databases (Bug 1, P54).
+/// data to live in different `PostgreSQL` databases (Bug 1, P54).
 pub struct PostgresEngine {
     pub(crate) pool: PgPool,
     /// Connection pool for the data database where `_ddb_*` tables live.
@@ -232,6 +232,7 @@ impl PostgresEngine {
     ///
     /// Must be called after construction, before serving requests.
     /// Returns `&Self` for chaining.
+    #[must_use]
     pub fn start_gsi_workers(mut self) -> Self {
         self.gsi_queue = Some(gsi_queue::GsiQueue::spawn(self.data_pool.clone()));
         self
@@ -239,6 +240,7 @@ impl PostgresEngine {
 
     /// Returns a handle to the control plane notify, for use by the
     /// background poller task (F-3).
+    #[must_use]
     pub fn control_plane_notify(&self) -> Arc<tokio::sync::Notify> {
         Arc::clone(&self.control_plane_notify)
     }
@@ -322,6 +324,7 @@ impl PostgresEngine {
 
     /// Returns a reference to the data pool for use by background workers
     /// that operate on `_ddb_*` tables (e.g., TTL cleanup, table size refresh).
+    #[must_use]
     pub fn data_pool(&self) -> &PgPool {
         &self.data_pool
     }
@@ -337,7 +340,7 @@ use extenddb_storage::server_components::{
     BackendError, ServerComponents, ServerComponentsRegistration,
 };
 
-/// Backend-specific runtime hooks for PostgreSQL.
+/// Backend-specific runtime hooks for `PostgreSQL`.
 struct PostgresRuntimeHooks {
     engine: Arc<PostgresEngine>,
     control_plane_notify: Arc<tokio::sync::Notify>,
@@ -356,7 +359,7 @@ impl ServerRuntimeHooks for PostgresRuntimeHooks {
         let catalog_store = ctx.catalog_store.clone();
         tokio::spawn(async move {
             workers::poll_control_plane_transitions(storage_for_poller, cp_notify, catalog_store)
-                .await
+                .await;
         });
 
         // 2. Table size refresh worker
@@ -367,14 +370,14 @@ impl ServerRuntimeHooks for PostgresRuntimeHooks {
         let storage_for_stream = self.engine.clone();
         let metrics = ctx.metrics.clone();
         tokio::spawn(async move {
-            workers::stream_record_cleanup_worker(storage_for_stream, metrics).await
+            workers::stream_record_cleanup_worker(storage_for_stream, metrics).await;
         });
 
         // 4. Idempotency token cleanup worker
         let storage_for_token = self.engine.clone();
         let metrics = ctx.metrics.clone();
         tokio::spawn(async move {
-            workers::idempotency_token_cleanup_worker(storage_for_token, metrics).await
+            workers::idempotency_token_cleanup_worker(storage_for_token, metrics).await;
         });
 
         // 5. TTL cleanup worker
@@ -387,7 +390,7 @@ impl ServerRuntimeHooks for PostgresRuntimeHooks {
         let data_pool = self.engine.data_pool().clone();
         let metrics = ctx.metrics.clone();
         tokio::spawn(async move {
-            workers::pool_metrics_worker(catalog_pool, data_pool, metrics).await
+            workers::pool_metrics_worker(catalog_pool, data_pool, metrics).await;
         });
 
         // 7. GSI delay poller

--- a/crates/storage-postgres/src/management_store/mod.rs
+++ b/crates/storage-postgres/src/management_store/mod.rs
@@ -74,7 +74,7 @@ impl extenddb_storage::management_store::ManagementStore for PostgresCatalogStor
     ) -> BoxFuture<'_, OpResult<()>> {
         let account_id = account_id.to_string();
         let user_name = user_name.to_string();
-        let password_hash = password_hash.map(|s| s.to_string());
+        let password_hash = password_hash.map(std::string::ToString::to_string);
         Box::pin(async move {
             self.create_user_impl(&account_id, &user_name, password_hash.as_deref())
                 .await

--- a/crates/storage-postgres/src/migrations.rs
+++ b/crates/storage-postgres/src/migrations.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! PostgreSQL schema migration helpers for catalog and data databases.
+//! `PostgreSQL` schema migration helpers for catalog and data databases.
 
 use extenddb_storage::management_store::{OpError, OpResult};
 use sqlx::PgPool;

--- a/crates/storage-postgres/src/operations.rs
+++ b/crates/storage-postgres/src/operations.rs
@@ -1,12 +1,12 @@
-// Copyright 2026 DynamoDB Open contributors
+// Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! PostgreSQL implementation of `OperationsEngine`.
+//! `PostgreSQL` implementation of `OperationsEngine`.
 
 use extenddb_storage::error::StorageError;
 use extenddb_storage::operations::{ConnectionParts, OperationsEngine};
 
-/// PostgreSQL operations engine for ddbo CLI commands.
+/// `PostgreSQL` operations engine for ddbo CLI commands.
 pub struct PostgresOperationsEngine;
 
 impl OperationsEngine for PostgresOperationsEngine {

--- a/crates/storage-postgres/src/pg_util.rs
+++ b/crates/storage-postgres/src/pg_util.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Shared PostgreSQL error classification helpers.
+//! Shared `PostgreSQL` error classification helpers.
 
 /// Check if a sqlx error is a unique constraint violation (PG error code 23505).
 pub(crate) fn is_unique_violation(e: &sqlx::Error) -> bool {

--- a/crates/storage-postgres/src/stream_engine.rs
+++ b/crates/storage-postgres/src/stream_engine.rs
@@ -19,7 +19,7 @@ use crate::PostgresEngine;
 const SHARDS_PER_STREAM: u32 = 4;
 
 impl PostgresEngine {
-    /// Initialize stream shards for a table and set the stream_label.
+    /// Initialize stream shards for a table and set the `stream_label`.
     ///
     /// Updates the stream label in the catalog (via the provided catalog
     /// transaction) and creates shard rows in the data database within a
@@ -126,7 +126,7 @@ impl StreamEngine for PostgresEngine {
         limit: i64,
     ) -> BoxFuture<'_, Result<(Vec<StreamRecord>, Option<String>), StorageError>> {
         let shard_id = shard_id.to_string();
-        let after_sequence = after_sequence.map(|s| s.to_string());
+        let after_sequence = after_sequence.map(std::string::ToString::to_string);
         Box::pin(async move {
             let rows: Vec<(serde_json::Value,)> = if let Some(after) = after_sequence {
                 sqlx::query_as(
@@ -192,8 +192,7 @@ impl StreamEngine for PostgresEngine {
             let (ks_json, _ad_json, stream_spec_json, table_status, table_id) =
                 row.ok_or_else(|| {
                     StorageError::TableNotFound(format!(
-                        "Requested resource not found: Stream: {arn} not found.",
-                        arn = stream_arn
+                        "Requested resource not found: Stream: {stream_arn} not found."
                     ))
                 })?;
 
@@ -285,8 +284,9 @@ impl StreamEngine for PostgresEngine {
         exclusive_start_stream_arn: Option<&str>,
     ) -> BoxFuture<'_, Result<(Vec<StreamSummary>, Option<String>), StorageError>> {
         let account_id = account_id.to_string();
-        let table_name = table_name.map(|s| s.to_string());
-        let exclusive_start_stream_arn = exclusive_start_stream_arn.map(|s| s.to_string());
+        let table_name = table_name.map(std::string::ToString::to_string);
+        let exclusive_start_stream_arn =
+            exclusive_start_stream_arn.map(std::string::ToString::to_string);
         Box::pin(async move {
             let rows: Vec<(String, String, String)> = match (
                 table_name.as_deref(),

--- a/crates/storage-postgres/src/table_helpers.rs
+++ b/crates/storage-postgres/src/table_helpers.rs
@@ -330,7 +330,7 @@ impl PostgresEngine {
             sse_description: row.sse_specification.as_ref().and_then(|spec| {
                 let enabled = spec
                     .get("Enabled")
-                    .and_then(|v| v.as_bool())
+                    .and_then(serde_json::Value::as_bool)
                     .unwrap_or(false);
                 if enabled {
                     Some(SseDescription {

--- a/crates/storage-postgres/src/ttl_worker.rs
+++ b/crates/storage-postgres/src/ttl_worker.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! TTL cleanup background worker for PostgreSQL.
+//! TTL cleanup background worker for `PostgreSQL`.
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/storage-postgres/src/update_table.rs
+++ b/crates/storage-postgres/src/update_table.rs
@@ -59,18 +59,18 @@ impl PostgresEngine {
 
             if let Some((current_bm, current_pt_opt)) = current_row {
                 let current_pt =
-                    current_pt_opt.unwrap_or(serde_json::Value::Object(Default::default()));
+                    current_pt_opt.unwrap_or(serde_json::Value::Object(serde_json::Map::default()));
                 let is_provisioned =
                     current_bm.as_deref() == Some("PROVISIONED") || current_bm.is_none();
                 let current_rcu = current_pt
                     .get("ReadCapacityUnits")
                     .or_else(|| current_pt.get("read_capacity_units"))
-                    .and_then(|v| v.as_i64())
+                    .and_then(serde_json::Value::as_i64)
                     .unwrap_or(0);
                 let current_wcu = current_pt
                     .get("WriteCapacityUnits")
                     .or_else(|| current_pt.get("write_capacity_units"))
-                    .and_then(|v| v.as_i64())
+                    .and_then(serde_json::Value::as_i64)
                     .unwrap_or(0);
 
                 if is_provisioned

--- a/crates/storage/src/bootstrapper.rs
+++ b/crates/storage/src/bootstrapper.rs
@@ -4,7 +4,7 @@
 //! Bootstrapper storage trait for init/destroy/migrate operations.
 //!
 //! These operations are inherently backend-specific (e.g., `CREATE DATABASE`
-//! is PostgreSQL DDL). The trait abstracts the high-level operations so the
+//! is `PostgreSQL` DDL). The trait abstracts the high-level operations so the
 //! CLI commands don't depend on a specific storage backend.
 
 use async_trait::async_trait;
@@ -44,7 +44,7 @@ pub struct AdminBootstrapResult {
 /// High-level bootstrap operations for storage backends.
 ///
 /// Covers the init, destroy, and migrate command paths. Implementations
-/// handle backend-specific DDL (e.g., `CREATE DATABASE` for PostgreSQL).
+/// handle backend-specific DDL (e.g., `CREATE DATABASE` for `PostgreSQL`).
 #[async_trait]
 pub trait Bootstrapper: Send + Sync {
     /// Ensure the application user exists in the storage backend.
@@ -111,7 +111,7 @@ pub trait Bootstrapper: Send + Sync {
     fn catalog_connection_url(&self) -> String;
 
     /// Generate the backend-specific configuration subsection for extenddb.toml.
-    /// Returns only the [storage.backend_name] section content, not the [storage] header.
+    /// Returns only the [`storage.backend_name`] section content, not the [storage] header.
     fn generate_backend_config_section(&self) -> String;
 }
 
@@ -179,6 +179,7 @@ pub async fn create_bootstrapper(
 }
 
 /// List all registered backends.
+#[must_use]
 pub fn list_backends() -> Vec<&'static str> {
     inventory::iter::<BackendRegistration>()
         .map(|r| r.name)
@@ -191,6 +192,7 @@ pub mod helpers {
     use crate::management_store::OpResult;
 
     /// Generate a random 12-digit numeric account ID (matches AWS account ID format).
+    #[must_use]
     pub fn generate_account_id() -> String {
         use rand::Rng;
         let mut rng = rand::rng();
@@ -203,6 +205,7 @@ pub mod helpers {
     /// Restricted to `[a-zA-Z0-9]` to avoid URL-encoding issues in form submissions,
     /// shell copy-paste problems, and other contexts where special characters break.
     /// At 24 characters from a 62-char alphabet, entropy is ~143 bits.
+    #[must_use]
     pub fn generate_random_password() -> String {
         use rand::Rng;
         const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -219,8 +222,8 @@ pub mod helpers {
     pub async fn hash_password_async(password: String) -> OpResult<String> {
         tokio::task::spawn_blocking(move || bcrypt::hash(password, bcrypt::DEFAULT_COST))
             .await
-            .map_err(|e| OpError::Internal(format!("bcrypt hash task failed: {}", e)))?
-            .map_err(|e| OpError::Internal(format!("bcrypt hash failed: {}", e)))
+            .map_err(|e| OpError::Internal(format!("bcrypt hash task failed: {e}")))?
+            .map_err(|e| OpError::Internal(format!("bcrypt hash failed: {e}")))
     }
 
     /// Generate a 256-bit AES-GCM encryption key and return it as base64.
@@ -245,14 +248,14 @@ pub mod helpers {
             && v != config_val
         {
             return Err(crate::error::StorageError::Internal(format!(
-                "{} value '{}' conflicts with config file value '{}'",
-                flag, v, config_val
+                "{flag} value '{v}' conflicts with config file value '{config_val}'"
             )));
         }
         Ok(())
     }
 
     /// Extract a CLI argument value by flag name.
+    #[must_use]
     pub fn extract_arg(args: &[String], flag: &str) -> Option<String> {
         args.windows(2).find(|w| w[0] == flag).map(|w| w[1].clone())
     }

--- a/crates/storage/src/config.rs
+++ b/crates/storage/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 DynamoDB Open contributors
+// Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Storage configuration trait and registry for storage backends.
@@ -11,7 +11,7 @@
 pub trait StorageConfig: Send + Sync + std::fmt::Debug {
     /// Backend-specific connection configuration as a string.
     ///
-    /// For PostgreSQL: connection string (postgresql://...)
+    /// For `PostgreSQL`: connection string (postgresql://...)
     fn connection_config(&self) -> &str;
 
     /// Maximum concurrent connections for data operations.
@@ -63,5 +63,5 @@ pub fn deserialize_storage_config(
             return (reg.deserializer)(table);
         }
     }
-    Err(format!("Unknown backend: {}", backend))
+    Err(format!("Unknown backend: {backend}"))
 }

--- a/crates/storage/src/diagnostics.rs
+++ b/crates/storage/src/diagnostics.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 DynamoDB Open contributors
+// Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Diagnostics trait for deployment health checks and verification.
@@ -18,8 +18,8 @@ pub enum DiagError {
 impl std::fmt::Display for DiagError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ConnectionFailed(msg) => write!(f, "Connection failed: {}", msg),
-            Self::QueryFailed(msg) => write!(f, "Query failed: {}", msg),
+            Self::ConnectionFailed(msg) => write!(f, "Connection failed: {msg}"),
+            Self::QueryFailed(msg) => write!(f, "Query failed: {msg}"),
         }
     }
 }
@@ -30,7 +30,7 @@ impl std::error::Error for DiagError {}
 ///
 /// Used by `ddbo verify` to check catalog integrity and enumerate resources.
 pub trait DiagnosticsStore: Send + Sync {
-    /// Count the number of DynamoDB tables in the catalog.
+    /// Count the number of `DynamoDB` tables in the catalog.
     fn count_tables(&self) -> BoxFuture<'_, DiagResult<i64>>;
 
     /// Count the number of secondary indexes in the catalog.

--- a/crates/storage/src/diagnostics_store.rs
+++ b/crates/storage/src/diagnostics_store.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 DynamoDB Open contributors
+// Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Diagnostics store factory registry for backend-agnostic instantiation.

--- a/crates/storage/src/hooks.rs
+++ b/crates/storage/src/hooks.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 DynamoDB Open contributors
+// Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Backend-specific runtime hooks for worker spawning and initialization.
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tracing_subscriber::{EnvFilter, Registry, reload};
 
-/// Context passed to ServerRuntimeHooks::spawn_workers.
+/// Context passed to `ServerRuntimeHooks::spawn_workers`.
 ///
 /// Contains shared resources that backend-specific workers might need.
 pub struct WorkerContext {
@@ -21,7 +21,7 @@ pub struct WorkerContext {
 /// Backend-specific runtime hooks for worker spawning and initialization.
 ///
 /// Backends implement this trait to spawn workers that are tightly coupled
-/// to their implementation details (e.g., PostgreSQL's control plane poller,
+/// to their implementation details (e.g., `PostgreSQL`'s control plane poller,
 /// pool metrics, GSI delay polling).
 #[async_trait]
 pub trait ServerRuntimeHooks: Send + Sync {
@@ -34,7 +34,7 @@ pub trait ServerRuntimeHooks: Send + Sync {
 
     /// Get backend-specific info for logging (optional).
     ///
-    /// Example: "data_db=ddbo_data" for PostgreSQL
+    /// Example: "`data_db=ddbo_data`" for `PostgreSQL`
     fn backend_info(&self) -> Option<String> {
         None
     }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -226,7 +226,7 @@ pub trait DataEngine: Send + Sync {
 
     /// Update an item by primary key using update actions.
     ///
-    /// UpdateItem is an upsert: if the item doesn't exist, a new item is created
+    /// `UpdateItem` is an upsert: if the item doesn't exist, a new item is created
     /// containing the key attributes plus the SET values.
     ///
     /// If `condition` is `Some`, evaluates the condition against the existing item
@@ -339,7 +339,7 @@ pub trait DataEngine: Send + Sync {
 /// TTL, tag, and table-size management operations.
 ///
 /// Methods that operate on table-scoped resources receive `account_id`.
-/// Tag methods use ARN (which embeds account_id) so they don't need it separately.
+/// Tag methods use ARN (which embeds `account_id`) so they don't need it separately.
 pub trait MetadataEngine: Send + Sync {
     /// Return the TTL configuration for a table.
     fn describe_ttl(
@@ -427,7 +427,7 @@ pub trait MetadataEngine: Send + Sync {
     fn all_active_tables(&self) -> BoxFuture<'_, Result<Vec<(String, String)>, StorageError>>;
 }
 
-/// DynamoDB Streams record storage and retrieval.
+/// `DynamoDB` Streams record storage and retrieval.
 pub trait StreamEngine: Send + Sync {
     /// Write a stream record atomically (called within the data write transaction).
     fn write_stream_record(
@@ -577,11 +577,11 @@ pub trait BackupEngine: Send + Sync {
     ) -> BoxFuture<'_, Result<TableDescription, StorageError>>;
 }
 
-/// Supertrait combining all DynamoDB operation traits.
+/// Supertrait combining all `DynamoDB` operation traits.
 ///
 /// All storage backends must implement this to provide a complete
 /// DynamoDB-compatible API. This trait has NO additional methods beyond
-/// the trait bounds — backend-specific concerns belong in ServerRuntimeHooks.
+/// the trait bounds — backend-specific concerns belong in `ServerRuntimeHooks`.
 pub trait StorageEngine:
     TableEngine + DataEngine + MetadataEngine + StreamEngine + BackupEngine + WorkerStore + Send + Sync
 {
@@ -617,7 +617,7 @@ pub trait CatalogStore:
     /// Get the cached encryption key (if available).
     ///
     /// Returns None if encryption key is not cached. This is used by
-    /// cmd_serve to construct the auth provider without re-querying
+    /// `cmd_serve` to construct the auth provider without re-querying
     /// the settings table.
     fn cached_encryption_key(&self) -> Option<String>;
 }

--- a/crates/storage/src/management_store/mod.rs
+++ b/crates/storage/src/management_store/mod.rs
@@ -157,7 +157,7 @@ pub trait ManagementStore: Send + Sync {
     /// List all accounts as `(account_id, account_name)`.
     fn list_all_accounts(&self) -> BoxFuture<'_, OpResult<Vec<(String, String)>>>;
 
-    /// List all accounts with created_at as `(account_id, account_name, created_at)`.
+    /// List all accounts with `created_at` as `(account_id, account_name, created_at)`.
     fn list_all_accounts_full(
         &self,
     ) -> BoxFuture<'_, OpResult<Vec<(String, String, time::OffsetDateTime)>>>;

--- a/crates/storage/src/operations.rs
+++ b/crates/storage/src/operations.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 DynamoDB Open contributors
+// Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Backend operations for ddbo CLI commands.
@@ -8,8 +8,8 @@
 //! support the ddbo platform lifecycle, runtime operations, and diagnostics.
 //!
 //! This is distinct from:
-//! - Data plane operations (PutItem, Query) — handled by `DataEngine`
-//! - Control plane operations (CreateTable) — handled by `TableEngine`
+//! - Data plane operations (`PutItem`, Query) — handled by `DataEngine`
+//! - Control plane operations (`CreateTable`) — handled by `TableEngine`
 //! - Management operations (IAM, accounts) — handled by `ManagementStore`
 
 use crate::error::StorageError;
@@ -72,6 +72,7 @@ pub fn get_operations_engine(backend: &str) -> Result<&'static dyn OperationsEng
 }
 
 /// List all registered backend names.
+#[must_use]
 pub fn list_operations_backends() -> Vec<&'static str> {
     inventory::iter::<OperationsEngineRegistration>()
         .map(|r| r.name)
@@ -82,7 +83,7 @@ pub fn list_operations_backends() -> Vec<&'static str> {
 
 /// Get the catalog version for a backend.
 pub fn catalog_version(backend: &str) -> Result<String, StorageError> {
-    get_operations_engine(backend).map(|ops| ops.catalog_version())
+    get_operations_engine(backend).map(OperationsEngine::catalog_version)
 }
 
 /// Redact sensitive information from a connection string.

--- a/crates/storage/src/server_components.rs
+++ b/crates/storage/src/server_components.rs
@@ -4,7 +4,7 @@
 //! Backend factory infrastructure for creating server components.
 //!
 //! This module provides the factory pattern for creating storage backends.
-//! Backends register themselves via the inventory crate, allowing cmd_serve
+//! Backends register themselves via the inventory crate, allowing `cmd_serve`
 //! to remain backend-agnostic.
 
 use std::future::Future;
@@ -20,7 +20,7 @@ use crate::{CatalogStore, StorageEngine};
 /// Components needed to run the extenddb server.
 ///
 /// Returned by backend factories. Contains all the trait objects needed
-/// by cmd_serve to start the HTTP server and spawn workers.
+/// by `cmd_serve` to start the HTTP server and spawn workers.
 pub struct ServerComponents {
     /// Storage engine implementing all data/metadata operations
     pub engine: Arc<dyn StorageEngine>,
@@ -82,8 +82,8 @@ impl std::error::Error for BackendError {}
 
 /// Factory function type for creating server components.
 ///
-/// Takes a StorageConfig trait object and region string, returns a Future
-/// that resolves to ServerComponents or BackendError.
+/// Takes a `StorageConfig` trait object and region string, returns a Future
+/// that resolves to `ServerComponents` or `BackendError`.
 pub type ServerComponentsFactory =
     fn(
         &dyn StorageConfig,
@@ -92,7 +92,7 @@ pub type ServerComponentsFactory =
 
 /// Registration for backend server components factory.
 ///
-/// Backends submit this via inventory::submit! to register themselves.
+/// Backends submit this via `inventory::submit`! to register themselves.
 pub struct ServerComponentsRegistration {
     /// Backend name (e.g., "postgres")
     pub backend: &'static str,
@@ -106,7 +106,7 @@ inventory::collect!(ServerComponentsRegistration);
 /// Create server components for the specified backend.
 ///
 /// Searches registered backends via inventory and calls the matching factory.
-/// Returns UnknownBackend error if the backend is not registered.
+/// Returns `UnknownBackend` error if the backend is not registered.
 pub async fn create_server_components(
     backend: &str,
     config: &dyn StorageConfig,

--- a/crates/storage/src/settings_store.rs
+++ b/crates/storage/src/settings_store.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 DynamoDB Open contributors
+// Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Settings store factory registry for backend-agnostic instantiation.

--- a/crates/storage/src/util/arn.rs
+++ b/crates/storage/src/util/arn.rs
@@ -5,28 +5,22 @@
 
 use crate::error::StorageError;
 
-/// Returns an ARN for the specified DynamoDB index.
+/// Returns an ARN for the specified `DynamoDB` index.
+#[must_use]
 pub fn index_arn(region: &str, account_id: &str, table_name: &str, index_name: &str) -> String {
-    format!(
-        "arn:aws:dynamodb:{}:{}:table/{}/index/{}",
-        region, account_id, table_name, index_name
-    )
+    format!("arn:aws:dynamodb:{region}:{account_id}:table/{table_name}/index/{index_name}")
 }
 
-/// Returns an ARN for the specified DynamoDB stream.
+/// Returns an ARN for the specified `DynamoDB` stream.
+#[must_use]
 pub fn stream_arn(region: &str, account_id: &str, table_name: &str, stream_label: &str) -> String {
-    format!(
-        "arn:aws:dynamodb:{}:{}:table/{}/stream/{}",
-        region, account_id, table_name, stream_label
-    )
+    format!("arn:aws:dynamodb:{region}:{account_id}:table/{table_name}/stream/{stream_label}")
 }
 
-/// Returns an ARN for the specified DynamoDB table.
+/// Returns an ARN for the specified `DynamoDB` table.
+#[must_use]
 pub fn table_arn(region: &str, account_id: &str, table_name: &str) -> String {
-    format!(
-        "arn:aws:dynamodb:{}:{}:table/{}",
-        region, account_id, table_name
-    )
+    format!("arn:aws:dynamodb:{region}:{account_id}:table/{table_name}")
 }
 
 /// Parse a stream ARN into (`table_name`, `stream_label`).

--- a/crates/storage/src/util/key.rs
+++ b/crates/storage/src/util/key.rs
@@ -23,7 +23,7 @@ pub enum SortKeyValue {
 /// For single-attribute keys, returns the value directly (no encoding).
 /// For multi-attribute keys, uses netstring encoding: each part is encoded as
 /// `<decimal-length>:<value>,` and concatenated. This is provably collision-free
-/// regardless of value content, and compatible with PostgreSQL TEXT columns
+/// regardless of value content, and compatible with `PostgreSQL` TEXT columns
 /// (no null bytes).
 pub fn composite_pk_to_text(
     item: &Item,
@@ -86,6 +86,7 @@ pub fn pk_to_text(value: &AttributeValue) -> Result<Cow<'_, str>, StorageError> 
 }
 
 /// Determine which sort key column to use based on the attribute type.
+#[must_use]
 pub fn sk_column(attr_type: ScalarAttributeType) -> &'static str {
     match attr_type {
         ScalarAttributeType::S => "sk_s",
@@ -100,6 +101,7 @@ pub fn sk_column(attr_type: ScalarAttributeType) -> &'static str {
 /// backward compatible with single-SK tables), index 1 → `sk2_s`, index 2 →
 /// `sk3_s`, etc. The offset-by-one is intentional to preserve backward
 /// compatibility with existing single-SK data tables.
+#[must_use]
 pub fn sk_column_n(index: usize, attr_type: ScalarAttributeType) -> String {
     let suffix = match attr_type {
         ScalarAttributeType::S => "s",
@@ -114,6 +116,7 @@ pub fn sk_column_n(index: usize, attr_type: ScalarAttributeType) -> String {
 }
 
 /// Look up the sort key attribute definition from the key schema.
+#[must_use]
 pub fn sk_info<'a>(
     key_schema: &'a [KeySchemaElement],
     attr_defs: &'a [AttributeDefinition],
@@ -129,6 +132,7 @@ pub fn sk_info<'a>(
 ///
 /// Format: `<len>:<value>,<len>:<value>,...` — e.g., `"abc"` + `"de"` → `"3:abc,2:de,"`.
 /// This encoding is unambiguous for arbitrary byte content and contains no null bytes.
+#[must_use]
 pub fn encode_netstring_composite(parts: &[String]) -> String {
     let mut out = String::new();
     for p in parts {


### PR DESCRIPTION
- Update 7 files with old 'DynamoDB Open' copyright to 'ExtendDB contributors'
- Rename _backend field to backend (resolves underscore-prefix warnings)
- Apply clippy auto-fixes: redundant closures, format string variables, unnecessary raw string hashes, missing backtick docs, must_use attributes
- Rewrite match-to-let-else patterns (6 instances)
- Fix long literal lacking separators in build.rs
- Fix Map::default() clarity warning

Clippy pedantic count: 504 -> 171 (66% reduction)

## What

<!-- Describe what this PR changes. -->

## Why

<!-- Link the issue this addresses. Explain the motivation. -->

Closes #

## Testing done

<!-- How did you verify this change works? Include test commands or output. -->

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [ ] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: <!-- link or "n/a" -->

## Breaking changes

<!-- If this PR introduces breaking changes, describe them here. Otherwise delete this section. -->

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
