### PR TITLE
Fix/projection overlapping paths across every read API

### DIFF
--- a/crates/core/src/expression/mod.rs
+++ b/crates/core/src/expression/mod.rs
@@ -26,7 +26,7 @@ pub use evaluator::evaluate_condition;
 pub use key_condition::{KeyCondition, SortKeyCondition, parse_key_condition};
 pub use kind::ExpressionKind;
 pub use parser::{parse_condition, parse_condition_with_depth_limit};
-pub use projection::{apply_projection, parse_projection};
+pub use projection::{apply_projection, detect_overlapping_paths, parse_projection};
 pub use reserved_words::validate_no_reserved_words;
 pub use resolver::{
     ExpressionMaps, collect_key_condition_refs, collect_value_placeholders, resolve_element_name,

--- a/crates/core/src/expression/mod.rs
+++ b/crates/core/src/expression/mod.rs
@@ -26,7 +26,7 @@ pub use evaluator::evaluate_condition;
 pub use key_condition::{KeyCondition, SortKeyCondition, parse_key_condition};
 pub use kind::ExpressionKind;
 pub use parser::{parse_condition, parse_condition_with_depth_limit};
-pub use projection::{apply_projection, detect_overlapping_paths, parse_projection};
+pub use projection::{Projection, parse_projection};
 pub use reserved_words::validate_no_reserved_words;
 pub use resolver::{
     ExpressionMaps, collect_key_condition_refs, collect_value_placeholders, resolve_element_name,

--- a/crates/core/src/expression/projection.rs
+++ b/crates/core/src/expression/projection.rs
@@ -84,6 +84,81 @@ pub fn apply_projection(
     Ok(result)
 }
 
+/// A path element after `#name` resolution, used for overlap detection.
+#[derive(PartialEq, Eq)]
+enum ResolvedElement {
+    Attr(String),
+    Index(usize),
+}
+
+/// Reject a `ProjectionExpression` whose paths overlap, matching Amazon DynamoDB.
+///
+/// Two paths overlap when one is a prefix of the other (this includes equal
+/// paths), for example `a` and `a.b`, or `a[0]` and `a[0].b`, or a duplicate
+/// `a` and `a`. Sibling paths such as `a.b` and `a.c`, or `a[0]` and `a[1]`,
+/// do not overlap. `#name` references are resolved first, so the reported
+/// paths use the resolved attribute names. The first offending pair in
+/// expression order is reported.
+///
+/// # Errors
+///
+/// Returns `ValidationException` with the overlap message, or an unresolvable
+/// `#name` reference error.
+pub fn detect_overlapping_paths(
+    paths: &[Vec<PathElement>],
+    maps: &ExpressionMaps,
+) -> Result<(), DynamoDbError> {
+    let mut resolved: Vec<Vec<ResolvedElement>> = Vec::with_capacity(paths.len());
+    for path in paths {
+        if path.is_empty() {
+            continue;
+        }
+        let mut elems = Vec::with_capacity(path.len());
+        for element in path {
+            match element {
+                PathElement::Attribute(raw) => {
+                    elems.push(ResolvedElement::Attr(
+                        resolve_name_ref(raw, maps)?.into_owned(),
+                    ));
+                }
+                PathElement::Index(idx) => elems.push(ResolvedElement::Index(*idx)),
+            }
+        }
+        resolved.push(elems);
+    }
+
+    for i in 0..resolved.len() {
+        for j in (i + 1)..resolved.len() {
+            if is_prefix(&resolved[i], &resolved[j]) || is_prefix(&resolved[j], &resolved[i]) {
+                return Err(DynamoDbError::ValidationException(format!(
+                    "Invalid ProjectionExpression: Two document paths overlap with each other; \
+                     must remove or rewrite one of these paths; path one: {}, path two: {}",
+                    render_path(&resolved[i]),
+                    render_path(&resolved[j]),
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Return true when `a` is a prefix of `b` (equal paths included).
+fn is_prefix(a: &[ResolvedElement], b: &[ResolvedElement]) -> bool {
+    a.len() <= b.len() && a == &b[..a.len()]
+}
+
+/// Render a resolved path as DynamoDB does: `[a, [0], b]`.
+fn render_path(path: &[ResolvedElement]) -> String {
+    let parts: Vec<String> = path
+        .iter()
+        .map(|el| match el {
+            ResolvedElement::Attr(name) => name.clone(),
+            ResolvedElement::Index(idx) => format!("[{idx}]"),
+        })
+        .collect();
+    format!("[{}]", parts.join(", "))
+}
+
 /// Build the projection trie from the parsed paths, resolving `#name` refs.
 fn build_trie(
     paths: &[Vec<PathElement>],
@@ -451,6 +526,92 @@ mod tests {
         expected.insert("a".into(), AttributeValue::S("av".into()));
         expected.insert("c".into(), AttributeValue::S("cv".into()));
         assert_list(&result, "l", &[AttributeValue::M(expected)]);
+    }
+
+    fn check_overlap(expr: &str, names: HashMap<String, String>) -> Result<(), DynamoDbError> {
+        let tokens = tokenize(expr).unwrap();
+        let paths = parse_projection(&tokens).unwrap();
+        let maps = ExpressionMaps::new(names, HashMap::new());
+        detect_overlapping_paths(&paths, &maps)
+    }
+
+    fn overlap_msg(expr: &str) -> String {
+        match check_overlap(expr, HashMap::new()) {
+            Err(DynamoDbError::ValidationException(m)) => m,
+            other => panic!("expected ValidationException, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn overlap_parent_then_child() {
+        assert_eq!(
+            overlap_msg("a, a.b"),
+            "Invalid ProjectionExpression: Two document paths overlap with each other; \
+             must remove or rewrite one of these paths; path one: [a], path two: [a, b]"
+        );
+    }
+
+    #[test]
+    fn overlap_child_then_parent() {
+        assert_eq!(
+            overlap_msg("a.b, a"),
+            "Invalid ProjectionExpression: Two document paths overlap with each other; \
+             must remove or rewrite one of these paths; path one: [a, b], path two: [a]"
+        );
+    }
+
+    #[test]
+    fn overlap_exact_duplicate() {
+        assert_eq!(
+            overlap_msg("a, a"),
+            "Invalid ProjectionExpression: Two document paths overlap with each other; \
+             must remove or rewrite one of these paths; path one: [a], path two: [a]"
+        );
+    }
+
+    #[test]
+    fn overlap_index_path_rendering() {
+        assert_eq!(
+            overlap_msg("a[0], a"),
+            "Invalid ProjectionExpression: Two document paths overlap with each other; \
+             must remove or rewrite one of these paths; path one: [a, [0]], path two: [a]"
+        );
+        assert_eq!(
+            overlap_msg("a[0].b, a[0]"),
+            "Invalid ProjectionExpression: Two document paths overlap with each other; \
+             must remove or rewrite one of these paths; path one: [a, [0], b], path two: [a, [0]]"
+        );
+    }
+
+    #[test]
+    fn overlap_reports_first_pair_in_order() {
+        assert_eq!(
+            overlap_msg("x, a.b, a"),
+            "Invalid ProjectionExpression: Two document paths overlap with each other; \
+             must remove or rewrite one of these paths; path one: [a, b], path two: [a]"
+        );
+    }
+
+    #[test]
+    fn overlap_uses_resolved_names() {
+        let mut names = HashMap::new();
+        names.insert("p".into(), "a".into());
+        names.insert("q".into(), "b".into());
+        match check_overlap("#p, #p.#q", names) {
+            Err(DynamoDbError::ValidationException(m)) => assert_eq!(
+                m,
+                "Invalid ProjectionExpression: Two document paths overlap with each other; \
+                 must remove or rewrite one of these paths; path one: [a], path two: [a, b]"
+            ),
+            other => panic!("expected ValidationException, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_overlap_for_siblings() {
+        assert!(check_overlap("a.b, a.c", HashMap::new()).is_ok());
+        assert!(check_overlap("a[0], a[1]", HashMap::new()).is_ok());
+        assert!(check_overlap("a, b, c", HashMap::new()).is_ok());
     }
 
     #[test]

--- a/crates/core/src/expression/projection.rs
+++ b/crates/core/src/expression/projection.rs
@@ -9,7 +9,7 @@
 use std::collections::BTreeMap;
 
 use super::ast::PathElement;
-use super::resolver::{ExpressionMaps, resolve_element_name, resolve_name_ref};
+use super::resolver::{ExpressionMaps, resolve_name_ref};
 use super::tokenizer::Token;
 use crate::error::DynamoDbError;
 use crate::types::{AttributeValue, Item};
@@ -55,78 +55,117 @@ struct ProjNode {
     indices: BTreeMap<usize, ProjNode>,
 }
 
-/// Apply a projection to an item, returning only the requested attributes.
-///
-/// List elements selected by index are returned in a new list compacted in
-/// ascending original-index order (matching Amazon DynamoDB), not in the order
-/// the indices appear in the expression. Map keys not on a projected path are
-/// dropped. The structure of the original item is otherwise preserved.
-///
-/// # Errors
-///
-/// Returns `ValidationException` for unresolvable `#name` references or a path
-/// that starts with an index.
-pub fn apply_projection(
+/// A compiled projection: `#name` references resolved and paths merged into a
+/// trie. Compile once per request, then apply to any number of items.
+pub struct Projection {
+    root: ProjNode,
+}
+
+impl Projection {
+    /// Compile parsed paths into a trie, resolving `#name` references once.
+    /// With `reject_overlap`, rejects paths where one is a prefix of another
+    /// (DynamoDB's rule); pass `false` for desugared `AttributesToGet`.
+    pub fn compile(
+        paths: &[Vec<PathElement>],
+        maps: &ExpressionMaps,
+        reject_overlap: bool,
+    ) -> Result<Self, DynamoDbError> {
+        let resolved = resolve_paths(paths, maps).map_err(prefix_projection_error)?;
+        if reject_overlap {
+            check_overlap(&resolved)?;
+        }
+        Ok(Self {
+            root: build_trie(resolved),
+        })
+    }
+
+    /// Apply the projection to an item, returning only the requested attributes.
+    ///
+    /// List elements selected by index are returned in a new list compacted in
+    /// ascending original-index order (matching Amazon DynamoDB), not in the
+    /// order the indices appear in the expression. Map keys not on a projected
+    /// path are dropped. The structure of the original item is otherwise
+    /// preserved.
+    #[must_use]
+    pub fn apply(&self, item: &Item) -> Item {
+        let mut result = BTreeMap::new();
+        for (name, child) in &self.root.attrs {
+            if let Some(val) = item.get(name)
+                && let Some(projected) = project_value(val, child)
+            {
+                result.insert(name.clone(), projected);
+            }
+        }
+        result
+    }
+}
+
+/// Compile (no overlap rejection) and apply to one item. Test-only helper;
+/// production callers compile once via `Projection::compile` and apply per item.
+#[cfg(test)]
+fn apply_projection(
     item: &Item,
     paths: &[Vec<PathElement>],
     maps: &ExpressionMaps,
 ) -> Result<Item, DynamoDbError> {
-    let root = build_trie(paths, maps)?;
-
-    let mut result = BTreeMap::new();
-    for (name, child) in &root.attrs {
-        if let Some(val) = item.get(name)
-            && let Some(projected) = project_value(val, child)
-        {
-            result.insert(name.clone(), projected);
-        }
-    }
-    Ok(result)
+    Ok(Projection::compile(paths, maps, false)?.apply(item))
 }
 
-/// A path element after `#name` resolution, used for overlap detection.
+/// Prefix a projection resolve error with `Invalid ProjectionExpression:`,
+/// matching Amazon DynamoDB. Messages already carrying an `Invalid ` prefix
+/// (for example a path that starts with an index) are left unchanged.
+fn prefix_projection_error(err: DynamoDbError) -> DynamoDbError {
+    match err {
+        DynamoDbError::ValidationException(msg) if !msg.starts_with("Invalid ") => {
+            DynamoDbError::ValidationException(format!("Invalid ProjectionExpression: {msg}"))
+        }
+        other => other,
+    }
+}
+
+/// A path element after `#name` resolution.
 #[derive(PartialEq, Eq)]
 enum ResolvedElement {
     Attr(String),
     Index(usize),
 }
 
-/// Reject a `ProjectionExpression` whose paths overlap, matching Amazon DynamoDB.
-///
-/// Two paths overlap when one is a prefix of the other (this includes equal
-/// paths), for example `a` and `a.b`, or `a[0]` and `a[0].b`, or a duplicate
-/// `a` and `a`. Sibling paths such as `a.b` and `a.c`, or `a[0]` and `a[1]`,
-/// do not overlap. `#name` references are resolved first, so the reported
-/// paths use the resolved attribute names. The first offending pair in
-/// expression order is reported.
-///
-/// # Errors
-///
-/// Returns `ValidationException` with the overlap message, or an unresolvable
-/// `#name` reference error.
-pub fn detect_overlapping_paths(
+/// Resolve `#name` references in parsed paths, rejecting index-start paths.
+fn resolve_paths(
     paths: &[Vec<PathElement>],
     maps: &ExpressionMaps,
-) -> Result<(), DynamoDbError> {
-    let mut resolved: Vec<Vec<ResolvedElement>> = Vec::with_capacity(paths.len());
+) -> Result<Vec<Vec<ResolvedElement>>, DynamoDbError> {
+    let mut resolved = Vec::with_capacity(paths.len());
     for path in paths {
         if path.is_empty() {
             continue;
         }
         let mut elems = Vec::with_capacity(path.len());
-        for element in path {
+        for (i, element) in path.iter().enumerate() {
             match element {
                 PathElement::Attribute(raw) => {
                     elems.push(ResolvedElement::Attr(
                         resolve_name_ref(raw, maps)?.into_owned(),
                     ));
                 }
-                PathElement::Index(idx) => elems.push(ResolvedElement::Index(*idx)),
+                PathElement::Index(idx) => {
+                    if i == 0 {
+                        return Err(DynamoDbError::ValidationException(
+                            "Invalid expression: path cannot start with an index".to_owned(),
+                        ));
+                    }
+                    elems.push(ResolvedElement::Index(*idx));
+                }
             }
         }
         resolved.push(elems);
     }
+    Ok(resolved)
+}
 
+/// Reject paths where one is a prefix of another (DynamoDB's overlap rule),
+/// reporting the first offending pair in expression order. Siblings are fine.
+fn check_overlap(resolved: &[Vec<ResolvedElement>]) -> Result<(), DynamoDbError> {
     for i in 0..resolved.len() {
         for j in (i + 1)..resolved.len() {
             if is_prefix(&resolved[i], &resolved[j]) || is_prefix(&resolved[j], &resolved[i]) {
@@ -159,45 +198,20 @@ fn render_path(path: &[ResolvedElement]) -> String {
     format!("[{}]", parts.join(", "))
 }
 
-/// Build the projection trie from the parsed paths, resolving `#name` refs.
-fn build_trie(
-    paths: &[Vec<PathElement>],
-    maps: &ExpressionMaps,
-) -> Result<ProjNode, DynamoDbError> {
+/// Build the projection trie from resolved paths.
+fn build_trie(resolved: Vec<Vec<ResolvedElement>>) -> ProjNode {
     let mut root = ProjNode::default();
-    for path in paths {
-        if path.is_empty() {
-            continue;
-        }
+    for path in resolved {
         let mut node = &mut root;
-        for (i, element) in path.iter().enumerate() {
-            match element {
-                PathElement::Attribute(_) => {
-                    // The first element must be an attribute; `resolve_element_name`
-                    // rejects an index-start path, matching the prior behavior.
-                    let name = if i == 0 {
-                        resolve_element_name(element, maps)?
-                    } else {
-                        let PathElement::Attribute(raw) = element else {
-                            unreachable!()
-                        };
-                        resolve_name_ref(raw, maps)?
-                    };
-                    node = node.attrs.entry(name.into_owned()).or_default();
-                }
-                PathElement::Index(idx) => {
-                    if i == 0 {
-                        return Err(DynamoDbError::ValidationException(
-                            "Invalid expression: path cannot start with an index".to_owned(),
-                        ));
-                    }
-                    node = node.indices.entry(*idx).or_default();
-                }
-            }
+        for element in path {
+            node = match element {
+                ResolvedElement::Attr(name) => node.attrs.entry(name).or_default(),
+                ResolvedElement::Index(idx) => node.indices.entry(idx).or_default(),
+            };
         }
         node.terminal = true;
     }
-    Ok(root)
+    root
 }
 
 /// Project a single value against a trie node.
@@ -532,7 +546,30 @@ mod tests {
         let tokens = tokenize(expr).unwrap();
         let paths = parse_projection(&tokens).unwrap();
         let maps = ExpressionMaps::new(names, HashMap::new());
-        detect_overlapping_paths(&paths, &maps)
+        Projection::compile(&paths, &maps, true).map(|_| ())
+    }
+
+    #[test]
+    fn compile_without_overlap_rejection_accepts_duplicates() {
+        // Desugared AttributesToGet keeps the legacy accept-duplicates behavior.
+        let tokens = tokenize("a, a").unwrap();
+        let paths = parse_projection(&tokens).unwrap();
+        let maps = ExpressionMaps::new(HashMap::new(), HashMap::new());
+        assert!(Projection::compile(&paths, &maps, false).is_ok());
+    }
+
+    #[test]
+    fn compiled_projection_reusable_across_items() {
+        let tokens = tokenize("name").unwrap();
+        let paths = parse_projection(&tokens).unwrap();
+        let maps = ExpressionMaps::new(HashMap::new(), HashMap::new());
+        let proj = Projection::compile(&paths, &maps, true).unwrap();
+        let item = sample_item();
+        for _ in 0..2 {
+            let out = proj.apply(&item);
+            assert_eq!(out.len(), 1);
+            assert!(out.contains_key("name"));
+        }
     }
 
     fn overlap_msg(expr: &str) -> String {

--- a/crates/engine/src/batch_get_item.rs
+++ b/crates/engine/src/batch_get_item.rs
@@ -143,6 +143,10 @@ pub async fn handle_batch_get_item(
                 ka.expression_attribute_names.as_ref(),
                 paths,
             )?;
+            crate::read_helpers::validate_projection_overlap(
+                ka.expression_attribute_names.as_ref(),
+                paths,
+            )?;
         }
         let ean = if extra_proj_names.is_empty() {
             ka.expression_attribute_names.as_ref()

--- a/crates/engine/src/batch_get_item.rs
+++ b/crates/engine/src/batch_get_item.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use serde_json::Value;
 
 use extenddb_core::error::DynamoDbError;
-use extenddb_core::expression::apply_projection;
+use extenddb_core::expression::Projection;
 use extenddb_core::types::{BatchGetItemInput, BatchGetItemOutput, Item, item_size_bytes};
 use extenddb_core::validation::validate_batch_key_only;
 
@@ -125,7 +125,7 @@ pub async fn handle_batch_get_item(
             (None, HashMap::new())
         };
 
-        let projection = if let Some(ref proj_str) = effective_proj_str {
+        let parsed_projection = if let Some(ref proj_str) = effective_proj_str {
             Some(crate::expression_helpers::parse_projection_expr(
                 proj_str,
                 &ctx.limits,
@@ -133,34 +133,36 @@ pub async fn handle_batch_get_item(
         } else {
             None
         };
-        // Reject ExpressionAttributeNames entries the projection never
+        let maps = if extra_proj_names.is_empty() {
+            build_expression_maps(ka.expression_attribute_names.as_ref(), None)
+        } else {
+            // Merge extra names with any user-provided names.
+            let mut merged = ka.expression_attribute_names.clone().unwrap_or_default();
+            merged.extend(extra_proj_names);
+            build_expression_maps(Some(&merged), None)
+        };
+        // Compile once per table: resolves #names and rejects overlapping
+        // paths. DynamoDB checks overlap before the unused-name check, so this
+        // runs first. Overlap rejection is scoped to a user-supplied expression.
+        let projection = match parsed_projection {
+            Some(ref paths) => Some(Projection::compile(
+                paths,
+                &maps,
+                ka.projection_expression.is_some(),
+            )?),
+            None => None,
+        };
+        // Then reject ExpressionAttributeNames entries the projection never
         // references, matching Amazon DynamoDB. Scoped to a user-supplied
-        // ProjectionExpression; desugared AttributesToGet uses synthetic names.
+        // ProjectionExpression.
         if ka.projection_expression.is_some()
-            && let Some(ref paths) = projection
+            && let Some(ref paths) = parsed_projection
         {
             crate::read_helpers::validate_projection_unused_names(
                 ka.expression_attribute_names.as_ref(),
                 paths,
             )?;
-            crate::read_helpers::validate_projection_overlap(
-                ka.expression_attribute_names.as_ref(),
-                paths,
-            )?;
         }
-        let ean = if extra_proj_names.is_empty() {
-            ka.expression_attribute_names.as_ref()
-        } else {
-            // Merge extra names with any user-provided names.
-            None // extra_proj_names used directly below
-        };
-        let maps = if extra_proj_names.is_empty() {
-            build_expression_maps(ean, None)
-        } else {
-            let mut merged = ka.expression_attribute_names.clone().unwrap_or_default();
-            merged.extend(extra_proj_names);
-            build_expression_maps(Some(&merged), None)
-        };
 
         let mut table_items: Vec<Item> = Vec::new();
         let mut seen_keys: HashSet<Vec<u8>> = HashSet::with_capacity(ka.keys.len());
@@ -186,8 +188,8 @@ pub async fn handle_batch_get_item(
                 *per_table_rcu.entry(table_name.clone()).or_default() += item_rcu;
                 total_pre_proj_bytes += size;
                 returned_count += 1;
-                let item = if let Some(ref paths) = projection {
-                    apply_projection(&item, paths, &maps)?
+                let item = if let Some(ref projection) = projection {
+                    projection.apply(&item)
                 } else {
                     item
                 };

--- a/crates/engine/src/get_item.rs
+++ b/crates/engine/src/get_item.rs
@@ -128,6 +128,10 @@ pub async fn handle_get_item(
                     input.expression_attribute_names.as_ref(),
                     &parsed,
                 )?;
+                crate::read_helpers::validate_projection_overlap(
+                    input.expression_attribute_names.as_ref(),
+                    &parsed,
+                )?;
             }
             Some(parsed)
         }

--- a/crates/engine/src/get_item.rs
+++ b/crates/engine/src/get_item.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use serde_json::Value;
 
 use extenddb_core::error::DynamoDbError;
-use extenddb_core::expression::apply_projection;
+use extenddb_core::expression::Projection;
 use extenddb_core::types::GetItemInput;
 use extenddb_core::types::GetItemOutput;
 use extenddb_core::types::item_size_bytes;
@@ -116,33 +116,32 @@ pub async fn handle_get_item(
     };
 
     // Parse and validate the projection once, before the item fetch result
-    // matters, so the unused-name check runs whether or not the item exists.
+    // matters, so validation runs whether or not the item exists.
     let projection = match effective_projection {
         Some(ref proj_str) => {
             let parsed = crate::expression_helpers::parse_projection_expr(proj_str, &ctx.limits)?;
-            // Reject ExpressionAttributeNames entries the projection never
-            // references. Scoped to a user-supplied ProjectionExpression;
-            // desugared AttributesToGet uses synthetic placeholders.
+            // Compile once: resolves #names and rejects overlapping paths.
+            // DynamoDB checks overlap before the unused-name check, so this
+            // runs first. Overlap rejection is scoped to a user-supplied
+            // expression.
+            let maps = build_expression_maps(effective_proj_names.as_ref(), None);
+            let compiled =
+                Projection::compile(&parsed, &maps, input.projection_expression.is_some())?;
+            // Then reject ExpressionAttributeNames entries the projection never
+            // references. Scoped to a user-supplied ProjectionExpression.
             if input.projection_expression.is_some() {
                 crate::read_helpers::validate_projection_unused_names(
                     input.expression_attribute_names.as_ref(),
                     &parsed,
                 )?;
-                crate::read_helpers::validate_projection_overlap(
-                    input.expression_attribute_names.as_ref(),
-                    &parsed,
-                )?;
             }
-            Some(parsed)
+            Some(compiled)
         }
         None => None,
     };
 
     let item = match (projection, item) {
-        (Some(paths), Some(fetched)) => {
-            let maps = build_expression_maps(effective_proj_names.as_ref(), None);
-            Some(apply_projection(&fetched, &paths, &maps)?)
-        }
+        (Some(projection), Some(fetched)) => Some(projection.apply(&fetched)),
         (_, item) => item,
     };
 

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -304,6 +304,15 @@ pub async fn handle_query(
         None
     };
 
+    if input.projection_expression.is_some()
+        && let Some(ref paths) = projection
+    {
+        crate::read_helpers::validate_projection_overlap(
+            input.expression_attribute_names.as_ref(),
+            paths,
+        )?;
+    }
+
     // Validate unused expression attributes
     {
         let exprs: Vec<&extenddb_core::expression::Expr> = filter.iter().collect();

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use extenddb_core::error::DynamoDbError;
 use extenddb_core::expression::PathElement;
 use extenddb_core::expression::{
-    ExpressionKind, ExpressionMaps, parse_key_condition, tokenize_for,
+    ExpressionKind, ExpressionMaps, Projection, parse_key_condition, tokenize_for,
 };
 use extenddb_core::types::{
     IndexType, KeyType, QueryInput, QueryOutput, Select, TableKeyInfo, extract_key, item_size_bytes,
@@ -304,14 +304,24 @@ pub async fn handle_query(
         None
     };
 
-    if input.projection_expression.is_some()
-        && let Some(ref paths) = projection
-    {
-        crate::read_helpers::validate_projection_overlap(
-            input.expression_attribute_names.as_ref(),
-            paths,
-        )?;
-    }
+    // Compile once: resolves #names and rejects overlapping paths. Overlap
+    // rejection is scoped to a user-supplied ProjectionExpression.
+    let compiled_projection = match projection {
+        Some(ref paths) => {
+            let mut names = maps.names.clone();
+            for (k, v) in &extra_proj_names {
+                let stripped = k.strip_prefix('#').unwrap_or(k);
+                names.insert(stripped.to_owned(), v.clone());
+            }
+            let proj_maps = ExpressionMaps::new(names, HashMap::new());
+            Some(Projection::compile(
+                paths,
+                &proj_maps,
+                input.projection_expression.is_some(),
+            )?)
+        }
+        None => None,
+    };
 
     // Validate unused expression attributes
     {
@@ -441,7 +451,7 @@ pub async fn handle_query(
         &raw_items,
         enriched_storage_last_key,
         &filter,
-        &projection,
+        compiled_projection.as_ref(),
         &combined_maps,
         &lek_key_schema,
         input.select.as_ref(),

--- a/crates/engine/src/read_helpers.rs
+++ b/crates/engine/src/read_helpers.rs
@@ -11,8 +11,7 @@ use std::collections::{HashMap, HashSet};
 
 use extenddb_core::error::DynamoDbError;
 use extenddb_core::expression::{
-    Expr, ExpressionMaps, PathElement, apply_projection, detect_overlapping_paths,
-    evaluate_condition, validate_unused_attributes,
+    Expr, ExpressionMaps, PathElement, Projection, evaluate_condition, validate_unused_attributes,
 };
 use extenddb_core::types::{
     IndexInfo, Item, KeySchemaElement, Select, extract_key, item_size_bytes,
@@ -26,8 +25,10 @@ use crate::index_helpers::apply_index_projection;
 /// `validate_unused_attributes`, narrowed to read handlers that accept only a
 /// projection (`GetItem`, `BatchGetItem`). `names` is the raw request map with
 /// keys still carrying their `#` prefix. The caller passes this only for a
-/// user-supplied `ProjectionExpression`; desugared `AttributesToGet` uses
-/// synthetic placeholders and is governed by a separate rule.
+/// user-supplied `ProjectionExpression`. Desugared `AttributesToGet` uses
+/// synthetic placeholders, so it is not checked here; duplicate
+/// `AttributesToGet` entries are currently accepted (a divergence from
+/// Amazon DynamoDB, tracked separately).
 ///
 /// # Errors
 ///
@@ -59,23 +60,6 @@ pub fn validate_projection_unused_names(
     )
 }
 
-/// Reject a user-supplied `ProjectionExpression` whose paths overlap.
-///
-/// Resolves `#name` references using `names`, then matches Amazon DynamoDB's
-/// "Two document paths overlap" validation. Scoped to a user-supplied
-/// `ProjectionExpression`; desugared `AttributesToGet` is governed separately.
-///
-/// # Errors
-///
-/// Returns `DynamoDbError::ValidationException` when two paths overlap.
-pub fn validate_projection_overlap(
-    names: Option<&HashMap<String, String>>,
-    projection: &[Vec<PathElement>],
-) -> Result<(), DynamoDbError> {
-    let maps = crate::expression_helpers::build_expression_maps(names, None);
-    detect_overlapping_paths(projection, &maps)
-}
-
 /// Result of the post-read processing pipeline.
 pub struct PostReadResult {
     pub items: Option<Vec<Item>>,
@@ -94,7 +78,7 @@ pub fn apply_post_read(
     raw_items: &[Item],
     storage_last_key: Option<Item>,
     filter: &Option<Expr>,
-    projection: &Option<Vec<Vec<PathElement>>>,
+    projection: Option<&Projection>,
     maps: &ExpressionMaps,
     lek_key_schema: &[KeySchemaElement],
     select: Option<&Select>,
@@ -140,8 +124,8 @@ pub fn apply_post_read(
         filtered_count += 1;
 
         if !is_count {
-            let projected = if let Some(paths) = projection {
-                apply_projection(item, paths, maps)?
+            let projected = if let Some(proj) = projection {
+                proj.apply(item)
             } else if let Some(idx) = index_proj {
                 apply_index_projection(item, idx, base_key_schema)
             } else {

--- a/crates/engine/src/read_helpers.rs
+++ b/crates/engine/src/read_helpers.rs
@@ -11,8 +11,8 @@ use std::collections::{HashMap, HashSet};
 
 use extenddb_core::error::DynamoDbError;
 use extenddb_core::expression::{
-    Expr, ExpressionMaps, PathElement, apply_projection, evaluate_condition,
-    validate_unused_attributes,
+    Expr, ExpressionMaps, PathElement, apply_projection, detect_overlapping_paths,
+    evaluate_condition, validate_unused_attributes,
 };
 use extenddb_core::types::{
     IndexInfo, Item, KeySchemaElement, Select, extract_key, item_size_bytes,
@@ -57,6 +57,23 @@ pub fn validate_projection_unused_names(
         &used_names,
         &HashSet::new(),
     )
+}
+
+/// Reject a user-supplied `ProjectionExpression` whose paths overlap.
+///
+/// Resolves `#name` references using `names`, then matches Amazon DynamoDB's
+/// "Two document paths overlap" validation. Scoped to a user-supplied
+/// `ProjectionExpression`; desugared `AttributesToGet` is governed separately.
+///
+/// # Errors
+///
+/// Returns `DynamoDbError::ValidationException` when two paths overlap.
+pub fn validate_projection_overlap(
+    names: Option<&HashMap<String, String>>,
+    projection: &[Vec<PathElement>],
+) -> Result<(), DynamoDbError> {
+    let maps = crate::expression_helpers::build_expression_maps(names, None);
+    detect_overlapping_paths(projection, &maps)
 }
 
 /// Result of the post-read processing pipeline.

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use serde_json::Value;
 
 use extenddb_core::error::DynamoDbError;
-use extenddb_core::expression::{ExpressionKind, ExpressionMaps};
+use extenddb_core::expression::{ExpressionKind, ExpressionMaps, Projection};
 use extenddb_core::types::{
     IndexType, ScanInput, ScanOutput, Select, TableKeyInfo, extract_key, item_size_bytes,
 };
@@ -231,14 +231,24 @@ pub async fn handle_scan(
         None
     };
 
-    if input.projection_expression.is_some()
-        && let Some(ref paths) = projection
-    {
-        crate::read_helpers::validate_projection_overlap(
-            input.expression_attribute_names.as_ref(),
-            paths,
-        )?;
-    }
+    // Compile once: resolves #names and rejects overlapping paths. Overlap
+    // rejection is scoped to a user-supplied ProjectionExpression.
+    let compiled_projection = match projection {
+        Some(ref paths) => {
+            let mut names = maps.names.clone();
+            for (k, v) in &extra_proj_names {
+                let stripped = k.strip_prefix('#').unwrap_or(k);
+                names.insert(stripped.to_owned(), v.clone());
+            }
+            let proj_maps = ExpressionMaps::new(names, HashMap::new());
+            Some(Projection::compile(
+                paths,
+                &proj_maps,
+                input.projection_expression.is_some(),
+            )?)
+        }
+        None => None,
+    };
 
     // Validate unused expression attributes
     {
@@ -354,7 +364,7 @@ pub async fn handle_scan(
         &raw_items,
         enriched_storage_last_key,
         &filter,
-        &projection,
+        compiled_projection.as_ref(),
         &combined_maps,
         &lek_key_schema,
         input.select.as_ref(),

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -231,6 +231,15 @@ pub async fn handle_scan(
         None
     };
 
+    if input.projection_expression.is_some()
+        && let Some(ref paths) = projection
+    {
+        crate::read_helpers::validate_projection_overlap(
+            input.expression_attribute_names.as_ref(),
+            paths,
+        )?;
+    }
+
     // Validate unused expression attributes
     {
         let exprs: Vec<&extenddb_core::expression::Expr> = filter.iter().collect();

--- a/crates/engine/src/transact_get_items.rs
+++ b/crates/engine/src/transact_get_items.rs
@@ -137,6 +137,10 @@ pub async fn handle_transact_get_items(
                     ExpressionKind::Projection,
                 )?;
                 let projection = parse_projection(&proj_tokens)?;
+                crate::read_helpers::validate_projection_overlap(
+                    tgi.get.expression_attribute_names.as_ref(),
+                    &projection,
+                )?;
                 let mut extra_names = std::collections::HashSet::new();
                 for path in &projection {
                     for el in path {

--- a/crates/engine/src/transact_get_items.rs
+++ b/crates/engine/src/transact_get_items.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 use serde_json::Value;
 
 use extenddb_core::error::DynamoDbError;
-use extenddb_core::expression::{ExpressionKind, apply_projection, parse_projection, tokenize_for};
+use extenddb_core::expression::{ExpressionKind, Projection, parse_projection, tokenize_for};
 use extenddb_core::types::{
     ItemResponse, TransactGetItemsInput, TransactGetItemsOutput, item_size_bytes,
 };
@@ -82,6 +82,45 @@ pub async fn handle_transact_get_items(
         key_infos.push(key_info);
     }
 
+    // Validate and compile each projection before the transactional read, so a
+    // malformed request fails with ValidationException instead of executing the
+    // transaction. DynamoDB checks overlap before the unused-name check.
+    let mut projections: Vec<Option<Projection>> = Vec::with_capacity(input.transact_items.len());
+    for tgi in &input.transact_items {
+        if let Some(ref proj_str) = tgi.get.projection_expression {
+            let maps = build_expression_maps(tgi.get.expression_attribute_names.as_ref(), None);
+            let proj_tokens = tokenize_for(
+                proj_str,
+                ctx.limits.max_expression_tokens,
+                ExpressionKind::Projection,
+            )?;
+            let projection = parse_projection(&proj_tokens)?;
+            let compiled = Projection::compile(&projection, &maps, true)?;
+            let mut extra_names = HashSet::new();
+            for path in &projection {
+                for el in path {
+                    if let extenddb_core::expression::PathElement::Attribute(name) = el
+                        && let Some(ref_name) = name.strip_prefix('#')
+                    {
+                        extra_names.insert(ref_name.to_owned());
+                    }
+                }
+            }
+            extenddb_core::expression::validate_unused_attributes(
+                &maps.names,
+                &maps.values,
+                &[],
+                &[],
+                &extra_names,
+                &HashSet::new(),
+            )?;
+            projections.push(Some(compiled));
+        } else {
+            // No projection: transactions accept names with no expression.
+            projections.push(None);
+        }
+    }
+
     // Build storage operations
     let ops: Vec<TransactGetOp<'_>> = input
         .transact_items
@@ -124,52 +163,18 @@ pub async fn handle_transact_get_items(
         .sum();
     let returned_count = items.iter().filter(|opt| opt.is_some()).count() as u64;
 
-    // Apply per-item projection
+    // Apply per-item projection using the projections compiled before the read.
     let responses: Vec<ItemResponse> = items
         .into_iter()
-        .zip(input.transact_items.iter())
-        .map(|(opt, tgi)| {
-            let maps = build_expression_maps(tgi.get.expression_attribute_names.as_ref(), None);
-            if let Some(ref proj_str) = tgi.get.projection_expression {
-                let proj_tokens = tokenize_for(
-                    proj_str,
-                    ctx.limits.max_expression_tokens,
-                    ExpressionKind::Projection,
-                )?;
-                let projection = parse_projection(&proj_tokens)?;
-                crate::read_helpers::validate_projection_overlap(
-                    tgi.get.expression_attribute_names.as_ref(),
-                    &projection,
-                )?;
-                let mut extra_names = std::collections::HashSet::new();
-                for path in &projection {
-                    for el in path {
-                        if let extenddb_core::expression::PathElement::Attribute(name) = el
-                            && let Some(ref_name) = name.strip_prefix('#')
-                        {
-                            extra_names.insert(ref_name.to_owned());
-                        }
-                    }
-                }
-                extenddb_core::expression::validate_unused_attributes(
-                    &maps.names,
-                    &maps.values,
-                    &[],
-                    &[],
-                    &extra_names,
-                    &std::collections::HashSet::new(),
-                )?;
-                let item = opt
-                    .map(|item| apply_projection(&item, &projection, &maps))
-                    .transpose()?
-                    .filter(|i| !i.is_empty());
-                Ok(ItemResponse { item })
-            } else {
-                // No projection: transactions accept names with no expression.
-                Ok(ItemResponse { item: opt })
-            }
+        .zip(projections)
+        .map(|(opt, proj)| {
+            let item = match proj {
+                Some(p) => opt.map(|item| p.apply(&item)).filter(|i| !i.is_empty()),
+                None => opt,
+            };
+            ItemResponse { item }
         })
-        .collect::<Result<Vec<_>, DynamoDbError>>()?;
+        .collect();
 
     let consumed_capacity = capacity_helpers::batch_read_capacity(
         input.return_consumed_capacity,

--- a/tests/test_projection_overlapping_paths.py
+++ b/tests/test_projection_overlapping_paths.py
@@ -157,6 +157,56 @@ class TestProjectionOverlap:
             )
         assert _validation_message(ei) == OVERLAP.format(one="[a]", two="[a, b]")
 
+    def test_overlap_precedes_unused_name_get_item(self, dynamodb_client, overlap_table):
+        # With both an unused #name and an overlap, DynamoDB reports the overlap.
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.get_item(
+                TableName=overlap_table,
+                Key={"pk": {"S": "k1"}},
+                ProjectionExpression="a, a.b",
+                ExpressionAttributeNames={"#z": "zzz"},
+            )
+        assert _validation_message(ei) == OVERLAP.format(one="[a]", two="[a, b]")
+
+    def test_overlap_precedes_unused_name_query(self, dynamodb_client, overlap_table):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.query(
+                TableName=overlap_table,
+                KeyConditionExpression="pk = :p",
+                ExpressionAttributeValues={":p": {"S": "k1"}},
+                ProjectionExpression="a, a.b",
+                ExpressionAttributeNames={"#z": "zzz"},
+            )
+        assert _validation_message(ei) == OVERLAP.format(one="[a]", two="[a, b]")
+
+    def test_undefined_name_query_zero_match_validates_before_read(
+        self, dynamodb_client, overlap_table
+    ):
+        # An undefined #name in the projection is rejected up front, even when
+        # the query matches no items (validation runs before the read).
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.query(
+                TableName=overlap_table,
+                KeyConditionExpression="pk = :p",
+                ExpressionAttributeValues={":p": {"S": "no-such-pk"}},
+                ProjectionExpression="a.#u",
+            )
+        assert _validation_message(ei) == (
+            "Invalid ProjectionExpression: An expression attribute name used in the "
+            "document path is not defined; attribute name: #u"
+        )
+
+    def test_undefined_name_scan_validates_before_read(self, dynamodb_client, overlap_table):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.scan(
+                TableName=overlap_table,
+                ProjectionExpression="a.#u",
+            )
+        assert _validation_message(ei) == (
+            "Invalid ProjectionExpression: An expression attribute name used in the "
+            "document path is not defined; attribute name: #u"
+        )
+
     def test_siblings_accepted(self, dynamodb_client, overlap_table):
         # Non-overlapping sibling paths must still work.
         resp = dynamodb_client.get_item(

--- a/tests/test_projection_overlapping_paths.py
+++ b/tests/test_projection_overlapping_paths.py
@@ -1,0 +1,167 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Overlapping ProjectionExpression paths (C9).
+
+Amazon DynamoDB rejects a ProjectionExpression in which one path is a prefix
+of another (for example ``a`` and ``a.b``, or ``a[0]`` and ``a[0].b``, or a
+duplicate ``a`` and ``a``) with a ValidationException. Sibling paths such as
+``a.b`` and ``a.c`` are accepted. The rejection happens during request
+validation, so it fires even when the item does not exist, and it applies to
+every read API that takes a ProjectionExpression. All messages here were
+captured directly from Amazon DynamoDB via the AWS CLI.
+"""
+
+from __future__ import annotations
+
+import pytest
+from botocore.exceptions import ClientError
+
+from conftest import scoped_table
+
+OVERLAP = (
+    "Invalid ProjectionExpression: Two document paths overlap with each other; "
+    "must remove or rewrite one of these paths; path one: {one}, path two: {two}"
+)
+
+
+def _validation_message(excinfo) -> str:
+    err = excinfo.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    return err["Message"]
+
+
+class TestProjectionOverlap:
+    @pytest.fixture(scope="class")
+    def overlap_table(self, dynamodb_client):
+        with scoped_table(dynamodb_client) as name:
+            dynamodb_client.put_item(
+                TableName=name,
+                Item={
+                    "pk": {"S": "k1"},
+                    "a": {"M": {"b": {"S": "bv"}, "c": {"S": "cv"}}},
+                    "x": {"S": "xv"},
+                    "alist": {"L": [{"M": {"b": {"S": "lb"}}}]},
+                },
+            )
+            yield name
+
+    def test_get_item_parent_then_child(self, dynamodb_client, overlap_table):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.get_item(
+                TableName=overlap_table,
+                Key={"pk": {"S": "k1"}},
+                ProjectionExpression="a, a.b",
+            )
+        assert _validation_message(ei) == OVERLAP.format(one="[a]", two="[a, b]")
+
+    def test_get_item_child_then_parent(self, dynamodb_client, overlap_table):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.get_item(
+                TableName=overlap_table,
+                Key={"pk": {"S": "k1"}},
+                ProjectionExpression="a.b, a",
+            )
+        assert _validation_message(ei) == OVERLAP.format(one="[a, b]", two="[a]")
+
+    def test_get_item_exact_duplicate(self, dynamodb_client, overlap_table):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.get_item(
+                TableName=overlap_table,
+                Key={"pk": {"S": "k1"}},
+                ProjectionExpression="a, a",
+            )
+        assert _validation_message(ei) == OVERLAP.format(one="[a]", two="[a]")
+
+    def test_get_item_missing_item_still_validates(self, dynamodb_client, overlap_table):
+        # Validation runs before the lookup: a nonexistent key still errors.
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.get_item(
+                TableName=overlap_table,
+                Key={"pk": {"S": "does-not-exist"}},
+                ProjectionExpression="a, a.b",
+            )
+        assert _validation_message(ei) == OVERLAP.format(one="[a]", two="[a, b]")
+
+    def test_get_item_index_path_rendering(self, dynamodb_client, overlap_table):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.get_item(
+                TableName=overlap_table,
+                Key={"pk": {"S": "k1"}},
+                ProjectionExpression="alist[0], alist",
+            )
+        assert _validation_message(ei) == OVERLAP.format(one="[alist, [0]]", two="[alist]")
+
+    def test_get_item_resolved_names(self, dynamodb_client, overlap_table):
+        # The message reports resolved attribute names, not the #placeholders.
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.get_item(
+                TableName=overlap_table,
+                Key={"pk": {"S": "k1"}},
+                ProjectionExpression="#p, #p.#q",
+                ExpressionAttributeNames={"#p": "a", "#q": "b"},
+            )
+        assert _validation_message(ei) == OVERLAP.format(one="[a]", two="[a, b]")
+
+    def test_get_item_first_pair_in_order(self, dynamodb_client, overlap_table):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.get_item(
+                TableName=overlap_table,
+                Key={"pk": {"S": "k1"}},
+                ProjectionExpression="x, a.b, a",
+            )
+        assert _validation_message(ei) == OVERLAP.format(one="[a, b]", two="[a]")
+
+    def test_batch_get_item_overlap(self, dynamodb_client, overlap_table):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.batch_get_item(
+                RequestItems={
+                    overlap_table: {
+                        "Keys": [{"pk": {"S": "k1"}}],
+                        "ProjectionExpression": "a, a.b",
+                    }
+                }
+            )
+        assert _validation_message(ei) == OVERLAP.format(one="[a]", two="[a, b]")
+
+    def test_query_overlap(self, dynamodb_client, overlap_table):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.query(
+                TableName=overlap_table,
+                KeyConditionExpression="pk = :p",
+                ExpressionAttributeValues={":p": {"S": "k1"}},
+                ProjectionExpression="a, a.b",
+            )
+        assert _validation_message(ei) == OVERLAP.format(one="[a]", two="[a, b]")
+
+    def test_scan_overlap(self, dynamodb_client, overlap_table):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.scan(
+                TableName=overlap_table,
+                ProjectionExpression="a, a.b",
+            )
+        assert _validation_message(ei) == OVERLAP.format(one="[a]", two="[a, b]")
+
+    def test_transact_get_items_overlap(self, dynamodb_client, overlap_table):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.transact_get_items(
+                TransactItems=[
+                    {
+                        "Get": {
+                            "TableName": overlap_table,
+                            "Key": {"pk": {"S": "k1"}},
+                            "ProjectionExpression": "a, a.b",
+                        }
+                    }
+                ]
+            )
+        assert _validation_message(ei) == OVERLAP.format(one="[a]", two="[a, b]")
+
+    def test_siblings_accepted(self, dynamodb_client, overlap_table):
+        # Non-overlapping sibling paths must still work.
+        resp = dynamodb_client.get_item(
+            TableName=overlap_table,
+            Key={"pk": {"S": "k1"}},
+            ProjectionExpression="a.b, a.c",
+        )
+        assert resp["Item"]["a"]["M"].keys() == {"b", "c"}


### PR DESCRIPTION
## What

This makes a `ProjectionExpression` with overlapping document paths fail with a `ValidationException`, matching Amazon DynamoDB, across every read API that takes a projection (`GetItem`, `BatchGetItem`, `Query`, `Scan`, `TransactGetItems`).

Two paths overlap when one is a prefix of the other, including equal paths: for example `a` and `a.b`, or `a[0]` and `a[0].b`, or a duplicate `a` and `a`. Amazon DynamoDB rejects these. ExtendDB accepted them: the projection trie's terminal node won, so `a, a.b` silently returned the whole `a` and the request never errored. Sibling paths such as `a.b` and `a.c`, or `a[0]` and `a[1]`, do not overlap and are still accepted.

## Behavior: today vs Amazon DynamoDB

The table shows what ExtendDB returns before this PR and what Amazon DynamoDB returns. I captured every Amazon DynamoDB message directly via the AWS CLI. The item under test has `a = {b, c}` and `alist = [{b}]`.

| Scenario | ExtendDB (before this PR) | Amazon DynamoDB |
|---|---|---|
| `ProjectionExpression="a, a.b"` | Returns the whole `a`, no error | `ValidationException: Invalid ProjectionExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [a], path two: [a, b]` |
| `ProjectionExpression="a.b, a"` | Returns `a.b`, no error | `... path one: [a, b], path two: [a]` (order follows the expression, not sorted) |
| `ProjectionExpression="a, a"` (exact duplicate) | Returns `a`, no error | `... path one: [a], path two: [a]` |
| `ProjectionExpression="a[0], a"` | Returns `a[0]`, no error | `... path one: [a, [0]], path two: [a]` (an index renders as `[n]`) |
| `ProjectionExpression="x, a.b, a"` | Returns `x` and `a.b`, no error | `... path one: [a, b], path two: [a]` (first overlapping pair reported) |
| `ProjectionExpression="a.b, a.c"` (siblings) | Returns `a.b` and `a.c` | Same (no overlap) |
| `ProjectionExpression="a, a.b"` plus an unused `#z` (declared, not referenced) | Returns `a`, no error | Overlap `ValidationException` (overlap is checked before the unused-name check) |
| `Query`/`Scan` with an undefined `#u` in the projection and zero matching items | Returned `200` with no items | `ValidationException: Invalid ProjectionExpression: An expression attribute name used in the document path is not defined; attribute name: #u` |

### Behavior change

An undefined `#name` in a projection is now rejected during request validation, before the read. Previously, on a `Query`/`Scan` that matched no items, the request returned `200` with an empty result; it now returns the `ValidationException` Amazon DynamoDB returns.

## Why

This is a conformance gap and a correctness bug: customers issuing an overlapping projection got a silent wrong result (the whole parent attribute) instead of the `ValidationException` Amazon DynamoDB returns.

Closes: n/a (no separate issue; tracked as the deferred overlapping-paths item from #162/#171).

## Testing done

Added `tests/test_projection_overlapping_paths.py` (16 dual-target cases). Every expected message was captured from Amazon DynamoDB.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface, an RFC has been accepted or is linked below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a.

## Breaking changes

n/a

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
