### PR TITLE
fix: reject expression/non-expression param mix request-wide in BatchGetItem

### DIFF
--- a/crates/engine/src/batch_get_item.rs
+++ b/crates/engine/src/batch_get_item.rs
@@ -72,6 +72,25 @@ pub async fn handle_batch_get_item(
         }
     }
 
+    // Reject mixing expression and non-expression parameters anywhere in the
+    // request. The check is request-wide: ProjectionExpression on one table and
+    // AttributesToGet on another is still a mix, matching Amazon DynamoDB.
+    let has_projection_expr = input
+        .request_items
+        .values()
+        .any(|ka| ka.projection_expression.is_some());
+    let has_attributes_to_get = input
+        .request_items
+        .values()
+        .any(|ka| ka.attributes_to_get.as_ref().is_some_and(|a| !a.is_empty()));
+    if has_projection_expr && has_attributes_to_get {
+        return Err(DynamoDbError::ValidationException(
+            "Can not use both expression and non-expression parameters in the same request: \
+             Non-expression parameters: {AttributesToGet} Expression parameters: {ProjectionExpression}"
+                .to_owned(),
+        ));
+    }
+
     let mut responses: HashMap<String, Vec<Item>> = HashMap::new();
     let mut total_rcu: f64 = 0.0;
     let mut total_pre_proj_bytes: usize = 0;
@@ -87,16 +106,6 @@ pub async fn handle_batch_get_item(
 
         // Parse per-table projection. AttributesToGet is desugared into a
         // ProjectionExpression with synthetic name placeholders.
-        if ka.projection_expression.is_some()
-            && ka.attributes_to_get.as_ref().is_some_and(|a| !a.is_empty())
-        {
-            return Err(DynamoDbError::ValidationException(
-                "Can not use both expression and non-expression parameters in the same request: \
-                 Non-expression parameters: {AttributesToGet} Expression parameters: {ProjectionExpression}"
-                    .to_owned(),
-            ));
-        }
-
         extenddb_core::expression::validate_expression_param_usage(
             ka.expression_attribute_names.as_ref(),
             ka.projection_expression

--- a/tests/test_batch_operations.py
+++ b/tests/test_batch_operations.py
@@ -538,3 +538,139 @@ class TestBatchGetItemKeyValidation:
                 }
             )
         assert exc_info.value.response["Error"]["Code"] == "ValidationException"
+
+
+# Expected messages for the BatchGetItem expression / non-expression param mix.
+_MIXED_PARAMS_MSG = (
+    "Can not use both expression and non-expression parameters in the same "
+    "request: Non-expression parameters: {AttributesToGet} Expression "
+    "parameters: {ProjectionExpression}"
+)
+_NAMES_WITHOUT_EXPR_MSG = (
+    "ExpressionAttributeNames can only be specified when using expressions"
+)
+
+
+class TestBatchGetItemExpressionParamMix:
+    """BatchGetItem rejects mixing expression and non-expression parameters.
+
+    Amazon DynamoDB applies the check request-wide: a ProjectionExpression on
+    one table and AttributesToGet on another is a mix, even when each table is
+    internally consistent. ExpressionAttributeNames alone is not a mix trigger;
+    it fails the separate "can only be specified when using expressions" check.
+    """
+
+    def _expect_validation(self, func, expected_message):
+        with pytest.raises(ClientError) as exc_info:
+            func()
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert err["Message"] == expected_message
+
+    def test_same_table_proj_and_attrs_rejected(self, dynamodb_client, hash_table):
+        self._expect_validation(
+            lambda: dynamodb_client.batch_get_item(
+                RequestItems={
+                    hash_table: {
+                        "Keys": [{"pk": {"S": "a"}}],
+                        "ProjectionExpression": "pk",
+                        "AttributesToGet": ["pk"],
+                    }
+                }
+            ),
+            _MIXED_PARAMS_MSG,
+        )
+
+    def test_cross_table_proj_and_attrs_rejected(
+        self, dynamodb_client, hash_table, second_table
+    ):
+        self._expect_validation(
+            lambda: dynamodb_client.batch_get_item(
+                RequestItems={
+                    hash_table: {
+                        "Keys": [{"pk": {"S": "a"}}],
+                        "ProjectionExpression": "pk",
+                    },
+                    second_table: {
+                        "Keys": [{"id": {"S": "b"}}],
+                        "AttributesToGet": ["id"],
+                    },
+                }
+            ),
+            _MIXED_PARAMS_MSG,
+        )
+
+    def test_cross_table_proj_with_ean_and_attrs_rejected(
+        self, dynamodb_client, hash_table, second_table
+    ):
+        self._expect_validation(
+            lambda: dynamodb_client.batch_get_item(
+                RequestItems={
+                    hash_table: {
+                        "Keys": [{"pk": {"S": "a"}}],
+                        "ProjectionExpression": "#p",
+                        "ExpressionAttributeNames": {"#p": "pk"},
+                    },
+                    second_table: {
+                        "Keys": [{"id": {"S": "b"}}],
+                        "AttributesToGet": ["id"],
+                    },
+                }
+            ),
+            _MIXED_PARAMS_MSG,
+        )
+
+    def test_cross_table_ean_only_and_attrs_is_names_error(
+        self, dynamodb_client, hash_table, second_table
+    ):
+        self._expect_validation(
+            lambda: dynamodb_client.batch_get_item(
+                RequestItems={
+                    hash_table: {
+                        "Keys": [{"pk": {"S": "a"}}],
+                        "ExpressionAttributeNames": {"#p": "pk"},
+                    },
+                    second_table: {
+                        "Keys": [{"id": {"S": "b"}}],
+                        "AttributesToGet": ["id"],
+                    },
+                }
+            ),
+            _NAMES_WITHOUT_EXPR_MSG,
+        )
+
+    def test_cross_table_both_proj_accepted(
+        self, dynamodb_client, hash_table, second_table
+    ):
+        dynamodb_client.put_item(
+            TableName=hash_table, Item={"pk": {"S": "a"}, "foo": {"S": "x"}}
+        )
+        dynamodb_client.put_item(
+            TableName=second_table, Item={"id": {"S": "b"}, "foo": {"S": "y"}}
+        )
+        resp = dynamodb_client.batch_get_item(
+            RequestItems={
+                hash_table: {"Keys": [{"pk": {"S": "a"}}], "ProjectionExpression": "pk"},
+                second_table: {"Keys": [{"id": {"S": "b"}}], "ProjectionExpression": "id"},
+            }
+        )
+        assert resp["Responses"][hash_table] == [{"pk": {"S": "a"}}]
+        assert resp["Responses"][second_table] == [{"id": {"S": "b"}}]
+
+    def test_cross_table_both_attrs_accepted(
+        self, dynamodb_client, hash_table, second_table
+    ):
+        dynamodb_client.put_item(
+            TableName=hash_table, Item={"pk": {"S": "a"}, "foo": {"S": "x"}}
+        )
+        dynamodb_client.put_item(
+            TableName=second_table, Item={"id": {"S": "b"}, "foo": {"S": "y"}}
+        )
+        resp = dynamodb_client.batch_get_item(
+            RequestItems={
+                hash_table: {"Keys": [{"pk": {"S": "a"}}], "AttributesToGet": ["pk"]},
+                second_table: {"Keys": [{"id": {"S": "b"}}], "AttributesToGet": ["id"]},
+            }
+        )
+        assert resp["Responses"][hash_table] == [{"pk": {"S": "a"}}]
+        assert resp["Responses"][second_table] == [{"id": {"S": "b"}}]


### PR DESCRIPTION
## What

`BatchGetItem` rejected mixing an expression parameter (`ProjectionExpression`) with a non-expression parameter (`AttributesToGet`) only when both appeared on the same table. Amazon DynamoDB applies the check request-wide: the mix is rejected even when `ProjectionExpression` is on one table and `AttributesToGet` on another, with each table internally consistent.

This moves the mix check out of the per-table read loop into a single request-wide pass before the loop, in `crates/engine/src/batch_get_item.rs`.

Behavior, captured directly via the AWS CLI (two tables, each internally consistent):

| Scenario | ExtendDB (before) | Amazon DynamoDB |
|---|---|---|
| `ProjectionExpression` on t1, `AttributesToGet` on t2 | Runs, no error | `ValidationException: Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {AttributesToGet} Expression parameters: {ProjectionExpression}` |
| Both on one table | already rejected (unchanged) | same message |
| `ExpressionAttributeNames` only on t1, `AttributesToGet` on t2 | names error | `ExpressionAttributeNames can only be specified when using expressions` |

`ExpressionAttributeNames` alone is not a mix trigger: only `ProjectionExpression` (expression) versus `AttributesToGet` (non-expression) count, and `EAN` is never listed in the mixed-params set.

## Why

Conformance gap found by comparing ExtendDB against Amazon DynamoDB with the AWS CLI. The fix is engine-agnostic (one file, no PostgreSQL coupling). Part of the XC11 read-path expression follow-up that began with #162.

Closes # n/a

## Testing done

- Added 6 dual-target cases as `TestBatchGetItemExpressionParamMix` in `tests/test_batch_operations.py`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a

## Breaking changes

n/a.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.