### PR TITLE
fix: validate expression attribute entries and enforce expression size limits

### DIFF
--- a/crates/core/src/expression/kind.rs
+++ b/crates/core/src/expression/kind.rs
@@ -31,6 +31,17 @@ impl ExpressionKind {
             Self::Update => "UpdateExpression",
         }
     }
+
+    /// Whether the size-limit error appends `; expression size: N`. Amazon
+    /// `DynamoDB` appends it for `Filter` and `Condition` only.
+    ///
+    /// `Condition` MUST stay in this set: `Filter` size errors are built as
+    /// `Condition` then relabelled by `prefix_expression_error`, inheriting the
+    /// suffix.
+    #[must_use]
+    pub fn size_error_includes_length(self) -> bool {
+        matches!(self, Self::Filter | Self::Condition)
+    }
 }
 
 impl fmt::Display for ExpressionKind {

--- a/crates/core/src/limits/mod.rs
+++ b/crates/core/src/limits/mod.rs
@@ -43,6 +43,10 @@ pub struct LimitsConfig {
     /// Maximum number of tokens in a single expression (condition, update, projection, key-condition).
     #[serde(default = "default_max_expression_tokens")]
     pub max_expression_tokens: usize,
+    /// Maximum size in bytes of a single expression string, measured on the
+    /// raw text before `#name` / `:value` substitution (DynamoDB: 4096).
+    #[serde(default = "default_max_expression_length_bytes")]
+    pub max_expression_length_bytes: usize,
     /// Maximum nesting depth in condition expressions (parentheses, NOT, AND/OR).
     #[serde(default = "default_max_expression_depth")]
     pub max_expression_depth: usize,
@@ -82,6 +86,7 @@ impl Default for LimitsConfig {
             allow_multipart_table_keys: false,
             max_attribute_name_bytes: default_max_attribute_name_bytes(),
             max_expression_tokens: default_max_expression_tokens(),
+            max_expression_length_bytes: default_max_expression_length_bytes(),
             max_expression_depth: default_max_expression_depth(),
             max_policy_document_bytes: default_max_policy_document_bytes(),
             max_import_file_bytes: default_max_import_file_bytes(),
@@ -135,6 +140,9 @@ fn default_max_attribute_name_bytes() -> usize {
     65_535
 }
 fn default_max_expression_tokens() -> usize {
+    4096
+}
+fn default_max_expression_length_bytes() -> usize {
     4096
 }
 fn default_max_expression_depth() -> usize {

--- a/crates/core/src/serde_helpers.rs
+++ b/crates/core/src/serde_helpers.rs
@@ -2,92 +2,155 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Custom serde deserializers for `DynamoDB` input validation.
+//!
+//! Validate `ExpressionAttributeNames` / `ExpressionAttributeValues` map entries
+//! at deserialization time, before expression parsing, matching Amazon
+//! `DynamoDB`'s order: non-empty map, well-formed placeholder keys
+//! (`<prefix>[A-Za-z0-9_]+`, <=255 bytes incl. prefix), non-empty mapped value.
 
 use std::collections::HashMap;
-use std::fmt;
 
-use serde::de::{self, Deserializer, MapAccess, Visitor};
+use serde::de::{self, Deserialize, Deserializer};
+use serde_json::Value;
 
 use crate::types::AttributeValue;
 
-macro_rules! prefixed_map_deserializer {
-    ($fn_name:ident, $value_type:ty, $prefix:expr, $field_name:expr, $expecting:expr) => {
-        pub fn $fn_name<'de, D>(
-            deserializer: D,
-        ) -> Result<Option<HashMap<String, $value_type>>, D::Error>
-        where
-            D: Deserializer<'de>,
-        {
-            struct V;
+/// Maximum placeholder key length in bytes, including the `#` / `:` prefix.
+const MAX_PLACEHOLDER_KEY_BYTES: usize = 255;
 
-            fn check_keys(map: &HashMap<String, $value_type>) -> Result<(), String> {
-                if map.is_empty() {
-                    return Err(concat!($field_name, " must not be empty").to_owned());
-                }
-                for key in map.keys() {
-                    if !key.starts_with($prefix) {
-                        return Err(format!(
-                            concat!(
-                                $field_name,
-                                " contains invalid key: Syntax error; key: \"{}\""
-                            ),
-                            key
-                        ));
-                    }
-                }
-                Ok(())
-            }
-
-            impl<'de> Visitor<'de> for V {
-                type Value = Option<HashMap<String, $value_type>>;
-
-                fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                    f.write_str($expecting)
-                }
-
-                fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
-                    Ok(None)
-                }
-
-                fn visit_some<D2: Deserializer<'de>>(
-                    self,
-                    d: D2,
-                ) -> Result<Self::Value, D2::Error> {
-                    let map: HashMap<String, $value_type> = de::Deserialize::deserialize(d)?;
-                    check_keys(&map).map_err(de::Error::custom)?;
-                    Ok(Some(map))
-                }
-
-                fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
-                    let m: HashMap<String, $value_type> =
-                        de::Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))?;
-                    check_keys(&m).map_err(de::Error::custom)?;
-                    Ok(Some(m))
-                }
-            }
-
-            deserializer.deserialize_option(V)
-        }
-    };
+/// A placeholder identifier (the text after the `#` / `:`) is one or more of
+/// `[A-Za-z0-9_]`.
+fn is_placeholder_ident(rest: &str) -> bool {
+    !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
 }
 
-// Deserialize `ExpressionAttributeNames` — keys must start with `#`, map must not be empty.
-prefixed_map_deserializer!(
-    deserialize_expression_names,
-    String,
-    '#',
-    "ExpressionAttributeNames",
-    "a map of expression attribute names"
-);
+/// Validate one placeholder key. Length is checked before syntax.
+///
+/// `include_size_in_too_long`: the Names too-long message appends
+/// `; size of key: N`, the Values one does not (Amazon `DynamoDB` quirk).
+fn validate_placeholder_key(
+    key: &str,
+    prefix: char,
+    field_name: &str,
+    include_size_in_too_long: bool,
+) -> Result<(), String> {
+    if key.len() > MAX_PLACEHOLDER_KEY_BYTES {
+        let mut msg = format!(
+            "{field_name} contains invalid key: The expression attribute map \
+             contains a key that is too long;"
+        );
+        if include_size_in_too_long {
+            use std::fmt::Write as _;
+            let _ = write!(msg, " size of key: {}", key.len());
+        }
+        return Err(msg);
+    }
+    if !key.strip_prefix(prefix).is_some_and(is_placeholder_ident) {
+        return Err(format!(
+            "{field_name} contains invalid key: Syntax error; key: \"{key}\""
+        ));
+    }
+    Ok(())
+}
 
-// Deserialize `ExpressionAttributeValues` — keys must start with `:`, map must not be empty.
-prefixed_map_deserializer!(
-    deserialize_expression_values,
-    AttributeValue,
-    ':',
-    "ExpressionAttributeValues",
-    "a map of expression attribute values"
-);
+/// Deserialize a placeholder map, sharing the structure check (non-empty map,
+/// well-formed keys). The caller supplies the per-type value check and
+/// conversion. Values arrive as raw `serde_json::Value` so a value error can
+/// name its key (serde errors do not carry the failing key).
+fn deserialize_placeholder_map<'de, D, T>(
+    deserializer: D,
+    prefix: char,
+    field_name: &str,
+    include_size_in_too_long: bool,
+    check_value: impl Fn(&str, &Value) -> Result<(), String>,
+    convert: impl Fn(Value) -> Result<T, serde_json::Error>,
+) -> Result<Option<HashMap<String, T>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let Some(raw) = Option::<serde_json::Map<String, Value>>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    if raw.is_empty() {
+        return Err(de::Error::custom(format!("{field_name} must not be empty")));
+    }
+    let mut out = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        validate_placeholder_key(&key, prefix, field_name, include_size_in_too_long)
+            .map_err(de::Error::custom)?;
+        check_value(&key, &value).map_err(de::Error::custom)?;
+        let converted = convert(value).map_err(de::Error::custom)?;
+        out.insert(key, converted);
+    }
+    Ok(Some(out))
+}
+
+/// Deserialize `ExpressionAttributeNames`: keys are `#<ident>` (at most 255
+/// bytes), the map is non-empty, and each mapped attribute name is non-empty.
+///
+/// # Errors
+///
+/// Returns the deserializer error type when a map entry is malformed.
+pub fn deserialize_expression_names<'de, D>(
+    deserializer: D,
+) -> Result<Option<HashMap<String, String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_placeholder_map(
+        deserializer,
+        '#',
+        "ExpressionAttributeNames",
+        true,
+        |key, value| {
+            // Only a genuine empty *string* is rejected. A non-string falls
+            // through to `convert` -> type error -> SerializationException,
+            // matching Amazon DynamoDB. `is_none_or` would mislabel it.
+            if value.as_str().is_some_and(str::is_empty) {
+                return Err(format!(
+                    "ExpressionAttributeNames contains invalid value: \
+                     Empty attribute name for key {key}"
+                ));
+            }
+            Ok(())
+        },
+        serde_json::from_value::<String>,
+    )
+}
+
+/// Deserialize `ExpressionAttributeValues`: keys are `:<ident>` (at most 255
+/// bytes), the map is non-empty, and each `AttributeValue` carries a datatype.
+///
+/// # Errors
+///
+/// Returns the deserializer error type when a map entry is malformed.
+pub fn deserialize_expression_values<'de, D>(
+    deserializer: D,
+) -> Result<Option<HashMap<String, AttributeValue>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_placeholder_map(
+        deserializer,
+        ':',
+        "ExpressionAttributeValues",
+        false,
+        |key, value| {
+            // Empty AttributeValue (no datatype). Caught here so the error names
+            // its key. Mirrors the empty-object check in `types::attribute_value`;
+            // keep in sync. Only the empty case is prefixed, matching DynamoDB.
+            if value.as_object().is_some_and(serde_json::Map::is_empty) {
+                return Err(format!(
+                    "ExpressionAttributeValues contains invalid value: Supplied \
+                     AttributeValue is empty, must contain exactly one of the \
+                     supported datatypes for key {key}"
+                ));
+            }
+            Ok(())
+        },
+        serde_json::from_value::<AttributeValue>,
+    )
+}
 
 #[cfg(test)]
 mod tests {
@@ -106,58 +169,152 @@ mod tests {
         values: Option<HashMap<String, AttributeValue>>,
     }
 
+    fn names_err(json: &str) -> String {
+        serde_json::from_str::<TestNames>(json)
+            .unwrap_err()
+            .to_string()
+    }
+
+    fn values_err(json: &str) -> String {
+        serde_json::from_str::<TestValues>(json)
+            .unwrap_err()
+            .to_string()
+    }
+
     #[test]
     fn names_missing_hash_rejected() {
-        let json = r#"{"names":{"a":"real"}}"#;
-        let result: Result<TestNames, _> = serde_json::from_str(json);
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Syntax error; key")
-        );
+        assert!(names_err(r#"{"names":{"a":"real"}}"#).contains("Syntax error; key"));
     }
 
     #[test]
     fn names_with_hash_accepted() {
         let json = "{\"names\":{\"#a\":\"real\"}}";
-        let result: Result<TestNames, _> = serde_json::from_str(json);
-        assert!(result.is_ok());
-        assert!(result.unwrap().names.unwrap().contains_key("#a"));
+        let parsed: TestNames = serde_json::from_str(json).unwrap();
+        assert!(parsed.names.unwrap().contains_key("#a"));
     }
 
     #[test]
     fn names_empty_rejected() {
-        let json = r#"{"names":{}}"#;
-        let result: Result<TestNames, _> = serde_json::from_str(json);
-        assert!(result.is_err());
+        assert!(names_err(r#"{"names":{}}"#).contains("must not be empty"));
+    }
+
+    #[test]
+    fn names_prefix_only_key_rejected() {
+        assert!(names_err(r##"{"names":{"#":"foo"}}"##).contains(
+            r##"ExpressionAttributeNames contains invalid key: Syntax error; key: "#""##
+        ));
+    }
+
+    #[test]
+    fn names_invalid_char_key_rejected() {
+        assert!(names_err(r##"{"names":{"#a-b":"foo"}}"##).contains(
+            r##"ExpressionAttributeNames contains invalid key: Syntax error; key: "#a-b""##
+        ));
+    }
+
+    #[test]
+    fn names_key_too_long_reports_size() {
+        let key = format!("#{}", "a".repeat(255)); // 256 bytes including '#'
+        let json = format!(r#"{{"names":{{"{key}":"foo"}}}}"#);
+        let msg = names_err(&json);
         assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("must not be empty")
+            msg.contains("contains a key that is too long; size of key: 256"),
+            "{msg}"
         );
+    }
+
+    #[test]
+    fn names_length_checked_before_syntax() {
+        let key = format!("#{}-x", "a".repeat(255)); // too long AND invalid char
+        let json = format!(r#"{{"names":{{"{key}":"foo"}}}}"#);
+        let msg = names_err(&json);
+        assert!(msg.contains("too long; size of key: 258"), "{msg}");
+    }
+
+    #[test]
+    fn names_empty_value_rejected() {
+        assert!(names_err(r##"{"names":{"#a":""}}"##).contains(
+            "ExpressionAttributeNames contains invalid value: Empty attribute name for key #a"
+        ));
+    }
+
+    #[test]
+    fn names_valid_ident_with_digits_and_underscore_accepted() {
+        let parsed: TestNames = serde_json::from_str("{\"names\":{\"#a_1\":\"foo\"}}").unwrap();
+        assert!(parsed.names.unwrap().contains_key("#a_1"));
     }
 
     #[test]
     fn values_missing_colon_rejected() {
-        let json = r#"{"values":{"v":{"S":"x"}}}"#;
-        let result: Result<TestValues, _> = serde_json::from_str(json);
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Syntax error; key")
-        );
+        assert!(values_err(r#"{"values":{"v":{"S":"x"}}}"#).contains("Syntax error; key"));
     }
 
     #[test]
     fn values_with_colon_accepted() {
-        let json = r#"{"values":{":v":{"S":"x"}}}"#;
-        let result: Result<TestValues, _> = serde_json::from_str(json);
-        let parsed = result.unwrap();
+        let parsed: TestValues = serde_json::from_str(r#"{"values":{":v":{"S":"x"}}}"#).unwrap();
         assert!(parsed.values.is_some());
+    }
+
+    #[test]
+    fn values_prefix_only_key_rejected() {
+        assert!(
+            values_err(r#"{"values":{":":{"S":"x"}}}"#).contains(
+                r#"ExpressionAttributeValues contains invalid key: Syntax error; key: ":""#
+            )
+        );
+    }
+
+    #[test]
+    fn values_key_too_long_omits_size() {
+        let key = format!(":{}", "a".repeat(255)); // 256 bytes including ':'
+        let json = format!(r#"{{"values":{{"{key}":{{"S":"x"}}}}}}"#);
+        let msg = values_err(&json);
+        assert!(msg.contains("contains a key that is too long;"), "{msg}");
+        // Quirk: the values variant omits "; size of key: N".
+        assert!(!msg.contains("size of key"), "{msg}");
+    }
+
+    #[test]
+    fn values_empty_attribute_value_rejected() {
+        let msg = values_err(r#"{"values":{":v":{}}}"#);
+        assert!(
+            msg.contains(
+                "ExpressionAttributeValues contains invalid value: Supplied \
+                 AttributeValue is empty, must contain exactly one of the \
+                 supported datatypes for key :v"
+            ),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn values_empty_string_accepted() {
+        let parsed: TestValues = serde_json::from_str(r#"{"values":{":v":{"S":""}}}"#).unwrap();
+        assert!(parsed.values.is_some());
+    }
+
+    #[test]
+    fn names_key_length_is_bytes_not_chars() {
+        // 128 two-byte chars after '#' = 257 bytes (129 chars): too long, size in bytes.
+        let key = format!("#{}", "\u{00e9}".repeat(128));
+        assert_eq!(key.chars().count(), 129);
+        assert_eq!(key.len(), 257);
+        let json = format!(r#"{{"names":{{"{key}":"foo"}}}}"#);
+        let msg = names_err(&json);
+        assert!(
+            msg.contains("contains a key that is too long; size of key: 257"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn names_non_string_value_is_type_error_not_empty() {
+        // Non-string value: type error (SerializationException), not "Empty attribute name".
+        let msg = names_err(r##"{"names":{"#a":5}}"##);
+        assert!(!msg.contains("Empty attribute name"), "{msg}");
+        assert!(
+            msg.contains("invalid type") || msg.contains("expected a string"),
+            "{msg}"
+        );
     }
 }

--- a/crates/engine/src/expression_helpers.rs
+++ b/crates/engine/src/expression_helpers.rs
@@ -7,9 +7,9 @@ use std::collections::HashMap;
 
 use extenddb_core::error::DynamoDbError;
 use extenddb_core::expression::{
-    Expr, ExpressionKind, ExpressionMaps, PathElement, Token, UpdateAction,
-    parse_condition_with_depth_limit, parse_projection, parse_update_from, tokenize_for,
-    tokenize_with_limit, validate_no_reserved_words,
+    Expr, ExpressionKind, ExpressionMaps, KeyCondition, PathElement, Token, UpdateAction,
+    parse_condition_with_depth_limit, parse_key_condition, parse_projection, parse_update_from,
+    tokenize_for, tokenize_with_limit, validate_no_reserved_words,
 };
 use extenddb_core::limits::LimitsConfig;
 use extenddb_core::types::{AttributeValue, ConditionalOperator, ExpectedAttributeValue};
@@ -55,6 +55,30 @@ pub fn build_expression_maps(
     )
 }
 
+/// Reject an expression over the byte-size limit, measured on the raw text
+/// before `#name` / `:value` substitution (Amazon `DynamoDB`: 4096). The error
+/// carries the per-parameter prefix and, for Filter/Condition, the byte length.
+///
+/// # Errors
+///
+/// Returns `DynamoDbError::ValidationException` when `expr` is over the limit.
+pub fn check_expression_size(
+    expr: &str,
+    kind: ExpressionKind,
+    limits: &LimitsConfig,
+) -> Result<(), DynamoDbError> {
+    if expr.len() > limits.max_expression_length_bytes {
+        let mut msg =
+            format!("Invalid {kind}: Expression size has exceeded the maximum allowed size;");
+        if kind.size_error_includes_length() {
+            use std::fmt::Write as _;
+            let _ = write!(msg, " expression size: {}", expr.len());
+        }
+        return Err(DynamoDbError::ValidationException(msg));
+    }
+    Ok(())
+}
+
 /// Tokenize, reserved-word check, and parse a required `ConditionExpression`.
 ///
 /// Errors carry the `ConditionExpression` prefix, matching Amazon DynamoDB.
@@ -63,6 +87,7 @@ pub fn build_expression_maps(
 ///
 /// Returns `DynamoDbError::ValidationException` for syntax or reserved-word errors.
 pub fn parse_condition_expr(expr: &str, limits: &LimitsConfig) -> Result<Expr, DynamoDbError> {
+    check_expression_size(expr, ExpressionKind::Condition, limits)?;
     tokenize_expression(expr, limits)
         .and_then(|tokens| parse_condition_with_depth_limit(&tokens, limits.max_expression_depth))
         .map_err(|e| prefix_expression_error(e, ExpressionKind::Condition))
@@ -79,6 +104,7 @@ pub fn parse_update_expr(
     update_expr: &str,
     limits: &LimitsConfig,
 ) -> Result<Vec<UpdateAction>, DynamoDbError> {
+    check_expression_size(update_expr, ExpressionKind::Update, limits)?;
     tokenize_for(
         update_expr,
         limits.max_expression_tokens,
@@ -193,6 +219,7 @@ pub fn parse_projection_expr(
     proj_str: &str,
     limits: &LimitsConfig,
 ) -> Result<Vec<Vec<PathElement>>, DynamoDbError> {
+    check_expression_size(proj_str, ExpressionKind::Projection, limits)?;
     let result = tokenize_for(
         proj_str,
         limits.max_expression_tokens,
@@ -205,6 +232,33 @@ pub fn parse_projection_expr(
         parse_projection(&tokens)
     });
     result.map_err(|e| prefix_expression_error(e, ExpressionKind::Projection))
+}
+
+/// Size-check, tokenize, reserved-word check, and parse a `KeyConditionExpression`.
+///
+/// Errors carry the `KeyConditionExpression` prefix, matching Amazon `DynamoDB`.
+///
+/// # Errors
+///
+/// Returns `DynamoDbError::ValidationException` for over-size, syntax, or
+/// reserved-word errors.
+pub fn parse_key_condition_expr(
+    expr: &str,
+    limits: &LimitsConfig,
+) -> Result<KeyCondition, DynamoDbError> {
+    check_expression_size(expr, ExpressionKind::KeyCondition, limits)?;
+    tokenize_for(
+        expr,
+        limits.max_expression_tokens,
+        ExpressionKind::KeyCondition,
+    )
+    .and_then(|tokens| {
+        if limits.enforce_reserved_keywords {
+            validate_no_reserved_words(&tokens)?;
+        }
+        parse_key_condition(&tokens)
+    })
+    .map_err(|e| prefix_expression_error(e, ExpressionKind::KeyCondition))
 }
 
 /// Prefix an expression error with the expression type, matching `DynamoDB`'s format.
@@ -289,6 +343,66 @@ mod tests {
         assert!(
             matches!(&err, DynamoDbError::ValidationException(msg)
                 if msg.starts_with("Invalid FilterExpression:")),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn filter_over_size_limit_keeps_size_suffix_through_relabel() {
+        // Filter relabels through Condition; the size suffix must survive.
+        let limits = LimitsConfig::default();
+        let path = "a".to_owned() + &"z".repeat(limits.max_expression_length_bytes);
+        let expr = format!("{path} = :v");
+        let err = parse_optional_filter(Some(&expr), &limits).unwrap_err();
+        assert!(
+            matches!(&err, DynamoDbError::ValidationException(msg)
+                if *msg == format!(
+                    "Invalid FilterExpression: Expression size has exceeded the \
+                     maximum allowed size; expression size: {}", expr.len())),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn condition_over_size_limit_keeps_size_suffix() {
+        let limits = LimitsConfig::default();
+        let path = "a".to_owned() + &"z".repeat(limits.max_expression_length_bytes);
+        let expr = format!("attribute_not_exists({path})");
+        let err = parse_optional_condition(Some(&expr), &limits).unwrap_err();
+        assert!(
+            matches!(&err, DynamoDbError::ValidationException(msg)
+                if *msg == format!(
+                    "Invalid ConditionExpression: Expression size has exceeded the \
+                     maximum allowed size; expression size: {}", expr.len())),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn projection_over_size_limit_omits_size_suffix() {
+        let limits = LimitsConfig::default();
+        let expr = "a".to_owned() + &"z".repeat(limits.max_expression_length_bytes);
+        let err = parse_projection_expr(&expr, &limits).unwrap_err();
+        assert!(
+            matches!(&err, DynamoDbError::ValidationException(msg)
+                if msg == "Invalid ProjectionExpression: Expression size has exceeded \
+                           the maximum allowed size;"),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn expression_size_limit_is_bytes_not_chars() {
+        // Over the limit in bytes but not in chars: still rejected.
+        let limits = LimitsConfig::default();
+        let half = limits.max_expression_length_bytes / 2;
+        let path = "\u{00e9}".repeat(half + 1); // 'é' = 2 bytes; (half+1)*2 > limit
+        assert!(path.chars().count() <= limits.max_expression_length_bytes);
+        assert!(path.len() > limits.max_expression_length_bytes);
+        let err = parse_projection_expr(&path, &limits).unwrap_err();
+        assert!(
+            matches!(&err, DynamoDbError::ValidationException(msg)
+                if msg.contains("Expression size has exceeded the maximum allowed size")),
             "got {err:?}"
         );
     }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -153,6 +153,7 @@ pub(crate) fn deserialize_error(e: serde_json::Error) -> DynamoDbError {
         || msg.contains("contains duplicates")
         || msg.contains("must not be empty")
         || msg.contains("contains invalid key")
+        || msg.contains("contains invalid value")
         || msg.contains("Syntax error; key")
         || msg.contains("AttributeValue is empty")
         || msg.contains("AttributeValue has more than one datatypes set")

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -9,9 +9,7 @@ use serde_json::Value;
 
 use extenddb_core::error::DynamoDbError;
 use extenddb_core::expression::PathElement;
-use extenddb_core::expression::{
-    ExpressionKind, ExpressionMaps, Projection, parse_key_condition, tokenize_for,
-};
+use extenddb_core::expression::{ExpressionKind, ExpressionMaps, Projection};
 use extenddb_core::types::{
     IndexType, KeyType, QueryInput, QueryOutput, Select, TableKeyInfo, extract_key, item_size_bytes,
 };
@@ -166,20 +164,7 @@ pub async fn handle_query(
     let (mut key_condition, legacy_kc_maps) = if let Some(kce_str) =
         input.key_condition_expression.as_deref()
     {
-        let parsed = tokenize_for(
-            kce_str,
-            ctx.limits.max_expression_tokens,
-            ExpressionKind::KeyCondition,
-        )
-        .and_then(|tokens| {
-            if ctx.limits.enforce_reserved_keywords {
-                extenddb_core::expression::validate_no_reserved_words(&tokens)?;
-            }
-            parse_key_condition(&tokens)
-        })
-        .map_err(|e| {
-            crate::expression_helpers::prefix_expression_error(e, ExpressionKind::KeyCondition)
-        })?;
+        let parsed = crate::expression_helpers::parse_key_condition_expr(kce_str, &ctx.limits)?;
         (parsed, None)
     } else if let Some(ref kc) = input.key_conditions {
         let key_schema_pairs: Vec<(String, bool)> = query_key_info

--- a/crates/engine/src/transact_get_items.rs
+++ b/crates/engine/src/transact_get_items.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 use serde_json::Value;
 
 use extenddb_core::error::DynamoDbError;
-use extenddb_core::expression::{ExpressionKind, Projection, parse_projection, tokenize_for};
+use extenddb_core::expression::Projection;
 use extenddb_core::types::{
     ItemResponse, TransactGetItemsInput, TransactGetItemsOutput, item_size_bytes,
 };
@@ -89,12 +89,8 @@ pub async fn handle_transact_get_items(
     for tgi in &input.transact_items {
         if let Some(ref proj_str) = tgi.get.projection_expression {
             let maps = build_expression_maps(tgi.get.expression_attribute_names.as_ref(), None);
-            let proj_tokens = tokenize_for(
-                proj_str,
-                ctx.limits.max_expression_tokens,
-                ExpressionKind::Projection,
-            )?;
-            let projection = parse_projection(&proj_tokens)?;
+            let projection =
+                crate::expression_helpers::parse_projection_expr(proj_str, &ctx.limits)?;
             let compiled = Projection::compile(&projection, &maps, true)?;
             let mut extra_names = HashSet::new();
             for path in &projection {

--- a/docs/dynamodb-limits.md
+++ b/docs/dynamodb-limits.md
@@ -62,11 +62,13 @@ Source: [AWS DynamoDB Service Quotas](https://docs.aws.amazon.com/amazondynamodb
 |-------|---------------|--------|-------|
 | Response size per page | 1 MB (1,048,576 bytes) | Enforced | `read_helpers.rs` enforces 1 MB page limit |
 | `Limit` parameter (max items evaluated) | No maximum | Enforced | Honored in query/scan |
-| Filter expression size | 4 KB | Not enforced | No expression size validation |
-| Projection expression size | 4 KB | Not enforced | No expression size validation |
-| Condition expression size | 4 KB | Not enforced | No expression size validation |
-| Expression attribute names | 2 MB total | Not enforced | No aggregate size validation |
-| Expression attribute values | 2 MB total | Not enforced | No aggregate size validation |
+| Filter expression size | 4 KB | Enforced | `check_expression_size`, `LimitsConfig::max_expression_length_bytes` (raw bytes, pre-substitution) |
+| Projection expression size | 4 KB | Enforced | `check_expression_size`, `LimitsConfig::max_expression_length_bytes` |
+| Condition expression size | 4 KB | Enforced | `check_expression_size`, `LimitsConfig::max_expression_length_bytes` |
+| Update expression size | 4 KB | Enforced | `check_expression_size`, `LimitsConfig::max_expression_length_bytes` |
+| Key condition expression size | 4 KB | Enforced | `check_expression_size`, `LimitsConfig::max_expression_length_bytes` |
+| Expression attribute names | 2 MB total | Not enforced | Per-entry key/value validated (`serde_helpers`); no aggregate size validation |
+| Expression attribute values | 2 MB total | Not enforced | Per-entry key/value validated (`serde_helpers`); no aggregate size validation |
 
 ## Batch Operations
 
@@ -168,7 +170,7 @@ The following unenforced limits are tracked in `docs/technical-debt.md`:
 1. **Provisioned capacity decrease limit** (27/day) — would require per-table decrease counter with hourly replenishment
 2. **Projected attributes across all indexes** (100) — requires cross-index attribute counting in CreateTable validation
 3. **LSI item collection size** (10 GB) — requires per-partition size tracking in storage layer
-4. **Expression size limits** (4 KB condition/filter/projection, 2 MB names/values) — requires byte-length checks on expression strings
+4. **Expression aggregate size limits** (2 MB total expression attribute names/values) — requires aggregate byte-length tracking across all expression parameters. (Per-expression 4 KB limits for condition/filter/projection/update/key-condition are enforced via `check_expression_size`.)
 5. **BatchGetItem response size** (16 MB) — requires aggregate response size tracking
 6. **BatchWriteItem request size** (16 MB) — requires aggregate request size tracking
 7. **Transaction request size** (4 MB) — requires aggregate request size tracking

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -88,7 +88,7 @@ See `docs/dynamodb-limits.md` for the full catalog. The following are the highes
 | # | Limit | DynamoDB Value | Priority | Origin |
 |---|-------|---------------|----------|--------|
 | L-1 | Projected attributes across all indexes | 100 | Medium | P42 |
-| L-2 | Expression size limits (condition/filter/projection) | 4 KB each | Low | P42 |
+| L-2 | Expression aggregate size (attribute names/values, 2 MB total) | 2 MB | Low | P42 |
 | L-3 | Batch/transaction aggregate request size | 4–16 MB | Low | P42 |
 | L-4 | GetRecords max per call | 1,000 records | Low | P42 |
 | L-5 | Shard iterator lifetime | 15 minutes | Medium | P42 |

--- a/tests/test_expression_attribute_map_validation.py
+++ b/tests/test_expression_attribute_map_validation.py
@@ -1,0 +1,216 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""ExpressionAttributeNames / ExpressionAttributeValues map-entry validation.
+
+Distinct from the "unused" and "can only be specified when using expressions"
+checks: this validates the map entries themselves. Amazon DynamoDB rejects:
+
+  - a placeholder key that is not ``<prefix><ident>`` (prefix-only ``#`` / ``:``,
+    or characters outside ``[A-Za-z0-9_]``) with a Syntax error,
+  - a placeholder key longer than 255 bytes (including the prefix),
+  - an ExpressionAttributeNames mapped value that is the empty string,
+  - an ExpressionAttributeValues AttributeValue that carries no datatype.
+
+Key-length is checked before key-syntax (a too-long key with an invalid
+character reports the length error).
+
+Messages captured directly from Amazon DynamoDB (asomasun-admin, us-east-1).
+Dual-target against Amazon DynamoDB and extenddb.
+"""
+
+from __future__ import annotations
+
+import pytest
+from botocore.exceptions import ClientError
+
+from conftest import scoped_table
+
+
+@pytest.fixture(scope="class")
+def hash_table(dynamodb_client):
+    """Hash-only table for the class, deleted on teardown."""
+    with scoped_table(dynamodb_client) as name:
+        dynamodb_client.put_item(
+            TableName=name,
+            Item={"pk": {"S": "k1"}, "foo": {"S": "a"}, "bar": {"S": "b"}},
+        )
+        yield name
+
+
+class TestExpressionAttributeNamesEntries:
+    """ExpressionAttributeNames map entries must be well-formed."""
+
+    def test_name_key_prefix_only(self, dynamodb_client_no_validation, hash_table):
+        # "#" alone is not a valid placeholder.
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client_no_validation.get_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ProjectionExpression="#",
+                ExpressionAttributeNames={"#": "foo"},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert err["Message"] == (
+            'ExpressionAttributeNames contains invalid key: Syntax error; key: "#"'
+        )
+
+    def test_name_key_invalid_char(self, dynamodb_client_no_validation, hash_table):
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client_no_validation.get_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ProjectionExpression="#a",
+                ExpressionAttributeNames={"#a-b": "foo"},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert err["Message"] == (
+            'ExpressionAttributeNames contains invalid key: Syntax error; key: "#a-b"'
+        )
+
+    def test_name_key_too_long(self, dynamodb_client_no_validation, hash_table):
+        # 256 bytes including the '#' prefix => too long (255 is the max).
+        key = "#" + "a" * 255
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client_no_validation.get_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ProjectionExpression="#a",
+                ExpressionAttributeNames={key: "foo"},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert err["Message"] == (
+            "ExpressionAttributeNames contains invalid key: The expression "
+            "attribute map contains a key that is too long; size of key: 256"
+        )
+
+    def test_name_key_length_before_syntax(self, dynamodb_client_no_validation, hash_table):
+        # A key that is both too long and has an invalid char reports length.
+        key = "#" + "a" * 255 + "-x"
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client_no_validation.get_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ProjectionExpression="#a",
+                ExpressionAttributeNames={key: "foo"},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert "too long" in err["Message"]
+        assert "size of key: 258" in err["Message"]
+
+    def test_name_empty_mapped_value(self, dynamodb_client_no_validation, hash_table):
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client_no_validation.get_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ProjectionExpression="#a",
+                ExpressionAttributeNames={"#a": ""},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert err["Message"] == (
+            "ExpressionAttributeNames contains invalid value: "
+            "Empty attribute name for key #a"
+        )
+
+    def test_name_valid_entry_succeeds(self, dynamodb_client, hash_table):
+        # Positive control: digit-bearing ident and underscore are valid.
+        resp = dynamodb_client.get_item(
+            TableName=hash_table,
+            Key={"pk": {"S": "k1"}},
+            ProjectionExpression="#a_1",
+            ExpressionAttributeNames={"#a_1": "foo"},
+        )
+        assert resp["Item"] == {"foo": {"S": "a"}}
+
+    def test_name_non_string_value_is_serialization_error(
+        self, dynamodb_client_no_validation, hash_table
+    ):
+        # Non-string value is a wire type mismatch: Amazon DynamoDB returns
+        # SerializationException ("NUMBER_VALUE cannot be converted to String").
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client_no_validation.get_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ProjectionExpression="#a",
+                ExpressionAttributeNames={"#a": 5},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "SerializationException"
+        assert "Empty attribute name" not in err["Message"]
+
+
+class TestExpressionAttributeValuesEntries:
+    """ExpressionAttributeValues map entries must be well-formed."""
+
+    def test_value_key_prefix_only(self, dynamodb_client_no_validation, hash_table):
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client_no_validation.scan(
+                TableName=hash_table,
+                FilterExpression="foo = :",
+                ExpressionAttributeValues={":": {"S": "x"}},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert err["Message"] == (
+            'ExpressionAttributeValues contains invalid key: Syntax error; key: ":"'
+        )
+
+    def test_value_key_invalid_char(self, dynamodb_client_no_validation, hash_table):
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client_no_validation.scan(
+                TableName=hash_table,
+                FilterExpression="foo = :v",
+                ExpressionAttributeValues={":a-b": {"S": "x"}},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert err["Message"] == (
+            'ExpressionAttributeValues contains invalid key: Syntax error; key: ":a-b"'
+        )
+
+    def test_value_key_too_long(self, dynamodb_client_no_validation, hash_table):
+        key = ":" + "a" * 255
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client_no_validation.scan(
+                TableName=hash_table,
+                FilterExpression="foo = :v",
+                ExpressionAttributeValues={key: {"S": "x"}},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        # Quirk: unlike ExpressionAttributeNames, the values variant omits the
+        # "; size of key: N" suffix.
+        assert err["Message"] == (
+            "ExpressionAttributeValues contains invalid key: The expression "
+            "attribute map contains a key that is too long;"
+        )
+
+    def test_value_empty_attribute_value(self, dynamodb_client_no_validation, hash_table):
+        # An AttributeValue with no datatype member set.
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client_no_validation.scan(
+                TableName=hash_table,
+                FilterExpression="foo = :v",
+                ExpressionAttributeValues={":v": {}},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert err["Message"] == (
+            "ExpressionAttributeValues contains invalid value: Supplied "
+            "AttributeValue is empty, must contain exactly one of the "
+            "supported datatypes for key :v"
+        )
+
+    def test_value_empty_string_is_accepted(self, dynamodb_client, hash_table):
+        # Positive control: an empty *string* value is valid (no match here).
+        resp = dynamodb_client.scan(
+            TableName=hash_table,
+            FilterExpression="foo = :v",
+            ExpressionAttributeValues={":v": {"S": ""}},
+        )
+        assert resp["Count"] == 0

--- a/tests/test_expression_size_limit.py
+++ b/tests/test_expression_size_limit.py
@@ -1,0 +1,140 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Expression size-limit validation.
+
+Amazon DynamoDB caps each expression string at 4096 bytes, measured on the
+raw expression text (before #name / :value substitution). Over the limit it
+returns ``Invalid <Param>: Expression size has exceeded the maximum allowed
+size;``.
+
+A captured quirk: FilterExpression and ConditionExpression append
+`` expression size: <N>`` (N = raw byte length); ProjectionExpression,
+UpdateExpression, and KeyConditionExpression do not.
+
+Messages captured directly from Amazon DynamoDB (asomasun-admin, us-east-1).
+Dual-target against Amazon DynamoDB and extenddb.
+"""
+
+from __future__ import annotations
+
+import pytest
+from botocore.exceptions import ClientError
+
+from conftest import scoped_table
+
+MAX = 4096
+PREFIX = "Expression size has exceeded the maximum allowed size;"
+
+
+@pytest.fixture(scope="class")
+def hash_table(dynamodb_client):
+    """Hash-only table for the class, deleted on teardown."""
+    with scoped_table(dynamodb_client) as name:
+        dynamodb_client.put_item(
+            TableName=name,
+            Item={"pk": {"S": "k1"}, "foo": {"S": "a"}},
+        )
+        yield name
+
+
+def _name_of_len(total: int) -> str:
+    """A single valid attribute-name path of exactly ``total`` bytes."""
+    return "a" + "z" * (total - 1)
+
+
+class TestExpressionSizeLimit:
+    """Each expression string is capped at 4096 raw bytes."""
+
+    def test_projection_over_limit(self, dynamodb_client, hash_table):
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.get_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ProjectionExpression=_name_of_len(MAX + 1),
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        # Projection has no "expression size: N" suffix.
+        assert err["Message"] == f"Invalid ProjectionExpression: {PREFIX}"
+
+    def test_projection_at_limit_ok(self, dynamodb_client, hash_table):
+        # Exactly 4096 bytes is accepted (resolves to a missing attribute).
+        resp = dynamodb_client.get_item(
+            TableName=hash_table,
+            Key={"pk": {"S": "k1"}},
+            ProjectionExpression=_name_of_len(MAX),
+        )
+        assert resp.get("Item", {}) == {}
+
+    def test_filter_over_limit_has_size_suffix(self, dynamodb_client, hash_table):
+        path = _name_of_len(MAX + 1)
+        expr = f"{path} = :v"
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.scan(
+                TableName=hash_table,
+                FilterExpression=expr,
+                ExpressionAttributeValues={":v": {"S": "x"}},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        # Filter appends the raw byte length.
+        assert err["Message"] == (
+            f"Invalid FilterExpression: {PREFIX} expression size: {len(expr)}"
+        )
+
+    def test_condition_over_limit_has_size_suffix(self, dynamodb_client, hash_table):
+        path = _name_of_len(MAX + 1)
+        expr = f"attribute_not_exists({path})"
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.put_item(
+                TableName=hash_table,
+                Item={"pk": {"S": "sztest"}},
+                ConditionExpression=expr,
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert err["Message"] == (
+            f"Invalid ConditionExpression: {PREFIX} expression size: {len(expr)}"
+        )
+
+    def test_key_condition_over_limit_no_suffix(self, dynamodb_client, hash_table):
+        path = _name_of_len(MAX + 1)
+        expr = f"pk = :p AND {path} = :q"
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.query(
+                TableName=hash_table,
+                KeyConditionExpression=expr,
+                ExpressionAttributeValues={":p": {"S": "k1"}, ":q": {"S": "x"}},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert err["Message"] == f"Invalid KeyConditionExpression: {PREFIX}"
+
+    def test_update_over_limit_no_suffix(self, dynamodb_client, hash_table):
+        path = _name_of_len(MAX + 1)
+        expr = f"SET {path} = :v"
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_client.update_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                UpdateExpression=expr,
+                ExpressionAttributeValues={":v": {"S": "x"}},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert err["Message"] == f"Invalid UpdateExpression: {PREFIX}"
+
+    def test_size_measured_on_raw_text_not_substituted(self, dynamodb_client, hash_table):
+        # 686 short #aN placeholders => raw ~4005 bytes (under limit) even though
+        # the substituted form would be larger. Must be accepted.
+        names = {f"#a{i}": f"attribute{i}" for i in range(686)}
+        proj = ",".join(names.keys())
+        assert len(proj) <= MAX
+        resp = dynamodb_client.get_item(
+            TableName=hash_table,
+            Key={"pk": {"S": "k1"}},
+            ProjectionExpression=proj,
+            ExpressionAttributeNames=names,
+        )
+        assert resp.get("Item", {}) == {}


### PR DESCRIPTION
## What

1. **ExpressionAttributeNames / ExpressionAttributeValues map-entry validation.** ExtendDB previously checked only that the map was non-empty and that each key started with `#` / `:`. Amazon DynamoDB also validates the entries themselves. This adds, at the serde deserialization layer (so it runs for every API before any expression is parsed):
   - placeholder key must be `<prefix><ident>` where `<ident>` is one or more of `[A-Za-z0-9_]` (rejects bare `#`, `#a-b`, `##a`, etc.),
   - placeholder key at most 255 bytes including the prefix (length is checked before syntax),
   - the mapped value must not be empty: an empty attribute name for ExpressionAttributeNames, an AttributeValue carrying no datatype for ExpressionAttributeValues.

2. **Per-expression size limit.** Each expression string is capped at 4096 raw bytes, measured on the wire text before `#name` / `:value` substitution. New `LimitsConfig::max_expression_length_bytes` (default 4096), enforced via `check_expression_size` in the five expression parse helpers (projection, condition, filter, update, key-condition).

## Behavior: today vs Amazon DynamoDB

Every Amazon DynamoDB message below was captured directly via the AWS CLI / SDK.

**Map-entry validation**

| Scenario | ExtendDB (before this PR) | Amazon DynamoDB |
|---|---|---|
| `ExpressionAttributeNames={"#a-b":"foo"}` (invalid key char) | Not validated; surfaced a different, later error | `ValidationException: ExpressionAttributeNames contains invalid key: Syntax error; key: "#a-b"` |
| `ExpressionAttributeNames` key of 256 bytes | Accepted | `... contains invalid key: The expression attribute map contains a key that is too long; size of key: 256` |
| `ExpressionAttributeValues` key of 256 bytes | Accepted | `... contains invalid key: The expression attribute map contains a key that is too long;` (no `size of key` suffix) |
| `ExpressionAttributeNames={"#a":""}` (empty mapped name) | Accepted | `... contains invalid value: Empty attribute name for key #a` |
| `ExpressionAttributeValues={":v":{}}` (no datatype) | Generic `Supplied AttributeValue is empty ...` without the key | `... contains invalid value: Supplied AttributeValue is empty, must contain exactly one of the supported datatypes for key :v` |

**Expression size limit (4096 raw bytes)**

| Scenario | ExtendDB (before this PR) | Amazon DynamoDB |
|---|---|---|
| `ProjectionExpression` over 4096 bytes | Accepted | `ValidationException: Invalid ProjectionExpression: Expression size has exceeded the maximum allowed size;` |
| `FilterExpression` / `ConditionExpression` over 4096 bytes | Accepted | `Invalid <Param>: Expression size has exceeded the maximum allowed size; expression size: <N>` |
| `KeyConditionExpression` / `UpdateExpression` over 4096 bytes | Accepted | `Invalid <Param>: Expression size has exceeded the maximum allowed size;` (no `expression size` suffix) |

## Why

Conformance gaps found by comparing ExtendDB against Amazon DynamoDB. Expression size limit is a documented unresolved tech debt.

Closes # n/a

## Testing done

Captured every expected message from Amazon DynamoDB, then validated dual-target (ExtendDB and Amazon DynamoDB).

- New pytest: `tests/test_expression_attribute_map_validation.py` (13 cases) and `tests/test_expression_size_limit.py` (8 cases). All 19 pass against ExtendDB and the same 19 pass against Amazon DynamoDB.
- New Rust unit tests: `serde_helpers` (17, including byte-vs-char key length and the non-string-value type error) and `expression_helpers`.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a

## Breaking changes

n/a

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.