### PR TITLE
feat: SQLite storage backend (in-tree) with developer mode

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,6 +75,57 @@ jobs:
           EXTENDDB_TEST_PG_ADMIN_CONNECTION_STRING: postgresql://postgres:devpass@127.0.0.1:5432
         run: devtools/run-tests --extenddb --pytest --comprehensive --parallel --filter "not import_export"
 
+  run-integration-sqlite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Build release (SQLite backend)
+        run: cargo build --release -p extenddb --no-default-features --features sqlite
+
+      - name: Initialize ExtendDB
+        id: init
+        run: |
+          output=$(./target/release/extenddb init --backend sqlite --config extenddb.toml 2>&1)
+          echo "$output"
+          password=$(echo "$output" | grep -oP 'Password: \K\S+')
+          echo "admin_password=$password" >> "$GITHUB_OUTPUT"
+
+      - name: Start ExtendDB
+        run: |
+          # --write-pid-file so devtools/run-tests can restart the server with
+          # 'extenddb stop' when it needs to apply a config change.
+          ./target/release/extenddb serve --config extenddb.toml --foreground --write-pid-file &
+          for i in $(seq 1 30); do
+            if curl -sk https://127.0.0.1:18443/health | grep -q healthy; then
+              echo "Server ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server failed to start"
+          exit 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run integration tests
+        env:
+          EXTENDDB_TEST_ENDPOINT: https://127.0.0.1:18443
+          EXTENDDB_ADMIN_USER: admin
+          EXTENDDB_ADMIN_PASSWORD: ${{ steps.init.outputs.admin_password }}
+        run: devtools/run-tests --extenddb --pytest --comprehensive --parallel --filter "not import_export"
+
   run-rust-integration:
     runs-on: ubuntu-latest
     services:
@@ -162,11 +213,12 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
-    needs: [run-integration, run-rust-integration]
+    needs: [run-integration, run-integration-sqlite, run-rust-integration]
     if: always()
     steps:
       - run: |
           if [ "${{ needs.run-integration.result }}" != "success" ] || \
+             [ "${{ needs.run-integration-sqlite.result }}" != "success" ] || \
              [ "${{ needs.run-rust-integration.result }}" != "success" ]; then
             exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ pdfs/
 docs/rendered/
 discussions/
 .DS_Store
+extenddb.sqlite
+extenddb.sqlite-shm
+extenddb.sqlite-wal
+extenddb.toml.bak

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,8 +864,10 @@ version = "0.1.2"
 dependencies = [
  "anyhow",
  "extenddb-app",
+ "extenddb-config",
  "extenddb-storage",
  "extenddb-storage-postgres",
+ "extenddb-storage-sqlite",
 ]
 
 [[package]]
@@ -1056,6 +1058,32 @@ dependencies = [
  "toml",
  "tracing",
  "urlencoding",
+ "uuid",
+ "zeroize",
+]
+
+[[package]]
+name = "extenddb-storage-sqlite"
+version = "0.1.2"
+dependencies = [
+ "aes-gcm",
+ "async-trait",
+ "base64 0.22.1",
+ "bcrypt",
+ "bigdecimal",
+ "crc32fast",
+ "extenddb-auth",
+ "extenddb-core",
+ "extenddb-storage",
+ "futures",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "time",
+ "tokio",
+ "toml",
+ "tracing",
  "uuid",
  "zeroize",
 ]
@@ -1683,6 +1711,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/storage",
     "crates/config",
     "crates/storage-postgres",
+    "crates/storage-sqlite",
     "crates/auth",
     "crates/server",
     "crates/app",
@@ -29,6 +30,7 @@ extenddb-engine = { path = "crates/engine" }
 extenddb-storage = { path = "crates/storage" }
 extenddb-config = { path = "crates/config" }
 extenddb-storage-postgres = { path = "crates/storage-postgres" }
+extenddb-storage-sqlite = { path = "crates/storage-sqlite" }
 extenddb-auth = { path = "crates/auth" }
 extenddb-server = { path = "crates/server" }
 extenddb-app = { path = "crates/app" }

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -7,6 +7,12 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[features]
+# Developer mode: plain HTTP on loopback, open authorization (SigV4 still
+# enforced), seeded dev credential. A build-time profile for local/CI only;
+# the thin bin enforces that it is paired with a dev/CI backend.
+dev-mode = ["extenddb-config/dev-mode"]
+
 [dependencies]
 extenddb-auth = { workspace = true }
 extenddb-cache = { workspace = true }

--- a/crates/app/src/cmd_init.rs
+++ b/crates/app/src/cmd_init.rs
@@ -16,8 +16,9 @@ use extenddb_config as config;
 #[derive(Args)]
 #[allow(clippy::doc_markdown)] // Clap help text, not rustdoc
 pub struct InitArgs {
-    /// Storage backend (postgres) (default: postgres)
-    #[arg(long, default_value = "postgres")]
+    /// Storage backend. Optional: the binary's compiled-in backend is used;
+    /// when given, it is validated against that backend.
+    #[arg(long)]
     backend: Option<String>,
 
     /// Data database name (default: extenddb)
@@ -120,15 +121,32 @@ fn discover_docs_dir() -> Option<String> {
 
 /// Returns exit code: 0 = success, 255 = existing config preserved.
 pub async fn run(args: InitArgs) -> anyhow::Result<u8> {
-    // Determine backend: CLI flag > config file > default
-    let backend = if let Some(ref b) = args.backend {
-        b.clone()
-    } else if Path::new(&args.config).exists() {
+    // The installed backend is authoritative — there is exactly one compiled
+    // into this binary. An explicit --backend (or a config file's backend key)
+    // is validated against it rather than driving dispatch, so a mismatch is a
+    // clear startup error instead of a mis-generated config.
+    let backend = extenddb_storage::backend_name()
+        .ok_or_else(|| anyhow::anyhow!("no storage backend installed"))?
+        .to_owned();
+    if let Some(ref requested) = args.backend
+        && *requested != backend
+    {
+        anyhow::bail!(
+            "this binary is built with the '{backend}' backend; \
+             --backend {requested} requires the extenddb-{requested} binary"
+        );
+    }
+    if args.backend.is_none() && Path::new(&args.config).exists() {
         let app_config = config::load(&args.config)?;
-        app_config.storage.backend
-    } else {
-        "postgres".to_owned()
-    };
+        if app_config.storage.backend != backend {
+            anyhow::bail!(
+                "config file '{}' selects backend '{}', but this binary is built \
+                 with the '{backend}' backend",
+                args.config,
+                app_config.storage.backend,
+            );
+        }
+    }
 
     println!("=== extenddb init (backend: {backend}) ===");
 
@@ -262,7 +280,6 @@ pub async fn run(args: InitArgs) -> anyhow::Result<u8> {
     }
 
     // Generate or update extenddb.toml.
-    let backend = args.backend.as_deref().unwrap_or("postgres");
     let config_path = &args.config;
 
     if Path::new(config_path).exists() {
@@ -270,7 +287,7 @@ pub async fn run(args: InitArgs) -> anyhow::Result<u8> {
     }
     generate_config(
         config_path,
-        backend,
+        &backend,
         bootstrapper.as_ref(),
         &bind_addr,
         docs_dir.as_deref(),

--- a/crates/app/src/cmd_serve.rs
+++ b/crates/app/src/cmd_serve.rs
@@ -49,20 +49,27 @@ pub struct ServeArgs {
 /// Binding before forking ensures port conflicts are reported to stderr
 /// before the parent process exits (D-4).
 pub fn run(args: &ServeArgs, build: BuildInfo) -> anyhow::Result<()> {
-    // P50: Check config file permissions before loading. The config file may
-    // contain the encryption key (via `extenddb init`). Reject if more permissive
-    // than 0600 (owner read/write only).
-    if !std::path::Path::new(&args.config).exists() {
+    // Load config early so bind address is known before fork. A dev-mode
+    // build serves with built-in defaults when no config file exists
+    // (zero-config local/CI use: loopback, in-memory storage, seeded dev
+    // credential — a drop-in for DynamoDB Local). Production builds require
+    // an `init`-generated config.
+    let config_exists = std::path::Path::new(&args.config).exists();
+    let app_config = if config_exists {
+        // P50: Check config file permissions before loading. The config file
+        // may contain the encryption key (via `extenddb init`). Reject if more
+        // permissive than 0600 (owner read/write only).
+        check_config_permissions(&args.config)?;
+        config::load(&args.config)?
+    } else if cfg!(feature = "dev-mode") {
+        config::load_builtin_defaults()?
+    } else {
         anyhow::bail!(
             "Config file '{}' not found. Run 'extenddb init' to create one, \
              or use --config <path> to specify a different location.",
             args.config,
         );
-    }
-    check_config_permissions(&args.config)?;
-
-    // Load config early so bind address is known before fork.
-    let app_config = config::load(&args.config)?;
+    };
 
     // D5: TLS is mandatory — except in a dev-mode build, which deliberately
     // serves plain HTTP on loopback for frictionless local/CI use.
@@ -142,8 +149,11 @@ pub fn run(args: &ServeArgs, build: BuildInfo) -> anyhow::Result<()> {
         println!("{banner_line2}");
     }
     if cfg!(feature = "dev-mode") {
-        let msg = "  DEVELOPER MODE: plain HTTP on loopback, authorization open \
-                   (SigV4 still enforced). Not for production.";
+        let msg = format!(
+            "  DEVELOPER MODE: plain HTTP on loopback, authorization open \
+             (SigV4 still enforced). Serving storage: {}. Not for production.",
+            config::redact_password(app_config.storage.connection_config()),
+        );
         if args.foreground {
             eprintln!("{msg}");
         } else {

--- a/crates/app/src/cmd_serve.rs
+++ b/crates/app/src/cmd_serve.rs
@@ -64,8 +64,9 @@ pub fn run(args: &ServeArgs, build: BuildInfo) -> anyhow::Result<()> {
     // Load config early so bind address is known before fork.
     let app_config = config::load(&args.config)?;
 
-    // D5: TLS is mandatory. Reject explicit opt-out.
-    if !app_config.server.tls.enabled {
+    // D5: TLS is mandatory — except in a dev-mode build, which deliberately
+    // serves plain HTTP on loopback for frictionless local/CI use.
+    if !cfg!(feature = "dev-mode") && !app_config.server.tls.enabled {
         anyhow::bail!("TLS is mandatory. Remove `tls.enabled = false` from your config file.");
     }
 
@@ -88,6 +89,24 @@ pub fn run(args: &ServeArgs, build: BuildInfo) -> anyhow::Result<()> {
     let catalog_version = extenddb_storage::operations::catalog_version()?;
 
     let port = args.port.unwrap_or(app_config.server.port);
+
+    // Dev mode serves plain HTTP with relaxed authorization; confine it to
+    // loopback so it can never be exposed off-host.
+    if cfg!(feature = "dev-mode") {
+        let host = app_config.server.bind_addr.trim();
+        let loopback = host == "localhost"
+            || host
+                .parse::<std::net::IpAddr>()
+                .map(|ip| ip.is_loopback())
+                .unwrap_or(false);
+        if !loopback {
+            anyhow::bail!(
+                "dev-mode builds may only bind to loopback (127.0.0.1, ::1, localhost); \
+                 got server.bind_addr = '{host}'"
+            );
+        }
+    }
+
     let bind_addr = format!("{}:{}", app_config.server.bind_addr, port);
 
     // Bind in sync context — errors go to stderr before daemonizing.
@@ -122,6 +141,15 @@ pub fn run(args: &ServeArgs, build: BuildInfo) -> anyhow::Result<()> {
         println!("{banner_line1}");
         println!("{banner_line2}");
     }
+    if cfg!(feature = "dev-mode") {
+        let msg = "  DEVELOPER MODE: plain HTTP on loopback, authorization open \
+                   (SigV4 still enforced). Not for production.";
+        if args.foreground {
+            eprintln!("{msg}");
+        } else {
+            println!("{msg}");
+        }
+    }
 
     // D-3: A PID file lets `extenddb status` and `extenddb stop` find the
     // process. Daemon mode always writes one. Foreground mode writes one only on
@@ -147,6 +175,12 @@ pub fn run(args: &ServeArgs, build: BuildInfo) -> anyhow::Result<()> {
         let pid_file = pid_file
             .as_ref()
             .expect("daemon mode always has a PID file path");
+        // The listening socket bound successfully above, which proves no live
+        // server owns this port. Any existing PID file is therefore stale (a
+        // prior run that crashed or was killed without cleanup). Remove it
+        // before daemonizing so startup verification reads the new daemon's
+        // PID rather than a dead one from a previous run.
+        let _ = std::fs::remove_file(pid_file);
         let daemon = Daemonize::new().pid_file(pid_file);
         match daemon.execute() {
             daemonize::Outcome::Parent(Ok(_)) => {
@@ -181,13 +215,13 @@ pub fn run(args: &ServeArgs, build: BuildInfo) -> anyhow::Result<()> {
         .enable_all()
         .build()?
         .block_on(extenddb_server::serve(
-            ServeParams::new(app_config, std_listener, pid_file, build).with_log_target(
-                if args.foreground {
+            ServeParams::new(app_config, std_listener, pid_file, build)
+                .with_log_target(if args.foreground {
                     LogTarget::Stderr
                 } else {
                     LogTarget::Syslog
-                },
-            ),
+                })
+                .with_dev_mode(cfg!(feature = "dev-mode")),
         ))
 }
 

--- a/crates/app/src/manage_http.rs
+++ b/crates/app/src/manage_http.rs
@@ -38,12 +38,13 @@ pub fn resolve_endpoint(
             return Ok((rest.to_owned(), false, None));
         }
         let app_config = config::load(config_path)?;
-        let cert = if app_config.server.tls.enabled {
+        let use_tls = config::is_tls_enabled(&app_config);
+        let cert = if use_tls {
             Some(config::expand_tilde(&app_config.server.tls.cert_path))
         } else {
             None
         };
-        return Ok((ep.to_owned(), app_config.server.tls.enabled, cert));
+        return Ok((ep.to_owned(), use_tls, cert));
     }
     if !std::path::Path::new(config_path).exists() {
         anyhow::bail!(
@@ -57,16 +58,13 @@ pub fn resolve_endpoint(
     } else {
         &app_config.server.bind_addr
     };
-    let cert = if app_config.server.tls.enabled {
+    let use_tls = config::is_tls_enabled(&app_config);
+    let cert = if use_tls {
         Some(config::expand_tilde(&app_config.server.tls.cert_path))
     } else {
         None
     };
-    Ok((
-        format!("{addr}:{}", app_config.server.port),
-        app_config.server.tls.enabled,
-        cert,
-    ))
+    Ok((format!("{addr}:{}", app_config.server.port), use_tls, cert))
 }
 
 /// Resolve the password from: CLI arg or `EXTENDDB_PASSWORD` env var.

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -11,8 +11,21 @@ license.workspace = true
 name = "extenddb"
 path = "src/main.rs"
 
+[features]
+default = ["postgres"]
+postgres = ["extenddb-storage-postgres"]
+sqlite = ["extenddb-storage-sqlite"]
+# Build the SQLite backend in its zero-config, ephemeral in-memory mode.
+sqlite-memory = ["sqlite", "extenddb-storage-sqlite/memory"]
+# Developer mode: plain HTTP on loopback, open authorization (SigV4 still
+# enforced), seeded dev credential. A build-time profile for local/CI only; it
+# requires a dev backend (`sqlite`/`sqlite-memory`) and fails to build with a
+# production backend like `postgres` (enforced at compile time in `main.rs`).
+dev-mode = ["extenddb-app/dev-mode"]
+
 [dependencies]
 extenddb-app = { workspace = true }
 extenddb-storage = { workspace = true }
-extenddb-storage-postgres = { workspace = true }
+extenddb-storage-postgres = { workspace = true, optional = true }
+extenddb-storage-sqlite = { workspace = true, optional = true }
 anyhow = { workspace = true }

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -29,3 +29,4 @@ extenddb-storage = { workspace = true }
 extenddb-storage-postgres = { workspace = true, optional = true }
 extenddb-storage-sqlite = { workspace = true, optional = true }
 anyhow = { workspace = true }
+extenddb-config = { workspace = true }

--- a/crates/bin/src/main.rs
+++ b/crates/bin/src/main.rs
@@ -57,3 +57,53 @@ fn main() -> anyhow::Result<()> {
         build_time: env!("EXTENDDB_BUILD_TIME"),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    /// Install this binary's backend once for the test process.
+    fn install_backend() {
+        #[cfg(feature = "postgres")]
+        let _ = extenddb_storage::set_backend(extenddb_storage_postgres::backend());
+        #[cfg(feature = "sqlite")]
+        let _ = extenddb_storage::set_backend(extenddb_storage_sqlite::backend());
+    }
+
+    /// Zero-config serve contract: with the SQLite backend installed,
+    /// built-in defaults deserialize with no config file, bind to loopback
+    /// (so the dev-mode loopback guard passes), and select the backend's
+    /// default storage path.
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn builtin_defaults_load_for_sqlite_and_bind_loopback() {
+        install_backend();
+        let cfg = extenddb_config::load_builtin_defaults()
+            .expect("sqlite storage config has no required fields");
+        assert_eq!(cfg.server.bind_addr, "127.0.0.1");
+        assert_eq!(cfg.server.port, 18443);
+        // The sqlite config absolutizes a relative file path against the
+        // working directory, so match on the invariant part of each default.
+        let path = cfg.storage.connection_config();
+        if cfg!(feature = "sqlite-memory") {
+            assert_eq!(path, ":memory:");
+        } else {
+            assert!(
+                path.ends_with("extenddb.sqlite"),
+                "default file path should be extenddb.sqlite, got: {path}"
+            );
+        }
+    }
+
+    /// `load_builtin_defaults` is only reachable from dev-mode builds (a
+    /// postgres + dev-mode binary is a compile error), but its defaults must
+    /// never relax the production posture regardless of backend: loopback
+    /// bind and TLS enabled.
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn builtin_defaults_keep_loopback_and_tls_for_postgres() {
+        install_backend();
+        let cfg = extenddb_config::load_builtin_defaults()
+            .expect("postgres storage config defaults to a local dev connection");
+        assert_eq!(cfg.server.bind_addr, "127.0.0.1");
+        assert!(cfg.server.tls.enabled);
+    }
+}

--- a/crates/bin/src/main.rs
+++ b/crates/bin/src/main.rs
@@ -1,19 +1,53 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! extenddb — the PostgreSQL-backed ExtendDB server binary.
+//! extenddb — the ExtendDB server binary.
 //!
 //! This is the reference thin bin for the per-backend packaging model: it
 //! installs exactly one backend and hands off to the shared `extenddb-app` CLI.
 //! A third-party backend author copies this file, swaps the `backend()` call for
 //! their crate, and ships their own `extenddb-<backend>` image — with no edits to
 //! any ExtendDB core crate.
+//!
+//! In-tree backends are selected by mutually exclusive Cargo features
+//! (`postgres` is the default; `sqlite`/`sqlite-memory` build the dev/CI
+//! backend). Exactly one must be enabled: [`set_backend`] installs one backend
+//! per process, so a build with both would be ambiguous and is rejected at
+//! compile time.
+
+// Exactly one backend feature must be enabled.
+#[cfg(all(feature = "postgres", feature = "sqlite"))]
+compile_error!(
+    "the `postgres` and `sqlite` features are mutually exclusive: a thin bin \
+     installs exactly one backend (build the SQLite binary with \
+     `--no-default-features --features sqlite`)"
+);
+#[cfg(not(any(feature = "postgres", feature = "sqlite")))]
+compile_error!("no backend selected: enable the `postgres` (default) or `sqlite` feature");
+
+// Developer mode relaxes the security posture (plain HTTP on loopback, open
+// authorization). It is a dev/CI-only profile and must be built only with a
+// dev/CI-suitable backend. Rather than denying each production backend by name
+// (every backend is a production backend unless proven otherwise, so a deny-list
+// would have to grow with each new one), require a known dev backend: dev-mode
+// compiles only when `sqlite` is enabled. `sqlite-memory` enables `sqlite`, so it
+// is covered too; postgres — or any future production backend — fails the build,
+// so there is no path by which a production deployment can serve in dev mode.
+#[cfg(all(feature = "dev-mode", not(feature = "sqlite")))]
+compile_error!(
+    "the `dev-mode` feature requires a dev/CI backend such as `sqlite`; it must \
+     not be built with a production backend like `postgres` (build with \
+     `--no-default-features --features sqlite-memory,dev-mode`)"
+);
 
 fn main() -> anyhow::Result<()> {
     // Install the compiled-in backend before dispatch. The compiler checks this
     // call; there is no link-time auto-registration and no name to resolve, so a
     // missing or mistyped backend cannot become a runtime error.
+    #[cfg(feature = "postgres")]
     extenddb_storage::set_backend(extenddb_storage_postgres::backend())?;
+    #[cfg(feature = "sqlite")]
+    extenddb_storage::set_backend(extenddb_storage_sqlite::backend())?;
 
     extenddb_app::run(extenddb_app::BuildInfo {
         // Read from the bin crate so the reported version is the deployed

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -7,6 +7,11 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[features]
+# Developer mode: `is_tls_enabled` reports plain HTTP regardless of the
+# configured TLS state. Enabled only through the app crate's `dev-mode` feature.
+dev-mode = []
+
 [dependencies]
 extenddb-core = { workspace = true }
 extenddb-storage = { workspace = true }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -355,6 +355,18 @@ fn default_log_format() -> String {
     "pretty".to_owned()
 }
 
+/// Effective TLS state for a loaded config.
+///
+/// A `dev-mode` build always serves plain HTTP on loopback regardless of the
+/// configured `server.tls.enabled` (which defaults to `true`). This is the
+/// single source of truth so the server (`cmd_serve`) and the `manage` client
+/// agree on the scheme; reading `config.server.tls.enabled` directly is a bug
+/// in dev-mode builds.
+#[must_use]
+pub fn is_tls_enabled(config: &AppConfig) -> bool {
+    config.server.tls.enabled && !cfg!(feature = "dev-mode")
+}
+
 /// Load `AppConfig` from a config file (optional) and environment variables.
 ///
 /// # Errors

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -381,6 +381,37 @@ pub fn load(config_path: &str) -> anyhow::Result<AppConfig> {
     Ok(config.try_deserialize()?)
 }
 
+/// Load `AppConfig` entirely from built-in defaults and environment variables,
+/// with no config file.
+///
+/// Supports zero-config `serve` in dev-mode builds: the installed backend's
+/// `[storage.<name>]` section is synthesized empty, so every storage field
+/// takes its default (for the SQLite dev build that is the in-memory path).
+/// Server defaults are loopback + port 18443, satisfying the dev-mode
+/// loopback guard. `EXTENDDB__*` environment overrides still apply on top.
+///
+/// A backend whose storage config has required fields fails deserialization
+/// here with that field named, which is correct: such a backend cannot run
+/// without a config file.
+///
+/// # Errors
+///
+/// Returns an error if no backend is installed, or if environment variable
+/// values cannot be deserialized.
+pub fn load_builtin_defaults() -> anyhow::Result<AppConfig> {
+    let backend = extenddb_storage::backend_name()
+        .ok_or_else(|| anyhow::anyhow!("no storage backend installed"))?;
+    let storage_section = format!("[storage.{backend}]\n");
+    let config = config::Config::builder()
+        .add_source(config::File::from_str(
+            &storage_section,
+            config::FileFormat::Toml,
+        ))
+        .add_source(config::Environment::with_prefix("EXTENDDB").separator("__"))
+        .build()?;
+    Ok(config.try_deserialize()?)
+}
+
 /// Redact password from a connection string for safe logging (REQ-LOG-002).
 ///
 /// Uses the backend-specific operations engine to handle different connection

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -60,6 +60,10 @@ pub struct AppState {
     pub metrics: Arc<MetricsCollector>,
     /// Whether TLS is enabled (affects cookie Secure flag).
     pub tls_enabled: bool,
+    /// Developer mode: authorization is opened for authenticated callers (SigV4
+    /// is still verified). Only ever true in a `dev-mode` build bound to
+    /// loopback; the bin's serve path enforces those preconditions.
+    pub dev_mode: bool,
     /// Allowed directories for import file operations. Empty means imports
     /// are disabled (secure default).
     pub import_paths: Arc<[Arc<std::path::PathBuf>]>,

--- a/crates/server/src/request_helpers.rs
+++ b/crates/server/src/request_helpers.rs
@@ -108,6 +108,14 @@ pub(crate) async fn authorize_request(
         _ => None,
     };
 
+    // Developer mode opens authorization for the authenticated caller. SigV4
+    // verification already ran upstream, so the request is authenticated; only
+    // the IAM policy decision is skipped. key_info is still returned so the
+    // engine layer can reuse it.
+    if state.dev_mode {
+        return Ok(key_info);
+    }
+
     let pk_attr = key_info
         .as_ref()
         .map(|ki| ki.key_schema[0].attribute_name.clone());

--- a/crates/server/src/serve.rs
+++ b/crates/server/src/serve.rs
@@ -264,10 +264,15 @@ async fn serve_inner(params: ServeParams, port: u16) -> anyhow::Result<()> {
         .try_init()
         .map_err(|e| anyhow::anyhow!("Failed to initialize tracing: {e}"))?;
 
-    // Create server components via factory pattern
+    // Create server components via factory pattern. Dev mode asks the backend
+    // to bootstrap an uninitialized catalog at serve time (zero-config use).
+    let mut component_options =
+        extenddb_storage::server_components::ServerComponentsOptions::default();
+    component_options.bootstrap_if_uninitialized = dev_mode;
     let components = extenddb_storage::create_server_components(
         app_config.storage.as_trait(),
         &app_config.server.region,
+        component_options,
     )
     .await?;
 
@@ -284,7 +289,8 @@ async fn serve_inner(params: ServeParams, port: u16) -> anyhow::Result<()> {
         let dev_access_key = seed_dev_credential(catalog_store.as_ref()).await?;
         tracing::warn!(
             "DEVELOPER MODE active — plain HTTP, authorization open (SigV4 still \
-             enforced), loopback only. Signing credential: {dev_access_key}"
+             enforced), loopback only. Storage: {}. Signing credential: {dev_access_key}",
+            config::redact_password(app_config.storage.connection_config()),
         );
     }
 

--- a/crates/server/src/serve.rs
+++ b/crates/server/src/serve.rs
@@ -99,6 +99,11 @@ pub struct ServeParams {
     pub log_target: LogTarget,
     /// Build provenance of the deployed binary.
     pub build: BuildInfo,
+    /// Developer mode: serve plain HTTP, open authorization for authenticated
+    /// callers (SigV4 still verified), and seed the well-known dev credential.
+    /// Only a `dev-mode` build of the app crate ever sets this, and it enforces
+    /// the loopback-only bind before handing over the listener.
+    pub dev_mode: bool,
 }
 
 impl ServeParams {
@@ -116,6 +121,7 @@ impl ServeParams {
             pid_file,
             log_target: LogTarget::Syslog,
             build,
+            dev_mode: false,
         }
     }
 
@@ -123,6 +129,14 @@ impl ServeParams {
     #[must_use]
     pub fn with_log_target(mut self, target: LogTarget) -> Self {
         self.log_target = target;
+        self
+    }
+
+    /// Enable developer mode (plain HTTP, open authorization, seeded dev
+    /// credential). The caller is responsible for the loopback-only bind.
+    #[must_use]
+    pub fn with_dev_mode(mut self, dev_mode: bool) -> Self {
+        self.dev_mode = dev_mode;
         self
     }
 }
@@ -178,6 +192,7 @@ async fn serve_inner(params: ServeParams, port: u16) -> anyhow::Result<()> {
         pid_file,
         log_target,
         build,
+        dev_mode,
     } = params;
     let catalog_version =
         extenddb_storage::operations::catalog_version().unwrap_or_else(|_| "unknown".to_string());
@@ -260,6 +275,18 @@ async fn serve_inner(params: ServeParams, port: u16) -> anyhow::Result<()> {
     let catalog_store = components.catalog_store;
     let cred_store = components.credential_store;
     let runtime_hooks = components.runtime_hooks;
+
+    // Dev mode: adopt the credential the SDK will sign with (from the standard
+    // AWS_* env) and verify against it. Seeded here so it works for both
+    // file-backed and bootstrap-on-serve (in-memory) deployments. SigV4
+    // verification is unchanged; only the IAM policy decision is opened.
+    if dev_mode {
+        let dev_access_key = seed_dev_credential(catalog_store.as_ref()).await?;
+        tracing::warn!(
+            "DEVELOPER MODE active — plain HTTP, authorization open (SigV4 still \
+             enforced), loopback only. Signing credential: {dev_access_key}"
+        );
+    }
 
     // Build SwrCacheConfig values from the [auth.cache] TOML section.
     let cache_cfg = &app_config.auth.cache;
@@ -372,7 +399,9 @@ async fn serve_inner(params: ServeParams, port: u16) -> anyhow::Result<()> {
     // P120e: Create metrics collector early so workers can record health.
     let metrics = Arc::new(extenddb_core::metrics::MetricsCollector::new());
 
-    let tls_enabled = app_config.server.tls.enabled;
+    // Dev mode serves plain HTTP regardless of the configured TLS state; the
+    // app crate's `config::is_tls_enabled` applies the same rule for clients.
+    let tls_enabled = app_config.server.tls.enabled && !dev_mode;
 
     // P53: Resolve import and export path lists. Supports both the new
     // [import]/[export] sections and the deprecated import_export_root.
@@ -491,6 +520,7 @@ async fn serve_inner(params: ServeParams, port: u16) -> anyhow::Result<()> {
         ),
         metrics: metrics.clone(),
         tls_enabled,
+        dev_mode,
         import_paths,
         export_paths,
         throttle: throttle.clone(),
@@ -620,4 +650,78 @@ pub fn log_to_syslog_raw(msg: &str) {
             libc::syslog(libc::LOG_CRIT, c"%s".as_ptr(), cmsg.as_ptr());
         }
     }
+}
+
+/// Seed (or refresh) the developer-mode credential and return its access key id.
+///
+/// Dev mode verifies SigV4 exactly like production, so the server must know the
+/// credential the SDK signs with. To stay a drop-in for local development:
+///
+///  * If `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` are set in the server's
+///    environment, the server **adopts and verifies against them**. In the
+///    common CI case the SDK and the co-located server read the same env, so
+///    the user changes nothing but the endpoint URL.
+///  * Otherwise it seeds AWS's documented example credential as a well-known
+///    default the user can point any SDK at.
+///
+/// This mirrors the admin-credential pattern (env-or-default), differing only in
+/// that the default is well-known rather than randomly generated, because an SDK
+/// must know the credential up front (it cannot read a printed banner). Seeding
+/// goes through the generic management surface, so it is backend-agnostic.
+async fn seed_dev_credential(
+    catalog_store: &dyn extenddb_storage::CatalogStore,
+) -> anyhow::Result<String> {
+    use extenddb_storage::management_store::OpError;
+
+    // AWS's documented example credential (recognised everywhere and allowlisted
+    // by secret scanners): the zero-config default users point their SDK at.
+    const DEFAULT_ACCESS_KEY_ID: &str = "AKIAIOSFODNN7EXAMPLE";
+    const DEFAULT_SECRET: &str = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+
+    let access_key_id = std::env::var("AWS_ACCESS_KEY_ID")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_ACCESS_KEY_ID.to_owned());
+    let secret = std::env::var("AWS_SECRET_ACCESS_KEY")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_SECRET.to_owned());
+
+    // The access-key prefix is a credential-type discriminator across the auth
+    // layer: `AKIA*` = long-lived IAM user keys, `ASIA*` = temporary role
+    // session credentials (they carry `is_session`, are subject to
+    // ExpiredTokenException, and are invalidated with their role). The dev
+    // credential is a long-lived key on a *user*, so require the AKIA shape; an
+    // ASIA-shaped key here would be a user credential the rest of the system
+    // treats as a role session credential (e.g. user-delete invalidation
+    // matches `AKIA*`, not `ASIA*`).
+    if !access_key_id.starts_with("AKIA") {
+        anyhow::bail!(
+            "dev credential AWS_ACCESS_KEY_ID must be AKIA-shaped (got '{access_key_id}'); \
+             use e.g. AKIAIOSFODNN7EXAMPLE, or unset it to use the default."
+        );
+    }
+
+    // Attach the dev user to the deployment's recorded default account (set at
+    // bootstrap) rather than inferring it from account-list ordering.
+    let account_id = catalog_store
+        .default_account_id()
+        .await
+        .map_err(|e| anyhow::anyhow!("dev mode: failed to read default account: {e:?}"))?
+        .ok_or_else(|| {
+            anyhow::anyhow!("dev mode: no default account recorded (catalog not bootstrapped)")
+        })?;
+
+    match catalog_store.create_user(&account_id, "dev", None).await {
+        Ok(()) | Err(OpError::AlreadyExists(_)) => {}
+        Err(e) => anyhow::bail!("dev mode: failed to create dev user: {e:?}"),
+    }
+    match catalog_store
+        .import_access_key(&account_id, "dev", &access_key_id, &secret)
+        .await
+    {
+        Ok(()) | Err(OpError::AlreadyExists(_)) => {}
+        Err(e) => anyhow::bail!("dev mode: failed to import dev credential: {e:?}"),
+    }
+    Ok(access_key_id)
 }

--- a/crates/storage-postgres/src/bootstrapper.rs
+++ b/crates/storage-postgres/src/bootstrapper.rs
@@ -272,29 +272,45 @@ impl Bootstrapper for PostgresBootstrapper {
 
     async fn bootstrap_default_account(&self) -> OpResult<()> {
         let pool = self.app_pool(&self.config.catalog_db).await?;
-        let exists: bool = sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM accounts)")
-            .fetch_one(&pool)
-            .await
-            .map_err(|e| OpError::Internal(format!("Check accounts: {e}")))?;
-
-        if exists {
-            println!("--- Default account already exists, skipping.");
-            return Ok(());
-        }
-
-        let account_id = generate_account_id();
-        println!("--- Creating default account '{account_id}'...");
+        // Reuse the existing account when already bootstrapped, otherwise create
+        // the single default account. Either way, record its id as the canonical
+        // default account so callers never infer it from list ordering. The
+        // settings write is idempotent, so it also backfills the marker for
+        // catalogs bootstrapped before it existed.
+        let account_id: String =
+            match sqlx::query_scalar("SELECT account_id FROM accounts ORDER BY account_id LIMIT 1")
+                .fetch_optional(&pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("Check accounts: {e}")))?
+            {
+                Some(id) => {
+                    println!("--- Default account already exists, skipping.");
+                    id
+                }
+                None => {
+                    let id = generate_account_id();
+                    println!("--- Creating default account '{id}'...");
+                    sqlx::query(
+                        "INSERT INTO accounts (account_id, account_name) VALUES ($1, $2) \
+                     ON CONFLICT (account_id) DO NOTHING",
+                    )
+                    .bind(&id)
+                    .bind("default")
+                    .execute(&pool)
+                    .await
+                    .map_err(|e| OpError::Internal(format!("Create account: {e}")))?;
+                    println!("    Account ID: {id}");
+                    id
+                }
+            };
         sqlx::query(
-            "INSERT INTO accounts (account_id, account_name) VALUES ($1, $2) \
-             ON CONFLICT (account_id) DO NOTHING",
+            "INSERT INTO settings (key, value) VALUES ('default_account_id', $1) \
+             ON CONFLICT (key) DO NOTHING",
         )
         .bind(&account_id)
-        .bind("default")
         .execute(&pool)
         .await
-        .map_err(|e| OpError::Internal(format!("Create account: {e}")))?;
-
-        println!("    Account ID: {account_id}");
+        .map_err(|e| OpError::Internal(format!("Record default account id: {e}")))?;
         Ok(())
     }
 

--- a/crates/storage-postgres/src/lib.rs
+++ b/crates/storage-postgres/src/lib.rs
@@ -429,6 +429,10 @@ impl ServerRuntimeHooks for PostgresRuntimeHooks {
 fn server_components_factory(
     config: &dyn extenddb_storage::config::StorageConfig,
     region: &str,
+    // PostgreSQL bootstrap needs operator input (databases, roles, admin
+    // credentials), so `bootstrap_if_uninitialized` is not honored here:
+    // an uninitialized catalog fails with the explicit-`init` guidance.
+    _options: extenddb_storage::server_components::ServerComponentsOptions,
 ) -> std::pin::Pin<
     Box<dyn std::future::Future<Output = Result<ServerComponents, BackendError>> + Send>,
 > {

--- a/crates/storage-postgres/src/management_store/accounts.rs
+++ b/crates/storage-postgres/src/management_store/accounts.rs
@@ -99,6 +99,16 @@ impl PostgresCatalogStore {
             })
     }
 
+    pub(crate) async fn default_account_id_impl(&self) -> OpResult<Option<String>> {
+        sqlx::query_scalar("SELECT value FROM settings WHERE key = 'default_account_id'")
+            .fetch_optional(self.pool())
+            .await
+            .map_err(|e| {
+                tracing::error!("default_account_id: {e}");
+                OpError::Internal("Database error".to_owned())
+            })
+    }
+
     pub(crate) async fn list_all_accounts_full_impl(
         &self,
     ) -> OpResult<Vec<(String, String, time::OffsetDateTime)>> {

--- a/crates/storage-postgres/src/management_store/mod.rs
+++ b/crates/storage-postgres/src/management_store/mod.rs
@@ -38,6 +38,10 @@ impl extenddb_storage::management_store::ManagementStore for PostgresCatalogStor
         Box::pin(async move { self.list_all_accounts_impl().await })
     }
 
+    fn default_account_id(&self) -> BoxFuture<'_, OpResult<Option<String>>> {
+        Box::pin(async move { self.default_account_id_impl().await })
+    }
+
     fn list_all_accounts_full(
         &self,
     ) -> BoxFuture<'_, OpResult<Vec<(String, String, time::OffsetDateTime)>>> {

--- a/crates/storage-sqlite/.gitignore
+++ b/crates/storage-sqlite/.gitignore
@@ -1,0 +1,5 @@
+/target
+Cargo.lock
+*.db
+*.db-wal
+*.db-shm

--- a/crates/storage-sqlite/Cargo.toml
+++ b/crates/storage-sqlite/Cargo.toml
@@ -1,0 +1,37 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+[package]
+name = "extenddb-storage-sqlite"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[features]
+# Compile the in-memory (`:memory:`) database in as the default storage path,
+# yielding a zero-config, ephemeral, bootstrap-on-serve deployment (no `init`,
+# no file on disk). Without this feature the backend is file-backed and the path
+# must be configured as usual.
+memory = []
+
+[dependencies]
+extenddb-core = { workspace = true }
+extenddb-storage = { workspace = true }
+extenddb-auth = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { workspace = true, features = ["sqlite"] }
+tokio = { workspace = true, features = ["sync"] }
+toml = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true }
+time = { workspace = true }
+base64 = { workspace = true }
+bcrypt = { workspace = true }
+aes-gcm = { workspace = true }
+rand = { workspace = true }
+bigdecimal = { workspace = true }
+crc32fast = { workspace = true }
+zeroize = { workspace = true }

--- a/crates/storage-sqlite/README.md
+++ b/crates/storage-sqlite/README.md
@@ -1,0 +1,115 @@
+# extenddb-storage-sqlite
+
+SQLite storage backend for [ExtendDB](https://github.com/ExtendDB/extenddb), an
+in-tree workspace crate selected by Cargo feature.
+
+## Design
+
+Single-file (or in-memory) storage using SQLite via `sqlx`. Targets:
+
+- Local development without PostgreSQL
+- CI / integration tests (especially the ephemeral in-memory mode)
+- Single-node, embedded, and edge deployments
+
+Key differences from the PostgreSQL backend:
+
+- One connection pool for all operations (catalog and data share a single SQLite
+  database rather than separate catalog/data databases)
+- WAL mode for concurrent reads; writes are serialized by the engine
+- GSI propagation via a persistent `gsi_pending` queue with a configurable delay
+  (a delay of 0 applies updates synchronously on the write path); LSI
+  propagation is synchronous
+- OR-expansion for pagination (SQLite lacks row-value tuple comparison)
+
+It shares the PostgreSQL backend's catalog version gate: the server refuses to
+start unless its compiled `CATALOG_VERSION` matches the stored `catalog_version`.
+
+## Building
+
+The backend is compiled into the `extenddb` binary via feature flags (Postgres
+remains the default):
+
+```bash
+# Postgres (default) plus the file-backed SQLite backend
+cargo build -p extenddb --features sqlite
+
+# SQLite only, no Postgres compiled in
+cargo build -p extenddb --no-default-features --features sqlite
+
+# SQLite in zero-config, ephemeral in-memory mode
+cargo build -p extenddb --no-default-features --features sqlite-memory
+```
+
+## Configuration
+
+```toml
+[storage]
+backend = "sqlite"
+
+[storage.sqlite]
+# Database file path, or ":memory:" for an ephemeral in-memory database.
+path = "extenddb.sqlite"
+# Read connection pool size (writes are serialized regardless).
+pool_size = 10
+```
+
+### In-memory mode
+
+`path = ":memory:"` selects an ephemeral database that bootstraps on `serve`
+(no `init`, no file on disk). The `memory` crate feature (exposed by the binary
+as `sqlite-memory`) makes `:memory:` the compiled-in default path, so a binary
+built with that feature needs no path configured.
+
+## Developer mode
+
+A build-time profile that makes ExtendDB a drop-in replacement for DynamoDB
+Local: plain HTTP on loopback, open authorization, and a seeded credential — with
+real SigV4 verification still in force. It is enabled by the `dev-mode` feature
+and, by a compile-time guard, **can never be built with the Postgres backend**.
+
+```bash
+# Zero-config ephemeral server (in-memory, plain HTTP, dev credential)
+cargo build -p extenddb --no-default-features --features sqlite-memory,dev-mode
+extenddb serve --config extenddb.toml   # bootstraps on serve; no init
+```
+
+Point any SDK at it with the well-known default credential:
+
+```python
+boto3.client(
+    "dynamodb",
+    endpoint_url="http://127.0.0.1:18443",
+    region_name="us-east-1",
+    aws_access_key_id="AKIAIOSFODNN7EXAMPLE",
+    aws_secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+)
+```
+
+The server adopts the credential from its own `AWS_ACCESS_KEY_ID` /
+`AWS_SECRET_ACCESS_KEY` if set (so a CI job that already exports those works with
+no change), otherwise it seeds the AWS example credential shown above. Either way
+SigV4 is verified — a request signed with a different secret is rejected with
+`InvalidSignatureException`. Dev mode binds to loopback only.
+
+## Conformance
+
+Per [RFC-0002](https://github.com/ExtendDB/extenddb/blob/main/docs/rfcs), this
+backend implements the full storage trait surface.
+
+Mandatory traits (required for acceptance):
+
+- `TableEngine`, `DataEngine`
+- `ManagementStore`, `AdminStore`, `Bootstrapper`
+
+Optional traits (all implemented):
+
+- `MetadataEngine`, `StreamEngine`, `WorkerStore`
+- `SettingsStore`, `MetricsStore`, `RateLimitStore`, `AuthorizationStore`,
+  `BackupEngine`
+
+Conformance is validated by the shared ExtendDB integration suite run against a
+SQLite-served instance; per-trait results are tracked in CI.
+
+## License
+
+Apache License 2.0 — see the workspace [LICENSE](../../LICENSE).

--- a/crates/storage-sqlite/docs/design-decisions.md
+++ b/crates/storage-sqlite/docs/design-decisions.md
@@ -117,7 +117,12 @@ only) — identical to Postgres, no change needed.
   `schema.rs`. SQL logic is ported from PR #109 and corrected/retargeted.
 - **Single file, single logical DB.** Catalog and data tables co-locate (SQLite
   has no multi-database server). The dual-pool Postgres split collapses to one
-  store; `data_database_name` is recorded for diagnostics parity only.
+  logical store; `data_database_name` is recorded for diagnostics parity only.
+  Connection *pools* are not collapsed for file-backed databases: the serve path
+  opens two pools — the engine pool (all data reads/writes, serialized by
+  `write_lock`) and a separate catalog pool (catalog + credential stores) so
+  catalog reads don't contend with the data write lock. Only `:memory:` uses a
+  single pinned connection (see D4).
 - **Schema** is one authoritative migration mirroring Postgres `001_schema.sql`
   semantics: accounts, tables, indexes, tags, settings (seeded `catalog_version`
   = the compiled `CATALOG_VERSION`), stream_shards/records, seq_counters,

--- a/crates/storage-sqlite/docs/design-decisions.md
+++ b/crates/storage-sqlite/docs/design-decisions.md
@@ -1,0 +1,227 @@
+<!--
+Copyright 2026 ExtendDB contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+# extenddb-storage-sqlite — Design Decisions
+
+Status: **D1 and D2 APPROVED.** Rationale stands on correctness grounds below:
+`BEGIN IMMEDIATE` + single writer is the only model that makes
+condition-check-then-write atomic under SQLite (D1); an order-preserving TEXT
+encoding ordered under SQLite's default BINARY collation is the only portable way
+to preserve DynamoDB's 38-digit numeric ordering and precision without a custom
+collation or `REAL` truncation (D2).
+
+This memo records the SQLite-specific decisions taken to reach behavioural
+parity with the reference PostgreSQL backend (`crates/storage-postgres`). It is
+the SQLite analogue of the project's ADRs. The guiding principle is the one
+stated for the task: **correctness and as close to DynamoDB semantics as
+possible**, matching the integrity of the Postgres backend.
+
+The trait contract is the local `extenddb` working tree on `main`
+(v0.1.1-17-g93de8e3 at time of writing).
+
+---
+
+## D1 — Transaction isolation model  *(needs sign-off)*
+
+### Requirement
+DynamoDB requires, and the Postgres backend provides:
+- Condition expressions evaluated **atomically** with the write they guard.
+- `TransactWriteItems`: all-or-nothing across multiple items/tables.
+- `TransactGetItems`: a single consistent (serializable) snapshot.
+- Atomic stream-record capture in the same transaction as the data write.
+- Atomic idempotency-token check+store with the writes.
+
+Postgres achieves this with `BEGIN ISOLATION LEVEL SERIALIZABLE`. SQLite has no
+equivalent knob; a naive multi-connection pool with deferred `BEGIN` allows
+write-skew and `SQLITE_BUSY` on the read-then-write path.
+
+### Options considered
+- **(A) Deferred `BEGIN` on a shared pool** — what a naive port does. Rejected:
+  a `SELECT` (condition read) that later `UPDATE`s upgrades the lock late and
+  can deadlock/`SQLITE_BUSY`, and two concurrent guarded writes can interleave
+  (write-skew). Not correct.
+- **(B) `BEGIN IMMEDIATE` on every write txn + `busy_timeout`** — acquires the
+  reserved write lock up front, so the condition read and the write are inside
+  the writer lock; other writers wait (bounded by `busy_timeout`) rather than
+  failing. Correct. Still allows many concurrent readers (WAL).
+- **(C) Single dedicated writer connection behind an async `Mutex`** (reads use
+  a separate read pool). All writes globally serialized in-process — this is
+  the exact model the in-memory backend uses (one global `RwLock`), which the
+  project accepts as behaving "the same as Postgres". SQLite already serializes
+  writes physically, so this sheds little real throughput while removing all
+  `SQLITE_BUSY` races by construction.
+
+### Recommendation
+**(C) + (B): a single writer connection (async `Mutex`) AND `BEGIN IMMEDIATE`,
+with `busy_timeout` as a safety net; reads served from a concurrent WAL read
+pool.** This is the most defensible for correctness, mirrors the in-memory
+backend's accepted serialization model, and eliminates write-skew and
+`SQLITE_BUSY` deterministically. Tradeoff: one writer at a time — acceptable for
+SQLite's single-node/embedded target, and SQLite serializes writes anyway.
+
+PRAGMAs on every connection: `journal_mode=WAL`, `busy_timeout=5000`,
+`foreign_keys=ON`, `synchronous=NORMAL`.
+
+---
+
+## D2 — Numeric (`N`) sort-key encoding  *(needs sign-off — main fidelity risk)*
+
+### Requirement
+DynamoDB numbers are signed decimals with up to 38 significant digits. Sort-key
+semantics require **numeric ordering** for `Query` ordering, `BETWEEN`, `<`,
+`<=`, `>`, `>=`, and **numeric equality** (so `5`, `5.0`, `+5` compare equal).
+Postgres stores `N` sort keys in a `NUMERIC` column → exact precision + correct
+order, binding the shared `SortKeyValue::N(BigDecimal)` directly.
+
+SQLite's only column affinities are INTEGER / REAL / TEXT / BLOB — **no
+arbitrary-precision numeric type.**
+
+### Options considered
+- **(A) `REAL` (f64)** — PR #109's approach. **Rejected (defect):** silently
+  truncates beyond ~15–17 digits, corrupting ordering and equality for
+  large/high-precision sort keys. Fails number-precision conformance.
+- **(B) Custom SQLite collation** registered per-connection that compares the
+  raw decimal string as `BigDecimal`. Exact, but: must be registered on every
+  pooled connection and on the persisted index, adds a non-portable
+  `libsqlite3-sys` dependency surface, and a missing-collation path silently
+  reverts to wrong ordering. Higher operational fragility.
+- **(C) Order-preserving TEXT encoding** — store `N` sort keys in a TEXT column
+  holding a canonical, byte-lexicographically order-preserving encoding of the
+  `BigDecimal` (sign + normalized exponent + normalized mantissa). SQLite's
+  default BINARY collation then yields exact numeric ordering. The **exact
+  original value is preserved in `item_data` JSON** (what we return to clients),
+  so there is zero precision loss on read; the encoded column is used only for
+  ordering/range/equality. Canonicalization makes `5` / `5.0` / `+5` collapse to
+  one key (matching DynamoDB normalization).
+
+### Recommendation
+**(C) Order-preserving TEXT encoding**, implemented as a small, exhaustively
+unit-tested function `encode_orderable_number(&BigDecimal) -> String` with
+property tests asserting `a.cmp(b) == enc(a).cmp(enc(b))` across negatives,
+zero, varying scale, and 38-digit extremes. This is portable (no extra native
+deps), keeps full precision in `item_data`, and is correctness-critical so it
+gets its own dedicated test module before any data-path code depends on it.
+
+Partition keys (incl. `N`) remain TEXT via the shared `pk_to_text` (equality
+only) — identical to Postgres, no change needed.
+
+---
+
+## D3 — Structural & schema decisions (informational, no sign-off needed)
+
+- **Module layout** mirrors the in-memory crate (the current, same-packaging
+  sibling): `store.rs`, `bootstrapper.rs`, `catalog*.rs`, `data*.rs`,
+  `metadata.rs`, `stream.rs`, `backup.rs`, `credential_store.rs`, `hooks.rs`,
+  `worker.rs`, `operations.rs`, `diagnostics.rs`, `registration.rs`, `config.rs`,
+  `schema.rs`. SQL logic is ported from PR #109 and corrected/retargeted.
+- **Single file, single logical DB.** Catalog and data tables co-locate (SQLite
+  has no multi-database server). The dual-pool Postgres split collapses to one
+  store; `data_database_name` is recorded for diagnostics parity only.
+- **Schema** is one authoritative migration mirroring Postgres `001_schema.sql`
+  semantics: accounts, tables, indexes, tags, settings (seeded `catalog_version`
+  = the compiled `CATALOG_VERSION`), stream_shards/records, seq_counters,
+  admin_users, full IAM (users/groups/roles/policies/boundaries/sessions),
+  access_keys, idempotency_tokens, metrics, login_attempts, backups/backup_items,
+  continuous_backups. Per-DynamoDB-table data tables (`_ddb_<id>`) are created
+  dynamically by `create_table`, same as Postgres.
+- **Contract drift already identified to honour:** `ServerComponents` uses
+  `credential_store` (not PR #109's `auth_provider`); `StorageConfig` requires
+  `as_any`; `TableKeyInfo` now carries `base_key_schema`.
+- **LSI propagation is synchronous; GSI propagation is a persistent queue.**
+  LSIs (always) and GSIs with an effective delay of 0 are reconciled inside the
+  base write transaction, so they are strongly consistent. GSIs with a non-zero
+  effective propagation delay are deferred: a single row capturing the base-item
+  transition (`table_id`, `old_item`, `new_item`, `ready_at = now + delay`) is
+  inserted into a `gsi_pending` table **inside the same write transaction** as
+  the item mutation, giving a zero crash window (the queue entry commits atomically
+  with the data). A background worker claims rows whose `ready_at` has passed via
+  `DELETE … WHERE id IN (SELECT … WHERE ready_at <= ? ORDER BY id LIMIT ?)
+  RETURNING …` and applies the index updates; claim and apply share one
+  transaction under the engine write lock, so a crash rolls back and the rows are
+  retried (at-least-once; the index writes are idempotent). This mirrors the
+  Postgres backend's persistent-queue design rather than its `FOR UPDATE SKIP
+  LOCKED` mechanics, which are unnecessary under the single-writer model.
+  The effective delay is the per-GSI `propagation_delay_ms` override when set,
+  otherwise the `gsi_propagation_delay_ms` runtime setting (cached on the engine
+  and refreshed by a poller). Delay 0 ⇒ fully synchronous GSI maintenance.
+  This **supersedes the earlier "synchronous because local I/O is fast"
+  rationale**: that approach ignored the configured propagation delay and so did
+  not match the Postgres backend's eventual-consistency behaviour for GSIs.
+- **Stream sequence numbers** come from a `seq_counters` row updated inside the
+  write txn → monotonic per the contract.
+- **Parallel scan** uses `rowid % total_segments`.
+- **Encryption** (access-key secrets) reuses AES-256-GCM with AAD, identical to
+  Postgres/memory.
+
+---
+
+## D4 — In-memory (`:memory:`) support and the dedicated-memory-backend consolidation question
+
+**Capability.** The backend supports `path = ":memory:"` as a first-class,
+ephemeral mode for local dev / CI/CD. Two pieces make it work:
+
+- **Single shared connection.** An in-memory database lives only inside its own
+  connection — a second connection opens a *separate* empty database. So for
+  `:memory:` the pool is pinned to one connection that is never recycled (idle
+  and lifetime timeouts disabled), giving one shared database for the process
+  lifetime. Writes are already serialized by `write_lock`, so a single
+  connection costs only read concurrency. File-backed databases keep the full
+  WAL pool (concurrent readers + one writer).
+- **Serve-time bootstrap.** An in-memory database does not survive the `init`
+  process, so the `ServerComponents` factory bootstraps the catalog at serve
+  time on the engine's shared connection (`SqliteEngine::bootstrap_ephemeral`:
+  schema, encryption key, default account, env-driven admin) and reuses that
+  connection for the catalog/credential stores. This mirrors the dedicated
+  in-process memory backend, which also bootstraps account + admin from
+  `EXTENDDB_ADMIN_PASSWORD` on every start.
+
+**Benchmark vs the dedicated in-memory backend.** Measured end-to-end over HTTP
+with `extenddb-bench`'s open-loop, HDR-histogram load generator (same laptop,
+sweep 2k→20k rps, 1 KiB items, putitem / getitem / mixed-80:20), then fused with
+`report-compare` (bootstrap 95% CI):
+
+- **At low/moderate load (~2k rps) the two are within noise** — both sub-ms p50
+  (~300–430 µs). This is the regime a CI/CD test suite actually generates.
+- **Above that, sqlite `:memory:` saturates ~3–4× earlier** (clean ceiling:
+  put ~2k / get ~5k / mixed ~5k rps, vs the dedicated backend's ~10k / >20k /
+  ~10–20k). `report-compare` headline verdict was `Regression` on all three
+  workloads, driven entirely by the high-rps steps.
+- **Root cause is the connection model, not SQL overhead.** `:memory:` uses one
+  connection, so every read and write serializes through it; the dedicated
+  backend uses an `RwLock` over in-process maps (concurrent reads, cheap
+  writes). It is SQLite's single-writer-per-database nature surfacing, not
+  query cost.
+
+**Account/region sharding — considered and rejected for this use case.** SQLite
+lacks Postgres's MVCC, so the global `write_lock` serializes writes across all
+accounts and tables. Sharding the *data* into one SQLite database per
+`(account, region)` — a single global catalog plus per-account data
+connections — would recover cross-account write concurrency while keeping
+multi-table `TransactWriteItems` atomic (an account's tables stay in one
+database; per-*table* sharding would not). It is the right granularity *if*
+cross-account concurrency matters. It does **not** help single-account
+throughput, and the in-memory backend's mandate is single-account, ephemeral
+CI/CD, which never sees cross-account load. So account sharding is **not
+pursued for `:memory:`**; it remains a possible future direction for
+high-tenant-count *file* deployments only.
+
+**Conclusion (consolidation).** For the in-memory backend's real mandate —
+local dev, CI/CD, unit tests: single-account, low/moderate throughput,
+discarded between runs — sqlite `:memory:` is performance-equivalent to the
+dedicated in-process backend and identical in correctness (same engine, same
+conformance/parity results). A single SQLite package can therefore cover both
+the persistent (file) and ephemeral (`:memory:`) cases, retiring the separate
+in-memory crate to cut maintenance, with no practical loss for how in-memory is
+used. The dedicated backend retains only marginal high-concurrency headroom
+that CI/CD does not exercise.
+
+This refines **D3's "single file, single logical DB"**: still one database per
+server, but that database may be in memory, and an in-memory server
+bootstraps its catalog at serve time rather than during `init`.
+
+---
+
+## Open items requiring your decision
+1. **D1** — approve "single writer + `BEGIN IMMEDIATE`" isolation model.
+2. **D2** — approve "order-preserving TEXT encoding" for `N` sort keys.

--- a/crates/storage-sqlite/src/admin_store.rs
+++ b/crates/storage-sqlite/src/admin_store.rs
@@ -1,0 +1,127 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `AdminStore` implementation: admin-user management, separate from IAM users.
+
+use extenddb_storage::management_store::{AdminEntry, AdminStore, OpError, OpResult};
+use futures::future::BoxFuture;
+
+use crate::catalog_store::SqliteCatalogStore;
+use crate::sqlite_util::{is_unique_violation, parse_timestamp};
+
+impl AdminStore for SqliteCatalogStore {
+    fn create_admin(&self, admin_name: &str, password_hash: &str) -> BoxFuture<'_, OpResult<()>> {
+        let admin_name = admin_name.to_owned();
+        let password_hash = password_hash.to_owned();
+        Box::pin(async move {
+            sqlx::query("INSERT INTO admin_users (admin_name, password_hash) VALUES (?, ?)")
+                .bind(&admin_name)
+                .bind(&password_hash)
+                .execute(self.pool())
+                .await
+                .map_err(|e| {
+                    if is_unique_violation(&e) {
+                        OpError::AlreadyExists("Admin user already exists".to_owned())
+                    } else {
+                        tracing::error!("create_admin: {e}");
+                        OpError::Internal("Database error".to_owned())
+                    }
+                })?;
+            Ok(())
+        })
+    }
+
+    fn list_admins(&self) -> BoxFuture<'_, OpResult<Vec<AdminEntry>>> {
+        Box::pin(async move {
+            let rows: Vec<(String, String)> = sqlx::query_as(
+                "SELECT admin_name, created_at FROM admin_users ORDER BY admin_name",
+            )
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| {
+                tracing::error!("list_admins: {e}");
+                OpError::Internal("Database error".to_owned())
+            })?;
+            rows.into_iter()
+                .map(|(admin_name, created)| {
+                    Ok(AdminEntry {
+                        admin_name,
+                        created_at: parse_timestamp(&created)
+                            .map_err(|e| OpError::Internal(format!("parse created_at: {e}")))?,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn delete_admin(&self, admin_name: &str) -> BoxFuture<'_, OpResult<()>> {
+        let admin_name = admin_name.to_owned();
+        Box::pin(async move {
+            let result = sqlx::query("DELETE FROM admin_users WHERE admin_name = ?")
+                .bind(&admin_name)
+                .execute(self.pool())
+                .await
+                .map_err(|e| {
+                    tracing::error!("delete_admin: {e}");
+                    OpError::Internal("Database error".to_owned())
+                })?;
+            if result.rows_affected() == 0 {
+                return Err(OpError::NotFound("Admin user not found".to_owned()));
+            }
+            Ok(())
+        })
+    }
+
+    fn change_admin_password(
+        &self,
+        admin_name: &str,
+        password_hash: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let admin_name = admin_name.to_owned();
+        let password_hash = password_hash.to_owned();
+        Box::pin(async move {
+            let result =
+                sqlx::query("UPDATE admin_users SET password_hash = ? WHERE admin_name = ?")
+                    .bind(&password_hash)
+                    .bind(&admin_name)
+                    .execute(self.pool())
+                    .await
+                    .map_err(|e| {
+                        tracing::error!("change_admin_password: {e}");
+                        OpError::Internal("Database error".to_owned())
+                    })?;
+            if result.rows_affected() == 0 {
+                return Err(OpError::NotFound("Admin user not found".to_owned()));
+            }
+            Ok(())
+        })
+    }
+
+    fn verify_admin_password(
+        &self,
+        admin_name: &str,
+        password: &str,
+    ) -> BoxFuture<'_, OpResult<Option<bool>>> {
+        let admin_name = admin_name.to_owned();
+        let password = password.to_owned();
+        Box::pin(async move {
+            let row: Option<(String,)> =
+                sqlx::query_as("SELECT password_hash FROM admin_users WHERE admin_name = ?")
+                    .bind(&admin_name)
+                    .fetch_optional(self.pool())
+                    .await
+                    .map_err(|e| {
+                        tracing::error!("verify_admin_password: {e}");
+                        OpError::Internal("Database error".to_owned())
+                    })?;
+            let Some((hash,)) = row else {
+                return Ok(None);
+            };
+            let verified = tokio::task::spawn_blocking(move || bcrypt::verify(&password, &hash))
+                .await
+                .map_err(|e| OpError::Internal(format!("bcrypt task: {e}")))?
+                .unwrap_or(false);
+            Ok(Some(verified))
+        })
+    }
+}

--- a/crates/storage-sqlite/src/authorization_store.rs
+++ b/crates/storage-sqlite/src/authorization_store.rs
@@ -1,0 +1,252 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `AuthorizationStore` implementation: read-only IAM policy, boundary,
+//! session, and tag lookups used by the policy evaluator on every authorized
+//! request. Policy documents are stored as JSON text and returned verbatim.
+
+use extenddb_storage::authorization_store::{AuthorizationStore, SessionData};
+use extenddb_storage::management_store::{OpError, OpResult};
+use futures::future::BoxFuture;
+
+use crate::catalog_store::SqliteCatalogStore;
+use crate::sqlite_util::parse_timestamp;
+
+/// Map any query error to a sanitized internal error, logging the detail.
+fn db_err(ctx: &str, e: sqlx::Error) -> OpError {
+    tracing::error!("{ctx}: {e}");
+    OpError::Internal("Database error".to_owned())
+}
+
+impl AuthorizationStore for SqliteCatalogStore {
+    fn fetch_user_policies(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<String>>> {
+        let account_id = account_id.to_owned();
+        let user_name = user_name.to_owned();
+        Box::pin(async move {
+            let rows: Vec<(String,)> = sqlx::query_as(
+                "SELECT policy_document FROM iam_policies \
+                 WHERE account_id = ? AND principal_type = 'user' AND principal_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&user_name)
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_user_policies", e))?;
+            Ok(rows.into_iter().map(|(d,)| d).collect())
+        })
+    }
+
+    fn fetch_user_group_policies(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<String>>> {
+        let account_id = account_id.to_owned();
+        let user_name = user_name.to_owned();
+        Box::pin(async move {
+            let rows: Vec<(String,)> = sqlx::query_as(
+                "SELECT p.policy_document FROM iam_policies p \
+                 JOIN iam_group_members m \
+                   ON m.account_id = p.account_id AND m.group_name = p.principal_name \
+                 WHERE p.account_id = ? AND p.principal_type = 'group' AND m.user_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&user_name)
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_user_group_policies", e))?;
+            Ok(rows.into_iter().map(|(d,)| d).collect())
+        })
+    }
+
+    fn fetch_user_boundary(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<String>>> {
+        let account_id = account_id.to_owned();
+        let user_name = user_name.to_owned();
+        Box::pin(async move {
+            let row: Option<(String,)> = sqlx::query_as(
+                "SELECT policy_document FROM iam_permissions_boundaries \
+                 WHERE account_id = ? AND principal_type = 'user' AND principal_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&user_name)
+            .fetch_optional(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_user_boundary", e))?;
+            Ok(row.map(|(d,)| d))
+        })
+    }
+
+    fn fetch_role_policies(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<String>>> {
+        let account_id = account_id.to_owned();
+        let role_name = role_name.to_owned();
+        Box::pin(async move {
+            let rows: Vec<(String,)> = sqlx::query_as(
+                "SELECT policy_document FROM iam_policies \
+                 WHERE account_id = ? AND principal_type = 'role' AND principal_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&role_name)
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_role_policies", e))?;
+            Ok(rows.into_iter().map(|(d,)| d).collect())
+        })
+    }
+
+    fn fetch_role_boundary(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<String>>> {
+        let account_id = account_id.to_owned();
+        let role_name = role_name.to_owned();
+        Box::pin(async move {
+            let row: Option<(String,)> = sqlx::query_as(
+                "SELECT policy_document FROM iam_permissions_boundaries \
+                 WHERE account_id = ? AND principal_type = 'role' AND principal_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&role_name)
+            .fetch_optional(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_role_boundary", e))?;
+            Ok(row.map(|(d,)| d))
+        })
+    }
+
+    fn fetch_session_data(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        session_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<SessionData>>> {
+        let account_id = account_id.to_owned();
+        let role_name = role_name.to_owned();
+        let session_name = session_name.to_owned();
+        Box::pin(async move {
+            let row: Option<(Option<String>, Option<String>, String)> = sqlx::query_as(
+                "SELECT session_policy, session_tags, expires_at FROM iam_sessions \
+                 WHERE account_id = ? AND role_name = ? AND session_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&role_name)
+            .bind(&session_name)
+            .fetch_optional(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_session_data", e))?;
+
+            let Some((session_policy, tags_json, expires_at)) = row else {
+                return Ok(None);
+            };
+
+            // Treat an expired session as absent (parity with the Postgres
+            // expiry filter). Authentication already rejects expired sessions,
+            // so this is defense-in-depth; evaluate it with the same parser
+            // lookup_session uses rather than a format-fragile SQL comparison.
+            if let Ok(expires) = parse_timestamp(&expires_at)
+                && expires < time::OffsetDateTime::now_utc()
+            {
+                return Ok(None);
+            }
+
+            // session_tags is stored as JSON: either an object {key: value} or
+            // an array [{"Key": ..., "Value": ...}] (the form AWS SDKs send).
+            // Handle both, matching the Postgres backend.
+            let session_tags: Vec<(String, String)> = tags_json
+                .as_deref()
+                .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+                .map(|v| {
+                    if let Some(arr) = v.as_array() {
+                        arr.iter()
+                            .filter_map(|tag| {
+                                match (
+                                    tag.get("Key").and_then(|k| k.as_str()),
+                                    tag.get("Value").and_then(|x| x.as_str()),
+                                ) {
+                                    (Some(k), Some(val)) => Some((k.to_owned(), val.to_owned())),
+                                    _ => None,
+                                }
+                            })
+                            .collect()
+                    } else if let Some(obj) = v.as_object() {
+                        obj.iter()
+                            .filter_map(|(k, val)| val.as_str().map(|s| (k.clone(), s.to_owned())))
+                            .collect()
+                    } else {
+                        Vec::new()
+                    }
+                })
+                .unwrap_or_default();
+
+            Ok(Some(SessionData {
+                session_policy,
+                session_tags,
+            }))
+        })
+    }
+
+    fn fetch_user_tags(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        let account_id = account_id.to_owned();
+        let user_name = user_name.to_owned();
+        Box::pin(async move {
+            sqlx::query_as(
+                "SELECT tag_key, tag_value FROM iam_user_tags \
+                 WHERE account_id = ? AND user_name = ? ORDER BY tag_key",
+            )
+            .bind(&account_id)
+            .bind(&user_name)
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_user_tags", e))
+        })
+    }
+
+    fn fetch_role_tags(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        let account_id = account_id.to_owned();
+        let role_name = role_name.to_owned();
+        Box::pin(async move {
+            sqlx::query_as(
+                "SELECT tag_key, tag_value FROM iam_role_tags \
+                 WHERE account_id = ? AND role_name = ? ORDER BY tag_key",
+            )
+            .bind(&account_id)
+            .bind(&role_name)
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_role_tags", e))
+        })
+    }
+
+    fn fetch_resource_tags(&self, arn: &str) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        let arn = arn.to_owned();
+        Box::pin(async move {
+            sqlx::query_as(
+                "SELECT tag_key, tag_value FROM tags WHERE resource_arn = ? ORDER BY tag_key",
+            )
+            .bind(&arn)
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_resource_tags", e))
+        })
+    }
+}

--- a/crates/storage-sqlite/src/backup.rs
+++ b/crates/storage-sqlite/src/backup.rs
@@ -1,0 +1,525 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `BackupEngine` for the SQLite backend.
+//!
+//! A backup snapshots every item's `item_data` into `backup_items`. Restore
+//! recreates the table via `create_table` and upserts the snapshot under the
+//! engine write lock. `RestoreTableToPointInTime` is implemented as a
+//! snapshot-then-restore (then discard the temporary backup), matching the
+//! PostgreSQL backend's behaviour.
+
+use extenddb_core::types::{
+    AttributeDefinition, BackupDescription, BackupDetails, BackupSummary, BillingMode,
+    ContinuousBackupsDescription, CreateTableInput, KeySchemaElement,
+    PointInTimeRecoveryDescription, ProvisionedThroughput, SourceTableDetails, TableDescription,
+    TableKeyInfo,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::{BackupEngine, TableEngine};
+use futures::future::BoxFuture;
+
+use crate::data::{data_table_name, upsert_item_in_tx};
+use crate::sqlite_util::parse_timestamp;
+use crate::store::SqliteEngine;
+
+fn epoch_millis() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+/// Backup id: creation timestamp plus an 8-hex random suffix, matching the
+/// PostgreSQL backend. The suffix makes ARNs non-guessable and prevents two
+/// backups created in the same millisecond from colliding.
+fn backup_id() -> String {
+    use rand::Rng;
+    let suffix: u32 = rand::rng().random();
+    format!("{ts}-{suffix:08x}", ts = epoch_millis())
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn ts_to_epoch(s: &str) -> f64 {
+    parse_timestamp(s)
+        .map(|dt| dt.unix_timestamp() as f64)
+        .unwrap_or(0.0)
+}
+
+impl BackupEngine for SqliteEngine {
+    fn create_backup(
+        &self,
+        account_id: &str,
+        table_name: &str,
+        backup_name: &str,
+    ) -> BoxFuture<'_, Result<BackupDetails, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        let backup_name = backup_name.to_owned();
+        Box::pin(async move {
+            let row: Option<(String, String, String, String, i64)> = sqlx::query_as(
+                "SELECT table_id, key_schema, attribute_definitions, billing_mode, table_size_bytes \
+                 FROM tables WHERE account_id = ? AND table_name = ? AND table_status = 'ACTIVE'",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let (table_id, key_schema, attr_defs, billing_mode, size_bytes) =
+                row.ok_or_else(|| StorageError::TableNotFound(table_name.clone()))?;
+
+            let backup_arn = format!(
+                "arn:aws:dynamodb:{region}:{account_id}:table/{table_name}/backup/{id}",
+                region = self.region,
+                id = backup_id()
+            );
+
+            let ddb_table = data_table_name(&table_id);
+            let items: Vec<(String,)> =
+                sqlx::query_as(&format!("SELECT item_data FROM {ddb_table}"))
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let item_count = i64::try_from(items.len()).unwrap_or(i64::MAX);
+
+            let _writer = self.write_lock.lock().await;
+            let mut tx = self
+                .pool
+                .begin_with("BEGIN IMMEDIATE")
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            sqlx::query(
+                "INSERT INTO backups (backup_arn, backup_name, table_id, table_name, account_id, \
+                 backup_status, backup_size_bytes, item_count, key_schema, attribute_definitions, \
+                 billing_mode) VALUES (?, ?, ?, ?, ?, 'AVAILABLE', ?, ?, ?, ?, ?)",
+            )
+            .bind(&backup_arn)
+            .bind(&backup_name)
+            .bind(&table_id)
+            .bind(&table_name)
+            .bind(&account_id)
+            .bind(size_bytes)
+            .bind(item_count)
+            .bind(&key_schema)
+            .bind(&attr_defs)
+            .bind(&billing_mode)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            for (item_data,) in &items {
+                sqlx::query(
+                    "INSERT INTO backup_items (backup_arn, pk, sk, item_data) VALUES (?, '', NULL, ?)",
+                )
+                .bind(&backup_arn)
+                .bind(item_data)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            }
+
+            let created_at: (String,) =
+                sqlx::query_as("SELECT created_at FROM backups WHERE backup_arn = ?")
+                    .bind(&backup_arn)
+                    .fetch_one(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            tx.commit()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            Ok(BackupDetails {
+                backup_arn,
+                backup_name,
+                backup_status: "AVAILABLE".to_owned(),
+                backup_type: "USER".to_owned(),
+                backup_size_bytes: size_bytes,
+                backup_creation_date_time: ts_to_epoch(&created_at.0),
+            })
+        })
+    }
+
+    fn describe_backup(
+        &self,
+        account_id: &str,
+        backup_arn: &str,
+    ) -> BoxFuture<'_, Result<BackupDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        let backup_arn = backup_arn.to_owned();
+        Box::pin(async move {
+            #[allow(clippy::type_complexity)]
+            let row: Option<(String, String, String, String, i64, i64, String, String, String, String)> =
+                sqlx::query_as(
+                    "SELECT b.backup_name, b.backup_status, b.table_id, b.table_name, \
+                     b.backup_size_bytes, b.item_count, b.key_schema, b.billing_mode, \
+                     COALESCE(t.table_arn, \
+                       'arn:aws:dynamodb:' || ? || ':' || b.account_id || ':table/' || b.table_name), \
+                     b.created_at \
+                     FROM backups b LEFT JOIN tables t ON t.table_id = b.table_id \
+                     WHERE b.backup_arn = ? AND b.account_id = ? \
+                     AND b.backup_status != 'DELETED'",
+                )
+                .bind(&self.region)
+                .bind(&backup_arn)
+                .bind(&account_id)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let (name, status, table_id, table_name, size, count, ks, billing, table_arn, created) =
+                row.ok_or_else(|| {
+                    StorageError::Validation(format!("Backup not found: {backup_arn}"))
+                })?;
+
+            let key_schema: Vec<KeySchemaElement> =
+                serde_json::from_str(&ks).map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            Ok(BackupDescription {
+                backup_details: BackupDetails {
+                    backup_arn: backup_arn.clone(),
+                    backup_name: name,
+                    backup_status: status,
+                    backup_type: "USER".to_owned(),
+                    backup_size_bytes: size,
+                    backup_creation_date_time: ts_to_epoch(&created),
+                },
+                source_table_details: SourceTableDetails {
+                    table_name,
+                    table_id,
+                    table_arn,
+                    key_schema,
+                    item_count: count,
+                    table_size_bytes: size,
+                    billing_mode: Some(billing),
+                    table_creation_date_time: ts_to_epoch(&created),
+                },
+            })
+        })
+    }
+
+    fn list_backups(
+        &self,
+        account_id: &str,
+        table_name: Option<&str>,
+    ) -> BoxFuture<'_, Result<Vec<BackupSummary>, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.map(str::to_owned);
+        Box::pin(async move {
+            let rows: Vec<(String, String, String, String, i64, String, String)> =
+                if let Some(tn) = table_name {
+                    sqlx::query_as(
+                        "SELECT b.backup_arn, b.backup_name, b.table_name, b.backup_status, \
+                         b.backup_size_bytes, \
+                         COALESCE(t.table_arn, 'arn:aws:dynamodb:' || ? || ':' || b.account_id || ':table/' || b.table_name), \
+                         b.created_at FROM backups b LEFT JOIN tables t ON t.table_id = b.table_id \
+                         WHERE b.account_id = ? AND b.table_name = ? AND b.backup_status != 'DELETED' \
+                         ORDER BY b.created_at DESC",
+                    )
+                    .bind(&self.region)
+                    .bind(&account_id)
+                    .bind(tn)
+                    .fetch_all(&self.pool)
+                    .await
+                } else {
+                    sqlx::query_as(
+                        "SELECT b.backup_arn, b.backup_name, b.table_name, b.backup_status, \
+                         b.backup_size_bytes, \
+                         COALESCE(t.table_arn, 'arn:aws:dynamodb:' || ? || ':' || b.account_id || ':table/' || b.table_name), \
+                         b.created_at FROM backups b LEFT JOIN tables t ON t.table_id = b.table_id \
+                         WHERE b.account_id = ? AND b.backup_status != 'DELETED' \
+                         ORDER BY b.created_at DESC",
+                    )
+                    .bind(&self.region)
+                    .bind(&account_id)
+                    .fetch_all(&self.pool)
+                    .await
+                }
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            Ok(rows
+                .into_iter()
+                .map(
+                    |(arn, name, tn, status, size, table_arn, created)| BackupSummary {
+                        backup_arn: arn,
+                        backup_name: name,
+                        table_name: tn,
+                        table_arn,
+                        backup_status: status,
+                        backup_type: "USER".to_owned(),
+                        backup_size_bytes: size,
+                        backup_creation_date_time: ts_to_epoch(&created),
+                    },
+                )
+                .collect())
+        })
+    }
+
+    fn delete_backup(
+        &self,
+        account_id: &str,
+        backup_arn: &str,
+    ) -> BoxFuture<'_, Result<BackupDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        let backup_arn = backup_arn.to_owned();
+        Box::pin(async move {
+            // Resolves account-scoped, so a backup owned by another account is
+            // reported missing here and the writes below never run.
+            let desc = self.describe_backup(&account_id, &backup_arn).await?;
+
+            // The account predicate is repeated on both writes rather than
+            // relying on the lookup above, so the statements are correct on
+            // their own terms.
+            sqlx::query(
+                "DELETE FROM backup_items WHERE backup_arn = ?1 AND EXISTS (\
+                 SELECT 1 FROM backups b WHERE b.backup_arn = ?1 AND b.account_id = ?2)",
+            )
+            .bind(&backup_arn)
+            .bind(&account_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            sqlx::query(
+                "UPDATE backups SET backup_status = 'DELETED' \
+                 WHERE backup_arn = ? AND account_id = ?",
+            )
+            .bind(&backup_arn)
+            .bind(&account_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(BackupDescription {
+                backup_details: BackupDetails {
+                    backup_status: "DELETED".to_owned(),
+                    ..desc.backup_details
+                },
+                source_table_details: desc.source_table_details,
+            })
+        })
+    }
+
+    fn restore_table_from_backup(
+        &self,
+        account_id: &str,
+        target_table_name: &str,
+        backup_arn: &str,
+    ) -> BoxFuture<'_, Result<TableDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        let target_table_name = target_table_name.to_owned();
+        let backup_arn = backup_arn.to_owned();
+        Box::pin(async move {
+            let row: Option<(String, String, String)> = sqlx::query_as(
+                "SELECT key_schema, attribute_definitions, billing_mode \
+                 FROM backups WHERE backup_arn = ? AND account_id = ? \
+                 AND backup_status = 'AVAILABLE'",
+            )
+            .bind(&backup_arn)
+            .bind(&account_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let (ks, ad, billing) = row.ok_or_else(|| {
+                StorageError::Validation(format!("Backup not found: {backup_arn}"))
+            })?;
+            let key_schema: Vec<KeySchemaElement> =
+                serde_json::from_str(&ks).map_err(|e| StorageError::Internal(e.to_string()))?;
+            let attr_defs: Vec<AttributeDefinition> =
+                serde_json::from_str(&ad).map_err(|e| StorageError::Internal(e.to_string()))?;
+            let billing_mode = Some(if billing == "PAY_PER_REQUEST" {
+                BillingMode::PayPerRequest
+            } else {
+                BillingMode::Provisioned
+            });
+
+            let create_input = CreateTableInput {
+                table_name: target_table_name.clone(),
+                key_schema: key_schema.clone(),
+                attribute_definitions: attr_defs.clone(),
+                billing_mode,
+                provisioned_throughput: Some(ProvisionedThroughput {
+                    read_capacity_units: 5,
+                    write_capacity_units: 5,
+                }),
+                global_secondary_indexes: None,
+                local_secondary_indexes: None,
+                stream_specification: None,
+                tags: None,
+                deletion_protection_enabled: None,
+                sse_specification: None,
+                table_class: None,
+                on_demand_throughput: None,
+            };
+
+            let desc = self.create_table(&account_id, create_input).await?;
+            let key_info = TableKeyInfo {
+                table_name: target_table_name.clone(),
+                account_id: account_id.clone(),
+                table_id: desc.table_id.clone(),
+                base_key_schema: key_schema.clone(),
+                key_schema,
+                attribute_definitions: attr_defs,
+                has_lsi: false,
+                // The restored table is created above without secondary
+                // indexes, so there is no index metadata to carry.
+                global_secondary_indexes: Vec::new(),
+                local_secondary_indexes: Vec::new(),
+                stream_specification: None,
+            };
+
+            let items: Vec<(String,)> =
+                sqlx::query_as("SELECT item_data FROM backup_items WHERE backup_arn = ?")
+                    .bind(&backup_arn)
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let item_count = i64::try_from(items.len()).unwrap_or(i64::MAX);
+
+            let _writer = self.write_lock.lock().await;
+            let mut tx = self
+                .pool
+                .begin_with("BEGIN IMMEDIATE")
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            for (item_json,) in &items {
+                let item: extenddb_core::types::Item = serde_json::from_str(item_json)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                upsert_item_in_tx(&mut tx, &key_info, &item).await?;
+            }
+            sqlx::query("UPDATE tables SET item_count = ? WHERE account_id = ? AND table_name = ?")
+                .bind(item_count)
+                .bind(&account_id)
+                .bind(&target_table_name)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            // Mark the restored table ACTIVE immediately: the data is fully
+            // populated and ready to serve. This matches the Postgres backend
+            // and real DynamoDB, where a restored table becomes ACTIVE once the
+            // restore completes (the CREATING status is transient) rather than
+            // waiting for the control-plane transition poller.
+            sqlx::query(
+                "UPDATE tables SET table_status = 'ACTIVE', status_transition_at = NULL \
+                 WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&target_table_name)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            tx.commit()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            Ok(desc)
+        })
+    }
+
+    fn describe_continuous_backups(
+        &self,
+        account_id: &str,
+        table_name: &str,
+    ) -> BoxFuture<'_, Result<ContinuousBackupsDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        Box::pin(async move {
+            let exists: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM tables WHERE account_id = ? AND table_name = ?)",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if !exists {
+                return Err(StorageError::TableNotFound(table_name));
+            }
+
+            let pitr: Option<(bool,)> = sqlx::query_as(
+                "SELECT pitr_enabled FROM continuous_backups WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let enabled = pitr.is_some_and(|r| r.0);
+
+            #[allow(clippy::cast_precision_loss)]
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as f64;
+
+            Ok(ContinuousBackupsDescription {
+                continuous_backups_status: "ENABLED".to_owned(),
+                point_in_time_recovery_description: Some(PointInTimeRecoveryDescription {
+                    point_in_time_recovery_status: if enabled { "ENABLED" } else { "DISABLED" }
+                        .to_owned(),
+                    earliest_restorable_date_time: enabled.then_some(now - 35.0 * 24.0 * 3600.0),
+                    latest_restorable_date_time: enabled.then_some(now),
+                }),
+            })
+        })
+    }
+
+    fn update_continuous_backups(
+        &self,
+        account_id: &str,
+        table_name: &str,
+        pitr_enabled: bool,
+    ) -> BoxFuture<'_, Result<ContinuousBackupsDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        Box::pin(async move {
+            let exists: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM tables WHERE account_id = ? AND table_name = ?)",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if !exists {
+                return Err(StorageError::TableNotFound(table_name));
+            }
+            sqlx::query(
+                "INSERT INTO continuous_backups (account_id, table_name, pitr_enabled) \
+                 VALUES (?, ?, ?) \
+                 ON CONFLICT (account_id, table_name) DO UPDATE SET pitr_enabled = excluded.pitr_enabled",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .bind(pitr_enabled)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            self.describe_continuous_backups(&account_id, &table_name)
+                .await
+        })
+    }
+
+    fn restore_table_to_point_in_time(
+        &self,
+        account_id: &str,
+        source_table_name: &str,
+        target_table_name: &str,
+    ) -> BoxFuture<'_, Result<TableDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        let source_table_name = source_table_name.to_owned();
+        let target_table_name = target_table_name.to_owned();
+        Box::pin(async move {
+            let backup = self
+                .create_backup(&account_id, &source_table_name, "__pitr_restore__")
+                .await?;
+            let desc = self
+                .restore_table_from_backup(&account_id, &target_table_name, &backup.backup_arn)
+                .await?;
+            let _ = self.delete_backup(&account_id, &backup.backup_arn).await;
+            Ok(desc)
+        })
+    }
+}

--- a/crates/storage-sqlite/src/bootstrapper.rs
+++ b/crates/storage-sqlite/src/bootstrapper.rs
@@ -1,0 +1,332 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `Bootstrapper` implementation for the SQLite backend.
+//!
+//! SQLite has no server, users, or roles, and catalog and data live in one
+//! file. Initialization therefore reduces to: create the file, apply the
+//! catalog schema, and seed the encryption key, default account, and admin
+//! user. Destruction removes the database file and its WAL/SHM sidecars.
+
+use async_trait::async_trait;
+use extenddb_storage::bootstrapper::{AdminBootstrapResult, Bootstrapper, helpers};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::management_store::{OpError, OpResult};
+use sqlx::SqlitePool;
+use sqlx::sqlite::SqlitePoolOptions;
+
+use crate::schema::{self, CATALOG_VERSION};
+use crate::sqlite_util::sqlite_url;
+
+/// SQLite backend bootstrapper.
+///
+/// Holds the database file path. Each operation opens a short-lived
+/// single-connection pool, since `init`/`destroy`/`migrate` are one-shot CLI
+/// paths, not the hot serving path.
+pub struct SqliteBootstrapper {
+    path: String,
+}
+
+impl SqliteBootstrapper {
+    pub fn new(path: impl Into<String>) -> Self {
+        Self { path: path.into() }
+    }
+
+    /// Build a `SqliteBootstrapper` from the config file and CLI args.
+    ///
+    /// Resolution order for the database path: `--sqlite-path <p>` CLI flag,
+    /// then `[storage.sqlite].path` in the config file, then the default
+    /// `extenddb.sqlite`.
+    pub async fn from_config(config_path: &str, cli_args: &[String]) -> Result<Self, StorageError> {
+        if let Some(p) = helpers::extract_arg(cli_args, "--sqlite-path") {
+            return Ok(Self::new(p));
+        }
+
+        let path = if std::path::Path::new(config_path).exists() {
+            let content = std::fs::read_to_string(config_path)
+                .map_err(|e| StorageError::Internal(format!("read config {config_path}: {e}")))?;
+            let parsed: toml::Value = toml::from_str(&content)
+                .map_err(|e| StorageError::Internal(format!("parse config {config_path}: {e}")))?;
+            parsed
+                .get("storage")
+                .and_then(|s| s.get("sqlite"))
+                .and_then(|s| s.get("path"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("extenddb.sqlite")
+                .to_owned()
+        } else {
+            "extenddb.sqlite".to_owned()
+        };
+
+        Ok(Self::new(path))
+    }
+
+    fn is_memory(&self) -> bool {
+        self.path == ":memory:" || self.path.starts_with("file::memory:")
+    }
+
+    /// Open a short-lived single-connection pool with the standard PRAGMAs.
+    async fn pool(&self) -> OpResult<SqlitePool> {
+        SqlitePoolOptions::new()
+            .max_connections(1)
+            .after_connect(|conn, _| {
+                Box::pin(async move {
+                    use sqlx::Executor;
+                    conn.execute("PRAGMA journal_mode = WAL").await?;
+                    conn.execute("PRAGMA foreign_keys = ON").await?;
+                    conn.execute("PRAGMA synchronous = NORMAL").await?;
+                    conn.execute("PRAGMA busy_timeout = 5000").await?;
+                    Ok(())
+                })
+            })
+            .connect(&sqlite_url(&self.path))
+            .await
+            .map_err(|e| OpError::Internal(format!("open SQLite database '{}': {e}", self.path)))
+    }
+}
+
+#[async_trait]
+impl Bootstrapper for SqliteBootstrapper {
+    async fn ensure_app_user(&self) -> OpResult<()> {
+        Ok(()) // SQLite has no user concept.
+    }
+
+    async fn grant_app_role_to_admin(&self) -> OpResult<()> {
+        Ok(()) // SQLite has no role concept.
+    }
+
+    async fn create_catalog_db(&self) -> OpResult<()> {
+        // Connecting with mode=rwc creates the file; refuse to clobber an
+        // existing database so `init` is not silently destructive.
+        if !self.is_memory() && std::path::Path::new(&self.path).exists() {
+            return Err(OpError::AlreadyExists(format!(
+                "SQLite database '{}' already exists. Run 'destroy' first, then 'init'.",
+                self.path
+            )));
+        }
+        Ok(())
+    }
+
+    async fn create_data_db(&self) -> OpResult<()> {
+        Ok(()) // Catalog and data share one file.
+    }
+
+    async fn run_catalog_migrations(&self) -> OpResult<()> {
+        let pool = self.pool().await?;
+        schema::apply(&pool).await
+    }
+
+    async fn run_data_migrations(&self) -> OpResult<()> {
+        Ok(()) // Single file — schema applied in run_catalog_migrations.
+    }
+
+    async fn pending_data_migrations(&self) -> OpResult<Vec<String>> {
+        // SQLite applies its complete schema in run_catalog_migrations (a single
+        // file), so there are no separately-tracked data migrations that can be
+        // pending.
+        Ok(Vec::new())
+    }
+
+    async fn record_data_connection(&self) -> OpResult<()> {
+        let pool = self.pool().await?;
+        sqlx::query(
+            "INSERT INTO settings (key, value) VALUES ('data_database_name', ?) \
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        )
+        .bind(&self.path)
+        .execute(&pool)
+        .await
+        .map_err(|e| OpError::Internal(format!("record data db name: {e}")))?;
+        Ok(())
+    }
+
+    async fn bootstrap_encryption_key(&self) -> OpResult<()> {
+        let pool = self.pool().await?;
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM settings WHERE key = 'encryption_key')",
+        )
+        .fetch_one(&pool)
+        .await
+        .map_err(|e| OpError::Internal(format!("check encryption key: {e}")))?;
+        if exists {
+            return Ok(());
+        }
+        let key = helpers::generate_encryption_key();
+        sqlx::query("INSERT OR IGNORE INTO settings (key, value) VALUES ('encryption_key', ?)")
+            .bind(&key)
+            .execute(&pool)
+            .await
+            .map_err(|e| OpError::Internal(format!("store encryption key: {e}")))?;
+        Ok(())
+    }
+
+    async fn bootstrap_default_account(&self) -> OpResult<()> {
+        let pool = self.pool().await?;
+        // Reuse the existing account when already bootstrapped, otherwise create
+        // the single default account. Either way, record its id as the canonical
+        // default account so callers never infer it from list ordering. The
+        // settings write is idempotent (INSERT OR IGNORE), so it also backfills
+        // the marker for catalogs bootstrapped before it existed.
+        let account_id: String = match sqlx::query_scalar(
+            "SELECT account_id FROM accounts ORDER BY account_id LIMIT 1",
+        )
+        .fetch_optional(&pool)
+        .await
+        .map_err(|e| OpError::Internal(format!("check accounts: {e}")))?
+        {
+            Some(id) => id,
+            None => {
+                let id = helpers::generate_account_id();
+                sqlx::query(
+                    "INSERT OR IGNORE INTO accounts (account_id, account_name) VALUES (?, 'default')",
+                )
+                .bind(&id)
+                .execute(&pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("create default account: {e}")))?;
+                id
+            }
+        };
+        sqlx::query("INSERT OR IGNORE INTO settings (key, value) VALUES ('default_account_id', ?)")
+            .bind(&account_id)
+            .execute(&pool)
+            .await
+            .map_err(|e| OpError::Internal(format!("record default account id: {e}")))?;
+        Ok(())
+    }
+
+    async fn bootstrap_admin_user(
+        &self,
+        env_user: Option<&str>,
+        env_password: Option<&str>,
+    ) -> OpResult<AdminBootstrapResult> {
+        let pool = self.pool().await?;
+        let username = env_user
+            .filter(|s| !s.is_empty())
+            .unwrap_or("admin")
+            .to_owned();
+
+        let exists: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM admin_users WHERE admin_name = ?)")
+                .bind(&username)
+                .fetch_one(&pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("check admin user: {e}")))?;
+        if exists {
+            return Ok(AdminBootstrapResult {
+                username,
+                generated_password: None,
+                already_existed: true,
+                from_env: env_user.is_some(),
+            });
+        }
+
+        let (password, from_env) = match env_password.filter(|s| !s.is_empty()) {
+            Some(p) => (p.to_owned(), true),
+            None => (helpers::generate_random_password(), false),
+        };
+        let password_hash = helpers::hash_password_async(password.clone()).await?;
+
+        sqlx::query("INSERT INTO admin_users (admin_name, password_hash) VALUES (?, ?)")
+            .bind(&username)
+            .bind(&password_hash)
+            .execute(&pool)
+            .await
+            .map_err(|e| OpError::Internal(format!("create admin user: {e}")))?;
+
+        Ok(AdminBootstrapResult {
+            username,
+            generated_password: if from_env { None } else { Some(password) },
+            already_existed: false,
+            from_env,
+        })
+    }
+
+    async fn is_catalog_initialized(&self) -> OpResult<bool> {
+        if !self.is_memory() && !std::path::Path::new(&self.path).exists() {
+            return Ok(false);
+        }
+        let Ok(pool) = self.pool().await else {
+            return Ok(false);
+        };
+        schema::table_exists(&pool, "settings").await
+    }
+
+    async fn list_table_names(&self) -> OpResult<Vec<String>> {
+        let Ok(pool) = self.pool().await else {
+            return Ok(Vec::new());
+        };
+        let rows: Vec<(String,)> =
+            sqlx::query_as("SELECT table_name FROM tables ORDER BY table_name")
+                .fetch_all(&pool)
+                .await
+                .unwrap_or_default();
+        Ok(rows.into_iter().map(|(n,)| n).collect())
+    }
+
+    async fn get_data_db_name(&self) -> OpResult<Option<String>> {
+        let Ok(pool) = self.pool().await else {
+            return Ok(None);
+        };
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT value FROM settings WHERE key = 'data_database_name'")
+                .fetch_optional(&pool)
+                .await
+                .unwrap_or(None);
+        Ok(row.map(|(v,)| v))
+    }
+
+    async fn drop_databases(&self, _data_db: &str) -> OpResult<()> {
+        if self.is_memory() {
+            return Ok(());
+        }
+        if std::path::Path::new(&self.path).exists() {
+            std::fs::remove_file(&self.path)
+                .map_err(|e| OpError::Internal(format!("remove database file: {e}")))?;
+        }
+        // Remove WAL and shared-memory sidecars if present.
+        let _ = std::fs::remove_file(format!("{}-wal", self.path));
+        let _ = std::fs::remove_file(format!("{}-shm", self.path));
+        Ok(())
+    }
+
+    async fn read_catalog_version(&self) -> OpResult<Option<String>> {
+        let Ok(pool) = self.pool().await else {
+            return Ok(None);
+        };
+        if !schema::table_exists(&pool, "settings").await? {
+            return Ok(None);
+        }
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT value FROM settings WHERE key = 'catalog_version'")
+                .fetch_optional(&pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("read catalog version: {e}")))?;
+        Ok(row.map(|(v,)| v))
+    }
+
+    fn expected_catalog_version(&self) -> String {
+        CATALOG_VERSION.to_string()
+    }
+
+    fn catalog_database_name(&self) -> String {
+        self.path.clone()
+    }
+
+    fn endpoint_info(&self) -> String {
+        format!("sqlite:{}", self.path)
+    }
+
+    fn catalog_connection_url(&self) -> String {
+        sqlite_url(&self.path)
+    }
+
+    fn generate_backend_config_section(&self) -> String {
+        format!(
+            "[storage.sqlite]\n\
+             path = \"{}\"\n\
+             # pool_size = 10",
+            self.path
+        )
+    }
+}

--- a/crates/storage-sqlite/src/catalog_store.rs
+++ b/crates/storage-sqlite/src/catalog_store.rs
@@ -1,0 +1,355 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `SqliteCatalogStore`: the catalog/management store backing the management
+//! API and authorization. Implements `SettingsStore`, `MetricsStore`,
+//! `RateLimitStore`, `DiagnosticsStore`, `AdminStore` (in `admin_store`),
+//! `AuthorizationStore` (in `authorization_store`), `ManagementStore` (in the
+//! `management_store` module), and the `CatalogStore` supertrait.
+
+use std::sync::Arc;
+
+use extenddb_storage::CatalogStore;
+use extenddb_storage::diagnostics::{DiagError, DiagResult, DiagnosticsStore};
+use extenddb_storage::management_store::{
+    MetricsRow, MetricsStore, OpError, OpResult, RateLimitStore, SettingsStore,
+};
+use futures::future::BoxFuture;
+use sqlx::SqlitePool;
+use time::OffsetDateTime;
+
+use crate::sqlite_util::{format_timestamp, parse_timestamp};
+
+/// Catalog store over the shared SQLite pool.
+///
+/// The encryption key is cached at construction (from the `settings` table) so
+/// access-key creation/import can encrypt secrets without an extra query.
+pub struct SqliteCatalogStore {
+    pool: SqlitePool,
+    encryption_key: Option<Arc<str>>,
+}
+
+impl SqliteCatalogStore {
+    /// Construct without a cached encryption key (settings/diagnostics-only use).
+    pub fn new(pool: SqlitePool) -> Self {
+        Self {
+            pool,
+            encryption_key: None,
+        }
+    }
+
+    /// Construct with the cached AES-256-GCM encryption key (base64).
+    pub fn with_encryption_key(pool: SqlitePool, encryption_key: String) -> Self {
+        Self {
+            pool,
+            encryption_key: Some(Arc::from(encryption_key.as_str())),
+        }
+    }
+
+    pub(crate) fn pool(&self) -> &SqlitePool {
+        &self.pool
+    }
+
+    pub(crate) fn encryption_key(&self) -> Option<&Arc<str>> {
+        self.encryption_key.as_ref()
+    }
+}
+
+// ── SettingsStore ──────────────────────────────────────────────────────
+
+impl SettingsStore for SqliteCatalogStore {
+    fn get_setting(&self, key: &str) -> BoxFuture<'_, OpResult<Option<String>>> {
+        let key = key.to_owned();
+        Box::pin(async move {
+            let row: Option<(String,)> = sqlx::query_as("SELECT value FROM settings WHERE key = ?")
+                .bind(&key)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("get_setting: {e}")))?;
+            Ok(row.map(|(v,)| v))
+        })
+    }
+
+    fn set_setting(&self, key: &str, value: &str) -> BoxFuture<'_, OpResult<()>> {
+        let key = key.to_owned();
+        let value = value.to_owned();
+        Box::pin(async move {
+            sqlx::query(
+                "INSERT INTO settings (key, value) VALUES (?, ?) \
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            )
+            .bind(&key)
+            .bind(&value)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| OpError::Internal(format!("set_setting: {e}")))?;
+            Ok(())
+        })
+    }
+
+    fn list_settings(&self) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        Box::pin(async move {
+            sqlx::query_as("SELECT key, value FROM settings ORDER BY key")
+                .fetch_all(&self.pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("list_settings: {e}")))
+        })
+    }
+
+    fn cached_encryption_key(&self) -> Option<String> {
+        self.encryption_key.as_ref().map(|k| k.to_string())
+    }
+}
+
+// ── MetricsStore ───────────────────────────────────────────────────────
+
+#[derive(sqlx::FromRow)]
+struct DbMetricsRow {
+    bucket: String,
+    metric: String,
+    table_name: String,
+    index_name: String,
+    operation: String,
+    sum: f64,
+    count: i64,
+    min: f64,
+    max: f64,
+}
+
+impl MetricsStore for SqliteCatalogStore {
+    fn insert_metrics(&self, rows: &[MetricsRow]) -> BoxFuture<'_, OpResult<()>> {
+        let rows = rows.to_vec();
+        Box::pin(async move {
+            for row in &rows {
+                let bucket = format_timestamp(row.bucket);
+                let result = sqlx::query(
+                    "INSERT INTO metrics \
+                     (bucket, metric, table_name, index_name, operation, sum, count, min, max) \
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) \
+                     ON CONFLICT(bucket, metric, table_name, index_name, operation) DO UPDATE SET \
+                       sum = metrics.sum + excluded.sum, \
+                       count = metrics.count + excluded.count, \
+                       min = MIN(metrics.min, excluded.min), \
+                       max = MAX(metrics.max, excluded.max)",
+                )
+                .bind(&bucket)
+                .bind(&row.metric)
+                .bind(row.table_name.as_deref().unwrap_or(""))
+                .bind(row.index_name.as_deref().unwrap_or(""))
+                .bind(row.operation.as_deref().unwrap_or(""))
+                .bind(row.sum)
+                .bind(row.count)
+                .bind(row.min)
+                .bind(row.max)
+                .execute(&self.pool)
+                .await;
+                if let Err(e) = result {
+                    tracing::warn!("insert_metrics row failed: {e}");
+                }
+            }
+            Ok(())
+        })
+    }
+
+    fn query_metrics(
+        &self,
+        start: OffsetDateTime,
+        end: OffsetDateTime,
+        table_name: Option<&str>,
+        metric: Option<&str>,
+    ) -> BoxFuture<'_, OpResult<Vec<MetricsRow>>> {
+        let table_name = table_name.map(str::to_owned);
+        let metric = metric.map(str::to_owned);
+        let start_str = format_timestamp(start);
+        let end_str = format_timestamp(end);
+        Box::pin(async move {
+            let mut sql = String::from(
+                "SELECT bucket, metric, table_name, index_name, operation, sum, count, min, max \
+                 FROM metrics WHERE bucket >= ? AND bucket <= ?",
+            );
+            let table_filter = table_name.as_deref().filter(|s| !s.is_empty());
+            if table_filter.is_some() {
+                sql.push_str(" AND table_name = ?");
+            }
+            if metric.is_some() {
+                sql.push_str(" AND metric = ?");
+            }
+            sql.push_str(" ORDER BY bucket");
+
+            let mut q = sqlx::query_as::<_, DbMetricsRow>(&sql)
+                .bind(&start_str)
+                .bind(&end_str);
+            if let Some(tn) = table_filter {
+                q = q.bind(tn.to_owned());
+            }
+            if let Some(m) = metric.as_deref() {
+                q = q.bind(m.to_owned());
+            }
+
+            let rows = q
+                .fetch_all(&self.pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("query_metrics: {e}")))?;
+
+            Ok(rows
+                .into_iter()
+                .filter_map(|r| {
+                    Some(MetricsRow {
+                        bucket: parse_timestamp(&r.bucket).ok()?,
+                        metric: r.metric,
+                        table_name: (!r.table_name.is_empty()).then_some(r.table_name),
+                        index_name: (!r.index_name.is_empty()).then_some(r.index_name),
+                        operation: (!r.operation.is_empty()).then_some(r.operation),
+                        sum: r.sum,
+                        count: r.count,
+                        min: r.min,
+                        max: r.max,
+                    })
+                })
+                .collect())
+        })
+    }
+
+    fn prune_metrics(&self, retention: std::time::Duration) -> BoxFuture<'_, OpResult<()>> {
+        Box::pin(async move {
+            let cutoff = OffsetDateTime::now_utc()
+                - time::Duration::seconds(i64::try_from(retention.as_secs()).unwrap_or(i64::MAX));
+            let cutoff_str = format_timestamp(cutoff);
+            sqlx::query("DELETE FROM metrics WHERE bucket < ?")
+                .bind(&cutoff_str)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("prune_metrics: {e}")))?;
+            Ok(())
+        })
+    }
+}
+
+// ── RateLimitStore ─────────────────────────────────────────────────────
+
+impl RateLimitStore for SqliteCatalogStore {
+    fn count_principal_failures(
+        &self,
+        principal: &str,
+        window_seconds: i64,
+    ) -> BoxFuture<'_, OpResult<i64>> {
+        let principal = principal.to_owned();
+        Box::pin(async move {
+            let cutoff = format_timestamp(
+                OffsetDateTime::now_utc() - time::Duration::seconds(window_seconds),
+            );
+            let row: (i64,) = sqlx::query_as(
+                "SELECT COUNT(*) FROM login_attempts \
+                 WHERE principal = ? AND success = 0 AND attempted_at > ?",
+            )
+            .bind(&principal)
+            .bind(&cutoff)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| OpError::Internal(format!("count_principal_failures: {e}")))?;
+            Ok(row.0)
+        })
+    }
+
+    fn count_ip_failures(
+        &self,
+        source_ip: &str,
+        window_seconds: i64,
+    ) -> BoxFuture<'_, OpResult<i64>> {
+        let source_ip = source_ip.to_owned();
+        Box::pin(async move {
+            let cutoff = format_timestamp(
+                OffsetDateTime::now_utc() - time::Duration::seconds(window_seconds),
+            );
+            let row: (i64,) = sqlx::query_as(
+                "SELECT COUNT(*) FROM login_attempts \
+                 WHERE source_ip = ? AND success = 0 AND attempted_at > ?",
+            )
+            .bind(&source_ip)
+            .bind(&cutoff)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| OpError::Internal(format!("count_ip_failures: {e}")))?;
+            Ok(row.0)
+        })
+    }
+
+    fn record_failed_login(&self, principal: &str, source_ip: Option<&str>) -> BoxFuture<'_, ()> {
+        let principal = principal.to_owned();
+        let source_ip = source_ip.map(str::to_owned);
+        Box::pin(async move {
+            let now = format_timestamp(OffsetDateTime::now_utc());
+            let result = sqlx::query(
+                "INSERT INTO login_attempts (principal, attempted_at, success, source_ip) \
+                 VALUES (?, ?, 0, ?)",
+            )
+            .bind(&principal)
+            .bind(&now)
+            .bind(source_ip.as_deref())
+            .execute(&self.pool)
+            .await;
+            if let Err(e) = result {
+                tracing::error!("record_failed_login: {e}");
+            }
+        })
+    }
+
+    fn cleanup_old_attempts(&self, max_age_seconds: i64) -> BoxFuture<'_, ()> {
+        Box::pin(async move {
+            let cutoff = format_timestamp(
+                OffsetDateTime::now_utc() - time::Duration::seconds(max_age_seconds),
+            );
+            if let Err(e) = sqlx::query("DELETE FROM login_attempts WHERE attempted_at < ?")
+                .bind(&cutoff)
+                .execute(&self.pool)
+                .await
+            {
+                tracing::error!("cleanup_old_attempts: {e}");
+            }
+        })
+    }
+}
+
+// ── DiagnosticsStore ───────────────────────────────────────────────────
+
+impl DiagnosticsStore for SqliteCatalogStore {
+    fn count_tables(&self) -> BoxFuture<'_, DiagResult<i64>> {
+        Box::pin(async move {
+            let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM tables")
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|e| DiagError::QueryFailed(e.to_string()))?;
+            Ok(count)
+        })
+    }
+
+    fn count_indexes(&self) -> BoxFuture<'_, DiagResult<i64>> {
+        Box::pin(async move {
+            let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM indexes")
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|e| DiagError::QueryFailed(e.to_string()))?;
+            Ok(count)
+        })
+    }
+
+    fn test_data_database_connection(&self) -> BoxFuture<'_, DiagResult<String>> {
+        Box::pin(async move {
+            // Catalog and data share one SQLite file; report its recorded name.
+            let row: Option<(String,)> =
+                sqlx::query_as("SELECT value FROM settings WHERE key = 'data_database_name'")
+                    .fetch_optional(&self.pool)
+                    .await
+                    .map_err(|e| DiagError::QueryFailed(e.to_string()))?;
+            Ok(row.map_or_else(|| "sqlite (embedded)".to_owned(), |(n,)| n))
+        })
+    }
+}
+
+// ── CatalogStore supertrait ────────────────────────────────────────────
+
+impl CatalogStore for SqliteCatalogStore {
+    fn cached_encryption_key(&self) -> Option<String> {
+        self.encryption_key.as_ref().map(|k| k.to_string())
+    }
+}

--- a/crates/storage-sqlite/src/config.rs
+++ b/crates/storage-sqlite/src/config.rs
@@ -1,0 +1,144 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Storage configuration for the SQLite backend (`[storage.sqlite]`).
+
+use std::any::Any;
+
+use extenddb_storage::config::StorageConfig;
+use serde::Deserialize;
+
+/// SQLite backend configuration.
+///
+/// `path` is the database file location; `:memory:` selects an ephemeral
+/// in-memory database. `pool_size` bounds the read connection pool (writes are
+/// serialized by the engine regardless).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SqliteConfig {
+    #[serde(default = "default_path")]
+    pub path: String,
+    #[serde(default = "default_pool_size")]
+    pub pool_size: u32,
+}
+
+impl Default for SqliteConfig {
+    fn default() -> Self {
+        Self {
+            path: default_path(),
+            pool_size: default_pool_size(),
+        }
+    }
+}
+
+/// The compiled-in default database location.
+///
+/// With the `memory` feature the default is `:memory:`, producing an ephemeral,
+/// bootstrap-on-serve deployment with no file on disk. Otherwise the default is
+/// a file in the working directory.
+fn default_path() -> String {
+    if cfg!(feature = "memory") {
+        ":memory:".to_owned()
+    } else {
+        "extenddb.sqlite".to_owned()
+    }
+}
+
+fn default_pool_size() -> u32 {
+    10
+}
+
+impl StorageConfig for SqliteConfig {
+    fn connection_config(&self) -> &str {
+        &self.path
+    }
+
+    fn max_connections(&self) -> u32 {
+        self.pool_size
+    }
+
+    fn max_catalog_connections(&self) -> u32 {
+        // Single SQLite file — catalog and data share one connection pool.
+        self.pool_size
+    }
+
+    fn clone_box(&self) -> Box<dyn StorageConfig> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Deserialize a `[storage.sqlite]` TOML table into a boxed `StorageConfig`.
+pub fn deserialize_config(table: &toml::Table) -> Result<Box<dyn StorageConfig>, String> {
+    let mut config: SqliteConfig = table
+        .clone()
+        .try_into()
+        .map_err(|e: toml::de::Error| format!("Failed to parse sqlite config: {e}"))?;
+    config.path = resolve_path(config.path);
+    Ok(Box::new(config))
+}
+
+/// Resolve a relative database file path to absolute, against the current
+/// working directory.
+///
+/// This runs at config load — before `serve` daemonizes. Daemonization changes
+/// the process working directory, so a relative `path` would otherwise resolve
+/// differently (or fail to open) in the daemonized child. In-memory and URI
+/// paths are left untouched.
+fn resolve_path(path: String) -> String {
+    if path.contains(":memory:") || path.starts_with("file:") || path.starts_with("sqlite:") {
+        return path;
+    }
+    let p = std::path::Path::new(&path);
+    if p.is_absolute() {
+        return path;
+    }
+    match std::env::current_dir() {
+        Ok(cwd) => cwd.join(p).to_string_lossy().into_owned(),
+        Err(_) => path,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults() {
+        let c = SqliteConfig::default();
+        #[cfg(not(feature = "memory"))]
+        assert_eq!(c.path, "extenddb.sqlite");
+        #[cfg(feature = "memory")]
+        assert_eq!(c.path, ":memory:");
+        assert_eq!(c.pool_size, 10);
+        assert_eq!(c.max_connections(), 10);
+        assert_eq!(c.max_catalog_connections(), 10);
+    }
+
+    #[cfg(feature = "memory")]
+    #[test]
+    fn memory_feature_defaults_to_in_memory() {
+        assert_eq!(SqliteConfig::default().path, ":memory:");
+        assert_eq!(default_path(), ":memory:");
+    }
+
+    #[test]
+    fn deserialize_full() {
+        let mut t = toml::Table::new();
+        t.insert("path".into(), toml::Value::String(":memory:".into()));
+        t.insert("pool_size".into(), toml::Value::Integer(4));
+        let boxed = deserialize_config(&t).expect("parse");
+        assert_eq!(boxed.connection_config(), ":memory:");
+        assert_eq!(boxed.max_connections(), 4);
+    }
+
+    #[test]
+    fn deserialize_rejects_unknown_field() {
+        let mut t = toml::Table::new();
+        t.insert("bogus".into(), toml::Value::Integer(1));
+        assert!(deserialize_config(&t).is_err());
+    }
+}

--- a/crates/storage-sqlite/src/create_table.rs
+++ b/crates/storage-sqlite/src/create_table.rs
@@ -1,0 +1,403 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `create_table` implementation for `SqliteEngine`.
+//!
+//! Catalog metadata (table row, indexes, tags, stream shards) is written in one
+//! transaction; the per-table/index data tables are created in a second
+//! transaction afterward, with catalog cleanup if the data DDL fails. The
+//! control-plane delay (`control_plane_delay_seconds`) decides whether the
+//! table starts ACTIVE (delay 0) or CREATING with a scheduled transition.
+
+use extenddb_core::types::{
+    BillingMode, BillingModeSummary, CreateTableInput, GsiDescription, LsiDescription,
+    ProvisionedThroughputDescription, SseDescription, SseType, TableDescription, TableStatus,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::{index_arn, stream_arn, table_arn};
+
+use crate::sqlite_util::{format_timestamp, is_unique_violation};
+use crate::store::SqliteEngine;
+
+impl SqliteEngine {
+    pub(crate) async fn create_table_impl(
+        &self,
+        account_id: &str,
+        input: CreateTableInput,
+    ) -> Result<TableDescription, StorageError> {
+        Self::validate_account_id(account_id)?;
+        let table_id = uuid::Uuid::new_v4().to_string();
+        let table_arn = table_arn(&self.region, account_id, &input.table_name);
+        let billing_mode = input.billing_mode.unwrap_or(BillingMode::Provisioned);
+        let billing_str = match billing_mode {
+            BillingMode::Provisioned => "PROVISIONED",
+            BillingMode::PayPerRequest => "PAY_PER_REQUEST",
+        };
+
+        let to_str = |v: &serde_json::Value| -> Result<String, StorageError> {
+            serde_json::to_string(v).map_err(|e| StorageError::Internal(e.to_string()))
+        };
+        let key_schema_json = serde_json::to_string(&input.key_schema)
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let attr_defs_json = serde_json::to_string(&input.attribute_definitions)
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let pt_json = input
+            .provisioned_throughput
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let stream_json = input
+            .stream_specification
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let sse_json = input.sse_specification.as_ref().map(to_str).transpose()?;
+        let on_demand_json = input
+            .on_demand_throughput
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let deletion_protection = input.deletion_protection_enabled.unwrap_or(false);
+
+        // Control-plane delay decides initial status and scheduled transition.
+        let delay_secs: f64 = sqlx::query_scalar::<_, String>(
+            "SELECT value FROM settings WHERE key = 'control_plane_delay_seconds'",
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?
+        .and_then(|v| v.parse::<f64>().ok())
+        .unwrap_or(0.25);
+
+        let now = time::OffsetDateTime::now_utc();
+        let creation_ts = format_timestamp(now);
+        #[allow(clippy::cast_precision_loss)]
+        let creation_epoch = now.unix_timestamp() as f64;
+        let (initial_status, status_transition_at) = if delay_secs <= 0.0 {
+            ("ACTIVE", None)
+        } else {
+            (
+                "CREATING",
+                Some(format_timestamp(
+                    now + time::Duration::seconds_f64(delay_secs),
+                )),
+            )
+        };
+
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        sqlx::query(
+            "INSERT INTO tables \
+             (account_id, table_name, key_schema, attribute_definitions, billing_mode, \
+              provisioned_throughput, stream_specification, table_status, creation_date_time, \
+              table_arn, table_id, deletion_protection_enabled, status_transition_at, \
+              table_class, sse_specification, on_demand_throughput) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(account_id)
+        .bind(&input.table_name)
+        .bind(&key_schema_json)
+        .bind(&attr_defs_json)
+        .bind(billing_str)
+        .bind(&pt_json)
+        .bind(&stream_json)
+        .bind(initial_status)
+        .bind(&creation_ts)
+        .bind(&table_arn)
+        .bind(&table_id)
+        .bind(deletion_protection)
+        .bind(&status_transition_at)
+        .bind(&input.table_class)
+        .bind(&sse_json)
+        .bind(&on_demand_json)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| {
+            if is_unique_violation(&e) {
+                StorageError::TableAlreadyExists(input.table_name.clone())
+            } else {
+                StorageError::Internal(e.to_string())
+            }
+        })?;
+
+        // GSI / LSI metadata.
+        let mut gsi_ids: Vec<String> = Vec::new();
+        if let Some(gsis) = &input.global_secondary_indexes {
+            for gsi in gsis {
+                let ks = serde_json::to_string(&gsi.key_schema)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                let proj = serde_json::to_string(&gsi.projection)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                let pt = gsi
+                    .provisioned_throughput
+                    .as_ref()
+                    .map(|pt| {
+                        serde_json::to_string(&ProvisionedThroughputDescription {
+                            read_capacity_units: pt.read_capacity_units,
+                            write_capacity_units: pt.write_capacity_units,
+                            number_of_decreases_today: 0,
+                            last_increase_date_time: None,
+                            last_decrease_date_time: None,
+                        })
+                    })
+                    .transpose()
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                let index_id = uuid::Uuid::new_v4().to_string();
+                sqlx::query(
+                    "INSERT INTO indexes \
+                     (table_id, index_name, index_id, index_type, key_schema, projection, \
+                      index_status, provisioned_throughput) \
+                     VALUES (?, ?, ?, 'GSI', ?, ?, 'ACTIVE', ?)",
+                )
+                .bind(&table_id)
+                .bind(&gsi.index_name)
+                .bind(&index_id)
+                .bind(&ks)
+                .bind(&proj)
+                .bind(&pt)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+                gsi_ids.push(index_id);
+            }
+        }
+        let mut lsi_ids: Vec<String> = Vec::new();
+        if let Some(lsis) = &input.local_secondary_indexes {
+            for lsi in lsis {
+                let ks = serde_json::to_string(&lsi.key_schema)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                let proj = serde_json::to_string(&lsi.projection)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                let index_id = uuid::Uuid::new_v4().to_string();
+                sqlx::query(
+                    "INSERT INTO indexes \
+                     (table_id, index_name, index_id, index_type, key_schema, projection, \
+                      index_status, provisioned_throughput) \
+                     VALUES (?, ?, ?, 'LSI', ?, ?, 'ACTIVE', NULL)",
+                )
+                .bind(&table_id)
+                .bind(&lsi.index_name)
+                .bind(&index_id)
+                .bind(&ks)
+                .bind(&proj)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+                lsi_ids.push(index_id);
+            }
+        }
+
+        // Tags.
+        if let Some(tags) = &input.tags {
+            for tag in tags {
+                sqlx::query("INSERT INTO tags (resource_arn, tag_key, tag_value) VALUES (?, ?, ?)")
+                    .bind(&table_arn)
+                    .bind(&tag.key)
+                    .bind(&tag.value)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            }
+        }
+
+        // Stream shards (same transaction — single file).
+        let stream_label = if input
+            .stream_specification
+            .as_ref()
+            .is_some_and(|s| s.stream_enabled)
+        {
+            Some(Self::init_stream_shards(&mut tx, account_id, &input.table_name, &table_id).await?)
+        } else {
+            None
+        };
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        // Data tables in a second transaction; clean up catalog on failure.
+        let data_result = async {
+            let mut data_tx = self
+                .pool
+                .begin_with("BEGIN IMMEDIATE")
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Self::create_data_table(
+                &mut data_tx,
+                &table_id,
+                &input.key_schema,
+                &input.attribute_definitions,
+            )
+            .await?;
+            if let Some(gsis) = &input.global_secondary_indexes {
+                for (i, gsi) in gsis.iter().enumerate() {
+                    Self::create_index_data_table(
+                        &mut data_tx,
+                        &gsi_ids[i],
+                        &gsi.key_schema,
+                        &input.attribute_definitions,
+                        &input.key_schema,
+                        &input.attribute_definitions,
+                    )
+                    .await?;
+                }
+            }
+            if let Some(lsis) = &input.local_secondary_indexes {
+                for (i, lsi) in lsis.iter().enumerate() {
+                    Self::create_index_data_table(
+                        &mut data_tx,
+                        &lsi_ids[i],
+                        &lsi.key_schema,
+                        &input.attribute_definitions,
+                        &input.key_schema,
+                        &input.attribute_definitions,
+                    )
+                    .await?;
+                }
+            }
+            data_tx
+                .commit()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok::<(), StorageError>(())
+        }
+        .await;
+
+        if let Err(e) = data_result {
+            tracing::error!(
+                "Failed to create data tables for '{}', cleaning up catalog: {e}",
+                input.table_name
+            );
+            let _ = sqlx::query("DELETE FROM tables WHERE account_id = ? AND table_name = ?")
+                .bind(account_id)
+                .bind(&input.table_name)
+                .execute(&self.pool)
+                .await;
+            return Err(e);
+        }
+
+        self.control_plane_notify.notify_one();
+
+        // Build the response from in-scope data (avoids a post-commit read race).
+        let (rcu, wcu) = input.provisioned_throughput.as_ref().map_or((0, 0), |pt| {
+            (pt.read_capacity_units, pt.write_capacity_units)
+        });
+
+        let gsis = input.global_secondary_indexes.as_ref().map(|gs| {
+            gs.iter()
+                .map(|g| GsiDescription {
+                    index_name: g.index_name.clone(),
+                    key_schema: g.key_schema.clone(),
+                    projection: g.projection.clone(),
+                    index_status: "ACTIVE".to_owned(),
+                    provisioned_throughput: Some(ProvisionedThroughputDescription {
+                        read_capacity_units: g
+                            .provisioned_throughput
+                            .as_ref()
+                            .map_or(0, |pt| pt.read_capacity_units),
+                        write_capacity_units: g
+                            .provisioned_throughput
+                            .as_ref()
+                            .map_or(0, |pt| pt.write_capacity_units),
+                        number_of_decreases_today: 0,
+                        last_increase_date_time: None,
+                        last_decrease_date_time: None,
+                    }),
+                    index_size_bytes: 0,
+                    item_count: 0,
+                    index_arn: index_arn(
+                        &self.region,
+                        account_id,
+                        &input.table_name,
+                        &g.index_name,
+                    ),
+                })
+                .collect()
+        });
+        let lsis = input.local_secondary_indexes.as_ref().map(|ls| {
+            ls.iter()
+                .map(|l| LsiDescription {
+                    index_name: l.index_name.clone(),
+                    key_schema: l.key_schema.clone(),
+                    projection: l.projection.clone(),
+                    index_size_bytes: 0,
+                    item_count: 0,
+                    index_arn: index_arn(
+                        &self.region,
+                        account_id,
+                        &input.table_name,
+                        &l.index_name,
+                    ),
+                })
+                .collect()
+        });
+
+        let billing_mode_summary = (billing_mode == BillingMode::PayPerRequest).then_some({
+            BillingModeSummary {
+                billing_mode: BillingMode::PayPerRequest,
+                last_update_to_pay_per_request_date_time: Some(creation_epoch),
+            }
+        });
+        let latest_stream_arn = stream_label
+            .as_ref()
+            .map(|label| stream_arn(&self.region, account_id, &input.table_name, label));
+        let response_status = if initial_status == "ACTIVE" {
+            TableStatus::Active
+        } else {
+            TableStatus::Creating
+        };
+        let sse_description = input.sse_specification.as_ref().and_then(|spec| {
+            let enabled = spec
+                .get("Enabled")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+            enabled.then(|| SseDescription {
+                status: "ENABLED".to_owned(),
+                sse_type: Some(SseType::KMS),
+                kms_master_key_arn: Some(format!(
+                    "arn:aws:kms:{}:{}:key/default",
+                    self.region, account_id
+                )),
+            })
+        });
+
+        Ok(TableDescription {
+            table_name: input.table_name,
+            key_schema: input.key_schema,
+            attribute_definitions: input.attribute_definitions,
+            table_status: response_status,
+            creation_date_time: creation_epoch,
+            table_size_bytes: 0,
+            item_count: 0,
+            table_arn,
+            table_id,
+            provisioned_throughput: ProvisionedThroughputDescription {
+                read_capacity_units: rcu,
+                write_capacity_units: wcu,
+                number_of_decreases_today: 0,
+                last_increase_date_time: None,
+                last_decrease_date_time: None,
+            },
+            billing_mode_summary,
+            global_secondary_indexes: gsis,
+            local_secondary_indexes: lsis,
+            stream_specification: input.stream_specification,
+            latest_stream_arn,
+            latest_stream_label: stream_label,
+            deletion_protection_enabled: deletion_protection,
+            sse_description,
+            table_class_summary: input
+                .table_class
+                .as_ref()
+                .map(|tc| serde_json::json!({ "TableClass": tc })),
+            on_demand_throughput: input.on_demand_throughput,
+        })
+    }
+}

--- a/crates/storage-sqlite/src/credential_store.rs
+++ b/crates/storage-sqlite/src/credential_store.rs
@@ -1,0 +1,172 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! SQLite-backed `CredentialStore` for SigV4 verification.
+//!
+//! `AKIA…` keys resolve to long-lived IAM user access keys; `ASIA…` keys
+//! resolve to temporary `AssumeRole` sessions (with expiry enforcement).
+//! Secrets are decrypted with AES-256-GCM; the `access_key_id` is the AAD, with
+//! a no-AAD fallback for any legacy ciphertext.
+
+use aes_gcm::aead::{Aead, Payload};
+use aes_gcm::{Aes256Gcm, Key, KeyInit, Nonce};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use extenddb_auth::{CredentialStore, StoredCredential};
+use extenddb_core::error::DynamoDbError;
+use sqlx::SqlitePool;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use crate::sqlite_util::parse_timestamp;
+
+/// Decrypt a `nonce(12) || ciphertext` secret with AES-256-GCM.
+fn decrypt_secret(encrypted: &[u8], key_b64: &str, aad: &str) -> Result<String, String> {
+    if encrypted.len() < 28 {
+        return Err("ciphertext too short (need 12-byte nonce + 16-byte tag)".to_owned());
+    }
+    let key_bytes = BASE64
+        .decode(key_b64)
+        .map_err(|e| format!("decode encryption key: {e}"))?;
+    if key_bytes.len() != 32 {
+        return Err("encryption key must be 32 bytes".to_owned());
+    }
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key_bytes));
+    let nonce = Nonce::from_slice(&encrypted[..12]);
+
+    if let Ok(plaintext) = cipher.decrypt(
+        nonce,
+        Payload {
+            msg: &encrypted[12..],
+            aad: aad.as_bytes(),
+        },
+    ) {
+        return String::from_utf8(plaintext).map_err(|e| format!("secret not UTF-8: {e}"));
+    }
+    // Fallback: ciphertext written without AAD.
+    let plaintext = cipher
+        .decrypt(nonce, &encrypted[12..])
+        .map_err(|e| format!("decrypt: {e}"))?;
+    String::from_utf8(plaintext).map_err(|e| format!("secret not UTF-8: {e}"))
+}
+
+/// Credential store over the catalog SQLite pool.
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct SqliteCredentialStore {
+    #[zeroize(skip)]
+    pool: SqlitePool,
+    encryption_key: String,
+}
+
+impl SqliteCredentialStore {
+    pub fn new(pool: SqlitePool, encryption_key: String) -> Self {
+        Self {
+            pool,
+            encryption_key,
+        }
+    }
+
+    async fn lookup_user(
+        &self,
+        access_key_id: &str,
+    ) -> Result<Option<StoredCredential>, DynamoDbError> {
+        let row: Option<(Vec<u8>, String, String, bool)> = sqlx::query_as(
+            "SELECT secret_key_encrypted, account_id, user_name, is_active \
+             FROM access_keys WHERE access_key_id = ?",
+        )
+        .bind(access_key_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!("credential lookup failed for {access_key_id}: {e}");
+            DynamoDbError::InternalServerError("Internal error during authentication".to_owned())
+        })?;
+
+        let Some((encrypted, account_id, user_name, is_active)) = row else {
+            return Ok(None);
+        };
+        let secret_key =
+            decrypt_secret(&encrypted, &self.encryption_key, access_key_id).map_err(|e| {
+                tracing::error!("secret decryption failed for {access_key_id}: {e}");
+                DynamoDbError::InternalServerError(
+                    "Internal error during authentication".to_owned(),
+                )
+            })?;
+        Ok(Some(StoredCredential {
+            secret_key,
+            account_id,
+            principal_name: user_name,
+            session_name: None,
+            is_session: false,
+            session_token: None,
+            is_active,
+            expires_at: None,
+        }))
+    }
+
+    async fn lookup_session(
+        &self,
+        access_key_id: &str,
+    ) -> Result<Option<StoredCredential>, DynamoDbError> {
+        let row: Option<(Vec<u8>, String, String, String, String, String)> = sqlx::query_as(
+            "SELECT secret_key_encrypted, account_id, role_name, session_name, \
+                    session_token, expires_at \
+             FROM iam_sessions WHERE access_key_id = ?",
+        )
+        .bind(access_key_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!("session lookup failed for {access_key_id}: {e}");
+            DynamoDbError::InternalServerError("Internal error during authentication".to_owned())
+        })?;
+
+        let Some((encrypted, account_id, role_name, session_name, session_token, expires_at)) = row
+        else {
+            return Ok(None);
+        };
+
+        let expires = parse_timestamp(&expires_at).map_err(|e| {
+            tracing::error!("session expiry parse error: {e}");
+            DynamoDbError::InternalServerError("Internal error during authentication".to_owned())
+        })?;
+        if expires < time::OffsetDateTime::now_utc() {
+            return Err(DynamoDbError::ExpiredTokenException(
+                "The security token included in the request is expired".to_owned(),
+            ));
+        }
+
+        let secret_key =
+            decrypt_secret(&encrypted, &self.encryption_key, access_key_id).map_err(|e| {
+                tracing::error!("session secret decryption failed for {access_key_id}: {e}");
+                DynamoDbError::InternalServerError(
+                    "Internal error during authentication".to_owned(),
+                )
+            })?;
+        Ok(Some(StoredCredential {
+            secret_key,
+            account_id,
+            principal_name: role_name,
+            session_name: Some(session_name),
+            is_session: true,
+            session_token: Some(session_token),
+            is_active: true,
+            expires_at: Some(expires),
+        }))
+    }
+}
+
+#[async_trait::async_trait]
+impl CredentialStore for SqliteCredentialStore {
+    async fn lookup_credential(
+        &self,
+        access_key_id: &str,
+    ) -> Result<Option<StoredCredential>, DynamoDbError> {
+        if access_key_id.starts_with("ASIA") {
+            self.lookup_session(access_key_id).await
+        } else if access_key_id.starts_with("AKIA") {
+            self.lookup_user(access_key_id).await
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/crates/storage-sqlite/src/data/data_engine.rs
+++ b/crates/storage-sqlite/src/data/data_engine.rs
@@ -1,0 +1,391 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `DataEngine` trait implementation for `SqliteEngine`.
+//!
+//! Each method clones its borrowed arguments into owned values and delegates to
+//! the corresponding `*_impl` method inside a boxed future. The transact-write
+//! path rebuilds borrowed `TransactWriteOp`s from owned components inside the
+//! future, since the trait's borrowed ops cannot outlive the call.
+
+use extenddb_core::expression::{Expr, ExpressionMaps, KeyCondition, UpdateAction};
+use extenddb_core::types::{Item, ReturnValuesOnConditionCheckFailure, TableKeyInfo};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::{DataEngine, IdempotencyKey, StreamCapture, TransactGetOp, TransactWriteOp};
+use futures::future::BoxFuture;
+
+use crate::store::SqliteEngine;
+
+impl DataEngine for SqliteEngine {
+    fn put_item(
+        &self,
+        key_info: &TableKeyInfo,
+        item: Item,
+        return_old: bool,
+        condition: Option<&Expr>,
+        maps: &ExpressionMaps,
+        stream: Option<&StreamCapture>,
+    ) -> BoxFuture<'_, Result<Option<Item>, StorageError>> {
+        let key_info = key_info.clone();
+        let condition = condition.cloned();
+        let maps = maps.clone();
+        let stream = stream.cloned();
+        Box::pin(async move {
+            self.put_item_impl(
+                &key_info,
+                item,
+                return_old,
+                condition.as_ref(),
+                &maps,
+                stream.as_ref(),
+            )
+            .await
+        })
+    }
+
+    fn get_item(
+        &self,
+        key_info: &TableKeyInfo,
+        key: &Item,
+    ) -> BoxFuture<'_, Result<Option<Item>, StorageError>> {
+        let key_info = key_info.clone();
+        let key = key.clone();
+        Box::pin(async move { self.get_item_impl(&key_info, &key).await })
+    }
+
+    fn delete_item(
+        &self,
+        key_info: &TableKeyInfo,
+        key: &Item,
+        return_old: bool,
+        condition: Option<&Expr>,
+        maps: &ExpressionMaps,
+        stream: Option<&StreamCapture>,
+    ) -> BoxFuture<'_, Result<Option<Item>, StorageError>> {
+        let key_info = key_info.clone();
+        let key = key.clone();
+        let condition = condition.cloned();
+        let maps = maps.clone();
+        let stream = stream.cloned();
+        Box::pin(async move {
+            self.delete_item_impl(
+                &key_info,
+                &key,
+                return_old,
+                condition.as_ref(),
+                &maps,
+                stream.as_ref(),
+            )
+            .await
+        })
+    }
+
+    fn update_item(
+        &self,
+        key_info: &TableKeyInfo,
+        key: &Item,
+        actions: &[UpdateAction],
+        return_old: bool,
+        return_new: bool,
+        condition: Option<&Expr>,
+        maps: &ExpressionMaps,
+        stream: Option<&StreamCapture>,
+    ) -> BoxFuture<'_, Result<(Option<Item>, Option<Item>), StorageError>> {
+        let key_info = key_info.clone();
+        let key = key.clone();
+        let actions = actions.to_vec();
+        let condition = condition.cloned();
+        let maps = maps.clone();
+        let stream = stream.cloned();
+        Box::pin(async move {
+            self.update_item_impl(
+                &key_info,
+                &key,
+                &actions,
+                return_old,
+                return_new,
+                condition.as_ref(),
+                &maps,
+                stream.as_ref(),
+            )
+            .await
+        })
+    }
+
+    fn query(
+        &self,
+        key_info: &TableKeyInfo,
+        key_condition: &KeyCondition,
+        maps: &ExpressionMaps,
+        forward: bool,
+        limit: Option<i64>,
+        exclusive_start_key: Option<&Item>,
+        index_name: Option<&str>,
+    ) -> BoxFuture<'_, Result<(Vec<Item>, Option<Item>), StorageError>> {
+        let key_info = key_info.clone();
+        let key_condition = key_condition.clone();
+        let maps = maps.clone();
+        let exclusive_start_key = exclusive_start_key.cloned();
+        let index_name = index_name.map(str::to_owned);
+        Box::pin(async move {
+            self.query_impl(
+                &key_info,
+                &key_condition,
+                &maps,
+                forward,
+                limit,
+                exclusive_start_key.as_ref(),
+                index_name.as_deref(),
+            )
+            .await
+        })
+    }
+
+    fn scan(
+        &self,
+        key_info: &TableKeyInfo,
+        limit: Option<i64>,
+        exclusive_start_key: Option<&Item>,
+        segment: Option<i64>,
+        total_segments: Option<i64>,
+        index_name: Option<&str>,
+    ) -> BoxFuture<'_, Result<(Vec<Item>, Option<Item>), StorageError>> {
+        let key_info = key_info.clone();
+        let exclusive_start_key = exclusive_start_key.cloned();
+        let index_name = index_name.map(str::to_owned);
+        Box::pin(async move {
+            self.scan_impl(
+                &key_info,
+                limit,
+                exclusive_start_key.as_ref(),
+                segment,
+                total_segments,
+                index_name.as_deref(),
+            )
+            .await
+        })
+    }
+
+    fn transact_get_items(
+        &self,
+        ops: &[TransactGetOp<'_>],
+    ) -> BoxFuture<'_, Result<Vec<Option<Item>>, StorageError>> {
+        let owned: Vec<(TableKeyInfo, Item)> = ops
+            .iter()
+            .map(|op| (op.key_info.clone(), op.key.clone()))
+            .collect();
+        Box::pin(async move {
+            let borrowed: Vec<TransactGetOp> = owned
+                .iter()
+                .map(|(key_info, key)| TransactGetOp { key_info, key })
+                .collect();
+            self.transact_get_items_impl(&borrowed).await
+        })
+    }
+
+    fn transact_write_items(
+        &self,
+        ops: &[TransactWriteOp<'_>],
+        idempotency: Option<IdempotencyKey<'_>>,
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let owned: Vec<OwnedWriteOp> = ops.iter().map(OwnedWriteOp::from_op).collect();
+        let idempotency = idempotency.map(|k| {
+            (
+                k.account_id.to_owned(),
+                k.token.to_owned(),
+                k.fingerprint.to_owned(),
+            )
+        });
+        Box::pin(async move {
+            let borrowed: Vec<TransactWriteOp> = owned.iter().map(OwnedWriteOp::as_op).collect();
+            self.transact_write_items_impl(
+                &borrowed,
+                idempotency.as_ref().map(|(a, t, f)| IdempotencyKey {
+                    account_id: a,
+                    token: t,
+                    fingerprint: f,
+                }),
+            )
+            .await
+        })
+    }
+
+    fn cleanup_expired_idempotency_tokens(
+        &self,
+        max_age_seconds: i64,
+    ) -> BoxFuture<'_, Result<u64, StorageError>> {
+        Box::pin(async move {
+            self.cleanup_expired_idempotency_tokens_impl(max_age_seconds)
+                .await
+        })
+    }
+}
+
+/// Owned form of a `TransactWriteOp`, so the borrowed ops can be reconstructed
+/// inside the `'static` future.
+enum OwnedWriteOp {
+    Put {
+        key_info: TableKeyInfo,
+        item: Item,
+        condition: Option<Expr>,
+        maps: ExpressionMaps,
+        rv: ReturnValuesOnConditionCheckFailure,
+        stream: Option<StreamCapture>,
+    },
+    Delete {
+        key_info: TableKeyInfo,
+        key: Item,
+        condition: Option<Expr>,
+        maps: ExpressionMaps,
+        rv: ReturnValuesOnConditionCheckFailure,
+        stream: Option<StreamCapture>,
+    },
+    Update {
+        key_info: TableKeyInfo,
+        key: Item,
+        actions: Vec<UpdateAction>,
+        condition: Option<Expr>,
+        maps: ExpressionMaps,
+        rv: ReturnValuesOnConditionCheckFailure,
+        stream: Option<StreamCapture>,
+    },
+    ConditionCheck {
+        key_info: TableKeyInfo,
+        key: Item,
+        condition: Expr,
+        maps: ExpressionMaps,
+        rv: ReturnValuesOnConditionCheckFailure,
+    },
+}
+
+impl OwnedWriteOp {
+    fn from_op(op: &TransactWriteOp<'_>) -> Self {
+        match op {
+            TransactWriteOp::Put {
+                key_info,
+                item,
+                condition,
+                maps,
+                return_values_on_ccf,
+                stream,
+            } => Self::Put {
+                key_info: (*key_info).clone(),
+                item: (*item).clone(),
+                condition: condition.cloned(),
+                maps: (*maps).clone(),
+                rv: *return_values_on_ccf,
+                stream: stream.clone(),
+            },
+            TransactWriteOp::Delete {
+                key_info,
+                key,
+                condition,
+                maps,
+                return_values_on_ccf,
+                stream,
+            } => Self::Delete {
+                key_info: (*key_info).clone(),
+                key: (*key).clone(),
+                condition: condition.cloned(),
+                maps: (*maps).clone(),
+                rv: *return_values_on_ccf,
+                stream: stream.clone(),
+            },
+            TransactWriteOp::Update {
+                key_info,
+                key,
+                actions,
+                condition,
+                maps,
+                return_values_on_ccf,
+                stream,
+            } => Self::Update {
+                key_info: (*key_info).clone(),
+                key: (*key).clone(),
+                actions: actions.to_vec(),
+                condition: condition.cloned(),
+                maps: (*maps).clone(),
+                rv: *return_values_on_ccf,
+                stream: stream.clone(),
+            },
+            TransactWriteOp::ConditionCheck {
+                key_info,
+                key,
+                condition,
+                maps,
+                return_values_on_ccf,
+            } => Self::ConditionCheck {
+                key_info: (*key_info).clone(),
+                key: (*key).clone(),
+                condition: (*condition).clone(),
+                maps: (*maps).clone(),
+                rv: *return_values_on_ccf,
+            },
+        }
+    }
+
+    fn as_op(&self) -> TransactWriteOp<'_> {
+        match self {
+            Self::Put {
+                key_info,
+                item,
+                condition,
+                maps,
+                rv,
+                stream,
+            } => TransactWriteOp::Put {
+                key_info,
+                item,
+                condition: condition.as_ref(),
+                maps,
+                return_values_on_ccf: *rv,
+                stream: stream.clone(),
+            },
+            Self::Delete {
+                key_info,
+                key,
+                condition,
+                maps,
+                rv,
+                stream,
+            } => TransactWriteOp::Delete {
+                key_info,
+                key,
+                condition: condition.as_ref(),
+                maps,
+                return_values_on_ccf: *rv,
+                stream: stream.clone(),
+            },
+            Self::Update {
+                key_info,
+                key,
+                actions,
+                condition,
+                maps,
+                rv,
+                stream,
+            } => TransactWriteOp::Update {
+                key_info,
+                key,
+                actions,
+                condition: condition.as_ref(),
+                maps,
+                return_values_on_ccf: *rv,
+                stream: stream.clone(),
+            },
+            Self::ConditionCheck {
+                key_info,
+                key,
+                condition,
+                maps,
+                rv,
+            } => TransactWriteOp::ConditionCheck {
+                key_info,
+                key,
+                condition,
+                maps,
+                return_values_on_ccf: *rv,
+            },
+        }
+    }
+}

--- a/crates/storage-sqlite/src/data/ddl.rs
+++ b/crates/storage-sqlite/src/data/ddl.rs
@@ -1,0 +1,366 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! DDL for per-DynamoDB-table and per-index data tables, plus catalog fetches
+//! of `TableKeyInfo` / `IndexInfo`.
+//!
+//! Sort-key columns follow design decision D2: `sk_s`/`base_sk_s` are `TEXT`,
+//! `sk_n`/`base_sk_n` are `TEXT` (order-preserving numeric encoding, never
+//! `REAL`), `sk_b`/`base_sk_b` are `BLOB`.
+
+use extenddb_core::types::{
+    AttributeDefinition, IndexInfo, IndexType, KeySchemaElement, Projection, StreamSpecification,
+    TableKeyInfo,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::sk_column_n;
+
+use super::{all_sort_key_info, data_table_name, index_table_name};
+use crate::store::SqliteEngine;
+
+/// SQLite column type for the Nth sort-key position and scalar type (D2).
+fn sk_col_defs(index: usize) -> [String; 3] {
+    if index == 0 {
+        [
+            "sk_s TEXT".to_owned(),
+            "sk_n TEXT".to_owned(),
+            "sk_b BLOB".to_owned(),
+        ]
+    } else {
+        let n = index + 1;
+        [
+            format!("sk{n}_s TEXT"),
+            format!("sk{n}_n TEXT"),
+            format!("sk{n}_b BLOB"),
+        ]
+    }
+}
+
+/// SQLite column type for the Nth base-table sort-key position (D2).
+fn base_sk_col_defs(index: usize) -> [String; 3] {
+    if index == 0 {
+        [
+            "base_sk_s TEXT".to_owned(),
+            "base_sk_n TEXT".to_owned(),
+            "base_sk_b BLOB".to_owned(),
+        ]
+    } else {
+        let n = index + 1;
+        [
+            format!("base_sk{n}_s TEXT"),
+            format!("base_sk{n}_n TEXT"),
+            format!("base_sk{n}_b BLOB"),
+        ]
+    }
+}
+
+impl SqliteEngine {
+    /// Create the per-DynamoDB-table data table.
+    ///
+    /// # Safety (SQL injection)
+    /// `table_id` is a server-generated UUID; column names are constants. No
+    /// user input is interpolated into the DDL.
+    pub(crate) async fn create_data_table(
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        table_id: &str,
+        key_schema: &[KeySchemaElement],
+        attr_defs: &[AttributeDefinition],
+    ) -> Result<(), StorageError> {
+        let ddb_table = data_table_name(table_id);
+        let sk_infos = all_sort_key_info(key_schema, attr_defs);
+
+        let ddl = if sk_infos.is_empty() {
+            format!(
+                "CREATE TABLE {ddb_table} (pk TEXT NOT NULL PRIMARY KEY, item_data TEXT NOT NULL)"
+            )
+        } else {
+            let mut col_defs = vec!["pk TEXT NOT NULL".to_owned()];
+            let mut pk_cols = vec!["pk".to_owned()];
+            for (i, &(_, sk_type)) in sk_infos.iter().enumerate() {
+                col_defs.extend(sk_col_defs(i));
+                pk_cols.push(sk_column_n(i, sk_type));
+            }
+            col_defs.push("item_data TEXT NOT NULL".to_owned());
+            format!(
+                "CREATE TABLE {ddb_table} (\n    {},\n    PRIMARY KEY ({})\n)",
+                col_defs.join(",\n    "),
+                pk_cols.join(", ")
+            )
+        };
+
+        sqlx::query(&ddl)
+            .execute(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Drop the per-DynamoDB-table data table.
+    pub(crate) async fn drop_data_table(
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        table_id: &str,
+    ) -> Result<(), StorageError> {
+        let ddb_table = data_table_name(table_id);
+        sqlx::query(&format!("DROP TABLE IF EXISTS {ddb_table}"))
+            .execute(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Create a GSI/LSI data table. GSI keys are not unique, so the primary key
+    /// is `(pk, sk*, base_pk, base_sk*)` to keep one row per base item, and an
+    /// ordering index covers `(pk, sk*, base_pk, base_sk*)`.
+    pub(crate) async fn create_index_data_table(
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        index_id: &str,
+        index_key_schema: &[KeySchemaElement],
+        attr_defs: &[AttributeDefinition],
+        base_key_schema: &[KeySchemaElement],
+        base_attr_defs: &[AttributeDefinition],
+    ) -> Result<(), StorageError> {
+        let idx_table = index_table_name(index_id);
+        let idx_sks = all_sort_key_info(index_key_schema, attr_defs);
+        let base_sks = all_sort_key_info(base_key_schema, base_attr_defs);
+
+        let mut col_defs = vec!["pk TEXT NOT NULL".to_owned()];
+        for i in 0..idx_sks.len() {
+            col_defs.extend(sk_col_defs(i));
+        }
+        col_defs.push("base_pk TEXT NOT NULL".to_owned());
+        for i in 0..base_sks.len() {
+            col_defs.extend(base_sk_col_defs(i));
+        }
+        col_defs.push("item_data TEXT NOT NULL".to_owned());
+
+        let mut pk_cols = vec!["pk".to_owned(), "base_pk".to_owned()];
+        for (i, &(_, sk_type)) in base_sks.iter().enumerate() {
+            pk_cols.push(format!("base_{}", sk_column_n(i, sk_type)));
+        }
+
+        let ddl = format!(
+            "CREATE TABLE {idx_table} (\n    {},\n    PRIMARY KEY ({})\n)",
+            col_defs.join(",\n    "),
+            pk_cols.join(", ")
+        );
+        sqlx::query(&ddl)
+            .execute(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        if !idx_sks.is_empty() {
+            let mut order_cols = vec!["pk".to_owned()];
+            for (i, &(_, sk_type)) in idx_sks.iter().enumerate() {
+                order_cols.push(sk_column_n(i, sk_type));
+            }
+            order_cols.push("base_pk".to_owned());
+            for (i, &(_, sk_type)) in base_sks.iter().enumerate() {
+                order_cols.push(format!("base_{}", sk_column_n(i, sk_type)));
+            }
+            let order_idx = format!(
+                "CREATE INDEX \"idx_order_{index_id}\" ON {idx_table} ({})",
+                order_cols.join(", ")
+            );
+            sqlx::query(&order_idx)
+                .execute(&mut **tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    /// Drop a GSI/LSI data table.
+    pub(crate) async fn drop_index_data_table(
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        index_id: &str,
+    ) -> Result<(), StorageError> {
+        let idx_table = index_table_name(index_id);
+        sqlx::query(&format!("DROP TABLE IF EXISTS {idx_table}"))
+            .execute(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Fetch `TableKeyInfo` for an ACTIVE table from the catalog.
+    pub(crate) async fn fetch_table_key_info(
+        &self,
+        account_id: &str,
+        table_name: &str,
+    ) -> Result<TableKeyInfo, StorageError> {
+        let row: Option<(String, String, String, String, Option<String>)> = sqlx::query_as(
+            "SELECT key_schema, attribute_definitions, table_status, table_id, \
+             stream_specification \
+             FROM tables WHERE account_id = ? AND table_name = ?",
+        )
+        .bind(account_id)
+        .bind(table_name)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let (ks_str, ad_str, status, table_id, stream_spec_str) =
+            row.ok_or_else(|| StorageError::TableNotFound(table_name.to_owned()))?;
+
+        match status.as_str() {
+            "ACTIVE" => {}
+            // A table still being created, or being deleted, is not usable for
+            // data-plane operations; DynamoDB reports it as not found (not
+            // in-use). UPDATING keeps the not-active classification.
+            "CREATING" | "DELETING" => {
+                return Err(StorageError::TableNotFound(table_name.to_owned()));
+            }
+            _ => return Err(StorageError::TableNotActive(table_name.to_owned())),
+        }
+
+        let key_schema: Vec<KeySchemaElement> =
+            serde_json::from_str(&ks_str).map_err(|e| StorageError::Internal(e.to_string()))?;
+        let attribute_definitions: Vec<AttributeDefinition> =
+            serde_json::from_str(&ad_str).map_err(|e| StorageError::Internal(e.to_string()))?;
+        let stream_specification: Option<StreamSpecification> = stream_spec_str
+            .as_deref()
+            .map(serde_json::from_str)
+            .transpose()
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        // Full secondary-index metadata rides on the (cached) TableKeyInfo so
+        // per-index consumed-capacity accounting avoids a separate
+        // describe_table round-trip on every write; it also supplies `has_lsi`.
+        let (global_secondary_indexes, local_secondary_indexes) =
+            self.fetch_all_index_info(&table_id).await?;
+        let has_lsi = !local_secondary_indexes.is_empty();
+
+        Ok(TableKeyInfo {
+            table_name: table_name.to_owned(),
+            account_id: account_id.to_owned(),
+            table_id,
+            base_key_schema: key_schema.clone(),
+            key_schema,
+            attribute_definitions,
+            has_lsi,
+            global_secondary_indexes,
+            local_secondary_indexes,
+            stream_specification,
+        })
+    }
+
+    /// Fetch every secondary index defined on a table, split into
+    /// `(global_secondary_indexes, local_secondary_indexes)`.
+    async fn fetch_all_index_info(
+        &self,
+        table_id: &str,
+    ) -> Result<(Vec<IndexInfo>, Vec<IndexInfo>), StorageError> {
+        let rows: Vec<(String, String, String, String, String)> = sqlx::query_as(
+            "SELECT index_name, index_type, index_id, key_schema, projection \
+             FROM indexes WHERE table_id = ?",
+        )
+        .bind(table_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let mut gsis = Vec::new();
+        let mut lsis = Vec::new();
+        for (index_name, idx_type_str, index_id, ks_json, proj_json) in rows {
+            let index_type = match idx_type_str.as_str() {
+                "GSI" => IndexType::Gsi,
+                "LSI" => IndexType::Lsi,
+                other => {
+                    return Err(StorageError::Internal(format!(
+                        "unknown index type in database: {other}"
+                    )));
+                }
+            };
+            let key_schema: Vec<KeySchemaElement> = serde_json::from_str(&ks_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let projection: Projection = serde_json::from_str(&proj_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let info = IndexInfo {
+                index_name,
+                index_id,
+                index_type,
+                key_schema,
+                projection,
+            };
+            match index_type {
+                IndexType::Gsi => gsis.push(info),
+                IndexType::Lsi => lsis.push(info),
+            }
+        }
+        Ok((gsis, lsis))
+    }
+
+    /// Fetch `IndexInfo` for a secondary index, validating the table is ACTIVE.
+    pub(crate) async fn fetch_index_info(
+        &self,
+        account_id: &str,
+        table_name: &str,
+        index_name: &str,
+    ) -> Result<IndexInfo, StorageError> {
+        let row: Option<(String, String)> = sqlx::query_as(
+            "SELECT table_id, table_status FROM tables WHERE account_id = ? AND table_name = ?",
+        )
+        .bind(account_id)
+        .bind(table_name)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let (table_id, status) =
+            row.ok_or_else(|| StorageError::TableNotFound(table_name.to_owned()))?;
+        match status.as_str() {
+            "ACTIVE" => {}
+            // A table still being created, or being deleted, is not usable for
+            // data-plane operations; DynamoDB reports it as not found (not
+            // in-use). UPDATING keeps the not-active classification.
+            "CREATING" | "DELETING" => {
+                return Err(StorageError::TableNotFound(table_name.to_owned()));
+            }
+            _ => return Err(StorageError::TableNotActive(table_name.to_owned())),
+        }
+        self.fetch_index_info_by_table_id(&table_id, index_name)
+            .await
+    }
+
+    /// Fetch `IndexInfo` using a known `table_id`.
+    pub(crate) async fn fetch_index_info_by_table_id(
+        &self,
+        table_id: &str,
+        index_name: &str,
+    ) -> Result<IndexInfo, StorageError> {
+        let row: Option<(String, String, String, String)> = sqlx::query_as(
+            "SELECT index_type, index_id, key_schema, projection \
+             FROM indexes WHERE table_id = ? AND index_name = ?",
+        )
+        .bind(table_id)
+        .bind(index_name)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let (idx_type_str, index_id, ks_str, proj_str) =
+            row.ok_or_else(|| StorageError::IndexNotFound(index_name.to_owned()))?;
+
+        let index_type = match idx_type_str.as_str() {
+            "GSI" => IndexType::Gsi,
+            "LSI" => IndexType::Lsi,
+            other => {
+                return Err(StorageError::Internal(format!(
+                    "unknown index type in database: {other}"
+                )));
+            }
+        };
+        let key_schema: Vec<KeySchemaElement> =
+            serde_json::from_str(&ks_str).map_err(|e| StorageError::Internal(e.to_string()))?;
+        let projection: Projection =
+            serde_json::from_str(&proj_str).map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        Ok(IndexInfo {
+            index_name: index_name.to_owned(),
+            index_id,
+            index_type,
+            key_schema,
+            projection,
+        })
+    }
+}

--- a/crates/storage-sqlite/src/data/delete_item.rs
+++ b/crates/storage-sqlite/src/data/delete_item.rs
@@ -1,0 +1,98 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `delete_item` for the SQLite backend.
+
+use extenddb_core::expression::{Expr, ExpressionMaps};
+use extenddb_core::types::{Item, TableKeyInfo};
+use extenddb_storage::StreamCapture;
+use extenddb_storage::error::StorageError;
+
+use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
+use super::query::check_condition;
+use super::tx_helpers::{delete_item_in_tx, fetch_item_in_tx, write_stream_record_in_tx};
+use crate::store::SqliteEngine;
+
+impl SqliteEngine {
+    pub(crate) async fn delete_item_impl(
+        &self,
+        key_info: &TableKeyInfo,
+        key: &Item,
+        return_old: bool,
+        condition: Option<&Expr>,
+        maps: &ExpressionMaps,
+        stream: Option<&StreamCapture>,
+    ) -> Result<Option<Item>, StorageError> {
+        let _writer = self.write_lock.lock().await;
+        // Read the index set after acquiring the write lock so a concurrently
+        // added GSI (UpdateTable holds the same lock) is not missed.
+        let indexes = fetch_indexes_for_table(&key_info.table_id, &self.pool).await?;
+        let system_delay = self.gsi_default_delay();
+
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let old = fetch_item_in_tx(&mut tx, key_info, key).await?;
+
+        if condition.is_some() {
+            let empty = Item::new();
+            let target = old.as_ref().unwrap_or(&empty);
+            if let Err(e) = check_condition(condition, target, maps) {
+                return match e {
+                    StorageError::ConditionFailed(_) => Err(StorageError::ConditionFailed(old)),
+                    other => Err(other),
+                };
+            }
+        }
+
+        // Only mutate when an item actually exists; deleting a missing item is
+        // a no-op (no row removed, no index change, no stream record).
+        let mut enqueued = false;
+        if old.is_some() {
+            delete_item_in_tx(&mut tx, key_info, key).await?;
+
+            if !indexes.is_empty() {
+                sync_indexes(
+                    &mut tx,
+                    &key_info.key_schema,
+                    &key_info.attribute_definitions,
+                    &indexes,
+                    old.as_ref(),
+                    None,
+                    system_delay,
+                )
+                .await?;
+            }
+            if enqueue_async_indexes(
+                &mut tx,
+                key_info,
+                &indexes,
+                old.as_ref(),
+                None,
+                system_delay,
+            )
+            .await?
+                > 0
+            {
+                enqueued = true;
+            }
+
+            if let Some(capture) = stream {
+                write_stream_record_in_tx(&mut tx, key_info, capture, old.as_ref(), None).await?;
+            }
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        if enqueued {
+            self.gsi_notify.notify_waiters();
+        }
+
+        Ok(if return_old { old } else { None })
+    }
+}

--- a/crates/storage-sqlite/src/data/index.rs
+++ b/crates/storage-sqlite/src/data/index.rs
@@ -1,0 +1,488 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! GSI/LSI index maintenance for the SQLite backend.
+//!
+//! Synchronous indexes (LSIs and zero-delay GSIs) are reconciled in the base
+//! write transaction. Async GSIs are deferred via the `gsi_pending` queue —
+//! **one self-describing row per index**: each row snapshots the base key
+//! schema, attribute definitions, and its single target index definition, so
+//! the worker applies with zero catalog reads. Each row carries its index's own
+//! (jittered) propagation delay, and `ready_at` is kept monotonic within the
+//! base key's `worker_partition` so jitter cannot reorder updates to one item.
+//! Index key columns follow D2 — `N` keys are stored as the order-preserving
+//! TEXT encoding, `S` as TEXT, `B` as BLOB — via [`sk_bound`].
+
+use extenddb_core::types::{
+    AttributeDefinition, Item, KeySchemaElement, Projection, ProjectionType, ScalarAttributeType,
+    TableKeyInfo,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::{composite_pk_to_text, parse_sk, sk_column, sk_column_n};
+use serde::{Deserialize, Serialize};
+
+use super::{BoundValue, all_sort_key_info, index_table_name, sk_bound};
+
+/// Number of partitions a base key can hash to. Updates to one base item share
+/// a partition; `ready_at` is clamped monotonic within a partition so the
+/// single drain worker (which orders by `id`) applies them in order. More
+/// partitions reduce false serialization between unrelated keys; there is no
+/// concurrency cost because SQLite has a single writer.
+const NUM_PARTITIONS: u64 = 16;
+
+/// Stable partition for a base-table key (FNV-1a, mapped to a partition). A
+/// local hash keeps the mapping fixed for a key across builds (`std`'s hasher
+/// is not guaranteed stable).
+fn partition_for(base_pk_text: &str) -> i64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325; // FNV-1a offset basis
+    for byte in base_pk_text.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3); // FNV prime
+    }
+    (hash % NUM_PARTITIONS) as i64
+}
+
+/// Jittered propagation delay (ms), uniform in `[delay_ms / 2, delay_ms]`.
+///
+/// Simulates DynamoDB's eventual-consistency variability (a fixed delay is
+/// perfectly predictable) while keeping the configured delay a meaningful lower
+/// bound — jittering all the way to ~0 would make the delay almost meaningless.
+/// `delay_ms <= 1` is returned unchanged. Callers only enqueue async indexes,
+/// so `delay_ms >= 1`.
+fn jitter_delay_ms(delay_ms: u64) -> u64 {
+    if delay_ms <= 1 {
+        delay_ms
+    } else {
+        use rand::Rng;
+        rand::rng().random_range(delay_ms / 2 + 1..=delay_ms)
+    }
+}
+
+/// A single target index definition, snapshotted at enqueue time. The
+/// propagation delay is not stored — it is already encoded in the row's
+/// `ready_at`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct GsiIndexDef {
+    pub(crate) index_id: String,
+    pub(crate) key_schema: Vec<KeySchemaElement>,
+    pub(crate) projection: Projection,
+}
+
+/// Self-describing apply context serialized into `gsi_pending.index_context`.
+/// One per row → exactly one target index, so the worker needs no catalog read.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct GsiApplyContext {
+    pub(crate) base_key_schema: Vec<KeySchemaElement>,
+    pub(crate) attribute_definitions: Vec<AttributeDefinition>,
+    pub(crate) index: GsiIndexDef,
+}
+
+/// Metadata for a single index, used on the write path and by the GSI worker.
+pub(crate) struct IndexMeta {
+    pub(super) index_id: String,
+    pub(super) index_name: String,
+    pub(super) index_type: String,
+    pub(super) key_schema: Vec<KeySchemaElement>,
+    pub(super) projection: Projection,
+    /// Per-GSI propagation delay (ms). `None` = use system default; `Some(0)` =
+    /// synchronous.
+    pub(super) propagation_delay_ms: Option<i64>,
+}
+
+/// Fetch all index metadata for a table from the catalog.
+pub(crate) async fn fetch_indexes_for_table(
+    table_id: &str,
+    pool: &sqlx::SqlitePool,
+) -> Result<Vec<IndexMeta>, StorageError> {
+    let rows: Vec<(String, String, String, String, String, Option<i64>)> = sqlx::query_as(
+        "SELECT index_id, index_name, index_type, key_schema, projection, propagation_delay_ms \
+         FROM indexes WHERE table_id = ?",
+    )
+    .bind(table_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    rows.into_iter()
+        .map(|(index_id, index_name, index_type, ks, proj, delay)| {
+            Ok(IndexMeta {
+                index_id,
+                index_name,
+                index_type,
+                key_schema: serde_json::from_str(&ks)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?,
+                projection: serde_json::from_str(&proj)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?,
+                propagation_delay_ms: delay,
+            })
+        })
+        .collect()
+}
+
+/// Effective GSI propagation delay (ms): per-GSI override, else system default.
+/// `Some(0)` forces synchronous; negative is treated as "use system default".
+pub(crate) fn effective_delay(idx: &IndexMeta, system_default: u64) -> u64 {
+    match idx.propagation_delay_ms {
+        Some(0) => 0,
+        Some(ms) if ms > 0 => ms as u64,
+        _ => system_default,
+    }
+}
+
+/// Enqueue async GSI propagation for a write: **one self-describing
+/// `gsi_pending` row per async index**, each honoring its own effective delay.
+///
+/// Returns the number of rows enqueued so callers can skip waking the worker
+/// when nothing was queued. Must run inside the base write transaction so the
+/// pending rows commit atomically with the item mutation.
+pub(crate) async fn enqueue_async_indexes(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    key_info: &TableKeyInfo,
+    indexes: &[IndexMeta],
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+    system_default_delay: u64,
+) -> Result<usize, StorageError> {
+    let mut enqueued = 0usize;
+    for idx in indexes {
+        if idx.index_type == "LSI" {
+            continue; // LSIs are always synchronous.
+        }
+        let delay = effective_delay(idx, system_default_delay);
+        if delay == 0 {
+            continue; // Synchronous GSI — handled in-txn by sync_indexes.
+        }
+        let context = GsiApplyContext {
+            base_key_schema: key_info.key_schema.clone(),
+            attribute_definitions: key_info.attribute_definitions.clone(),
+            index: GsiIndexDef {
+                index_id: idx.index_id.clone(),
+                key_schema: idx.key_schema.clone(),
+                projection: idx.projection.clone(),
+            },
+        };
+        enqueue_gsi_pending(tx, &key_info.table_id, old_item, new_item, delay, &context).await?;
+        enqueued += 1;
+    }
+    Ok(enqueued)
+}
+
+/// Insert one self-describing `gsi_pending` row for a single index inside the
+/// base write transaction (zero crash window).
+///
+/// `delay_ms` is the index's effective delay; a jitter in `[delay/2, delay]`
+/// is applied. `ready_at` is clamped to `max(now + jitter, MAX(ready_at) in the
+/// base key's partition)` so a later write that draws a smaller jitter can never
+/// become eligible before an earlier one — preserving per-key FIFO when the
+/// worker drains the partition in `id` order.
+pub(crate) async fn enqueue_gsi_pending(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    table_id: &str,
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+    delay_ms: u64,
+    context: &GsiApplyContext,
+) -> Result<(), StorageError> {
+    let old_json = old_item
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let new_json = new_item
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let context_json =
+        serde_json::to_string(context).map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    // Route all updates for one base item to a single partition (per-key FIFO).
+    // The base key is immutable: `new_item` carries it for puts/updates,
+    // `old_item` for deletes.
+    let worker_partition = match new_item.or(old_item) {
+        Some(item) => partition_for(&composite_pk_to_text(item, &context.base_key_schema)?),
+        None => 0,
+    };
+
+    // ready_at as RFC 3339 so it compares correctly (lexically) against the
+    // worker's RFC 3339 `now` cutoff and against other rows' ready_at.
+    let jittered = jitter_delay_ms(delay_ms);
+    let candidate = crate::sqlite_util::format_timestamp(
+        time::OffsetDateTime::now_utc()
+            + time::Duration::milliseconds(i64::try_from(jittered).unwrap_or(i64::MAX)),
+    );
+    // Monotonic clamp within the partition (RFC 3339 strings sort lexically).
+    let part_max: Option<String> =
+        sqlx::query_scalar("SELECT MAX(ready_at) FROM gsi_pending WHERE worker_partition = ?")
+            .bind(worker_partition)
+            .fetch_one(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let ready_at = match part_max {
+        Some(prev) if prev > candidate => prev,
+        _ => candidate,
+    };
+
+    sqlx::query(
+        "INSERT INTO gsi_pending \
+         (table_id, worker_partition, old_item, new_item, index_context, ready_at) \
+         VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(table_id)
+    .bind(worker_partition)
+    .bind(&old_json)
+    .bind(&new_json)
+    .bind(&context_json)
+    .bind(&ready_at)
+    .execute(&mut **tx)
+    .await
+    .map_err(|e| StorageError::Internal(e.to_string()))?;
+    Ok(())
+}
+
+/// Project an item according to an index's projection configuration.
+pub(crate) fn project_item_for_index(
+    item: &Item,
+    index_ks: &[KeySchemaElement],
+    base_ks: &[KeySchemaElement],
+    projection: &Projection,
+) -> Item {
+    match projection.projection_type {
+        ProjectionType::All => item.clone(),
+        ProjectionType::KeysOnly | ProjectionType::Include => {
+            let mut projected = Item::new();
+            for ks in base_ks.iter().chain(index_ks.iter()) {
+                if let Some(v) = item.get(&ks.attribute_name) {
+                    projected.insert(ks.attribute_name.clone(), v.clone());
+                }
+            }
+            if projection.projection_type == ProjectionType::Include
+                && let Some(attrs) = &projection.non_key_attributes
+            {
+                for attr in attrs {
+                    if let Some(v) = item.get(attr) {
+                        projected.insert(attr.clone(), v.clone());
+                    }
+                }
+            }
+            projected
+        }
+    }
+}
+
+/// Whether an item carries every key attribute an index requires.
+pub(crate) fn item_has_index_keys(item: &Item, index_ks: &[KeySchemaElement]) -> bool {
+    index_ks
+        .iter()
+        .all(|ks| item.contains_key(&ks.attribute_name))
+}
+
+/// Synchronously reconcile index tables for a base-item change — but only for
+/// indexes that are synchronous: LSIs (always) and GSIs whose effective delay
+/// is 0. GSIs with a non-zero delay are deferred via `gsi_pending` and applied
+/// by the worker, so they are skipped here.
+pub(crate) async fn sync_indexes(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    base_key_schema: &[KeySchemaElement],
+    attr_defs: &[AttributeDefinition],
+    indexes: &[IndexMeta],
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+    system_default_delay: u64,
+) -> Result<(), StorageError> {
+    let base_sks = all_sort_key_info(base_key_schema, attr_defs);
+    for idx in indexes {
+        if idx.index_type != "LSI" && effective_delay(idx, system_default_delay) != 0 {
+            continue; // Async GSI — applied later by the propagation worker.
+        }
+        let idx_table = index_table_name(&idx.index_id);
+        let idx_sks = all_sort_key_info(&idx.key_schema, attr_defs);
+
+        if let Some(old) = old_item
+            && item_has_index_keys(old, &idx.key_schema)
+        {
+            delete_index_row_multi(tx, &idx_table, old, base_key_schema, &base_sks).await?;
+        }
+
+        if let Some(new) = new_item
+            && item_has_index_keys(new, &idx.key_schema)
+        {
+            let projected =
+                project_item_for_index(new, &idx.key_schema, base_key_schema, &idx.projection);
+            insert_index_row_multi(
+                tx,
+                &idx_table,
+                new,
+                &projected,
+                &idx.key_schema,
+                base_key_schema,
+                &idx_sks,
+                &base_sks,
+            )
+            .await?;
+        }
+    }
+    Ok(())
+}
+
+/// Delete an index row identified by its base-table key columns.
+pub(crate) async fn delete_index_row_multi(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    idx_table: &str,
+    item: &Item,
+    base_ks: &[KeySchemaElement],
+    base_sks: &[(&str, ScalarAttributeType)],
+) -> Result<(), StorageError> {
+    let base_pk_text = composite_pk_to_text(item, base_ks)?;
+
+    let mut where_parts = vec!["base_pk = ?".to_owned()];
+    for (i, &(_, sk_type)) in base_sks.iter().enumerate() {
+        where_parts.push(format!("base_{} = ?", sk_column_n(i, sk_type)));
+    }
+    let sql = format!(
+        "DELETE FROM {idx_table} WHERE {}",
+        where_parts.join(" AND ")
+    );
+
+    let mut query = sqlx::query(&sql).bind(base_pk_text);
+    for &(sk_name, sk_type) in base_sks {
+        // Bind a value for every placeholder, mirroring insert_index_row_multi:
+        // a missing sort-key attribute binds an empty string rather than
+        // skipping the bind (which would desynchronise placeholders and binds).
+        let bound = match item.get(sk_name) {
+            Some(v) => sk_bound(&parse_sk(v, sk_type)?),
+            None => BoundValue::Text(String::new()),
+        };
+        query = super::bind_bound!(query, bound);
+    }
+    query
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    Ok(())
+}
+
+/// Insert (or replace) an index row for a base item.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn insert_index_row_multi(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    idx_table: &str,
+    item: &Item,
+    projected: &Item,
+    index_ks: &[KeySchemaElement],
+    base_ks: &[KeySchemaElement],
+    idx_sks: &[(&str, ScalarAttributeType)],
+    base_sks: &[(&str, ScalarAttributeType)],
+) -> Result<(), StorageError> {
+    let idx_pk_text = composite_pk_to_text(item, index_ks)?;
+    let base_pk_text = composite_pk_to_text(item, base_ks)?;
+    let item_json =
+        serde_json::to_string(projected).map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    // Columns and the matching bound values, in column order.
+    let mut cols = vec!["pk".to_owned()];
+    let mut values: Vec<BoundValue> = vec![BoundValue::Text(idx_pk_text)];
+
+    for (i, &(sk_name, sk_type)) in idx_sks.iter().enumerate() {
+        cols.push(sk_column_n(i, sk_type));
+        if let Some(v) = item.get(sk_name) {
+            values.push(sk_bound(&parse_sk(v, sk_type)?));
+        } else {
+            values.push(BoundValue::Text(String::new()));
+        }
+    }
+
+    cols.push("base_pk".to_owned());
+    values.push(BoundValue::Text(base_pk_text));
+
+    for (i, &(sk_name, sk_type)) in base_sks.iter().enumerate() {
+        cols.push(format!("base_{}", sk_column_n(i, sk_type)));
+        if let Some(v) = item.get(sk_name) {
+            values.push(sk_bound(&parse_sk(v, sk_type)?));
+        } else {
+            values.push(BoundValue::Text(String::new()));
+        }
+    }
+
+    cols.push("item_data".to_owned());
+    values.push(BoundValue::Text(item_json));
+
+    let placeholders = vec!["?"; cols.len()].join(", ");
+    let sql = format!(
+        "INSERT OR REPLACE INTO {idx_table} ({}) VALUES ({placeholders})",
+        cols.join(", ")
+    );
+
+    let mut query = sqlx::query(&sql);
+    for v in values {
+        query = super::bind_bound!(query, v);
+    }
+    query
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    Ok(())
+}
+
+/// Helper: derive the sort-key column name used by an index data table for the
+/// Nth index sort key. Exposed for query routing.
+#[allow(dead_code)]
+pub(crate) fn index_sk_column(index: usize, sk_type: ScalarAttributeType) -> String {
+    if index == 0 {
+        sk_column(sk_type).to_owned()
+    } else {
+        sk_column_n(index, sk_type)
+    }
+}
+
+/// True if a storage error is a "missing table" error (the `_ddb_*` index table
+/// was dropped, e.g. the base table was deleted while a `gsi_pending` row was
+/// in flight). Such rows are benignly skipped.
+fn is_no_such_table(e: &StorageError) -> bool {
+    matches!(e, StorageError::Internal(msg) if msg.contains("no such table"))
+}
+
+/// Apply one claimed `gsi_pending` row to its single target index, within the
+/// worker's transaction, using the row's self-describing `index_context` — no
+/// catalog read. A missing index data table (the base table was deleted while
+/// the row was in flight) is skipped benignly.
+pub(crate) async fn apply_claimed_row(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+    context: &GsiApplyContext,
+) -> Result<(), StorageError> {
+    let base_sks = all_sort_key_info(&context.base_key_schema, &context.attribute_definitions);
+    let idx = &context.index;
+    let idx_table = index_table_name(&idx.index_id);
+    let idx_sks = all_sort_key_info(&idx.key_schema, &context.attribute_definitions);
+
+    if let Some(old) = old_item
+        && item_has_index_keys(old, &idx.key_schema)
+    {
+        delete_index_row_multi(tx, &idx_table, old, &context.base_key_schema, &base_sks)
+            .await
+            .or_else(|e| if is_no_such_table(&e) { Ok(()) } else { Err(e) })?;
+    }
+    if let Some(new) = new_item
+        && item_has_index_keys(new, &idx.key_schema)
+    {
+        let projected = project_item_for_index(
+            new,
+            &idx.key_schema,
+            &context.base_key_schema,
+            &idx.projection,
+        );
+        insert_index_row_multi(
+            tx,
+            &idx_table,
+            new,
+            &projected,
+            &idx.key_schema,
+            &context.base_key_schema,
+            &idx_sks,
+            &base_sks,
+        )
+        .await
+        .or_else(|e| if is_no_such_table(&e) { Ok(()) } else { Err(e) })?;
+    }
+    Ok(())
+}

--- a/crates/storage-sqlite/src/data/mod.rs
+++ b/crates/storage-sqlite/src/data/mod.rs
@@ -1,0 +1,153 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-DynamoDB-table data storage for the SQLite backend.
+//!
+//! Each virtual DynamoDB table maps to a SQLite table named `_ddb_<table_id>`;
+//! each secondary index maps to `_ddb_<index_id>`. The full item is stored as
+//! JSON `TEXT` in `item_data`; key columns exist only for lookup and ordering.
+//!
+//! # Key column types (design decision D2)
+//!
+//! - Partition key (`pk`): always `TEXT` via the shared `pk_to_text` (equality
+//!   only) — identical to the PostgreSQL backend.
+//! - Sort key, by attribute type:
+//!   - `S` → `sk_s TEXT` (SQLite BINARY collation = DynamoDB UTF-8 byte order).
+//!   - `N` → `sk_n TEXT` holding [`encode_orderable_number`], so lexicographic
+//!     order equals numeric order with full 38-digit precision (never `REAL`).
+//!   - `B` → `sk_b BLOB` (memcmp = DynamoDB unsigned byte order).
+//!
+//! The exact, full-precision value is always preserved in `item_data` JSON, so
+//! reads lose nothing; the typed key columns are used only for
+//! lookup/range/ordering.
+
+use extenddb_core::types::{
+    AttributeDefinition, Item, KeySchemaElement, KeyType, ScalarAttributeType,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::SortKeyValue;
+
+use crate::number_key::encode_orderable_number;
+
+mod data_engine;
+mod ddl;
+mod delete_item;
+mod index;
+mod put_item;
+mod query;
+mod query_scan;
+mod transactions;
+mod tx_helpers;
+mod update_item;
+
+pub(crate) use index::{
+    GsiApplyContext, apply_claimed_row, insert_index_row_multi, project_item_for_index,
+};
+pub(crate) use tx_helpers::upsert_item_in_tx;
+
+/// Quoted SQL identifier for a virtual DynamoDB table's data table.
+pub(crate) fn data_table_name(table_id: &str) -> String {
+    format!("\"_ddb_{table_id}\"")
+}
+
+/// Quoted SQL identifier for a GSI/LSI data table.
+pub(crate) fn index_table_name(index_id: &str) -> String {
+    format!("\"_ddb_{index_id}\"")
+}
+
+/// All RANGE key attributes in key-schema order, paired with their scalar type.
+pub(crate) fn all_sort_key_info<'a>(
+    key_schema: &'a [KeySchemaElement],
+    attr_defs: &'a [AttributeDefinition],
+) -> Vec<(&'a str, ScalarAttributeType)> {
+    key_schema
+        .iter()
+        .filter(|ks| ks.key_type == KeyType::Range)
+        .filter_map(|ks| {
+            attr_defs
+                .iter()
+                .find(|ad| ad.attribute_name == ks.attribute_name)
+                .map(|ad| (ks.attribute_name.as_str(), ad.attribute_type))
+        })
+        .collect()
+}
+
+/// Deserialize an `item_data` JSON value into an `Item`.
+pub(crate) fn json_to_item(v: serde_json::Value) -> Result<Item, StorageError> {
+    serde_json::from_value(v).map_err(|e| StorageError::Internal(e.to_string()))
+}
+
+/// A value bound to a sort-key column, already mapped to its SQLite storage
+/// representation per D2.
+#[derive(Debug, Clone)]
+pub(crate) enum BoundValue {
+    /// `TEXT` — used for `S` (raw string) and `N` (order-preserving encoding).
+    Text(String),
+    /// `BLOB` — used for `B`.
+    Blob(Vec<u8>),
+}
+
+/// Map a parsed sort-key value to its SQLite storage representation (D2):
+/// `S` → TEXT, `N` → order-preserving TEXT, `B` → BLOB.
+pub(crate) fn sk_bound(sk: &SortKeyValue) -> BoundValue {
+    match sk {
+        SortKeyValue::S(s) => BoundValue::Text(s.clone()),
+        SortKeyValue::N(n) => BoundValue::Text(encode_orderable_number(n)),
+        SortKeyValue::B(b) => BoundValue::Blob(b.clone()),
+    }
+}
+
+/// Bind a [`BoundValue`] onto a positional `sqlx` query.
+macro_rules! bind_bound {
+    ($query:expr, $bound:expr) => {
+        match $bound {
+            crate::data::BoundValue::Text(s) => $query.bind(s),
+            crate::data::BoundValue::Blob(b) => $query.bind(b),
+        }
+    };
+}
+
+/// Bind `pk` then a sort-key value, then `fetch_optional` a single JSON column.
+macro_rules! bind_sk_fetch_optional {
+    ($sql:expr, $pk:expr, $sk:expr, $executor:expr) => {{
+        let __q = sqlx::query_as::<_, (serde_json::Value,)>($sql).bind($pk);
+        let __q = match crate::data::sk_bound($sk) {
+            crate::data::BoundValue::Text(s) => __q.bind(s),
+            crate::data::BoundValue::Blob(b) => __q.bind(b),
+        };
+        __q.fetch_optional($executor)
+            .await
+            .map_err(|e| extenddb_storage::error::StorageError::Internal(e.to_string()))
+    }};
+}
+
+/// Bind `pk`, a sort-key value, then `item_json`, and `execute`.
+macro_rules! bind_sk_execute {
+    ($sql:expr, $pk:expr, $sk:expr, $item_json:expr, $executor:expr) => {{
+        let __q = sqlx::query($sql).bind($pk);
+        let __q = match crate::data::sk_bound($sk) {
+            crate::data::BoundValue::Text(s) => __q.bind(s),
+            crate::data::BoundValue::Blob(b) => __q.bind(b),
+        };
+        __q.bind($item_json)
+            .execute($executor)
+            .await
+            .map_err(|e| extenddb_storage::error::StorageError::Internal(e.to_string()))
+    }};
+}
+
+/// Bind `pk` then a sort-key value, and `execute` (no item payload).
+macro_rules! bind_sk_only_execute {
+    ($sql:expr, $pk:expr, $sk:expr, $executor:expr) => {{
+        let __q = sqlx::query($sql).bind($pk);
+        let __q = match crate::data::sk_bound($sk) {
+            crate::data::BoundValue::Text(s) => __q.bind(s),
+            crate::data::BoundValue::Blob(b) => __q.bind(b),
+        };
+        __q.execute($executor)
+            .await
+            .map_err(|e| extenddb_storage::error::StorageError::Internal(e.to_string()))
+    }};
+}
+
+pub(crate) use {bind_bound, bind_sk_execute, bind_sk_fetch_optional, bind_sk_only_execute};

--- a/crates/storage-sqlite/src/data/put_item.rs
+++ b/crates/storage-sqlite/src/data/put_item.rs
@@ -1,0 +1,164 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `put_item` and `get_item` for the SQLite backend.
+//!
+//! Writes acquire the engine write lock (D1) and run in a transaction, so the
+//! condition check, the write, index sync, and stream capture are one atomic
+//! unit with no competing writer — no `INSERT ... ON CONFLICT DO NOTHING` race
+//! dance is needed.
+
+use extenddb_core::expression::{Expr, ExpressionMaps};
+use extenddb_core::types::{Item, TableKeyInfo};
+use extenddb_storage::StreamCapture;
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::{pk_to_text, sk_column, sk_info};
+
+use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
+use super::query::check_condition;
+use super::tx_helpers::{fetch_item_in_tx, upsert_item_in_tx, write_stream_record_in_tx};
+use super::{bind_sk_fetch_optional, data_table_name, json_to_item};
+use crate::store::SqliteEngine;
+
+impl SqliteEngine {
+    pub(crate) async fn put_item_impl(
+        &self,
+        key_info: &TableKeyInfo,
+        item: Item,
+        return_old: bool,
+        condition: Option<&Expr>,
+        maps: &ExpressionMaps,
+        stream: Option<&StreamCapture>,
+    ) -> Result<Option<Item>, StorageError> {
+        // Read the index set only after acquiring the write lock, so a GSI added
+        // by a concurrent UpdateTable (which holds the same lock) cannot be missed
+        // and left unmaintained by this write.
+        let _writer = self.write_lock.lock().await;
+        let indexes = fetch_indexes_for_table(&key_info.table_id, &self.pool).await?;
+
+        // Index key attributes present in the item must match their declared
+        // scalar type and be non-empty, matching real DynamoDB. This is up-front
+        // input validation (a top-level ValidationException), so it runs before
+        // any write work. Mirrors the PostgreSQL backend.
+        if !indexes.is_empty() {
+            let index_refs: Vec<extenddb_core::validation::IndexKeyRef<'_>> = indexes
+                .iter()
+                .map(|idx| extenddb_core::validation::IndexKeyRef {
+                    index_name: &idx.index_name,
+                    key_schema: &idx.key_schema,
+                })
+                .collect();
+            extenddb_core::validation::validate_index_keys(
+                &item,
+                &index_refs,
+                &key_info.attribute_definitions,
+            )
+            .map_err(|e| StorageError::Validation(e.to_string()))?;
+        }
+
+        let system_delay = self.gsi_default_delay();
+        let need_old = condition.is_some() || return_old || !indexes.is_empty() || stream.is_some();
+
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let old = if need_old {
+            fetch_item_in_tx(&mut tx, key_info, &item).await?
+        } else {
+            None
+        };
+
+        if condition.is_some() {
+            let empty = Item::new();
+            let target = old.as_ref().unwrap_or(&empty);
+            if let Err(e) = check_condition(condition, target, maps) {
+                return match e {
+                    StorageError::ConditionFailed(_) => Err(StorageError::ConditionFailed(old)),
+                    other => Err(other),
+                };
+            }
+        }
+
+        upsert_item_in_tx(&mut tx, key_info, &item).await?;
+
+        // Synchronous indexes (LSIs + zero-delay GSIs) are applied in-txn;
+        // async GSIs are enqueued into gsi_pending within the same txn.
+        if !indexes.is_empty() {
+            sync_indexes(
+                &mut tx,
+                &key_info.key_schema,
+                &key_info.attribute_definitions,
+                &indexes,
+                old.as_ref(),
+                Some(&item),
+                system_delay,
+            )
+            .await?;
+        }
+        let enqueued = enqueue_async_indexes(
+            &mut tx,
+            key_info,
+            &indexes,
+            old.as_ref(),
+            Some(&item),
+            system_delay,
+        )
+        .await?
+            > 0;
+
+        if let Some(capture) = stream {
+            write_stream_record_in_tx(&mut tx, key_info, capture, old.as_ref(), Some(&item))
+                .await?;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        if enqueued {
+            self.gsi_notify.notify_waiters();
+        }
+
+        Ok(if return_old { old } else { None })
+    }
+
+    pub(crate) async fn get_item_impl(
+        &self,
+        key_info: &TableKeyInfo,
+        key: &Item,
+    ) -> Result<Option<Item>, StorageError> {
+        let ddb_table = data_table_name(&key_info.table_id);
+        let pk_name = &key_info.key_schema[0].attribute_name;
+        let pk_value = key
+            .get(pk_name)
+            .ok_or_else(|| StorageError::Internal("missing partition key".to_owned()))?;
+        let pk_text = pk_to_text(pk_value)?;
+
+        let json_opt = if let Some((sk_name, sk_type)) =
+            sk_info(&key_info.key_schema, &key_info.attribute_definitions)
+        {
+            let sk_value = key
+                .get(sk_name)
+                .ok_or_else(|| StorageError::Internal("missing sort key".to_owned()))?;
+            let sk = extenddb_storage::util::parse_sk(sk_value, sk_type)?;
+            let sk_col = sk_column(sk_type);
+            let sql = format!("SELECT item_data FROM {ddb_table} WHERE pk = ? AND {sk_col} = ?");
+            let row: Option<(serde_json::Value,)> =
+                bind_sk_fetch_optional!(&sql, pk_text.as_ref(), &sk, &self.pool)?;
+            row.map(|(v,)| v)
+        } else {
+            let sql = format!("SELECT item_data FROM {ddb_table} WHERE pk = ?");
+            let row: Option<(serde_json::Value,)> = sqlx::query_as(&sql)
+                .bind(pk_text.as_ref())
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            row.map(|(v,)| v)
+        };
+
+        json_opt.map(json_to_item).transpose()
+    }
+}

--- a/crates/storage-sqlite/src/data/query.rs
+++ b/crates/storage-sqlite/src/data/query.rs
@@ -1,0 +1,154 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared query helpers: condition evaluation, key-condition SQL fragments,
+//! and dynamic query execution.
+//!
+//! Sort-key comparisons bind through [`super::sk_bound`], so `N` keys are
+//! compared as their order-preserving TEXT encoding (D2): `>`, `<`, `BETWEEN`
+//! all remain numerically correct. `begins_with` applies only to `S` (string
+//! prefix via the maximal code point `char(1114111)`) and `B` (byte-range via
+//! an incremented upper bound); DynamoDB rejects `begins_with` on `N`.
+
+use extenddb_core::expression::{self, CompareOp, Expr, ExpressionMaps, SortKeyCondition};
+use extenddb_core::types::{
+    AttributeValue, Item, KeySchemaElement, ScalarAttributeType, extract_key,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::{SortKeyValue, parse_sk};
+
+use super::BoundValue;
+
+/// Evaluate an optional condition expression against an item.
+/// Returns `ConditionFailed(None)` when the condition evaluates to false.
+pub(super) fn check_condition(
+    condition: Option<&Expr>,
+    item: &Item,
+    maps: &ExpressionMaps,
+) -> Result<(), StorageError> {
+    if let Some(cond) = condition {
+        let passed = expression::evaluate_condition(cond, item, maps)
+            .map_err(|e| StorageError::Validation(e.to_string()))?;
+        if !passed {
+            return Err(StorageError::ConditionFailed(None));
+        }
+    }
+    Ok(())
+}
+
+/// Resolve a key-condition placeholder expression to its `AttributeValue`.
+pub(super) fn resolve_expr_to_av(
+    expr: &Expr,
+    maps: &ExpressionMaps,
+) -> Result<AttributeValue, StorageError> {
+    match expr {
+        Expr::Placeholder(name) => maps
+            .resolve_value(name)
+            .cloned()
+            .map_err(|e| StorageError::Validation(e.to_string())),
+        _ => Err(StorageError::Internal(
+            "expected placeholder in key condition".to_owned(),
+        )),
+    }
+}
+
+/// SQL `WHERE` fragment for a sort-key condition on column `sk_col`.
+pub(super) fn build_sk_sql(sk_cond: &SortKeyCondition, sk_col: &str) -> String {
+    match sk_cond {
+        SortKeyCondition::Compare { op, .. } => {
+            let sql_op = match op {
+                CompareOp::Eq => "=",
+                CompareOp::Ne => "<>",
+                CompareOp::Lt => "<",
+                CompareOp::Le => "<=",
+                CompareOp::Gt => ">",
+                CompareOp::Ge => ">=",
+            };
+            format!(" AND {sk_col} {sql_op} ?")
+        }
+        SortKeyCondition::Between { .. } => format!(" AND {sk_col} BETWEEN ? AND ?"),
+        SortKeyCondition::BeginsWith { .. } => {
+            if sk_col.ends_with("_b") {
+                // Binary prefix: [prefix, incremented-prefix).
+                format!(" AND {sk_col} >= ? AND {sk_col} < ?")
+            } else {
+                // String prefix: [prefix, prefix || U+10FFFF).
+                format!(" AND {sk_col} >= ? AND {sk_col} < (? || char(1114111))")
+            }
+        }
+    }
+}
+
+/// The sort-key values to bind for a key condition, in placeholder order.
+pub(super) fn sk_condition_bind_values(
+    sk_cond: &SortKeyCondition,
+    sk_type: ScalarAttributeType,
+    maps: &ExpressionMaps,
+) -> Result<Vec<SortKeyValue>, StorageError> {
+    match sk_cond {
+        SortKeyCondition::Compare { value, .. } => {
+            Ok(vec![parse_sk(&resolve_expr_to_av(value, maps)?, sk_type)?])
+        }
+        SortKeyCondition::Between { low, high, .. } => Ok(vec![
+            parse_sk(&resolve_expr_to_av(low, maps)?, sk_type)?,
+            parse_sk(&resolve_expr_to_av(high, maps)?, sk_type)?,
+        ]),
+        SortKeyCondition::BeginsWith { prefix, .. } => {
+            let sk = parse_sk(&resolve_expr_to_av(prefix, maps)?, sk_type)?;
+            match sk {
+                SortKeyValue::B(b) => {
+                    let upper = increment_bytes(&b);
+                    Ok(vec![SortKeyValue::B(b), SortKeyValue::B(upper)])
+                }
+                // For strings the SQL upper bound is `? || char(1114111)`,
+                // so the same prefix is bound twice.
+                SortKeyValue::S(s) => Ok(vec![SortKeyValue::S(s.clone()), SortKeyValue::S(s)]),
+                SortKeyValue::N(_) => Err(StorageError::Validation(
+                    "begins_with is not supported on numeric sort keys".to_owned(),
+                )),
+            }
+        }
+    }
+}
+
+/// Exclusive upper bound for a binary prefix range: the smallest byte string
+/// greater than every string having `prefix` as a prefix. Returns an empty
+/// vector's successor convention when `prefix` is all `0xFF`.
+fn increment_bytes(prefix: &[u8]) -> Vec<u8> {
+    let mut out = prefix.to_vec();
+    while let Some(last) = out.last_mut() {
+        if *last < 0xFF {
+            *last += 1;
+            return out;
+        }
+        out.pop();
+    }
+    // All 0xFF: no finite successor within the same length convention; use a
+    // value that sorts after any prefixed string of practical length.
+    vec![0xFF; prefix.len() + 1]
+}
+
+/// Build a `LastEvaluatedKey` from an item's key attributes.
+pub(super) fn build_key(item: &Item, key_schema: &[KeySchemaElement]) -> Item {
+    extract_key(item, key_schema)
+}
+
+/// Execute a dynamically-built query, binding `BoundValue`s positionally.
+pub(super) async fn execute_dynamic_query(
+    sql: &str,
+    values: Vec<BoundValue>,
+    pool: &sqlx::SqlitePool,
+) -> Result<Vec<serde_json::Value>, StorageError> {
+    let mut query = sqlx::query_as::<_, (serde_json::Value,)>(sql);
+    for v in values {
+        query = match v {
+            BoundValue::Text(s) => query.bind(s),
+            BoundValue::Blob(b) => query.bind(b),
+        };
+    }
+    let rows: Vec<(serde_json::Value,)> = query
+        .fetch_all(pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    Ok(rows.into_iter().map(|(v,)| v).collect())
+}

--- a/crates/storage-sqlite/src/data/query_scan.rs
+++ b/crates/storage-sqlite/src/data/query_scan.rs
@@ -1,0 +1,432 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `query` and `scan` for the SQLite backend.
+//!
+//! Mirrors the PostgreSQL backend's index routing and pagination. For index
+//! operations the engine passes `key_info.key_schema` = index key schema and
+//! `key_info.base_key_schema` = base table key schema, so the index `sk_*`
+//! columns are addressed by the index sort key and `base_*` columns provide
+//! tie-breakers. SQLite differences: positional `?` placeholders, no `COLLATE`
+//! (the default BINARY collation already matches DynamoDB byte order, and `N`
+//! keys are stored as the order-preserving TEXT encoding per D2), `char()`
+//! instead of `chr()`, and `rowid % total_segments` for parallel scan.
+
+use std::fmt::Write;
+
+use extenddb_core::expression::{ExpressionMaps, KeyCondition, PathElement};
+use extenddb_core::types::{Item, ScalarAttributeType, TableKeyInfo};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::{
+    encode_netstring_composite, parse_sk, pk_to_text, sk_column, sk_column_n, sk_info,
+};
+
+use super::query::{
+    build_key, build_sk_sql, execute_dynamic_query, resolve_expr_to_av, sk_condition_bind_values,
+};
+use super::{
+    BoundValue, all_sort_key_info, data_table_name, index_table_name, json_to_item, sk_bound,
+};
+use crate::store::SqliteEngine;
+
+impl SqliteEngine {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn query_impl(
+        &self,
+        key_info: &TableKeyInfo,
+        key_condition: &KeyCondition,
+        maps: &ExpressionMaps,
+        forward: bool,
+        limit: Option<i64>,
+        exclusive_start_key: Option<&Item>,
+        index_name: Option<&str>,
+    ) -> Result<(Vec<Item>, Option<Item>), StorageError> {
+        let (ddb_table, is_lsi) = if let Some(idx_name) = index_name {
+            let info = self
+                .fetch_index_info_by_table_id(&key_info.table_id, idx_name)
+                .await?;
+            (
+                index_table_name(&info.index_id),
+                info.index_type == extenddb_core::types::IndexType::Lsi,
+            )
+        } else {
+            (data_table_name(&key_info.table_id), false)
+        };
+
+        // Partition key (composite via netstring when multi-HASH).
+        let pk_text = if key_condition.extra_pk_conditions.is_empty() {
+            pk_to_text(&resolve_expr_to_av(&key_condition.pk_value, maps)?)?.into_owned()
+        } else {
+            let mut parts =
+                vec![pk_to_text(&resolve_expr_to_av(&key_condition.pk_value, maps)?)?.into_owned()];
+            for (_, value) in &key_condition.extra_pk_conditions {
+                parts.push(pk_to_text(&resolve_expr_to_av(value, maps)?)?.into_owned());
+            }
+            encode_netstring_composite(&parts)
+        };
+
+        let sk_info_val = sk_info(&key_info.key_schema, &key_info.attribute_definitions);
+        let all_sks = all_sort_key_info(&key_info.key_schema, &key_info.attribute_definitions);
+        let base_sk_info: Option<(String, ScalarAttributeType)> = if index_name.is_some() {
+            sk_info(&key_info.base_key_schema, &key_info.attribute_definitions)
+                .map(|(n, t)| (n.to_owned(), t))
+        } else {
+            None
+        };
+
+        let mut sql = format!("SELECT item_data FROM {ddb_table} WHERE pk = ?");
+        let mut binds: Vec<BoundValue> = vec![BoundValue::Text(pk_text)];
+
+        // Primary sort-key condition.
+        if let (Some(sk_cond), Some((_, sk_type))) = (&key_condition.sk_condition, sk_info_val) {
+            sql.push_str(&build_sk_sql(sk_cond, sk_column(sk_type)));
+            for v in sk_condition_bind_values(sk_cond, sk_type, maps)? {
+                binds.push(sk_bound(&v));
+            }
+        }
+
+        // Extra RANGE-key equality conditions (multi-RANGE schemas).
+        for (path, value) in &key_condition.extra_sk_conditions {
+            let Some(attr_name) = resolve_attr_name(path, maps) else {
+                continue;
+            };
+            if let Some(pos) = all_sks.iter().position(|(n, _)| *n == attr_name)
+                && pos > 0
+            {
+                let (_, sk_type) = all_sks[pos];
+                let _ = write!(sql, " AND {} = ?", sk_column_n(pos, sk_type));
+                binds.push(sk_bound(&parse_sk(
+                    &resolve_expr_to_av(value, maps)?,
+                    sk_type,
+                )?));
+            }
+        }
+
+        // Pagination.
+        if exclusive_start_key.is_some() && sk_info_val.is_none() && index_name.is_none() {
+            return Ok((Vec::new(), None));
+        }
+        if let Some(start_key) = exclusive_start_key {
+            append_query_pagination(
+                &mut sql,
+                &mut binds,
+                start_key,
+                sk_info_val,
+                base_sk_info.as_ref(),
+                key_info,
+                index_name.is_some(),
+                is_lsi,
+                forward,
+            )?;
+        }
+
+        // ORDER BY.
+        let dir = if forward { "ASC" } else { "DESC" };
+        if let Some((_, sk_type)) = sk_info_val {
+            let sk_col = sk_column(sk_type);
+            if let Some((_, base_type)) = &base_sk_info {
+                let base_col = format!("base_{}", sk_column(*base_type));
+                let base_dir = if is_lsi { dir } else { "ASC" };
+                let _ = write!(sql, " ORDER BY {sk_col} {dir}, {base_col} {base_dir}");
+            } else if index_name.is_some() {
+                let _ = write!(sql, " ORDER BY {sk_col} {dir}, base_pk ASC");
+            } else {
+                let _ = write!(sql, " ORDER BY {sk_col} {dir}");
+            }
+        } else if index_name.is_some() {
+            if let Some((_, base_type)) = &base_sk_info {
+                let base_col = format!("base_{}", sk_column(*base_type));
+                let _ = write!(sql, " ORDER BY base_pk {dir}, {base_col} {dir}");
+            } else {
+                let _ = write!(sql, " ORDER BY base_pk {dir}");
+            }
+        }
+
+        let fetch_limit = limit.map_or(1_000_001, |l| l + 1);
+        let _ = write!(sql, " LIMIT {fetch_limit}");
+
+        let rows = execute_dynamic_query(&sql, binds, &self.pool).await?;
+        finalize(rows, limit, &key_info.key_schema)
+    }
+
+    pub(crate) async fn scan_impl(
+        &self,
+        key_info: &TableKeyInfo,
+        limit: Option<i64>,
+        exclusive_start_key: Option<&Item>,
+        segment: Option<i64>,
+        total_segments: Option<i64>,
+        index_name: Option<&str>,
+    ) -> Result<(Vec<Item>, Option<Item>), StorageError> {
+        let ddb_table = if let Some(idx_name) = index_name {
+            let info = self
+                .fetch_index_info_by_table_id(&key_info.table_id, idx_name)
+                .await?;
+            index_table_name(&info.index_id)
+        } else {
+            data_table_name(&key_info.table_id)
+        };
+
+        let sk_info_val = sk_info(&key_info.key_schema, &key_info.attribute_definitions);
+        let base_sk_info: Option<(String, ScalarAttributeType)> = if index_name.is_some() {
+            sk_info(&key_info.base_key_schema, &key_info.attribute_definitions)
+                .map(|(n, t)| (n.to_owned(), t))
+        } else {
+            None
+        };
+
+        let mut sql = format!("SELECT item_data FROM {ddb_table}");
+        let mut conditions: Vec<String> = Vec::new();
+        let mut binds: Vec<BoundValue> = Vec::new();
+
+        // Parallel scan: disjoint rowid partitioning. seg/total are validated
+        // non-negative integers at the engine layer, safe to interpolate.
+        if let (Some(seg), Some(total)) = (segment, total_segments) {
+            conditions.push(format!("(rowid % {total}) = {seg}"));
+        }
+
+        if let Some(start_key) = exclusive_start_key {
+            let pk_name = &key_info.key_schema[0].attribute_name;
+            if !start_key.contains_key(pk_name) {
+                return Err(StorageError::Validation(
+                    "The provided starting key is invalid: The provided key element does not match the schema".to_owned(),
+                ));
+            }
+            let pk_text = pk_to_text(start_key.get(pk_name).unwrap())?.into_owned();
+
+            if index_name.is_some() {
+                if let Some((sk_name, sk_type)) = sk_info_val {
+                    let sk_col = sk_column(sk_type);
+                    let sk_bv = start_key
+                        .get(sk_name)
+                        .map(|v| parse_sk(v, sk_type))
+                        .transpose()?
+                        .map(|s| sk_bound(&s));
+                    let base_pk_text = base_pk_from_start_key(start_key, key_info)?;
+                    if let Some((base_name, base_type)) = &base_sk_info {
+                        let base_col = format!("base_{}", sk_column(*base_type));
+                        conditions.push(format!(
+                            "(pk, {sk_col}, base_pk, {base_col}) > (?, ?, ?, ?)"
+                        ));
+                        binds.push(BoundValue::Text(pk_text));
+                        binds.push(sk_bv.unwrap_or(BoundValue::Text(String::new())));
+                        binds.push(BoundValue::Text(base_pk_text));
+                        if let Some(v) = start_key.get(base_name.as_str()) {
+                            binds.push(sk_bound(&parse_sk(v, *base_type)?));
+                        } else {
+                            binds.push(BoundValue::Text(String::new()));
+                        }
+                    } else {
+                        conditions.push(format!("(pk, {sk_col}, base_pk) > (?, ?, ?)"));
+                        binds.push(BoundValue::Text(pk_text));
+                        binds.push(sk_bv.unwrap_or(BoundValue::Text(String::new())));
+                        binds.push(BoundValue::Text(base_pk_text));
+                    }
+                } else {
+                    // Hash-only GSI. Include the base sort key in the
+                    // pagination predicate when the base table has one: the
+                    // index PRIMARY KEY is (pk, base_pk, base_sk*), so (pk,
+                    // base_pk) alone is not a total order and would skip rows
+                    // sharing a (pk, base_pk) across a page boundary.
+                    let base_pk_text = base_pk_from_start_key(start_key, key_info)?;
+                    if let Some((base_name, base_type)) = &base_sk_info {
+                        let base_col = format!("base_{}", sk_column(*base_type));
+                        conditions.push(format!("(pk, base_pk, {base_col}) > (?, ?, ?)"));
+                        binds.push(BoundValue::Text(pk_text));
+                        binds.push(BoundValue::Text(base_pk_text));
+                        if let Some(v) = start_key.get(base_name.as_str()) {
+                            binds.push(sk_bound(&parse_sk(v, *base_type)?));
+                        } else {
+                            binds.push(BoundValue::Text(String::new()));
+                        }
+                    } else {
+                        conditions.push("(pk, base_pk) > (?, ?)".to_owned());
+                        binds.push(BoundValue::Text(pk_text));
+                        binds.push(BoundValue::Text(base_pk_text));
+                    }
+                }
+            } else if let Some((sk_name, sk_type)) = sk_info_val {
+                let sk_col = sk_column(sk_type);
+                conditions.push(format!("(pk, {sk_col}) > (?, ?)"));
+                binds.push(BoundValue::Text(pk_text));
+                if let Some(v) = start_key.get(sk_name) {
+                    binds.push(sk_bound(&parse_sk(v, sk_type)?));
+                } else {
+                    binds.push(BoundValue::Text(String::new()));
+                }
+            } else {
+                conditions.push("pk > ?".to_owned());
+                binds.push(BoundValue::Text(pk_text));
+            }
+        }
+
+        if !conditions.is_empty() {
+            sql.push_str(" WHERE ");
+            sql.push_str(&conditions.join(" AND "));
+        }
+
+        // Deterministic ordering for pagination.
+        if index_name.is_some() {
+            if let Some((_, sk_type)) = sk_info_val {
+                let sk_col = sk_column(sk_type);
+                if let Some((_, base_type)) = &base_sk_info {
+                    let base_col = format!("base_{}", sk_column(*base_type));
+                    let _ = write!(sql, " ORDER BY pk, {sk_col}, base_pk, {base_col}");
+                } else {
+                    let _ = write!(sql, " ORDER BY pk, {sk_col}, base_pk");
+                }
+            } else if let Some((_, base_type)) = &base_sk_info {
+                // Hash-only GSI on a composite-key base table: order by the full
+                // index key so it is a total order matching the pagination
+                // predicate above.
+                let base_col = format!("base_{}", sk_column(*base_type));
+                let _ = write!(sql, " ORDER BY pk, base_pk, {base_col}");
+            } else {
+                let _ = write!(sql, " ORDER BY pk, base_pk");
+            }
+        } else if let Some((_, sk_type)) = sk_info_val {
+            let _ = write!(sql, " ORDER BY pk, {}", sk_column(sk_type));
+        } else {
+            sql.push_str(" ORDER BY pk");
+        }
+
+        let fetch_limit = limit.map_or(1_000_001, |l| l + 1);
+        let _ = write!(sql, " LIMIT {fetch_limit}");
+
+        let rows = execute_dynamic_query(&sql, binds, &self.pool).await?;
+        finalize(rows, limit, &key_info.key_schema)
+    }
+}
+
+/// Resolve a key-condition path's attribute name, handling `#name` references.
+fn resolve_attr_name(path: &[PathElement], maps: &ExpressionMaps) -> Option<String> {
+    match path.first() {
+        Some(PathElement::Attribute(name)) => {
+            if let Some(reference) = name.strip_prefix('#') {
+                maps.names.get(reference).cloned()
+            } else {
+                Some(name.clone())
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Extract the base-table partition key text from a (combined) start key.
+fn base_pk_from_start_key(
+    start_key: &Item,
+    key_info: &TableKeyInfo,
+) -> Result<String, StorageError> {
+    let base_pk_attr = &key_info.base_key_schema[0].attribute_name;
+    start_key
+        .get(base_pk_attr)
+        .map(pk_to_text)
+        .transpose()?
+        .map(|c| c.into_owned())
+        .ok_or_else(|| {
+            StorageError::Validation(
+                "The provided starting key is invalid: missing base table partition key".to_owned(),
+            )
+        })
+}
+
+/// Append the query pagination predicate and its binds, mirroring the
+/// PostgreSQL `build_pagination_where` cases.
+#[allow(clippy::too_many_arguments)]
+fn append_query_pagination(
+    sql: &mut String,
+    binds: &mut Vec<BoundValue>,
+    start_key: &Item,
+    sk_info_val: Option<(&str, ScalarAttributeType)>,
+    base_sk_info: Option<&(String, ScalarAttributeType)>,
+    key_info: &TableKeyInfo,
+    is_index: bool,
+    is_lsi: bool,
+    forward: bool,
+) -> Result<(), StorageError> {
+    let cmp = if forward { ">" } else { "<" };
+
+    if let Some((sk_name, sk_type)) = sk_info_val {
+        let sk_col = sk_column(sk_type);
+        let sk_bv = start_key
+            .get(sk_name)
+            .map(|v| parse_sk(v, sk_type))
+            .transpose()?
+            .map(|s| sk_bound(&s));
+
+        if let Some((base_name, base_type)) = base_sk_info {
+            let base_col = format!("base_{}", sk_column(*base_type));
+            let base_cmp = if is_lsi { cmp } else { ">" };
+            let _ = write!(
+                sql,
+                " AND ({sk_col} {cmp} ? OR ({sk_col} = ? AND {base_col} {base_cmp} ?))"
+            );
+            let sk_bv = sk_bv.unwrap_or(BoundValue::Text(String::new()));
+            binds.push(sk_bv.clone());
+            binds.push(sk_bv);
+            if let Some(v) = start_key.get(base_name.as_str()) {
+                binds.push(sk_bound(&parse_sk(v, *base_type)?));
+            } else {
+                binds.push(BoundValue::Text(String::new()));
+            }
+        } else if is_index {
+            let _ = write!(
+                sql,
+                " AND ({sk_col} {cmp} ? OR ({sk_col} = ? AND base_pk > ?))"
+            );
+            let sk_bv = sk_bv.unwrap_or(BoundValue::Text(String::new()));
+            binds.push(sk_bv.clone());
+            binds.push(sk_bv);
+            binds.push(BoundValue::Text(base_pk_from_start_key(
+                start_key, key_info,
+            )?));
+        } else {
+            let _ = write!(sql, " AND {sk_col} {cmp} ?");
+            binds.push(sk_bv.unwrap_or(BoundValue::Text(String::new())));
+        }
+    } else if is_index {
+        let base_pk_text = base_pk_from_start_key(start_key, key_info)?;
+        if let Some((base_name, base_type)) = base_sk_info {
+            let base_col = format!("base_{}", sk_column(*base_type));
+            let _ = write!(
+                sql,
+                " AND (base_pk > ? OR (base_pk = ? AND {base_col} > ?))"
+            );
+            binds.push(BoundValue::Text(base_pk_text.clone()));
+            binds.push(BoundValue::Text(base_pk_text));
+            if let Some(v) = start_key.get(base_name.as_str()) {
+                binds.push(sk_bound(&parse_sk(v, *base_type)?));
+            } else {
+                binds.push(BoundValue::Text(String::new()));
+            }
+        } else {
+            let _ = write!(sql, " AND base_pk > ?");
+            binds.push(BoundValue::Text(base_pk_text));
+        }
+    }
+    Ok(())
+}
+
+/// Trim the over-fetched extra row, deserialize items, and derive the
+/// `LastEvaluatedKey` (storage-side: the queried table's own key; the engine
+/// enriches index LEKs with base-table key attributes).
+fn finalize(
+    rows: Vec<serde_json::Value>,
+    limit: Option<i64>,
+    key_schema: &[extenddb_core::types::KeySchemaElement],
+) -> Result<(Vec<Item>, Option<Item>), StorageError> {
+    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+    let actual_limit = limit.map_or(1_000_000_usize, |l| l.max(0) as usize);
+    let has_more = rows.len() > actual_limit;
+    let items: Vec<Item> = rows
+        .into_iter()
+        .take(actual_limit)
+        .map(json_to_item)
+        .collect::<Result<Vec<_>, _>>()?;
+    let last_key = if has_more {
+        items.last().map(|item| build_key(item, key_schema))
+    } else {
+        None
+    };
+    Ok((items, last_key))
+}

--- a/crates/storage-sqlite/src/data/query_scan.rs
+++ b/crates/storage-sqlite/src/data/query_scan.rs
@@ -9,8 +9,8 @@
 //! columns are addressed by the index sort key and `base_*` columns provide
 //! tie-breakers. SQLite differences: positional `?` placeholders, no `COLLATE`
 //! (the default BINARY collation already matches DynamoDB byte order, and `N`
-//! keys are stored as the order-preserving TEXT encoding per D2), `char()`
-//! instead of `chr()`, and `rowid % total_segments` for parallel scan.
+//! keys are stored as the order-preserving TEXT encoding per D2), and
+//! `rowid % total_segments` for parallel scan.
 
 use std::fmt::Write;
 

--- a/crates/storage-sqlite/src/data/transactions.rs
+++ b/crates/storage-sqlite/src/data/transactions.rs
@@ -1,0 +1,470 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `TransactGetItems` / `TransactWriteItems` and idempotency-token cleanup.
+//!
+//! Writes run under the engine write lock (D1) in a single transaction, so all
+//! operations, the idempotency check, and stream capture commit atomically or
+//! roll back together. Reads run in one transaction for a consistent snapshot.
+
+use std::collections::HashMap;
+
+use extenddb_core::expression::{self, ExpressionMaps};
+use extenddb_core::types::{CancellationReason, Item, ReturnValuesOnConditionCheckFailure};
+use extenddb_core::validation;
+use extenddb_storage::error::StorageError;
+use extenddb_storage::{IdempotencyKey, TransactGetOp, TransactWriteOp};
+
+use super::index::{IndexMeta, enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
+use super::tx_helpers::{
+    check_idempotency_token_in_tx, delete_item_in_tx, fetch_item_for_update, fetch_item_in_tx,
+    upsert_item_in_tx, write_stream_record_in_tx,
+};
+use crate::sqlite_util::format_timestamp;
+use crate::store::SqliteEngine;
+
+impl SqliteEngine {
+    pub(crate) async fn transact_get_items_impl(
+        &self,
+        ops: &[TransactGetOp<'_>],
+    ) -> Result<Vec<Option<Item>>, StorageError> {
+        // Validate keys first, collecting per-item reasons (all-or-nothing).
+        let mut reasons = Vec::with_capacity(ops.len());
+        let mut any_failed = false;
+        for op in ops {
+            match validation::validate_key_only(
+                op.key,
+                &op.key_info.key_schema,
+                &op.key_info.attribute_definitions,
+            ) {
+                Ok(()) => reasons.push(CancellationReason::none()),
+                Err(e) => {
+                    any_failed = true;
+                    reasons.push(CancellationReason::validation_error(e.to_string()));
+                }
+            }
+        }
+        if any_failed {
+            return Err(StorageError::TransactionCanceled(reasons));
+        }
+
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let mut results = Vec::with_capacity(ops.len());
+        for op in ops {
+            results.push(fetch_item_in_tx(&mut tx, op.key_info, op.key).await?);
+        }
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        Ok(results)
+    }
+
+    pub(crate) async fn transact_write_items_impl(
+        &self,
+        ops: &[TransactWriteOp<'_>],
+        idempotency: Option<IdempotencyKey<'_>>,
+    ) -> Result<(), StorageError> {
+        let _writer = self.write_lock.lock().await;
+        // Fetch index metadata per distinct table AFTER acquiring the write lock,
+        // so a GSI added by a concurrent UpdateTable (same lock) is not missed and
+        // left unmaintained by these writes.
+        let mut table_indexes: HashMap<String, Vec<IndexMeta>> = HashMap::new();
+        for op in ops {
+            let name = op_table_name(op);
+            if !table_indexes.contains_key(name) {
+                let indexes = fetch_indexes_for_table(op_table_id(op), &self.pool).await?;
+                table_indexes.insert(name.to_owned(), indexes);
+            }
+        }
+
+        let system_delay = self.gsi_default_delay();
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        if let Some(key) = idempotency {
+            // Idempotency is per-account: the same ClientRequestToken in two
+            // accounts must not collide. The engine passes the caller's
+            // account explicitly.
+            check_idempotency_token_in_tx(&mut tx, key.account_id, key.token, key.fingerprint)
+                .await?;
+        }
+
+        let mut reasons: Vec<CancellationReason> = Vec::with_capacity(ops.len());
+        let mut op_items: Vec<(Option<Item>, Option<Item>)> = Vec::with_capacity(ops.len());
+        let mut any_failed = false;
+
+        for op in ops {
+            let indexes = &table_indexes[op_table_name(op)];
+            match execute_transact_write_op(
+                &mut tx,
+                op,
+                indexes,
+                self.max_item_size_bytes,
+                system_delay,
+            )
+            .await
+            {
+                Ok(items) => {
+                    op_items.push(items);
+                    reasons.push(CancellationReason::none());
+                }
+                Err(TxnOpError::Cancel(r)) => {
+                    op_items.push((None, None));
+                    any_failed = true;
+                    reasons.push(r);
+                }
+                Err(TxnOpError::Validation(msg)) => {
+                    // Up-front input validation (e.g. empty secondary-index key):
+                    // abort the whole transaction with a top-level
+                    // ValidationException, not a per-item cancellation reason.
+                    return Err(StorageError::Validation(msg));
+                }
+                Err(TxnOpError::Storage(e)) => return Err(e),
+            }
+        }
+
+        if any_failed {
+            // Dropping `tx` without commit rolls back all writes.
+            return Err(StorageError::TransactionCanceled(reasons));
+        }
+
+        // Capture stream records after all writes are staged.
+        for (op, (old_item, new_item)) in ops.iter().zip(op_items.iter()) {
+            let capture = match op {
+                TransactWriteOp::Put { stream, .. }
+                | TransactWriteOp::Delete { stream, .. }
+                | TransactWriteOp::Update { stream, .. } => stream.as_ref(),
+                TransactWriteOp::ConditionCheck { .. } => None,
+            };
+            if let Some(capture) = capture {
+                write_stream_record_in_tx(
+                    &mut tx,
+                    op_key_info(op),
+                    capture,
+                    old_item.as_ref(),
+                    new_item.as_ref(),
+                )
+                .await?;
+            }
+        }
+
+        // Persist async GSI work for each op inside the same transaction.
+        let mut needs_notify = false;
+        for (op, (old_item, new_item)) in ops.iter().zip(op_items.iter()) {
+            let indexes = &table_indexes[op_table_name(op)];
+            if old_item.is_some() || new_item.is_some() {
+                let n = enqueue_async_indexes(
+                    &mut tx,
+                    op_key_info(op),
+                    indexes,
+                    old_item.as_ref(),
+                    new_item.as_ref(),
+                    system_delay,
+                )
+                .await?;
+                if n > 0 {
+                    needs_notify = true;
+                }
+            }
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        if needs_notify {
+            self.gsi_notify.notify_waiters();
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn cleanup_expired_idempotency_tokens_impl(
+        &self,
+        max_age_seconds: i64,
+    ) -> Result<u64, StorageError> {
+        let cutoff = format_timestamp(
+            time::OffsetDateTime::now_utc() - time::Duration::seconds(max_age_seconds),
+        );
+        let result = sqlx::query("DELETE FROM idempotency_tokens WHERE created_at < ?")
+            .bind(&cutoff)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        Ok(result.rows_affected())
+    }
+}
+
+fn op_table_name<'a>(op: &'a TransactWriteOp<'_>) -> &'a str {
+    &op_key_info(op).table_name
+}
+
+fn op_table_id<'a>(op: &'a TransactWriteOp<'_>) -> &'a str {
+    &op_key_info(op).table_id
+}
+
+fn op_key_info<'a>(op: &'a TransactWriteOp<'_>) -> &'a extenddb_core::types::TableKeyInfo {
+    match op {
+        TransactWriteOp::Put { key_info, .. }
+        | TransactWriteOp::Delete { key_info, .. }
+        | TransactWriteOp::Update { key_info, .. }
+        | TransactWriteOp::ConditionCheck { key_info, .. } => key_info,
+    }
+}
+
+enum TxnOpError {
+    Cancel(CancellationReason),
+    /// Up-front input validation failure — aborts the whole transaction with a
+    /// top-level `ValidationException` (not a per-item cancellation reason).
+    Validation(String),
+    Storage(StorageError),
+}
+
+/// Build [`validation::IndexKeyRef`] views over the table's indexes for
+/// secondary-index key validation.
+fn index_key_refs(indexes: &[IndexMeta]) -> Vec<validation::IndexKeyRef<'_>> {
+    indexes
+        .iter()
+        .map(|idx| validation::IndexKeyRef {
+            index_name: &idx.index_name,
+            key_schema: &idx.key_schema,
+        })
+        .collect()
+}
+
+/// Execute one transact-write op, returning `(old, new)` images for stream
+/// capture, or a cancellation reason on a failed condition / validation.
+async fn execute_transact_write_op(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    op: &TransactWriteOp<'_>,
+    indexes: &[IndexMeta],
+    max_item_size_bytes: usize,
+    system_delay: u64,
+) -> Result<(Option<Item>, Option<Item>), TxnOpError> {
+    match op {
+        TransactWriteOp::Put {
+            key_info,
+            item,
+            condition,
+            maps,
+            return_values_on_ccf,
+            ..
+        } => {
+            validation::validate_item_keys(
+                item,
+                &key_info.key_schema,
+                &key_info.attribute_definitions,
+            )
+            .map_err(|e| TxnOpError::Cancel(CancellationReason::validation_error(e.to_string())))?;
+            // Secondary-index key faults split by kind: a type mismatch is a
+            // per-item cancellation reason; an empty index key is up-front input
+            // validation (a top-level ValidationException).
+            let idx_refs = index_key_refs(indexes);
+            validation::validate_index_key_types(item, &idx_refs, &key_info.attribute_definitions)
+                .map_err(|e| {
+                    TxnOpError::Cancel(CancellationReason::validation_error(e.to_string()))
+                })?;
+            validation::validate_index_key_not_empty(
+                item,
+                &idx_refs,
+                validation::SecondaryIndexEmptyContext::Item,
+            )
+            .map_err(|e| TxnOpError::Validation(e.to_string()))?;
+            let existing = fetch_item_for_update(tx, key_info, item)
+                .await
+                .map_err(TxnOpError::Storage)?;
+            let empty = Item::new();
+            eval_condition(
+                *condition,
+                existing.as_ref().unwrap_or(&empty),
+                maps,
+                *return_values_on_ccf,
+                existing.as_ref(),
+            )?;
+            upsert_item_in_tx(tx, key_info, item)
+                .await
+                .map_err(TxnOpError::Storage)?;
+            if !indexes.is_empty() {
+                sync_indexes(
+                    tx,
+                    &key_info.key_schema,
+                    &key_info.attribute_definitions,
+                    indexes,
+                    existing.as_ref(),
+                    Some(item),
+                    system_delay,
+                )
+                .await
+                .map_err(TxnOpError::Storage)?;
+            }
+            Ok((existing, Some((*item).clone())))
+        }
+        TransactWriteOp::Delete {
+            key_info,
+            key,
+            condition,
+            maps,
+            return_values_on_ccf,
+            ..
+        } => {
+            validation::validate_batch_key_only(
+                key,
+                &key_info.key_schema,
+                &key_info.attribute_definitions,
+            )
+            .map_err(|e| TxnOpError::Cancel(CancellationReason::validation_error(e.to_string())))?;
+            let existing = fetch_item_for_update(tx, key_info, key)
+                .await
+                .map_err(TxnOpError::Storage)?;
+            let empty = Item::new();
+            eval_condition(
+                *condition,
+                existing.as_ref().unwrap_or(&empty),
+                maps,
+                *return_values_on_ccf,
+                existing.as_ref(),
+            )?;
+            delete_item_in_tx(tx, key_info, key)
+                .await
+                .map_err(TxnOpError::Storage)?;
+            if !indexes.is_empty() {
+                sync_indexes(
+                    tx,
+                    &key_info.key_schema,
+                    &key_info.attribute_definitions,
+                    indexes,
+                    existing.as_ref(),
+                    None,
+                    system_delay,
+                )
+                .await
+                .map_err(TxnOpError::Storage)?;
+            }
+            Ok((existing, None))
+        }
+        TransactWriteOp::Update {
+            key_info,
+            key,
+            actions,
+            condition,
+            maps,
+            return_values_on_ccf,
+            ..
+        } => {
+            validation::validate_batch_key_only(
+                key,
+                &key_info.key_schema,
+                &key_info.attribute_definitions,
+            )
+            .map_err(|e| TxnOpError::Cancel(CancellationReason::validation_error(e.to_string())))?;
+            let existing = fetch_item_for_update(tx, key_info, key)
+                .await
+                .map_err(TxnOpError::Storage)?;
+            let empty = Item::new();
+            eval_condition(
+                *condition,
+                existing.as_ref().unwrap_or(&empty),
+                maps,
+                *return_values_on_ccf,
+                existing.as_ref(),
+            )?;
+            let mut item = existing.clone().unwrap_or_else(|| (*key).clone());
+            expression::apply_update(actions, &mut item, maps).map_err(|e| {
+                TxnOpError::Cancel(CancellationReason::validation_error(e.to_string()))
+            })?;
+            validation::validate_item_size(&item, max_item_size_bytes).map_err(|e| {
+                TxnOpError::Cancel(CancellationReason::validation_error(e.to_string()))
+            })?;
+            // Secondary-index key validation on the post-update item: a type
+            // mismatch is a cancellation reason; setting an index key to an
+            // empty value is a top-level ValidationException.
+            let idx_refs = index_key_refs(indexes);
+            validation::validate_index_key_types(&item, &idx_refs, &key_info.attribute_definitions)
+                .map_err(|e| {
+                    TxnOpError::Cancel(CancellationReason::validation_error(e.to_string()))
+                })?;
+            validation::validate_index_key_not_empty(
+                &item,
+                &idx_refs,
+                validation::SecondaryIndexEmptyContext::UpdateExpression,
+            )
+            .map_err(|e| TxnOpError::Validation(e.to_string()))?;
+            upsert_item_in_tx(tx, key_info, &item)
+                .await
+                .map_err(TxnOpError::Storage)?;
+            if !indexes.is_empty() {
+                sync_indexes(
+                    tx,
+                    &key_info.key_schema,
+                    &key_info.attribute_definitions,
+                    indexes,
+                    existing.as_ref(),
+                    Some(&item),
+                    system_delay,
+                )
+                .await
+                .map_err(TxnOpError::Storage)?;
+            }
+            Ok((existing, Some(item)))
+        }
+        TransactWriteOp::ConditionCheck {
+            key_info,
+            key,
+            condition,
+            maps,
+            return_values_on_ccf,
+        } => {
+            validation::validate_batch_key_only(
+                key,
+                &key_info.key_schema,
+                &key_info.attribute_definitions,
+            )
+            .map_err(|e| TxnOpError::Cancel(CancellationReason::validation_error(e.to_string())))?;
+            let existing = fetch_item_for_update(tx, key_info, key)
+                .await
+                .map_err(TxnOpError::Storage)?;
+            let empty = Item::new();
+            eval_condition(
+                Some(condition),
+                existing.as_ref().unwrap_or(&empty),
+                maps,
+                *return_values_on_ccf,
+                existing.as_ref(),
+            )?;
+            Ok((None, None))
+        }
+    }
+}
+
+/// Evaluate a transaction op's condition, producing a `CancellationReason` on
+/// failure (attaching the old item when `ReturnValuesOnConditionCheckFailure`
+/// is `AllOld`).
+fn eval_condition(
+    condition: Option<&expression::Expr>,
+    item: &Item,
+    maps: &ExpressionMaps,
+    return_values_on_ccf: ReturnValuesOnConditionCheckFailure,
+    existing: Option<&Item>,
+) -> Result<(), TxnOpError> {
+    if let Some(cond) = condition {
+        let passed = expression::evaluate_condition(cond, item, maps)
+            .map_err(|e| TxnOpError::Cancel(CancellationReason::validation_error(e.to_string())))?;
+        if !passed {
+            let returned = if return_values_on_ccf == ReturnValuesOnConditionCheckFailure::AllOld {
+                existing.cloned()
+            } else {
+                None
+            };
+            return Err(TxnOpError::Cancel(
+                CancellationReason::condition_check_failed_with_item(returned),
+            ));
+        }
+    }
+    Ok(())
+}

--- a/crates/storage-sqlite/src/data/transactions.rs
+++ b/crates/storage-sqlite/src/data/transactions.rs
@@ -228,7 +228,7 @@ enum TxnOpError {
 
 /// Build [`validation::IndexKeyRef`] views over the table's indexes for
 /// secondary-index key validation.
-fn index_key_refs(indexes: &[IndexMeta]) -> Vec<validation::IndexKeyRef<'_>> {
+pub(crate) fn index_key_refs(indexes: &[IndexMeta]) -> Vec<validation::IndexKeyRef<'_>> {
     indexes
         .iter()
         .map(|idx| validation::IndexKeyRef {

--- a/crates/storage-sqlite/src/data/tx_helpers.rs
+++ b/crates/storage-sqlite/src/data/tx_helpers.rs
@@ -1,0 +1,380 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Transaction helpers shared by the write path and transactions module:
+//! in-transaction item fetch/upsert/delete, monotonic stream sequencing,
+//! atomic stream-record capture, and idempotency-token checks.
+//!
+//! There is no `SELECT ... FOR UPDATE`: the engine's `write_lock` serializes
+//! all writers (design decision D1), so an in-transaction read followed by a
+//! write is already atomic with respect to other writers.
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use extenddb_core::types::{
+    AttributeValue, Item, StreamEventName, StreamRecord, StreamRecordData, StreamViewType,
+    TableKeyInfo, item_size_bytes,
+};
+use extenddb_storage::StreamCapture;
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::{pk_to_text, sk_column, sk_info};
+
+use super::{
+    bind_sk_execute, bind_sk_fetch_optional, bind_sk_only_execute, data_table_name, json_to_item,
+};
+use crate::sqlite_util::format_timestamp;
+
+/// Fetch a single item within a transaction by primary key.
+pub(super) async fn fetch_item_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    key_info: &TableKeyInfo,
+    key: &Item,
+) -> Result<Option<Item>, StorageError> {
+    let ddb_table = data_table_name(&key_info.table_id);
+    let pk_name = &key_info.key_schema[0].attribute_name;
+    let pk_value = key
+        .get(pk_name)
+        .ok_or_else(|| StorageError::Internal("missing partition key".to_owned()))?;
+    let pk_text = pk_to_text(pk_value)?;
+
+    let json_opt = if let Some((sk_name, sk_type)) =
+        sk_info(&key_info.key_schema, &key_info.attribute_definitions)
+    {
+        let sk_value = key
+            .get(sk_name)
+            .ok_or_else(|| StorageError::Internal("missing sort key".to_owned()))?;
+        let sk = extenddb_storage::util::parse_sk(sk_value, sk_type)?;
+        let sk_col = sk_column(sk_type);
+        let sql = format!("SELECT item_data FROM {ddb_table} WHERE pk = ? AND {sk_col} = ?");
+        let row: Option<(serde_json::Value,)> =
+            bind_sk_fetch_optional!(&sql, pk_text.as_ref(), &sk, &mut **tx)?;
+        row.map(|(v,)| v)
+    } else {
+        let sql = format!("SELECT item_data FROM {ddb_table} WHERE pk = ?");
+        let row: Option<(serde_json::Value,)> = sqlx::query_as(&sql)
+            .bind(pk_text.as_ref())
+            .fetch_optional(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        row.map(|(v,)| v)
+    };
+
+    json_opt.map(json_to_item).transpose()
+}
+
+/// Fetch for write. SQLite has no `FOR UPDATE`; the engine write lock provides
+/// the serialization, so this is the same as `fetch_item_in_tx`.
+pub(super) async fn fetch_item_for_update(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    key_info: &TableKeyInfo,
+    key: &Item,
+) -> Result<Option<Item>, StorageError> {
+    fetch_item_in_tx(tx, key_info, key).await
+}
+
+/// Insert or replace an item within a transaction.
+pub(crate) async fn upsert_item_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    key_info: &TableKeyInfo,
+    item: &Item,
+) -> Result<(), StorageError> {
+    let ddb_table = data_table_name(&key_info.table_id);
+    let pk_name = &key_info.key_schema[0].attribute_name;
+    let pk_value = item
+        .get(pk_name)
+        .ok_or_else(|| StorageError::Internal("missing partition key".to_owned()))?;
+    let pk_text = pk_to_text(pk_value)?;
+    let item_json =
+        serde_json::to_string(item).map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    if let Some((sk_name, sk_type)) = sk_info(&key_info.key_schema, &key_info.attribute_definitions)
+    {
+        let sk_value = item
+            .get(sk_name)
+            .ok_or_else(|| StorageError::Internal("missing sort key".to_owned()))?;
+        let sk = extenddb_storage::util::parse_sk(sk_value, sk_type)?;
+        let sk_col = sk_column(sk_type);
+        let sql = format!(
+            "INSERT INTO {ddb_table} (pk, {sk_col}, item_data) VALUES (?, ?, ?) \
+             ON CONFLICT (pk, {sk_col}) DO UPDATE SET item_data = excluded.item_data"
+        );
+        bind_sk_execute!(&sql, pk_text.as_ref(), &sk, &item_json, &mut **tx)?;
+    } else {
+        let sql = format!(
+            "INSERT INTO {ddb_table} (pk, item_data) VALUES (?, ?) \
+             ON CONFLICT (pk) DO UPDATE SET item_data = excluded.item_data"
+        );
+        sqlx::query(&sql)
+            .bind(pk_text.as_ref())
+            .bind(&item_json)
+            .execute(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+    }
+    Ok(())
+}
+
+/// Delete an item by key within a transaction.
+pub(super) async fn delete_item_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    key_info: &TableKeyInfo,
+    key: &Item,
+) -> Result<(), StorageError> {
+    let ddb_table = data_table_name(&key_info.table_id);
+    let pk_name = &key_info.key_schema[0].attribute_name;
+    let pk_value = key
+        .get(pk_name)
+        .ok_or_else(|| StorageError::Internal("missing partition key".to_owned()))?;
+    let pk_text = pk_to_text(pk_value)?;
+
+    if let Some((sk_name, sk_type)) = sk_info(&key_info.key_schema, &key_info.attribute_definitions)
+    {
+        let sk_value = key
+            .get(sk_name)
+            .ok_or_else(|| StorageError::Internal("missing sort key".to_owned()))?;
+        let sk = extenddb_storage::util::parse_sk(sk_value, sk_type)?;
+        let sk_col = sk_column(sk_type);
+        let sql = format!("DELETE FROM {ddb_table} WHERE pk = ? AND {sk_col} = ?");
+        bind_sk_only_execute!(&sql, pk_text.as_ref(), &sk, &mut **tx)?;
+    } else {
+        let sql = format!("DELETE FROM {ddb_table} WHERE pk = ?");
+        sqlx::query(&sql)
+            .bind(pk_text.as_ref())
+            .execute(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+    }
+    Ok(())
+}
+
+/// Allocate the next monotonic stream sequence number within a transaction.
+async fn next_stream_seq(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+) -> Result<i64, StorageError> {
+    sqlx::query("UPDATE seq_counters SET value = value + 1 WHERE name = 'stream'")
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let value: i64 = sqlx::query_scalar("SELECT value FROM seq_counters WHERE name = 'stream'")
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    Ok(value)
+}
+
+/// Write a stream record in the same transaction as the data write, so capture
+/// is atomic with the mutation (a hard requirement for correct streams).
+pub(super) async fn write_stream_record_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    key_info: &TableKeyInfo,
+    capture: &StreamCapture,
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+) -> Result<(), StorageError> {
+    let event_name = match (old_item, new_item) {
+        (None, Some(_)) => StreamEventName::Insert,
+        (Some(_), Some(_)) => StreamEventName::Modify,
+        (Some(_), None) => StreamEventName::Remove,
+        (None, None) => return Ok(()),
+    };
+    let source = new_item.or(old_item).expect("one image present");
+
+    // Keys are the primary-key attributes from whichever image is present.
+    let keys: Item = key_info
+        .key_schema
+        .iter()
+        .filter_map(|ks| {
+            source
+                .get(&ks.attribute_name)
+                .map(|v| (ks.attribute_name.clone(), v.clone()))
+        })
+        .collect();
+
+    let new_image = matches!(
+        capture.view_type,
+        StreamViewType::NewImage | StreamViewType::NewAndOldImages
+    )
+    .then(|| new_item.cloned())
+    .flatten();
+    let old_image = matches!(
+        capture.view_type,
+        StreamViewType::OldImage | StreamViewType::NewAndOldImages
+    )
+    .then(|| old_item.cloned())
+    .flatten();
+
+    let size_bytes = i64::try_from(item_size_bytes(source)).unwrap_or(i64::MAX);
+
+    // Hash the partition key to a shard.
+    let pk_name = &key_info.key_schema[0].attribute_name;
+    let pk_str = source
+        .get(pk_name)
+        .map(|v| match v {
+            AttributeValue::S(s) => s.clone(),
+            AttributeValue::N(n) => n.clone(),
+            AttributeValue::B(b) => BASE64.encode(b),
+            _ => String::new(),
+        })
+        .unwrap_or_default();
+
+    let shards: Vec<(String,)> =
+        sqlx::query_as("SELECT shard_id FROM stream_shards WHERE table_id = ? ORDER BY shard_id")
+            .bind(&key_info.table_id)
+            .fetch_all(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+    if shards.is_empty() {
+        return Ok(()); // Streams not enabled for this table.
+    }
+    let idx = (crc32fast::hash(pk_str.as_bytes()) as usize) % shards.len();
+    let shard_id = shards[idx].0.clone();
+
+    let seq = format!("{:021}", next_stream_seq(tx).await?);
+    let approximate_creation_date_time = i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    )
+    .unwrap_or(i64::MAX);
+
+    let record = StreamRecord {
+        event_id: uuid::Uuid::new_v4().to_string(),
+        event_name,
+        event_version: "1.1".to_owned(),
+        event_source: "aws:dynamodb".to_owned(),
+        aws_region: capture.region.to_string(),
+        dynamodb: StreamRecordData {
+            approximate_creation_date_time,
+            keys,
+            new_image,
+            old_image,
+            sequence_number: seq.clone(),
+            size_bytes,
+            stream_view_type: capture.view_type,
+        },
+        user_identity: capture.user_identity.clone(),
+    };
+    let record_json =
+        serde_json::to_string(&record).map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    sqlx::query(
+        "INSERT INTO stream_records (shard_id, sequence_number, table_id, event_name, record_data) \
+         VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(&shard_id)
+    .bind(&seq)
+    .bind(&key_info.table_id)
+    .bind(format!("{:?}", record.event_name))
+    .bind(&record_json)
+    .execute(&mut **tx)
+    .await
+    .map_err(|e| StorageError::Internal(e.to_string()))?;
+    Ok(())
+}
+
+/// Check (and record) an idempotency token within a transaction. Tokens are
+/// valid for 10 minutes; the cutoff is computed in Rust as RFC 3339 so it
+/// compares correctly against the stored RFC 3339 `created_at`.
+pub(super) async fn check_idempotency_token_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    account_id: &str,
+    token: &str,
+    fingerprint: &str,
+) -> Result<(), StorageError> {
+    let cutoff = format_timestamp(time::OffsetDateTime::now_utc() - time::Duration::minutes(10));
+    let existing: Option<(String,)> = sqlx::query_as(
+        "SELECT fingerprint FROM idempotency_tokens \
+         WHERE account_id = ? AND token = ? AND created_at > ?",
+    )
+    .bind(account_id)
+    .bind(token)
+    .bind(&cutoff)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    if let Some((stored_fp,)) = existing {
+        return if stored_fp == fingerprint {
+            Err(StorageError::IdempotentReplay)
+        } else {
+            Err(StorageError::IdempotentMismatch)
+        };
+    }
+
+    let now = format_timestamp(time::OffsetDateTime::now_utc());
+    sqlx::query(
+        "INSERT INTO idempotency_tokens (account_id, token, fingerprint, created_at) \
+         VALUES (?, ?, ?, ?) \
+         ON CONFLICT (account_id, token) DO UPDATE SET fingerprint = excluded.fingerprint, \
+         created_at = excluded.created_at",
+    )
+    .bind(account_id)
+    .bind(token)
+    .bind(fingerprint)
+    .bind(&now)
+    .execute(&mut **tx)
+    .await
+    .map_err(|e| StorageError::Internal(e.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod idempotency_tests {
+    use super::check_idempotency_token_in_tx;
+    use extenddb_storage::error::StorageError;
+    use sqlx::sqlite::SqlitePool;
+
+    async fn pool_with_schema() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE idempotency_tokens (\
+                 account_id  TEXT NOT NULL,\
+                 token       TEXT NOT NULL,\
+                 fingerprint TEXT NOT NULL,\
+                 created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),\
+                 PRIMARY KEY (account_id, token)\
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    async fn check(
+        pool: &SqlitePool,
+        account: &str,
+        token: &str,
+        fp: &str,
+    ) -> Result<(), StorageError> {
+        let mut tx = pool.begin().await.unwrap();
+        let r = check_idempotency_token_in_tx(&mut tx, account, token, fp).await;
+        tx.commit().await.unwrap();
+        r
+    }
+
+    #[tokio::test]
+    async fn idempotency_is_scoped_per_account() {
+        let pool = pool_with_schema().await;
+
+        // First use of (acctA, tok) records it.
+        check(&pool, "acctA", "tok", "fpX").await.unwrap();
+
+        // Same account + token + fingerprint = idempotent replay.
+        assert!(matches!(
+            check(&pool, "acctA", "tok", "fpX").await,
+            Err(StorageError::IdempotentReplay)
+        ));
+
+        // Same account + token, different fingerprint = mismatch.
+        assert!(matches!(
+            check(&pool, "acctA", "tok", "fpY").await,
+            Err(StorageError::IdempotentMismatch)
+        ));
+
+        // Regression: a DIFFERENT account reusing the same token value must be
+        // independent — not a replay and not a mismatch.
+        check(&pool, "acctB", "tok", "fpX").await.unwrap();
+    }
+}

--- a/crates/storage-sqlite/src/data/update_item.rs
+++ b/crates/storage-sqlite/src/data/update_item.rs
@@ -1,0 +1,109 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `update_item` for the SQLite backend.
+//!
+//! UpdateItem is an upsert: when the item is absent a new one is created from
+//! the key plus the applied actions. The condition is evaluated against the
+//! pre-update image (or an empty item), then update actions are applied and the
+//! result is validated and written — all under the engine write lock (D1).
+
+use extenddb_core::expression::{self, Expr, ExpressionMaps, UpdateAction};
+use extenddb_core::types::{Item, TableKeyInfo};
+use extenddb_core::validation;
+use extenddb_storage::StreamCapture;
+use extenddb_storage::error::StorageError;
+
+use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
+use super::query::check_condition;
+use super::tx_helpers::{fetch_item_in_tx, upsert_item_in_tx, write_stream_record_in_tx};
+use crate::store::SqliteEngine;
+
+impl SqliteEngine {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn update_item_impl(
+        &self,
+        key_info: &TableKeyInfo,
+        key: &Item,
+        actions: &[UpdateAction],
+        return_old: bool,
+        return_new: bool,
+        condition: Option<&Expr>,
+        maps: &ExpressionMaps,
+        stream: Option<&StreamCapture>,
+    ) -> Result<(Option<Item>, Option<Item>), StorageError> {
+        let _writer = self.write_lock.lock().await;
+        // Read the index set after acquiring the write lock so a concurrently
+        // added GSI (UpdateTable holds the same lock) is not missed.
+        let indexes = fetch_indexes_for_table(&key_info.table_id, &self.pool).await?;
+        let system_delay = self.gsi_default_delay();
+
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let old = fetch_item_in_tx(&mut tx, key_info, key).await?;
+
+        if condition.is_some() {
+            let empty = Item::new();
+            let target = old.as_ref().unwrap_or(&empty);
+            if let Err(e) = check_condition(condition, target, maps) {
+                return match e {
+                    StorageError::ConditionFailed(_) => Err(StorageError::ConditionFailed(old)),
+                    other => Err(other),
+                };
+            }
+        }
+
+        // Start from the existing image, or from the key for a fresh upsert.
+        let mut item = old.clone().unwrap_or_else(|| key.clone());
+        expression::apply_update(actions, &mut item, maps)
+            .map_err(|e| StorageError::Validation(e.to_string()))?;
+        validation::validate_item_size(&item, self.max_item_size_bytes)
+            .map_err(|e| StorageError::Validation(e.to_string()))?;
+
+        upsert_item_in_tx(&mut tx, key_info, &item).await?;
+
+        if !indexes.is_empty() {
+            sync_indexes(
+                &mut tx,
+                &key_info.key_schema,
+                &key_info.attribute_definitions,
+                &indexes,
+                old.as_ref(),
+                Some(&item),
+                system_delay,
+            )
+            .await?;
+        }
+        let enqueued = enqueue_async_indexes(
+            &mut tx,
+            key_info,
+            &indexes,
+            old.as_ref(),
+            Some(&item),
+            system_delay,
+        )
+        .await?
+            > 0;
+
+        if let Some(capture) = stream {
+            write_stream_record_in_tx(&mut tx, key_info, capture, old.as_ref(), Some(&item))
+                .await?;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        if enqueued {
+            self.gsi_notify.notify_waiters();
+        }
+
+        let old_ret = if return_old { old } else { None };
+        let new_ret = if return_new { Some(item) } else { None };
+        Ok((old_ret, new_ret))
+    }
+}

--- a/crates/storage-sqlite/src/data/update_item.rs
+++ b/crates/storage-sqlite/src/data/update_item.rs
@@ -16,6 +16,7 @@ use extenddb_storage::error::StorageError;
 
 use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
 use super::query::check_condition;
+use super::transactions::index_key_refs;
 use super::tx_helpers::{fetch_item_in_tx, upsert_item_in_tx, write_stream_record_in_tx};
 use crate::store::SqliteEngine;
 
@@ -63,6 +64,21 @@ impl SqliteEngine {
             .map_err(|e| StorageError::Validation(e.to_string()))?;
         validation::validate_item_size(&item, self.max_item_size_bytes)
             .map_err(|e| StorageError::Validation(e.to_string()))?;
+        // Secondary-index key validation on the post-update item, matching the
+        // TransactWriteItems update path: a wrong-typed index key attribute or
+        // an index key set to an empty value is a ValidationException up front,
+        // rather than silently producing a malformed / unmatchable index row.
+        if !indexes.is_empty() {
+            let idx_refs = index_key_refs(&indexes);
+            validation::validate_index_key_types(&item, &idx_refs, &key_info.attribute_definitions)
+                .map_err(|e| StorageError::Validation(e.to_string()))?;
+            validation::validate_index_key_not_empty(
+                &item,
+                &idx_refs,
+                validation::SecondaryIndexEmptyContext::UpdateExpression,
+            )
+            .map_err(|e| StorageError::Validation(e.to_string()))?;
+        }
 
         upsert_item_in_tx(&mut tx, key_info, &item).await?;
 

--- a/crates/storage-sqlite/src/delete_table.rs
+++ b/crates/storage-sqlite/src/delete_table.rs
@@ -1,0 +1,117 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `delete_table` implementation for `SqliteEngine`.
+//!
+//! With `control_plane_delay_seconds < 1` the table and its data tables are
+//! dropped immediately; otherwise the table is marked DELETING with a scheduled
+//! transition that the control-plane worker completes.
+
+use extenddb_core::types::{DeleteTableInput, TableDescription, TableStatus};
+use extenddb_storage::error::StorageError;
+
+use crate::sqlite_util::format_timestamp;
+use crate::store::SqliteEngine;
+use crate::table_helpers::{INDEX_COLUMNS, IndexRow, TABLE_COLUMNS, TableRow};
+
+impl SqliteEngine {
+    pub(crate) async fn delete_table_impl(
+        &self,
+        account_id: &str,
+        input: DeleteTableInput,
+    ) -> Result<TableDescription, StorageError> {
+        Self::validate_account_id(account_id)?;
+
+        let row: Option<TableRow> = sqlx::query_as(&format!(
+            "SELECT {TABLE_COLUMNS} FROM tables \
+             WHERE account_id = ? AND table_name = ? AND table_status IN ('ACTIVE', 'CREATING')"
+        ))
+        .bind(account_id)
+        .bind(&input.table_name)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let row = row.ok_or_else(|| StorageError::TableNotFound(input.table_name.clone()))?;
+        if row.deletion_protection_enabled {
+            return Err(StorageError::DeletionProtected(row.table_arn.clone()));
+        }
+
+        let index_rows: Vec<IndexRow> = sqlx::query_as(&format!(
+            "SELECT {INDEX_COLUMNS} FROM indexes WHERE table_id = ?"
+        ))
+        .bind(&row.table_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let delay_secs: f64 = sqlx::query_scalar::<_, String>(
+            "SELECT value FROM settings WHERE key = 'control_plane_delay_seconds'",
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?
+        .and_then(|v| v.parse::<f64>().ok())
+        .unwrap_or(0.25);
+
+        let index_ids: Vec<String> = index_rows.iter().map(|r| r.index_id.clone()).collect();
+        let table_id = row.table_id.clone();
+        let table_arn = row.table_arn.clone();
+
+        if delay_secs < 1.0 {
+            let _writer = self.write_lock.lock().await;
+            let mut tx = self
+                .pool
+                .begin_with("BEGIN IMMEDIATE")
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            sqlx::query("DELETE FROM tags WHERE resource_arn = ?")
+                .bind(&table_arn)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            // CASCADE removes indexes, stream shards/records.
+            sqlx::query("DELETE FROM tables WHERE table_id = ?")
+                .bind(&table_id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            for idx_id in &index_ids {
+                Self::drop_index_data_table(&mut tx, idx_id).await?;
+            }
+            Self::drop_data_table(&mut tx, &table_id).await?;
+            // Drop any still-pending GSI propagation rows for this table in the
+            // same transaction that drops the tables, so the worker doesn't
+            // waste a claim→deserialize→skip cycle on now-orphaned rows.
+            sqlx::query("DELETE FROM gsi_pending WHERE table_id = ?")
+                .bind(&table_id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            tx.commit()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+        } else {
+            let transition = format_timestamp(
+                time::OffsetDateTime::now_utc() + time::Duration::seconds_f64(delay_secs),
+            );
+            sqlx::query(
+                "UPDATE tables SET table_status = 'DELETING', status_transition_at = ? \
+                 WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(&transition)
+            .bind(account_id)
+            .bind(&input.table_name)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            self.control_plane_notify.notify_one();
+        }
+
+        let desc = self.build_table_description_from_row(account_id, row, index_rows)?;
+        Ok(TableDescription {
+            table_status: TableStatus::Deleting,
+            ..desc
+        })
+    }
+}

--- a/crates/storage-sqlite/src/hooks.rs
+++ b/crates/storage-sqlite/src/hooks.rs
@@ -1,0 +1,90 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `ServerRuntimeHooks` for the SQLite backend: spawns the background workers
+//! (control-plane poller, table-size refresh, stream/idempotency cleanup, TTL
+//! sweep).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use extenddb_storage::hooks::{ServerRuntimeHooks, WorkerContext};
+
+use crate::store::SqliteEngine;
+use crate::workers;
+
+pub(crate) struct SqliteRuntimeHooks {
+    pub(crate) engine: Arc<SqliteEngine>,
+    pub(crate) control_plane_notify: Arc<tokio::sync::Notify>,
+}
+
+#[async_trait]
+impl ServerRuntimeHooks for SqliteRuntimeHooks {
+    async fn spawn_workers(&self, ctx: &WorkerContext) -> Vec<tokio::task::JoinHandle<()>> {
+        // Backend-specific workers. Each takes the shutdown token and returns
+        // at its next tick after cancellation; the handles are returned so
+        // `serve` can drain them.
+        let engine = self.engine.clone();
+        let notify = self.control_plane_notify.clone();
+        let catalog_store = ctx.catalog_store.clone();
+        let token = ctx.shutdown.clone();
+        let control_plane = tokio::spawn(async move {
+            workers::poll_control_plane_transitions(engine, notify, catalog_store, token).await;
+        });
+
+        let engine = self.engine.clone();
+        let token = ctx.shutdown.clone();
+        let table_size =
+            tokio::spawn(async move { workers::table_size_refresh_worker(engine, token).await });
+
+        let engine = self.engine.clone();
+        let metrics = ctx.metrics.clone();
+        let token = ctx.shutdown.clone();
+        let stream_cleanup = tokio::spawn(async move {
+            workers::stream_record_cleanup_worker(engine, metrics, token).await;
+        });
+
+        let engine = self.engine.clone();
+        let metrics = ctx.metrics.clone();
+        let token = ctx.shutdown.clone();
+        let idempotency_cleanup = tokio::spawn(async move {
+            workers::idempotency_token_cleanup_worker(engine, metrics, token).await;
+        });
+
+        let engine = self.engine.clone();
+        let metrics = ctx.metrics.clone();
+        let token = ctx.shutdown.clone();
+        let ttl_cleanup =
+            tokio::spawn(async move { workers::ttl_cleanup_worker(engine, metrics, token).await });
+
+        // GSI propagation: drain gsi_pending after each write / on a sweep.
+        let engine = self.engine.clone();
+        let gsi_notify = engine.gsi_notify();
+        let token = ctx.shutdown.clone();
+        let gsi_propagation = tokio::spawn(async move {
+            workers::gsi_propagation_worker(engine, gsi_notify, token).await;
+        });
+
+        // Keep the cached GSI propagation delay in sync with the setting.
+        let gsi_default = self.engine.gsi_default_delay_ms.clone();
+        let catalog_store = ctx.catalog_store.clone();
+        let token = ctx.shutdown.clone();
+        let gsi_delay = tokio::spawn(async move {
+            workers::poll_gsi_delay(catalog_store, gsi_default, token).await;
+        });
+
+        vec![
+            control_plane,
+            table_size,
+            stream_cleanup,
+            idempotency_cleanup,
+            ttl_cleanup,
+            gsi_propagation,
+            gsi_delay,
+        ]
+    }
+
+    fn backend_info(&self) -> Option<String> {
+        Some("storage=sqlite (single-file)".to_owned())
+    }
+}

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -1,0 +1,266 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! SQLite storage backend for ExtendDB.
+//!
+//! Implements the full `StorageEngine` + `CatalogStore` trait surface using
+//! SQLite via `sqlx`, persisting to a single file (or `:memory:` for testing).
+//! WAL mode enables concurrent readers; writers are serialized by the engine
+//! (see `store`).
+//!
+//! # Design decisions vs the PostgreSQL backend
+//!
+//! - Placeholders: `?` positional (not `$N`).
+//! - Concurrency: single WAL-mode pool; an engine-level write lock plus
+//!   `BEGIN IMMEDIATE` replaces `SERIALIZABLE` / `FOR UPDATE`.
+//! - Numbers: `N` sort keys stored as order-preserving TEXT (never `REAL`),
+//!   full precision retained in the item JSON. See `docs/design-decisions.md`.
+//! - One file holds catalog and data (no separate catalog/data databases).
+//!
+//! NOTE: this is the catalog-layer build slice. The data-plane engine modules
+//! and the `ServerComponents` registration are added in the engine slice.
+
+mod admin_store;
+mod authorization_store;
+mod backup;
+mod bootstrapper;
+mod catalog_store;
+pub mod config;
+mod create_table;
+mod credential_store;
+mod data;
+mod delete_table;
+mod hooks;
+mod management_store;
+mod metadata;
+mod number_key;
+mod operations;
+mod schema;
+mod sqlite_util;
+mod store;
+mod stream;
+mod table_engine;
+mod table_helpers;
+mod update_table;
+mod worker;
+mod workers;
+
+pub use bootstrapper::SqliteBootstrapper;
+pub use catalog_store::SqliteCatalogStore;
+pub use config::SqliteConfig;
+pub use credential_store::SqliteCredentialStore;
+pub use schema::CATALOG_VERSION;
+pub use store::SqliteEngine;
+
+/// The SQLite backend, for installation via
+/// [`extenddb_storage::set_backend`] in a thin bin.
+///
+/// Bundles the bootstrapper, operations engine, config deserializer, and the
+/// settings/diagnostics/server-components factories under the `sqlite` name,
+/// which also selects the `[storage.sqlite]` config section.
+#[must_use]
+pub fn backend() -> extenddb_storage::Backend {
+    extenddb_storage::Backend {
+        name: "sqlite",
+        bootstrapper: sqlite_bootstrapper_factory,
+        storage_config: config::deserialize_config,
+        operations: &operations::SqliteOperationsEngine,
+        settings_store: sqlite_settings_store_factory,
+        diagnostics_store: sqlite_diagnostics_store_factory,
+        server_components: sqlite_server_components_factory,
+    }
+}
+
+use extenddb_storage::diagnostics::DiagnosticsStore;
+use extenddb_storage::diagnostics_store::DiagnosticsStoreError;
+use extenddb_storage::management_store::SettingsStore;
+use extenddb_storage::settings_store::SettingsStoreError;
+
+use crate::sqlite_util::sqlite_url;
+
+/// Open a small catalog-only pool for the settings/diagnostics factories,
+/// applying the same PRAGMAs as the engine.
+async fn catalog_pool(connection_string: &str) -> Result<sqlx::SqlitePool, sqlx::Error> {
+    sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(4)
+        .after_connect(|conn, _| {
+            Box::pin(async move {
+                use sqlx::Executor;
+                conn.execute("PRAGMA journal_mode = WAL").await?;
+                conn.execute("PRAGMA foreign_keys = ON").await?;
+                conn.execute("PRAGMA busy_timeout = 5000").await?;
+                Ok(())
+            })
+        })
+        .connect(&sqlite_url(connection_string))
+        .await
+}
+
+// ── Bootstrapper ───────────────────────────────────────────────────────
+
+fn sqlite_bootstrapper_factory(
+    config_path: String,
+    cli_args: Vec<String>,
+) -> futures::future::BoxFuture<
+    'static,
+    Result<
+        Box<dyn extenddb_storage::bootstrapper::Bootstrapper>,
+        extenddb_storage::error::StorageError,
+    >,
+> {
+    Box::pin(async move {
+        let store = SqliteBootstrapper::from_config(&config_path, &cli_args).await?;
+        Ok(Box::new(store) as Box<dyn extenddb_storage::bootstrapper::Bootstrapper>)
+    })
+}
+
+// ── Operations engine ──────────────────────────────────────────────────
+
+// ── Config deserializer ────────────────────────────────────────────────
+
+// ── Settings store factory ─────────────────────────────────────────────
+
+fn sqlite_settings_store_factory(
+    connection_string: &str,
+) -> futures::future::BoxFuture<'static, Result<Box<dyn SettingsStore>, SettingsStoreError>> {
+    let connection_string = connection_string.to_owned();
+    Box::pin(async move {
+        let pool = catalog_pool(&connection_string)
+            .await
+            .map_err(|e| SettingsStoreError::ConnectionFailed(e.to_string()))?;
+        Ok(Box::new(SqliteCatalogStore::new(pool)) as Box<dyn SettingsStore>)
+    })
+}
+
+// ── Diagnostics store factory ──────────────────────────────────────────
+
+fn sqlite_diagnostics_store_factory(
+    connection_string: &str,
+) -> futures::future::BoxFuture<'static, Result<Box<dyn DiagnosticsStore>, DiagnosticsStoreError>> {
+    let connection_string = connection_string.to_owned();
+    Box::pin(async move {
+        let pool = catalog_pool(&connection_string)
+            .await
+            .map_err(|e| DiagnosticsStoreError::ConnectionFailed(e.to_string()))?;
+        Ok(Box::new(SqliteCatalogStore::new(pool)) as Box<dyn DiagnosticsStore>)
+    })
+}
+
+// ── Server components factory ──────────────────────────────────────────
+
+use std::sync::Arc;
+
+use extenddb_auth::CredentialStore;
+use extenddb_storage::server_components::{BackendError, ServerComponents};
+
+use crate::hooks::SqliteRuntimeHooks;
+
+/// Maximum DynamoDB item size in bytes (post-update validation bound).
+const MAX_ITEM_SIZE_BYTES: usize = 400_000;
+
+fn sqlite_server_components_factory(
+    config: &dyn extenddb_storage::config::StorageConfig,
+    region: &str,
+) -> futures::future::BoxFuture<'static, Result<ServerComponents, BackendError>> {
+    let db_path = config.connection_config().to_owned();
+    let pool_size = config.max_connections();
+    let region = region.to_owned();
+    Box::pin(async move {
+        let engine = SqliteEngine::new(&db_path, pool_size, &region, MAX_ITEM_SIZE_BYTES)
+            .await
+            .map_err(|e| BackendError::ConnectionFailed {
+                backend: "sqlite".to_owned(),
+                details: e.to_string(),
+            })?;
+
+        // In-memory databases do not persist across the `init` process, so the
+        // catalog must be bootstrapped here, at serve time, on the engine's own
+        // shared connection (a second pool would open a separate empty DB).
+        let in_memory = db_path == ":memory:"
+            || db_path.starts_with("file::memory:")
+            || db_path.contains("mode=memory");
+        if in_memory {
+            let admin_user = std::env::var("EXTENDDB_ADMIN_USER").ok();
+            let admin_password = std::env::var("EXTENDDB_ADMIN_PASSWORD").ok();
+            if let Some(password) = engine
+                .bootstrap_ephemeral(admin_user.as_deref(), admin_password.as_deref())
+                .await
+                .map_err(|e| BackendError::InitializationFailed(e.to_string()))?
+            {
+                let user = admin_user.as_deref().unwrap_or("admin");
+                println!(
+                    "\n  In-memory backend: ephemeral admin credentials (lost on restart)\n  \
+                     Username: {user}\n  Password: {password}\n"
+                );
+            }
+        }
+
+        engine.check_catalog_version().await.map_err(|e| match e {
+            extenddb_storage::error::StorageError::CatalogVersionMismatch { expected, found } => {
+                BackendError::CatalogVersionMismatch { expected, found }
+            }
+            other => BackendError::InitializationFailed(other.to_string()),
+        })?;
+
+        // Recover any in-flight control-plane transitions from a prior run.
+        match engine.process_control_plane_transitions().await {
+            Ok(transitions) => {
+                for (name, transition) in &transitions {
+                    tracing::info!("Recovered table '{name}': {transition}");
+                }
+            }
+            Err(e) => tracing::error!("Failed to recover control plane transitions: {e}"),
+        }
+
+        // Rebuild any GSI left mid-backfill (status CREATING) by a prior crash.
+        match engine.reconcile_incomplete_gsis().await {
+            Ok(n) if n > 0 => tracing::info!("Reconciled {n} incomplete GSI(s) at startup"),
+            Ok(_) => {}
+            Err(e) => tracing::error!("Failed to reconcile incomplete GSIs: {e}"),
+        }
+
+        let control_plane_notify = engine.control_plane_notify();
+        let engine = Arc::new(engine);
+
+        // Catalog + auth queries: a file-backed database opens a dedicated
+        // catalog pool over the same file; an in-memory database must reuse the
+        // engine's single shared connection (its data lives only there).
+        let catalog_pool = if in_memory {
+            engine.pool.clone()
+        } else {
+            catalog_pool(&db_path)
+                .await
+                .map_err(|e| BackendError::ConnectionFailed {
+                    backend: "sqlite".to_owned(),
+                    details: format!("catalog pool: {e}"),
+                })?
+        };
+
+        let enc_key: Option<String> =
+            sqlx::query_scalar("SELECT value FROM settings WHERE key = 'encryption_key'")
+                .fetch_optional(&catalog_pool)
+                .await
+                .map_err(|e| {
+                    BackendError::InitializationFailed(format!("fetch encryption key: {e}"))
+                })?;
+        let enc_key = enc_key.ok_or(BackendError::MissingEncryptionKey)?;
+
+        let catalog_store: Arc<dyn extenddb_storage::CatalogStore> = Arc::new(
+            SqliteCatalogStore::with_encryption_key(catalog_pool.clone(), enc_key.clone()),
+        );
+        let credential_store: Arc<dyn CredentialStore> =
+            Arc::new(SqliteCredentialStore::new(catalog_pool, enc_key));
+
+        let runtime_hooks = Box::new(SqliteRuntimeHooks {
+            engine: engine.clone(),
+            control_plane_notify,
+        });
+
+        Ok(ServerComponents {
+            engine,
+            catalog_store,
+            credential_store,
+            runtime_hooks: Some(runtime_hooks),
+        })
+    })
+}

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -161,6 +161,7 @@ const MAX_ITEM_SIZE_BYTES: usize = 400_000;
 fn sqlite_server_components_factory(
     config: &dyn extenddb_storage::config::StorageConfig,
     region: &str,
+    options: extenddb_storage::server_components::ServerComponentsOptions,
 ) -> futures::future::BoxFuture<'static, Result<ServerComponents, BackendError>> {
     let db_path = config.connection_config().to_owned();
     let pool_size = config.max_connections();
@@ -176,10 +177,15 @@ fn sqlite_server_components_factory(
         // In-memory databases do not persist across the `init` process, so the
         // catalog must be bootstrapped here, at serve time, on the engine's own
         // shared connection (a second pool would open a separate empty DB).
+        // A dev-mode build extends the same bootstrap to an uninitialized FILE
+        // database (`bootstrap_if_uninitialized`), so zero-config dev serve
+        // works with a persistent path too; every bootstrap step is guarded
+        // (IF NOT EXISTS / INSERT OR IGNORE), so re-running on an initialized
+        // file is a no-op. Production builds keep the explicit-`init` contract.
         let in_memory = db_path == ":memory:"
             || db_path.starts_with("file::memory:")
             || db_path.contains("mode=memory");
-        if in_memory {
+        if in_memory || options.bootstrap_if_uninitialized {
             let admin_user = std::env::var("EXTENDDB_ADMIN_USER").ok();
             let admin_password = std::env::var("EXTENDDB_ADMIN_PASSWORD").ok();
             if let Some(password) = engine
@@ -188,10 +194,12 @@ fn sqlite_server_components_factory(
                 .map_err(|e| BackendError::InitializationFailed(e.to_string()))?
             {
                 let user = admin_user.as_deref().unwrap_or("admin");
-                println!(
-                    "\n  In-memory backend: ephemeral admin credentials (lost on restart)\n  \
-                     Username: {user}\n  Password: {password}\n"
-                );
+                let durability = if in_memory {
+                    "In-memory backend: ephemeral admin credentials (lost on restart)"
+                } else {
+                    "Bootstrapped file backend: admin credentials (stored in the database)"
+                };
+                println!("\n  {durability}\n  Username: {user}\n  Password: {password}\n");
             }
         }
 

--- a/crates/storage-sqlite/src/management_store/access_keys.rs
+++ b/crates/storage-sqlite/src/management_store/access_keys.rs
@@ -1,0 +1,217 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Access-key management for `SqliteCatalogStore`, including key generation
+//! and AES-256-GCM secret encryption.
+//!
+//! Secrets are encrypted with the catalog encryption key before storage. The
+//! ciphertext layout is `nonce(12) || aes_gcm_ciphertext`, with the
+//! `access_key_id` bound as additional authenticated data (AAD) so a stored
+//! secret cannot be transplanted onto a different key id.
+
+use aes_gcm::aead::{Aead, Payload};
+use aes_gcm::{Aes256Gcm, Key, KeyInit, Nonce};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use extenddb_storage::management_store::{AccessKeyCreated, OpError, OpResult};
+use time::OffsetDateTime;
+
+use crate::catalog_store::SqliteCatalogStore;
+use crate::sqlite_util::{is_fk_violation, is_unique_violation, parse_timestamp};
+
+impl SqliteCatalogStore {
+    /// Resolve the AES-256-GCM encryption key (base64), preferring the cached
+    /// value and falling back to the `settings` table.
+    async fn resolve_encryption_key(&self) -> OpResult<String> {
+        if let Some(k) = self.encryption_key() {
+            return Ok(k.to_string());
+        }
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT value FROM settings WHERE key = 'encryption_key'")
+                .fetch_optional(self.pool())
+                .await
+                .map_err(|e| OpError::Internal(format!("fetch encryption key: {e}")))?;
+        row.map(|(v,)| v)
+            .ok_or_else(|| OpError::Internal("Encryption key not configured".to_owned()))
+    }
+
+    pub(crate) async fn create_access_key_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> OpResult<AccessKeyCreated> {
+        let enc_key = self.resolve_encryption_key().await?;
+        let access_key_id = generate_access_key_id();
+        let secret_access_key = generate_secret_key();
+        let encrypted = encrypt_secret(&secret_access_key, &enc_key, &access_key_id)
+            .map_err(|e| OpError::Internal(format!("encrypt secret: {e}")))?;
+
+        sqlx::query(
+            "INSERT INTO access_keys \
+             (access_key_id, secret_key_encrypted, account_id, user_name) \
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(&access_key_id)
+        .bind(&encrypted)
+        .bind(account_id)
+        .bind(user_name)
+        .execute(self.pool())
+        .await
+        .map_err(|e| {
+            if is_fk_violation(&e) {
+                OpError::NotFound("IAM user not found".to_owned())
+            } else {
+                tracing::error!("create_access_key: {e}");
+                OpError::Internal("Database error".to_owned())
+            }
+        })?;
+
+        Ok(AccessKeyCreated {
+            access_key_id,
+            secret_access_key,
+        })
+    }
+
+    pub(crate) async fn delete_access_key_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        key_id: &str,
+    ) -> OpResult<()> {
+        let result = sqlx::query(
+            "DELETE FROM access_keys \
+             WHERE access_key_id = ? AND account_id = ? AND user_name = ?",
+        )
+        .bind(key_id)
+        .bind(account_id)
+        .bind(user_name)
+        .execute(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("delete_access_key: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        if result.rows_affected() == 0 {
+            return Err(OpError::NotFound("Access key not found".to_owned()));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn list_access_keys_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> OpResult<Vec<(String, bool, OffsetDateTime)>> {
+        let rows: Vec<(String, bool, String)> = sqlx::query_as(
+            "SELECT access_key_id, is_active, created_at FROM access_keys \
+             WHERE account_id = ? AND user_name = ? ORDER BY created_at",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("list_access_keys: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        rows.into_iter()
+            .map(|(id, active, ts)| {
+                Ok((
+                    id,
+                    active,
+                    parse_timestamp(&ts)
+                        .map_err(|e| OpError::Internal(format!("parse created_at: {e}")))?,
+                ))
+            })
+            .collect()
+    }
+
+    pub(crate) async fn import_access_key_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        access_key_id: &str,
+        secret_access_key: &str,
+    ) -> OpResult<()> {
+        let enc_key = self.resolve_encryption_key().await?;
+        let encrypted = encrypt_secret(secret_access_key, &enc_key, access_key_id)
+            .map_err(|e| OpError::Internal(format!("encrypt secret: {e}")))?;
+
+        sqlx::query(
+            "INSERT INTO access_keys \
+             (access_key_id, secret_key_encrypted, account_id, user_name) \
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(access_key_id)
+        .bind(&encrypted)
+        .bind(account_id)
+        .bind(user_name)
+        .execute(self.pool())
+        .await
+        .map(|_| ())
+        .map_err(|e| {
+            if is_unique_violation(&e) {
+                OpError::AlreadyExists("Access key ID already exists".to_owned())
+            } else if is_fk_violation(&e) {
+                OpError::NotFound("IAM user not found".to_owned())
+            } else {
+                tracing::error!("import_access_key: {e}");
+                OpError::Internal("Database error".to_owned())
+            }
+        })
+    }
+}
+
+// ── Key generation & crypto helpers ─────────────────────────────────────
+
+/// Generate a 20-character access key id (`AKIAEXTENDDB` + 8 uppercase
+/// alphanumerics), matching the prefix convention used across ExtendDB backends
+/// so generated keys are distinguishable from real AWS keys.
+fn generate_access_key_id() -> String {
+    const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    let mut rng = rand::rng();
+    let suffix: String = (0..8)
+        .map(|_| CHARSET[rand::Rng::random_range(&mut rng, 0..CHARSET.len())] as char)
+        .collect();
+    format!("AKIAEXTENDDB{suffix}")
+}
+
+/// Generate a 40-character secret access key, matching the AWS secret shape.
+fn generate_secret_key() -> String {
+    const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut rng = rand::rng();
+    let suffix: String = (0..32)
+        .map(|_| CHARSET[rand::Rng::random_range(&mut rng, 0..CHARSET.len())] as char)
+        .collect();
+    format!("extenddb{suffix}")
+}
+
+/// Encrypt a secret with AES-256-GCM. Output is `nonce(12) || ciphertext`,
+/// with `aad` (the access key id) bound as additional authenticated data.
+fn encrypt_secret(plaintext: &str, key_b64: &str, aad: &str) -> Result<Vec<u8>, String> {
+    let key_bytes = BASE64
+        .decode(key_b64)
+        .map_err(|e| format!("decode encryption key: {e}"))?;
+    if key_bytes.len() != 32 {
+        return Err("encryption key must be 32 bytes".to_owned());
+    }
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key_bytes));
+
+    let nonce_bytes: [u8; 12] = rand::random();
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let ciphertext = cipher
+        .encrypt(
+            nonce,
+            Payload {
+                msg: plaintext.as_bytes(),
+                aad: aad.as_bytes(),
+            },
+        )
+        .map_err(|e| format!("encrypt: {e}"))?;
+
+    let mut out = Vec::with_capacity(12 + ciphertext.len());
+    out.extend_from_slice(&nonce_bytes);
+    out.extend_from_slice(&ciphertext);
+    Ok(out)
+}

--- a/crates/storage-sqlite/src/management_store/accounts.rs
+++ b/crates/storage-sqlite/src/management_store/accounts.rs
@@ -1,0 +1,196 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Account management operations for `SqliteCatalogStore`.
+
+use extenddb_storage::management_store::{AccountDetail, OpError, OpResult};
+use time::OffsetDateTime;
+
+use crate::catalog_store::SqliteCatalogStore;
+use crate::sqlite_util::{is_unique_violation, parse_timestamp};
+
+impl SqliteCatalogStore {
+    pub(crate) async fn create_account_impl(
+        &self,
+        account_id: &str,
+        account_name: &str,
+    ) -> OpResult<()> {
+        sqlx::query("INSERT INTO accounts (account_id, account_name) VALUES (?, ?)")
+            .bind(account_id)
+            .bind(account_name)
+            .execute(self.pool())
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                if is_unique_violation(&e) {
+                    OpError::AlreadyExists("Account already exists".to_owned())
+                } else {
+                    tracing::error!("create_account: {e}");
+                    OpError::Internal("Database error".to_owned())
+                }
+            })
+    }
+
+    pub(crate) async fn delete_account_impl(&self, account_id: &str) -> OpResult<()> {
+        // Refuse to delete an account that still owns tables; all other IAM
+        // children cascade via foreign keys.
+        let exists: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM accounts WHERE account_id = ?)")
+                .bind(account_id)
+                .fetch_one(self.pool())
+                .await
+                .map_err(|e| {
+                    tracing::error!("delete_account check: {e}");
+                    OpError::Internal("Database error".to_owned())
+                })?;
+        if !exists {
+            return Err(OpError::NotFound("Account not found".to_owned()));
+        }
+
+        let (table_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM tables WHERE account_id = ?")
+                .bind(account_id)
+                .fetch_one(self.pool())
+                .await
+                .map_err(|e| {
+                    tracing::error!("delete_account table count: {e}");
+                    OpError::Internal("Database error".to_owned())
+                })?;
+        if table_count > 0 {
+            return Err(OpError::HasDependents(
+                "Cannot delete account with existing tables. Delete all tables first.".to_owned(),
+            ));
+        }
+
+        sqlx::query("DELETE FROM accounts WHERE account_id = ?")
+            .bind(account_id)
+            .execute(self.pool())
+            .await
+            .map_err(|e| {
+                tracing::error!("delete_account: {e}");
+                OpError::Internal("Database error".to_owned())
+            })?;
+        Ok(())
+    }
+
+    pub(crate) async fn list_all_accounts_impl(&self) -> OpResult<Vec<(String, String)>> {
+        sqlx::query_as("SELECT account_id, account_name FROM accounts ORDER BY account_id")
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| {
+                tracing::error!("list_all_accounts: {e}");
+                OpError::Internal("Database error".to_owned())
+            })
+    }
+
+    pub(crate) async fn default_account_id_impl(&self) -> OpResult<Option<String>> {
+        sqlx::query_scalar("SELECT value FROM settings WHERE key = 'default_account_id'")
+            .fetch_optional(self.pool())
+            .await
+            .map_err(|e| {
+                tracing::error!("default_account_id: {e}");
+                OpError::Internal("Database error".to_owned())
+            })
+    }
+
+    pub(crate) async fn list_all_accounts_full_impl(
+        &self,
+    ) -> OpResult<Vec<(String, String, OffsetDateTime)>> {
+        let rows: Vec<(String, String, String)> = sqlx::query_as(
+            "SELECT account_id, account_name, created_at FROM accounts ORDER BY account_id",
+        )
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("list_all_accounts_full: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        rows.into_iter()
+            .map(|(id, name, ts)| {
+                Ok((
+                    id,
+                    name,
+                    parse_timestamp(&ts)
+                        .map_err(|e| OpError::Internal(format!("parse created_at: {e}")))?,
+                ))
+            })
+            .collect()
+    }
+
+    pub(crate) async fn list_accounts_for_impl(
+        &self,
+        account_id: &str,
+    ) -> OpResult<Vec<(String, String)>> {
+        sqlx::query_as("SELECT account_id, account_name FROM accounts WHERE account_id = ?")
+            .bind(account_id)
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| {
+                tracing::error!("list_accounts_for: {e}");
+                OpError::Internal("Database error".to_owned())
+            })
+    }
+
+    pub(crate) async fn get_account_detail_impl(
+        &self,
+        account_id: &str,
+    ) -> OpResult<Option<AccountDetail>> {
+        let acct: Option<(String,)> =
+            sqlx::query_as("SELECT account_name FROM accounts WHERE account_id = ?")
+                .bind(account_id)
+                .fetch_optional(self.pool())
+                .await
+                .map_err(|e| {
+                    tracing::error!("get_account_detail: {e}");
+                    OpError::Internal("Database error".to_owned())
+                })?;
+        let Some((account_name,)) = acct else {
+            return Ok(None);
+        };
+
+        let names = |rows: Vec<(String,)>| rows.into_iter().map(|(n,)| n).collect::<Vec<_>>();
+
+        let users: Vec<(String,)> = sqlx::query_as(
+            "SELECT user_name FROM iam_users WHERE account_id = ? ORDER BY user_name",
+        )
+        .bind(account_id)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_account_detail users: {e}")))?;
+
+        let groups: Vec<(String,)> = sqlx::query_as(
+            "SELECT group_name FROM iam_groups WHERE account_id = ? ORDER BY group_name",
+        )
+        .bind(account_id)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_account_detail groups: {e}")))?;
+
+        let roles: Vec<(String,)> = sqlx::query_as(
+            "SELECT role_name FROM iam_roles WHERE account_id = ? ORDER BY role_name",
+        )
+        .bind(account_id)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_account_detail roles: {e}")))?;
+
+        Ok(Some(AccountDetail {
+            account_name,
+            users: names(users),
+            groups: names(groups),
+            roles: names(roles),
+        }))
+    }
+
+    pub(crate) async fn dashboard_counts_impl(&self) -> OpResult<(i64, i64)> {
+        let (accounts,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM accounts")
+            .fetch_one(self.pool())
+            .await
+            .map_err(|e| OpError::Internal(format!("dashboard_counts accounts: {e}")))?;
+        let (admins,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM admin_users")
+            .fetch_one(self.pool())
+            .await
+            .map_err(|e| OpError::Internal(format!("dashboard_counts admins: {e}")))?;
+        Ok((accounts, admins))
+    }
+}

--- a/crates/storage-sqlite/src/management_store/groups.rs
+++ b/crates/storage-sqlite/src/management_store/groups.rs
@@ -1,0 +1,188 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Group management operations for `SqliteCatalogStore`.
+
+use extenddb_storage::management_store::{GroupDetail, GroupListEntry, OpError, OpResult};
+
+use crate::catalog_store::SqliteCatalogStore;
+use crate::sqlite_util::{is_fk_violation, is_unique_violation, parse_timestamp};
+
+impl SqliteCatalogStore {
+    pub(crate) async fn create_group_impl(
+        &self,
+        account_id: &str,
+        group_name: &str,
+    ) -> OpResult<()> {
+        let group_arn = format!("arn:aws:iam::{account_id}:group/{group_name}");
+        sqlx::query("INSERT INTO iam_groups (account_id, group_name, group_arn) VALUES (?, ?, ?)")
+            .bind(account_id)
+            .bind(group_name)
+            .bind(&group_arn)
+            .execute(self.pool())
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                if is_unique_violation(&e) {
+                    OpError::AlreadyExists("IAM group already exists".to_owned())
+                } else if is_fk_violation(&e) {
+                    OpError::NotFound("Account not found".to_owned())
+                } else {
+                    tracing::error!("create_group: {e}");
+                    OpError::Internal("Database error".to_owned())
+                }
+            })
+    }
+
+    pub(crate) async fn delete_group_impl(
+        &self,
+        account_id: &str,
+        group_name: &str,
+    ) -> OpResult<()> {
+        let result = sqlx::query("DELETE FROM iam_groups WHERE account_id = ? AND group_name = ?")
+            .bind(account_id)
+            .bind(group_name)
+            .execute(self.pool())
+            .await
+            .map_err(|e| {
+                tracing::error!("delete_group: {e}");
+                OpError::Internal("Database error".to_owned())
+            })?;
+        if result.rows_affected() == 0 {
+            return Err(OpError::NotFound("IAM group not found".to_owned()));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn list_groups_impl(&self, account_id: &str) -> OpResult<Vec<GroupListEntry>> {
+        let rows: Vec<(String, String, String, String)> = sqlx::query_as(
+            "SELECT account_id, group_name, group_arn, created_at \
+             FROM iam_groups WHERE account_id = ? ORDER BY group_name",
+        )
+        .bind(account_id)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("list_groups: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        rows.into_iter()
+            .map(|(aid, gn, arn, ts)| {
+                Ok((
+                    aid,
+                    gn,
+                    arn,
+                    parse_timestamp(&ts)
+                        .map_err(|e| OpError::Internal(format!("parse created_at: {e}")))?,
+                ))
+            })
+            .collect()
+    }
+
+    pub(crate) async fn get_group_detail_impl(
+        &self,
+        account_id: &str,
+        group_name: &str,
+    ) -> OpResult<Option<GroupDetail>> {
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM iam_groups WHERE account_id = ? AND group_name = ?)",
+        )
+        .bind(account_id)
+        .bind(group_name)
+        .fetch_one(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_group_detail exists: {e}")))?;
+        if !exists {
+            return Ok(None);
+        }
+
+        let names = |rows: Vec<(String,)>| rows.into_iter().map(|(n,)| n).collect::<Vec<_>>();
+
+        let members: Vec<(String,)> = sqlx::query_as(
+            "SELECT user_name FROM iam_group_members \
+             WHERE account_id = ? AND group_name = ? ORDER BY user_name",
+        )
+        .bind(account_id)
+        .bind(group_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_group_detail members: {e}")))?;
+
+        let policies: Vec<(String,)> = sqlx::query_as(
+            "SELECT policy_name FROM iam_policies \
+             WHERE account_id = ? AND principal_type = 'group' AND principal_name = ? \
+             ORDER BY policy_name",
+        )
+        .bind(account_id)
+        .bind(group_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_group_detail policies: {e}")))?;
+
+        let all_users: Vec<(String,)> = sqlx::query_as(
+            "SELECT user_name FROM iam_users WHERE account_id = ? ORDER BY user_name",
+        )
+        .bind(account_id)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_group_detail all_users: {e}")))?;
+
+        Ok(Some(GroupDetail {
+            members: names(members),
+            policies: names(policies),
+            all_users: names(all_users),
+        }))
+    }
+
+    pub(crate) async fn add_group_member_impl(
+        &self,
+        account_id: &str,
+        group_name: &str,
+        user_name: &str,
+    ) -> OpResult<()> {
+        sqlx::query(
+            "INSERT INTO iam_group_members (account_id, group_name, user_name) VALUES (?, ?, ?)",
+        )
+        .bind(account_id)
+        .bind(group_name)
+        .bind(user_name)
+        .execute(self.pool())
+        .await
+        .map(|_| ())
+        .map_err(|e| {
+            if is_unique_violation(&e) {
+                OpError::AlreadyExists("User is already a member of this group".to_owned())
+            } else if is_fk_violation(&e) {
+                OpError::NotFound("Group or user not found".to_owned())
+            } else {
+                tracing::error!("add_group_member: {e}");
+                OpError::Internal("Database error".to_owned())
+            }
+        })
+    }
+
+    pub(crate) async fn remove_group_member_impl(
+        &self,
+        account_id: &str,
+        group_name: &str,
+        user_name: &str,
+    ) -> OpResult<()> {
+        let result = sqlx::query(
+            "DELETE FROM iam_group_members \
+             WHERE account_id = ? AND group_name = ? AND user_name = ?",
+        )
+        .bind(account_id)
+        .bind(group_name)
+        .bind(user_name)
+        .execute(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("remove_group_member: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        if result.rows_affected() == 0 {
+            return Err(OpError::NotFound("Membership not found".to_owned()));
+        }
+        Ok(())
+    }
+}

--- a/crates/storage-sqlite/src/management_store/mod.rs
+++ b/crates/storage-sqlite/src/management_store/mod.rs
@@ -1,0 +1,634 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `ManagementStore` implementation for `SqliteCatalogStore`.
+//!
+//! The IAM surface is split across submodules by entity (`accounts`, `users`,
+//! `groups`, `roles`, `policies`, `access_keys`), each providing inherent
+//! `*_impl` methods. This module declares those submodules and implements the
+//! `ManagementStore` trait by delegating to them, plus the session-storage and
+//! caller-tag lookups that don't belong to a single entity.
+
+mod access_keys;
+mod accounts;
+mod groups;
+mod policies;
+mod roles;
+mod users;
+
+use extenddb_storage::management_store::{
+    AccessKeyCreated, AccountDetail, GroupDetail, GroupListEntry, ManagementStore, OpError,
+    OpResult, RoleDetail, RoleListEntry, UserDetail, UserListEntry,
+};
+use futures::future::BoxFuture;
+use time::OffsetDateTime;
+
+use crate::catalog_store::SqliteCatalogStore;
+use crate::sqlite_util::format_timestamp;
+
+impl ManagementStore for SqliteCatalogStore {
+    // ── Accounts ───────────────────────────────────────────────────
+
+    fn create_account(&self, account_id: &str, account_name: &str) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, account_name) = (account_id.to_owned(), account_name.to_owned());
+        Box::pin(async move { self.create_account_impl(&account_id, &account_name).await })
+    }
+
+    fn delete_account(&self, account_id: &str) -> BoxFuture<'_, OpResult<()>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.delete_account_impl(&account_id).await })
+    }
+
+    fn list_all_accounts(&self) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        Box::pin(async move { self.list_all_accounts_impl().await })
+    }
+
+    fn default_account_id(&self) -> BoxFuture<'_, OpResult<Option<String>>> {
+        Box::pin(async move { self.default_account_id_impl().await })
+    }
+
+    fn list_all_accounts_full(
+        &self,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, String, OffsetDateTime)>>> {
+        Box::pin(async move { self.list_all_accounts_full_impl().await })
+    }
+
+    fn list_accounts_for(
+        &self,
+        account_id: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.list_accounts_for_impl(&account_id).await })
+    }
+
+    fn get_account_detail(
+        &self,
+        account_id: &str,
+    ) -> BoxFuture<'_, OpResult<Option<AccountDetail>>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.get_account_detail_impl(&account_id).await })
+    }
+
+    fn dashboard_counts(&self) -> BoxFuture<'_, OpResult<(i64, i64)>> {
+        Box::pin(async move { self.dashboard_counts_impl().await })
+    }
+
+    // ── Users ──────────────────────────────────────────────────────
+
+    fn create_user(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        password_hash: Option<&str>,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name) = (account_id.to_owned(), user_name.to_owned());
+        let password_hash = password_hash.map(str::to_owned);
+        Box::pin(async move {
+            self.create_user_impl(&account_id, &user_name, password_hash.as_deref())
+                .await
+        })
+    }
+
+    fn delete_user(&self, account_id: &str, user_name: &str) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name) = (account_id.to_owned(), user_name.to_owned());
+        Box::pin(async move { self.delete_user_impl(&account_id, &user_name).await })
+    }
+
+    fn list_users(&self, account_id: &str) -> BoxFuture<'_, OpResult<Vec<UserListEntry>>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.list_users_impl(&account_id).await })
+    }
+
+    fn get_user_detail(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<UserDetail>>> {
+        let (account_id, user_name) = (account_id.to_owned(), user_name.to_owned());
+        Box::pin(async move { self.get_user_detail_impl(&account_id, &user_name).await })
+    }
+
+    fn verify_iam_user_password(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        password: &str,
+    ) -> BoxFuture<'_, OpResult<bool>> {
+        let (account_id, user_name, password) = (
+            account_id.to_owned(),
+            user_name.to_owned(),
+            password.to_owned(),
+        );
+        Box::pin(async move {
+            self.verify_iam_user_password_impl(&account_id, &user_name, &password)
+                .await
+        })
+    }
+
+    fn change_user_password(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        password_hash: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name, password_hash) = (
+            account_id.to_owned(),
+            user_name.to_owned(),
+            password_hash.to_owned(),
+        );
+        Box::pin(async move {
+            self.change_user_password_impl(&account_id, &user_name, &password_hash)
+                .await
+        })
+    }
+
+    // ── User tags ──────────────────────────────────────────────────
+
+    fn tag_user(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        tags: &[(String, String)],
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name, tags) =
+            (account_id.to_owned(), user_name.to_owned(), tags.to_vec());
+        Box::pin(async move { self.tag_user_impl(&account_id, &user_name, &tags).await })
+    }
+
+    fn untag_user(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        tag_keys: &[String],
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name, tag_keys) = (
+            account_id.to_owned(),
+            user_name.to_owned(),
+            tag_keys.to_vec(),
+        );
+        Box::pin(async move {
+            self.untag_user_impl(&account_id, &user_name, &tag_keys)
+                .await
+        })
+    }
+
+    fn list_user_tags(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        let (account_id, user_name) = (account_id.to_owned(), user_name.to_owned());
+        Box::pin(async move { self.list_user_tags_impl(&account_id, &user_name).await })
+    }
+
+    // ── Groups ─────────────────────────────────────────────────────
+
+    fn create_group(&self, account_id: &str, group_name: &str) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, group_name) = (account_id.to_owned(), group_name.to_owned());
+        Box::pin(async move { self.create_group_impl(&account_id, &group_name).await })
+    }
+
+    fn delete_group(&self, account_id: &str, group_name: &str) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, group_name) = (account_id.to_owned(), group_name.to_owned());
+        Box::pin(async move { self.delete_group_impl(&account_id, &group_name).await })
+    }
+
+    fn list_groups(&self, account_id: &str) -> BoxFuture<'_, OpResult<Vec<GroupListEntry>>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.list_groups_impl(&account_id).await })
+    }
+
+    fn get_group_detail(
+        &self,
+        account_id: &str,
+        group_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<GroupDetail>>> {
+        let (account_id, group_name) = (account_id.to_owned(), group_name.to_owned());
+        Box::pin(async move { self.get_group_detail_impl(&account_id, &group_name).await })
+    }
+
+    fn add_group_member(
+        &self,
+        account_id: &str,
+        group_name: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, group_name, user_name) = (
+            account_id.to_owned(),
+            group_name.to_owned(),
+            user_name.to_owned(),
+        );
+        Box::pin(async move {
+            self.add_group_member_impl(&account_id, &group_name, &user_name)
+                .await
+        })
+    }
+
+    fn remove_group_member(
+        &self,
+        account_id: &str,
+        group_name: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, group_name, user_name) = (
+            account_id.to_owned(),
+            group_name.to_owned(),
+            user_name.to_owned(),
+        );
+        Box::pin(async move {
+            self.remove_group_member_impl(&account_id, &group_name, &user_name)
+                .await
+        })
+    }
+
+    // ── Roles ──────────────────────────────────────────────────────
+
+    fn create_role(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        trust_policy: &serde_json::Value,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, role_name, trust_policy) = (
+            account_id.to_owned(),
+            role_name.to_owned(),
+            trust_policy.clone(),
+        );
+        Box::pin(async move {
+            self.create_role_impl(&account_id, &role_name, &trust_policy)
+                .await
+        })
+    }
+
+    fn delete_role(&self, account_id: &str, role_name: &str) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, role_name) = (account_id.to_owned(), role_name.to_owned());
+        Box::pin(async move { self.delete_role_impl(&account_id, &role_name).await })
+    }
+
+    fn list_roles(&self, account_id: &str) -> BoxFuture<'_, OpResult<Vec<RoleListEntry>>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.list_roles_impl(&account_id).await })
+    }
+
+    fn get_role_detail(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<RoleDetail>>> {
+        let (account_id, role_name) = (account_id.to_owned(), role_name.to_owned());
+        Box::pin(async move { self.get_role_detail_impl(&account_id, &role_name).await })
+    }
+
+    fn get_role_trust_policy(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<serde_json::Value>>> {
+        let (account_id, role_name) = (account_id.to_owned(), role_name.to_owned());
+        Box::pin(async move {
+            self.get_role_trust_policy_impl(&account_id, &role_name)
+                .await
+        })
+    }
+
+    // ── Role tags ──────────────────────────────────────────────────
+
+    fn tag_role(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        tags: &[(String, String)],
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, role_name, tags) =
+            (account_id.to_owned(), role_name.to_owned(), tags.to_vec());
+        Box::pin(async move { self.tag_role_impl(&account_id, &role_name, &tags).await })
+    }
+
+    fn untag_role(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        tag_keys: &[String],
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, role_name, tag_keys) = (
+            account_id.to_owned(),
+            role_name.to_owned(),
+            tag_keys.to_vec(),
+        );
+        Box::pin(async move {
+            self.untag_role_impl(&account_id, &role_name, &tag_keys)
+                .await
+        })
+    }
+
+    fn list_role_tags(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        let (account_id, role_name) = (account_id.to_owned(), role_name.to_owned());
+        Box::pin(async move { self.list_role_tags_impl(&account_id, &role_name).await })
+    }
+
+    // ── Policies ───────────────────────────────────────────────────
+
+    fn put_policy(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+        policy_name: &str,
+        document: &serde_json::Value,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, principal_type, principal_name, policy_name, document) = (
+            account_id.to_owned(),
+            principal_type.to_owned(),
+            principal_name.to_owned(),
+            policy_name.to_owned(),
+            document.clone(),
+        );
+        Box::pin(async move {
+            self.put_policy_impl(
+                &account_id,
+                &principal_type,
+                &principal_name,
+                &policy_name,
+                &document,
+            )
+            .await
+        })
+    }
+
+    fn delete_policy(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+        policy_name: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, principal_type, principal_name, policy_name) = (
+            account_id.to_owned(),
+            principal_type.to_owned(),
+            principal_name.to_owned(),
+            policy_name.to_owned(),
+        );
+        Box::pin(async move {
+            self.delete_policy_impl(&account_id, &principal_type, &principal_name, &policy_name)
+                .await
+        })
+    }
+
+    fn list_policies(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, serde_json::Value, OffsetDateTime)>>> {
+        let (account_id, principal_type, principal_name) = (
+            account_id.to_owned(),
+            principal_type.to_owned(),
+            principal_name.to_owned(),
+        );
+        Box::pin(async move {
+            self.list_policies_impl(&account_id, &principal_type, &principal_name)
+                .await
+        })
+    }
+
+    // ── Permissions boundaries ─────────────────────────────────────
+
+    fn set_user_boundary(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        document: &serde_json::Value,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name, document) = (
+            account_id.to_owned(),
+            user_name.to_owned(),
+            document.clone(),
+        );
+        Box::pin(async move {
+            self.set_user_boundary_impl(&account_id, &user_name, &document)
+                .await
+        })
+    }
+
+    fn get_user_boundary(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<serde_json::Value>>> {
+        let (account_id, user_name) = (account_id.to_owned(), user_name.to_owned());
+        Box::pin(async move { self.get_user_boundary_impl(&account_id, &user_name).await })
+    }
+
+    fn delete_user_boundary(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name) = (account_id.to_owned(), user_name.to_owned());
+        Box::pin(async move {
+            self.delete_user_boundary_impl(&account_id, &user_name)
+                .await
+        })
+    }
+
+    fn set_role_boundary(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        document: &serde_json::Value,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, role_name, document) = (
+            account_id.to_owned(),
+            role_name.to_owned(),
+            document.clone(),
+        );
+        Box::pin(async move {
+            self.set_role_boundary_impl(&account_id, &role_name, &document)
+                .await
+        })
+    }
+
+    fn get_role_boundary(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<serde_json::Value>>> {
+        let (account_id, role_name) = (account_id.to_owned(), role_name.to_owned());
+        Box::pin(async move { self.get_role_boundary_impl(&account_id, &role_name).await })
+    }
+
+    fn delete_role_boundary(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, role_name) = (account_id.to_owned(), role_name.to_owned());
+        Box::pin(async move {
+            self.delete_role_boundary_impl(&account_id, &role_name)
+                .await
+        })
+    }
+
+    // ── Access keys ────────────────────────────────────────────────
+
+    fn create_access_key(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<AccessKeyCreated>> {
+        let (account_id, user_name) = (account_id.to_owned(), user_name.to_owned());
+        Box::pin(async move { self.create_access_key_impl(&account_id, &user_name).await })
+    }
+
+    fn delete_access_key(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        key_id: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name, key_id) = (
+            account_id.to_owned(),
+            user_name.to_owned(),
+            key_id.to_owned(),
+        );
+        Box::pin(async move {
+            self.delete_access_key_impl(&account_id, &user_name, &key_id)
+                .await
+        })
+    }
+
+    fn list_access_keys(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, bool, OffsetDateTime)>>> {
+        let (account_id, user_name) = (account_id.to_owned(), user_name.to_owned());
+        Box::pin(async move { self.list_access_keys_impl(&account_id, &user_name).await })
+    }
+
+    fn import_access_key(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        access_key_id: &str,
+        secret_access_key: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name, access_key_id, secret_access_key) = (
+            account_id.to_owned(),
+            user_name.to_owned(),
+            access_key_id.to_owned(),
+            secret_access_key.to_owned(),
+        );
+        Box::pin(async move {
+            self.import_access_key_impl(&account_id, &user_name, &access_key_id, &secret_access_key)
+                .await
+        })
+    }
+
+    // ── Sessions (AssumeRole) ──────────────────────────────────────
+
+    #[allow(clippy::too_many_arguments)]
+    fn store_session(
+        &self,
+        session_token: &str,
+        access_key_id: &str,
+        secret_key_encrypted: &[u8],
+        account_id: &str,
+        role_name: &str,
+        session_name: &str,
+        session_tags: &Option<serde_json::Value>,
+        session_policy: &Option<serde_json::Value>,
+        expires_at: OffsetDateTime,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let session_token = session_token.to_owned();
+        let access_key_id = access_key_id.to_owned();
+        let secret_key_encrypted = secret_key_encrypted.to_vec();
+        let account_id = account_id.to_owned();
+        let role_name = role_name.to_owned();
+        let session_name = session_name.to_owned();
+        let session_tags = session_tags.as_ref().map(ToString::to_string);
+        let session_policy = session_policy.as_ref().map(ToString::to_string);
+        let expires = format_timestamp(expires_at);
+        Box::pin(async move {
+            sqlx::query(
+                "INSERT INTO iam_sessions \
+                 (session_token, access_key_id, secret_key_encrypted, account_id, role_name, \
+                  session_name, session_tags, session_policy, expires_at) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&session_token)
+            .bind(&access_key_id)
+            .bind(&secret_key_encrypted)
+            .bind(&account_id)
+            .bind(&role_name)
+            .bind(&session_name)
+            .bind(&session_tags)
+            .bind(&session_policy)
+            .bind(&expires)
+            .execute(self.pool())
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                tracing::error!("store_session: {e}");
+                OpError::Internal("Database error".to_owned())
+            })
+        })
+    }
+
+    // ── Caller tags (trust-policy evaluation) ──────────────────────
+
+    fn fetch_caller_tags(
+        &self,
+        account_id: &str,
+        resource: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        let account_id = account_id.to_owned();
+        let resource = resource.to_owned();
+        Box::pin(async move {
+            // Resolve the principal kind and name from the ARN resource part.
+            if let Some(rest) = resource.split(":user/").nth(1) {
+                let user_name = rest.trim_end_matches('/');
+                return sqlx::query_as(
+                    "SELECT tag_key, tag_value FROM iam_user_tags \
+                     WHERE account_id = ? AND user_name = ? ORDER BY tag_key",
+                )
+                .bind(&account_id)
+                .bind(user_name)
+                .fetch_all(self.pool())
+                .await
+                .map_err(|e| {
+                    tracing::error!("fetch_caller_tags (user): {e}");
+                    OpError::Internal("Database error".to_owned())
+                });
+            }
+
+            // assumed-role/RoleName/SessionName or role/RoleName → role tags.
+            let role_name = resource
+                .split(":assumed-role/")
+                .nth(1)
+                .or_else(|| resource.split(":role/").nth(1))
+                .map(|rest| rest.split('/').next().unwrap_or(rest));
+
+            if let Some(role_name) = role_name {
+                return sqlx::query_as(
+                    "SELECT tag_key, tag_value FROM iam_role_tags \
+                     WHERE account_id = ? AND role_name = ? ORDER BY tag_key",
+                )
+                .bind(&account_id)
+                .bind(role_name)
+                .fetch_all(self.pool())
+                .await
+                .map_err(|e| {
+                    tracing::error!("fetch_caller_tags (role): {e}");
+                    OpError::Internal("Database error".to_owned())
+                });
+            }
+
+            Ok(Vec::new())
+        })
+    }
+}

--- a/crates/storage-sqlite/src/management_store/policies.rs
+++ b/crates/storage-sqlite/src/management_store/policies.rs
@@ -1,0 +1,233 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! IAM policy CRUD and permissions boundaries for `SqliteCatalogStore`.
+
+use extenddb_storage::management_store::{OpError, OpResult};
+use time::OffsetDateTime;
+
+use crate::catalog_store::SqliteCatalogStore;
+use crate::sqlite_util::parse_timestamp;
+
+impl SqliteCatalogStore {
+    pub(crate) async fn put_policy_impl(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+        policy_name: &str,
+        document: &serde_json::Value,
+    ) -> OpResult<()> {
+        let doc = serde_json::to_string(document)
+            .map_err(|e| OpError::Internal(format!("serialize policy: {e}")))?;
+        sqlx::query(
+            "INSERT INTO iam_policies \
+             (account_id, principal_type, principal_name, policy_name, policy_document) \
+             VALUES (?, ?, ?, ?, ?) \
+             ON CONFLICT(account_id, principal_type, principal_name, policy_name) \
+             DO UPDATE SET policy_document = excluded.policy_document",
+        )
+        .bind(account_id)
+        .bind(principal_type)
+        .bind(principal_name)
+        .bind(policy_name)
+        .bind(&doc)
+        .execute(self.pool())
+        .await
+        .map(|_| ())
+        .map_err(|e| {
+            tracing::error!("put_policy: {e}");
+            OpError::Internal("Database error".to_owned())
+        })
+    }
+
+    pub(crate) async fn delete_policy_impl(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+        policy_name: &str,
+    ) -> OpResult<()> {
+        let result = sqlx::query(
+            "DELETE FROM iam_policies \
+             WHERE account_id = ? AND principal_type = ? AND principal_name = ? AND policy_name = ?",
+        )
+        .bind(account_id)
+        .bind(principal_type)
+        .bind(principal_name)
+        .bind(policy_name)
+        .execute(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("delete_policy: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        if result.rows_affected() == 0 {
+            return Err(OpError::NotFound("Policy not found".to_owned()));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn list_policies_impl(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+    ) -> OpResult<Vec<(String, serde_json::Value, OffsetDateTime)>> {
+        let rows: Vec<(String, String, String)> = sqlx::query_as(
+            "SELECT policy_name, policy_document, created_at FROM iam_policies \
+             WHERE account_id = ? AND principal_type = ? AND principal_name = ? \
+             ORDER BY policy_name",
+        )
+        .bind(account_id)
+        .bind(principal_type)
+        .bind(principal_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("list_policies: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        rows.into_iter()
+            .map(|(name, doc, ts)| {
+                Ok((
+                    name,
+                    serde_json::from_str(&doc)
+                        .map_err(|e| OpError::Internal(format!("parse policy doc: {e}")))?,
+                    parse_timestamp(&ts)
+                        .map_err(|e| OpError::Internal(format!("parse created_at: {e}")))?,
+                ))
+            })
+            .collect()
+    }
+
+    // ── Permissions boundaries ─────────────────────────────────────
+
+    async fn set_boundary(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+        document: &serde_json::Value,
+    ) -> OpResult<()> {
+        let doc = serde_json::to_string(document)
+            .map_err(|e| OpError::Internal(format!("serialize boundary: {e}")))?;
+        sqlx::query(
+            "INSERT INTO iam_permissions_boundaries \
+             (account_id, principal_type, principal_name, policy_document) \
+             VALUES (?, ?, ?, ?) \
+             ON CONFLICT(account_id, principal_type, principal_name) \
+             DO UPDATE SET policy_document = excluded.policy_document",
+        )
+        .bind(account_id)
+        .bind(principal_type)
+        .bind(principal_name)
+        .bind(&doc)
+        .execute(self.pool())
+        .await
+        .map(|_| ())
+        .map_err(|e| {
+            tracing::error!("set_boundary: {e}");
+            OpError::Internal("Database error".to_owned())
+        })
+    }
+
+    async fn get_boundary(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+    ) -> OpResult<Option<serde_json::Value>> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT policy_document FROM iam_permissions_boundaries \
+             WHERE account_id = ? AND principal_type = ? AND principal_name = ?",
+        )
+        .bind(account_id)
+        .bind(principal_type)
+        .bind(principal_name)
+        .fetch_optional(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("get_boundary: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        row.map(|(d,)| {
+            serde_json::from_str(&d).map_err(|e| OpError::Internal(format!("parse boundary: {e}")))
+        })
+        .transpose()
+    }
+
+    async fn delete_boundary(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+    ) -> OpResult<()> {
+        sqlx::query(
+            "DELETE FROM iam_permissions_boundaries \
+             WHERE account_id = ? AND principal_type = ? AND principal_name = ?",
+        )
+        .bind(account_id)
+        .bind(principal_type)
+        .bind(principal_name)
+        .execute(self.pool())
+        .await
+        .map(|_| ())
+        .map_err(|e| {
+            tracing::error!("delete_boundary: {e}");
+            OpError::Internal("Database error".to_owned())
+        })
+    }
+
+    pub(crate) async fn set_user_boundary_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        document: &serde_json::Value,
+    ) -> OpResult<()> {
+        self.set_boundary(account_id, "user", user_name, document)
+            .await
+    }
+
+    pub(crate) async fn get_user_boundary_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> OpResult<Option<serde_json::Value>> {
+        self.get_boundary(account_id, "user", user_name).await
+    }
+
+    pub(crate) async fn delete_user_boundary_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> OpResult<()> {
+        self.delete_boundary(account_id, "user", user_name).await
+    }
+
+    pub(crate) async fn set_role_boundary_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        document: &serde_json::Value,
+    ) -> OpResult<()> {
+        self.set_boundary(account_id, "role", role_name, document)
+            .await
+    }
+
+    pub(crate) async fn get_role_boundary_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> OpResult<Option<serde_json::Value>> {
+        self.get_boundary(account_id, "role", role_name).await
+    }
+
+    pub(crate) async fn delete_role_boundary_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> OpResult<()> {
+        self.delete_boundary(account_id, "role", role_name).await
+    }
+}

--- a/crates/storage-sqlite/src/management_store/roles.rs
+++ b/crates/storage-sqlite/src/management_store/roles.rs
@@ -1,0 +1,244 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Role management, trust-policy access, and role tags for `SqliteCatalogStore`.
+//!
+//! Trust policies and policy documents are stored as JSON text; this module
+//! serializes `serde_json::Value` on write and parses it back on read.
+
+use extenddb_storage::management_store::{OpError, OpResult, RoleDetail, RoleListEntry};
+
+use crate::catalog_store::SqliteCatalogStore;
+use crate::sqlite_util::{is_fk_violation, is_unique_violation, parse_timestamp};
+
+/// Parse a stored JSON-text column into a `serde_json::Value`.
+fn parse_json(s: &str, ctx: &str) -> OpResult<serde_json::Value> {
+    serde_json::from_str(s).map_err(|e| OpError::Internal(format!("{ctx} parse json: {e}")))
+}
+
+impl SqliteCatalogStore {
+    pub(crate) async fn create_role_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        trust_policy: &serde_json::Value,
+    ) -> OpResult<()> {
+        let role_arn = format!("arn:aws:iam::{account_id}:role/{role_name}");
+        let trust = serde_json::to_string(trust_policy)
+            .map_err(|e| OpError::Internal(format!("serialize trust policy: {e}")))?;
+        sqlx::query(
+            "INSERT INTO iam_roles (account_id, role_name, role_arn, trust_policy) \
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(account_id)
+        .bind(role_name)
+        .bind(&role_arn)
+        .bind(&trust)
+        .execute(self.pool())
+        .await
+        .map(|_| ())
+        .map_err(|e| {
+            if is_unique_violation(&e) {
+                OpError::AlreadyExists("IAM role already exists".to_owned())
+            } else if is_fk_violation(&e) {
+                OpError::NotFound("Account not found".to_owned())
+            } else {
+                tracing::error!("create_role: {e}");
+                OpError::Internal("Database error".to_owned())
+            }
+        })
+    }
+
+    pub(crate) async fn delete_role_impl(&self, account_id: &str, role_name: &str) -> OpResult<()> {
+        let result = sqlx::query("DELETE FROM iam_roles WHERE account_id = ? AND role_name = ?")
+            .bind(account_id)
+            .bind(role_name)
+            .execute(self.pool())
+            .await
+            .map_err(|e| {
+                tracing::error!("delete_role: {e}");
+                OpError::Internal("Database error".to_owned())
+            })?;
+        if result.rows_affected() == 0 {
+            return Err(OpError::NotFound("IAM role not found".to_owned()));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn list_roles_impl(&self, account_id: &str) -> OpResult<Vec<RoleListEntry>> {
+        let rows: Vec<(String, String, String, String, String)> = sqlx::query_as(
+            "SELECT account_id, role_name, role_arn, trust_policy, created_at \
+             FROM iam_roles WHERE account_id = ? ORDER BY role_name",
+        )
+        .bind(account_id)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("list_roles: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        rows.into_iter()
+            .map(|(aid, rn, arn, trust, ts)| {
+                Ok((
+                    aid,
+                    rn,
+                    arn,
+                    parse_json(&trust, "list_roles trust_policy")?,
+                    parse_timestamp(&ts)
+                        .map_err(|e| OpError::Internal(format!("parse created_at: {e}")))?,
+                ))
+            })
+            .collect()
+    }
+
+    pub(crate) async fn get_role_detail_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> OpResult<Option<RoleDetail>> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT trust_policy FROM iam_roles WHERE account_id = ? AND role_name = ?",
+        )
+        .bind(account_id)
+        .bind(role_name)
+        .fetch_optional(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_role_detail: {e}")))?;
+        let Some((trust,)) = row else {
+            return Ok(None);
+        };
+        let trust_policy = parse_json(&trust, "get_role_detail trust_policy")?;
+
+        let policies: Vec<(String,)> = sqlx::query_as(
+            "SELECT policy_name FROM iam_policies \
+             WHERE account_id = ? AND principal_type = 'role' AND principal_name = ? \
+             ORDER BY policy_name",
+        )
+        .bind(account_id)
+        .bind(role_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_role_detail policies: {e}")))?;
+
+        let tags: Vec<(String, String)> = sqlx::query_as(
+            "SELECT tag_key, tag_value FROM iam_role_tags \
+             WHERE account_id = ? AND role_name = ? ORDER BY tag_key",
+        )
+        .bind(account_id)
+        .bind(role_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_role_detail tags: {e}")))?;
+
+        Ok(Some(RoleDetail {
+            trust_policy,
+            policies: policies.into_iter().map(|(n,)| n).collect(),
+            tags,
+        }))
+    }
+
+    pub(crate) async fn get_role_trust_policy_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> OpResult<Option<serde_json::Value>> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT trust_policy FROM iam_roles WHERE account_id = ? AND role_name = ?",
+        )
+        .bind(account_id)
+        .bind(role_name)
+        .fetch_optional(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_role_trust_policy: {e}")))?;
+        row.map(|(t,)| parse_json(&t, "get_role_trust_policy"))
+            .transpose()
+    }
+
+    pub(crate) async fn tag_role_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        tags: &[(String, String)],
+    ) -> OpResult<()> {
+        let mut tx = self
+            .pool()
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(|e| OpError::Internal(format!("tag_role begin: {e}")))?;
+        for (k, v) in tags {
+            sqlx::query(
+                "INSERT INTO iam_role_tags (account_id, role_name, tag_key, tag_value) \
+                 VALUES (?, ?, ?, ?) \
+                 ON CONFLICT(account_id, role_name, tag_key) DO UPDATE SET tag_value = excluded.tag_value",
+            )
+            .bind(account_id)
+            .bind(role_name)
+            .bind(k)
+            .bind(v)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| {
+                if is_fk_violation(&e) {
+                    OpError::NotFound("IAM role not found".to_owned())
+                } else {
+                    tracing::error!("tag_role: {e}");
+                    OpError::Internal("Database error".to_owned())
+                }
+            })?;
+        }
+        tx.commit()
+            .await
+            .map_err(|e| OpError::Internal(format!("tag_role commit: {e}")))?;
+        Ok(())
+    }
+
+    pub(crate) async fn untag_role_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        tag_keys: &[String],
+    ) -> OpResult<()> {
+        let mut tx = self
+            .pool()
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(|e| OpError::Internal(format!("untag_role begin: {e}")))?;
+        for k in tag_keys {
+            sqlx::query(
+                "DELETE FROM iam_role_tags WHERE account_id = ? AND role_name = ? AND tag_key = ?",
+            )
+            .bind(account_id)
+            .bind(role_name)
+            .bind(k)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| {
+                tracing::error!("untag_role: {e}");
+                OpError::Internal("Database error".to_owned())
+            })?;
+        }
+        tx.commit()
+            .await
+            .map_err(|e| OpError::Internal(format!("untag_role commit: {e}")))?;
+        Ok(())
+    }
+
+    pub(crate) async fn list_role_tags_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> OpResult<Vec<(String, String)>> {
+        sqlx::query_as(
+            "SELECT tag_key, tag_value FROM iam_role_tags \
+             WHERE account_id = ? AND role_name = ? ORDER BY tag_key",
+        )
+        .bind(account_id)
+        .bind(role_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("list_role_tags: {e}");
+            OpError::Internal("Database error".to_owned())
+        })
+    }
+}

--- a/crates/storage-sqlite/src/management_store/users.rs
+++ b/crates/storage-sqlite/src/management_store/users.rs
@@ -1,0 +1,340 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! User management, console-password verification, and user tags for
+//! `SqliteCatalogStore`.
+
+use extenddb_storage::management_store::{OpError, OpResult, UserDetail, UserListEntry};
+
+use crate::catalog_store::SqliteCatalogStore;
+use crate::sqlite_util::{is_fk_violation, is_unique_violation, parse_timestamp};
+
+impl SqliteCatalogStore {
+    pub(crate) async fn create_user_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        password_hash: Option<&str>,
+    ) -> OpResult<()> {
+        let user_arn = format!("arn:aws:iam::{account_id}:user/{user_name}");
+
+        let mut tx = self
+            .pool()
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(|e| {
+                tracing::error!("create_user begin: {e}");
+                OpError::Internal("Database error".to_owned())
+            })?;
+
+        sqlx::query(
+            "INSERT INTO iam_users (account_id, user_name, user_arn, password_hash) \
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .bind(&user_arn)
+        .bind(password_hash)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| {
+            if is_unique_violation(&e) {
+                OpError::AlreadyExists("IAM user already exists".to_owned())
+            } else if is_fk_violation(&e) {
+                OpError::NotFound("Account not found".to_owned())
+            } else {
+                tracing::error!("create_user: {e}");
+                OpError::Internal("Database error".to_owned())
+            }
+        })?;
+
+        // Seed a default self-service policy so the user can manage its own
+        // access keys and password without an administrator attaching one
+        // (parity with the PostgreSQL backend).
+        let self_service_policy = serde_json::json!({
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": [
+                    "iam:CreateAccessKey",
+                    "iam:DeleteAccessKey",
+                    "iam:ListAccessKeys",
+                    "iam:ChangePassword"
+                ],
+                "Resource": user_arn,
+            }]
+        })
+        .to_string();
+
+        sqlx::query(
+            "INSERT INTO iam_policies \
+             (account_id, principal_type, principal_name, policy_name, policy_document) \
+             VALUES (?, 'user', ?, 'SelfServicePolicy', ?) ON CONFLICT DO NOTHING",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .bind(&self_service_policy)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| {
+            tracing::error!("seed self-service policy: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+
+        tx.commit().await.map_err(|e| {
+            tracing::error!("create_user commit: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        Ok(())
+    }
+
+    pub(crate) async fn delete_user_impl(&self, account_id: &str, user_name: &str) -> OpResult<()> {
+        let result = sqlx::query("DELETE FROM iam_users WHERE account_id = ? AND user_name = ?")
+            .bind(account_id)
+            .bind(user_name)
+            .execute(self.pool())
+            .await
+            .map_err(|e| {
+                tracing::error!("delete_user: {e}");
+                OpError::Internal("Database error".to_owned())
+            })?;
+        if result.rows_affected() == 0 {
+            return Err(OpError::NotFound("IAM user not found".to_owned()));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn list_users_impl(&self, account_id: &str) -> OpResult<Vec<UserListEntry>> {
+        let rows: Vec<(String, String, String, bool, String)> = sqlx::query_as(
+            "SELECT account_id, user_name, user_arn, (password_hash IS NOT NULL), created_at \
+             FROM iam_users WHERE account_id = ? ORDER BY user_name",
+        )
+        .bind(account_id)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("list_users: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        rows.into_iter()
+            .map(|(aid, un, arn, has_pw, ts)| {
+                Ok((
+                    aid,
+                    un,
+                    arn,
+                    has_pw,
+                    parse_timestamp(&ts)
+                        .map_err(|e| OpError::Internal(format!("parse created_at: {e}")))?,
+                ))
+            })
+            .collect()
+    }
+
+    pub(crate) async fn get_user_detail_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> OpResult<Option<UserDetail>> {
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM iam_users WHERE account_id = ? AND user_name = ?)",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .fetch_one(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_user_detail exists: {e}")))?;
+        if !exists {
+            return Ok(None);
+        }
+
+        let keys: Vec<(String, bool)> = sqlx::query_as(
+            "SELECT access_key_id, is_active FROM access_keys \
+             WHERE account_id = ? AND user_name = ? ORDER BY created_at",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_user_detail keys: {e}")))?;
+
+        let policies: Vec<(String,)> = sqlx::query_as(
+            "SELECT policy_name FROM iam_policies \
+             WHERE account_id = ? AND principal_type = 'user' AND principal_name = ? \
+             ORDER BY policy_name",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_user_detail policies: {e}")))?;
+
+        let tags: Vec<(String, String)> = sqlx::query_as(
+            "SELECT tag_key, tag_value FROM iam_user_tags \
+             WHERE account_id = ? AND user_name = ? ORDER BY tag_key",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_user_detail tags: {e}")))?;
+
+        let groups: Vec<(String,)> = sqlx::query_as(
+            "SELECT group_name FROM iam_group_members \
+             WHERE account_id = ? AND user_name = ? ORDER BY group_name",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_user_detail groups: {e}")))?;
+
+        Ok(Some(UserDetail {
+            keys,
+            policies: policies.into_iter().map(|(n,)| n).collect(),
+            tags,
+            groups: groups.into_iter().map(|(n,)| n).collect(),
+        }))
+    }
+
+    pub(crate) async fn verify_iam_user_password_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        password: &str,
+    ) -> OpResult<bool> {
+        let row: Option<(Option<String>,)> = sqlx::query_as(
+            "SELECT password_hash FROM iam_users WHERE account_id = ? AND user_name = ?",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .fetch_optional(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("verify_iam_user_password: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+
+        let Some((Some(hash),)) = row else {
+            // User absent or has no console password.
+            return Ok(false);
+        };
+        let password = password.to_owned();
+        let verified = tokio::task::spawn_blocking(move || bcrypt::verify(&password, &hash))
+            .await
+            .map_err(|e| OpError::Internal(format!("bcrypt task: {e}")))?
+            .unwrap_or(false);
+        Ok(verified)
+    }
+
+    pub(crate) async fn change_user_password_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        password_hash: &str,
+    ) -> OpResult<()> {
+        let result = sqlx::query(
+            "UPDATE iam_users SET password_hash = ? WHERE account_id = ? AND user_name = ?",
+        )
+        .bind(password_hash)
+        .bind(account_id)
+        .bind(user_name)
+        .execute(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("change_user_password: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        if result.rows_affected() == 0 {
+            return Err(OpError::NotFound("IAM user not found".to_owned()));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn tag_user_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        tags: &[(String, String)],
+    ) -> OpResult<()> {
+        let mut tx = self
+            .pool()
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(|e| OpError::Internal(format!("tag_user begin: {e}")))?;
+        for (k, v) in tags {
+            sqlx::query(
+                "INSERT INTO iam_user_tags (account_id, user_name, tag_key, tag_value) \
+                 VALUES (?, ?, ?, ?) \
+                 ON CONFLICT(account_id, user_name, tag_key) DO UPDATE SET tag_value = excluded.tag_value",
+            )
+            .bind(account_id)
+            .bind(user_name)
+            .bind(k)
+            .bind(v)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| {
+                if is_fk_violation(&e) {
+                    OpError::NotFound("IAM user not found".to_owned())
+                } else {
+                    tracing::error!("tag_user: {e}");
+                    OpError::Internal("Database error".to_owned())
+                }
+            })?;
+        }
+        tx.commit()
+            .await
+            .map_err(|e| OpError::Internal(format!("tag_user commit: {e}")))?;
+        Ok(())
+    }
+
+    pub(crate) async fn untag_user_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        tag_keys: &[String],
+    ) -> OpResult<()> {
+        let mut tx = self
+            .pool()
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(|e| OpError::Internal(format!("untag_user begin: {e}")))?;
+        for k in tag_keys {
+            sqlx::query(
+                "DELETE FROM iam_user_tags WHERE account_id = ? AND user_name = ? AND tag_key = ?",
+            )
+            .bind(account_id)
+            .bind(user_name)
+            .bind(k)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| {
+                tracing::error!("untag_user: {e}");
+                OpError::Internal("Database error".to_owned())
+            })?;
+        }
+        tx.commit()
+            .await
+            .map_err(|e| OpError::Internal(format!("untag_user commit: {e}")))?;
+        Ok(())
+    }
+
+    pub(crate) async fn list_user_tags_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> OpResult<Vec<(String, String)>> {
+        sqlx::query_as(
+            "SELECT tag_key, tag_value FROM iam_user_tags \
+             WHERE account_id = ? AND user_name = ? ORDER BY tag_key",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("list_user_tags: {e}");
+            OpError::Internal("Database error".to_owned())
+        })
+    }
+}

--- a/crates/storage-sqlite/src/metadata.rs
+++ b/crates/storage-sqlite/src/metadata.rs
@@ -1,0 +1,401 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `MetadataEngine` trait implementation for `SqliteEngine`: TTL configuration,
+//! resource tags, table statistics, and TTL-expiry scanning.
+//!
+//! Expired-item lookup uses `json_extract(item_data, ?)` with the JSON path
+//! bound as a parameter (`$."attr".N`), so the TTL attribute name is never
+//! interpolated into SQL. Table size uses `SUM(length(item_data))` (SQLite has
+//! no per-table physical size function).
+
+use extenddb_core::types::{Item, Tag, TimeToLiveDescription, TimeToLiveStatus};
+use extenddb_storage::MetadataEngine;
+use extenddb_storage::error::StorageError;
+use futures::future::BoxFuture;
+
+use crate::data;
+use crate::store::SqliteEngine;
+
+/// JSON path selecting a DynamoDB number attribute's value: `$."attr".N`.
+fn ttl_json_path(attr: &str) -> String {
+    // Escape embedded double quotes for the JSON path string. The value is
+    // bound as a parameter, so this is defense-in-depth, not SQL safety.
+    format!("$.\"{}\".N", attr.replace('"', "\"\""))
+}
+
+/// True if a TTL attribute name is safe to embed in a `CREATE INDEX` expression.
+fn safe_index_attr(attr: &str) -> bool {
+    !attr.is_empty()
+        && attr
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-'))
+}
+
+impl SqliteEngine {
+    async fn table_id_for(
+        &self,
+        account_id: &str,
+        table_name: &str,
+    ) -> Result<String, StorageError> {
+        sqlx::query_scalar("SELECT table_id FROM tables WHERE account_id = ? AND table_name = ?")
+            .bind(account_id)
+            .bind(table_name)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?
+            .ok_or_else(|| StorageError::TableNotFound(table_name.to_owned()))
+    }
+}
+
+impl MetadataEngine for SqliteEngine {
+    fn describe_ttl(
+        &self,
+        account_id: &str,
+        table_name: &str,
+    ) -> BoxFuture<'_, Result<TimeToLiveDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        Box::pin(async move {
+            let row: Option<(Option<String>,)> = sqlx::query_as(
+                "SELECT ttl_attribute FROM tables WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let (ttl_attr,) = row.ok_or_else(|| StorageError::TableNotFound(table_name.clone()))?;
+            Ok(match ttl_attr {
+                Some(attr) => TimeToLiveDescription {
+                    time_to_live_status: TimeToLiveStatus::Enabled,
+                    attribute_name: Some(attr),
+                },
+                None => TimeToLiveDescription {
+                    time_to_live_status: TimeToLiveStatus::Disabled,
+                    attribute_name: None,
+                },
+            })
+        })
+    }
+
+    fn update_ttl(
+        &self,
+        account_id: &str,
+        table_name: &str,
+        attribute_name: &str,
+        enabled: bool,
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        let attribute_name = attribute_name.to_owned();
+        Box::pin(async move {
+            let ttl_val: Option<&str> = if enabled { Some(&attribute_name) } else { None };
+            let result = sqlx::query(
+                "UPDATE tables SET ttl_attribute = ?, ttl_index_ready = 0 \
+                 WHERE account_id = ? AND table_name = ? AND table_status = 'ACTIVE'",
+            )
+            .bind(ttl_val)
+            .bind(&account_id)
+            .bind(&table_name)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if result.rows_affected() == 0 {
+                let exists: Option<(String,)> = sqlx::query_as(
+                    "SELECT table_status FROM tables WHERE account_id = ? AND table_name = ?",
+                )
+                .bind(&account_id)
+                .bind(&table_name)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+                return match exists {
+                    None => Err(StorageError::TableNotFound(table_name)),
+                    Some(_) => Err(StorageError::TableNotActive(table_name)),
+                };
+            }
+            Ok(())
+        })
+    }
+
+    fn tag_resource(&self, arn: &str, tags: &[Tag]) -> BoxFuture<'_, Result<(), StorageError>> {
+        let arn = arn.to_owned();
+        let tags = tags.to_vec();
+        Box::pin(async move {
+            for tag in &tags {
+                sqlx::query(
+                    "INSERT INTO tags (resource_arn, tag_key, tag_value) VALUES (?, ?, ?) \
+                     ON CONFLICT (resource_arn, tag_key) DO UPDATE SET tag_value = excluded.tag_value",
+                )
+                .bind(&arn)
+                .bind(&tag.key)
+                .bind(&tag.value)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            }
+            Ok(())
+        })
+    }
+
+    fn untag_resource(
+        &self,
+        arn: &str,
+        tag_keys: &[String],
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let arn = arn.to_owned();
+        let tag_keys = tag_keys.to_vec();
+        Box::pin(async move {
+            for key in &tag_keys {
+                sqlx::query("DELETE FROM tags WHERE resource_arn = ? AND tag_key = ?")
+                    .bind(&arn)
+                    .bind(key)
+                    .execute(&self.pool)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            }
+            Ok(())
+        })
+    }
+
+    fn list_tags(&self, arn: &str) -> BoxFuture<'_, Result<Vec<Tag>, StorageError>> {
+        let arn = arn.to_owned();
+        Box::pin(async move {
+            let rows: Vec<(String, String)> = sqlx::query_as(
+                "SELECT tag_key, tag_value FROM tags WHERE resource_arn = ? ORDER BY tag_key",
+            )
+            .bind(&arn)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(rows
+                .into_iter()
+                .map(|(key, value)| Tag { key, value })
+                .collect())
+        })
+    }
+
+    fn tables_with_ttl(
+        &self,
+        account_id: &str,
+    ) -> BoxFuture<'_, Result<Vec<(String, String)>, StorageError>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move {
+            sqlx::query_as(
+                "SELECT table_name, ttl_attribute FROM tables \
+                 WHERE account_id = ? AND ttl_attribute IS NOT NULL AND table_status = 'ACTIVE'",
+            )
+            .bind(&account_id)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))
+        })
+    }
+
+    fn all_tables_with_ttl(
+        &self,
+    ) -> BoxFuture<'_, Result<Vec<(String, String, String)>, StorageError>> {
+        Box::pin(async move {
+            sqlx::query_as(
+                "SELECT account_id, table_name, ttl_attribute FROM tables \
+                 WHERE ttl_attribute IS NOT NULL AND table_status = 'ACTIVE'",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))
+        })
+    }
+
+    fn all_tables_with_ttl_index_ready(
+        &self,
+    ) -> BoxFuture<'_, Result<Vec<(String, String, String)>, StorageError>> {
+        Box::pin(async move {
+            sqlx::query_as(
+                "SELECT account_id, table_name, ttl_attribute FROM tables \
+                 WHERE ttl_attribute IS NOT NULL AND ttl_index_ready = 1 AND table_status = 'ACTIVE'",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))
+        })
+    }
+
+    fn create_ttl_index(
+        &self,
+        account_id: &str,
+        table_name: &str,
+        ttl_attribute: &str,
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        let ttl_attribute = ttl_attribute.to_owned();
+        Box::pin(async move {
+            Self::validate_account_id(&account_id)?;
+            let table_id = self.table_id_for(&account_id, &table_name).await?;
+            let data_table = data::data_table_name(&table_id);
+
+            // Best-effort partial expression index to accelerate the sweep.
+            if safe_index_attr(&ttl_attribute) {
+                let path = ttl_json_path(&ttl_attribute);
+                let index_name = format!("idx_ttl_{table_id}");
+                let sql = format!(
+                    "CREATE INDEX IF NOT EXISTS \"{index_name}\" ON {data_table} \
+                     (CAST(json_extract(item_data, '{path}') AS INTEGER)) \
+                     WHERE json_extract(item_data, '{path}') IS NOT NULL"
+                );
+                sqlx::query(&sql).execute(&self.pool).await.map_err(|e| {
+                    StorageError::Internal(format!("TTL index creation failed: {e}"))
+                })?;
+            }
+
+            sqlx::query(
+                "UPDATE tables SET ttl_index_ready = 1 WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(())
+        })
+    }
+
+    fn drop_ttl_index(
+        &self,
+        account_id: &str,
+        table_name: &str,
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        Box::pin(async move {
+            Self::validate_account_id(&account_id)?;
+            let table_id = self.table_id_for(&account_id, &table_name).await?;
+            sqlx::query(
+                "UPDATE tables SET ttl_index_ready = 0 WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let index_name = format!("idx_ttl_{table_id}");
+            sqlx::query(&format!("DROP INDEX IF EXISTS \"{index_name}\""))
+                .execute(&self.pool)
+                .await
+                .map_err(|e| StorageError::Internal(format!("TTL index drop failed: {e}")))?;
+            Ok(())
+        })
+    }
+
+    fn find_expired_items_indexed(
+        &self,
+        account_id: &str,
+        table_name: &str,
+        ttl_attribute: &str,
+        limit: usize,
+    ) -> BoxFuture<'_, Result<Vec<Item>, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        let ttl_attribute = ttl_attribute.to_owned();
+        Box::pin(async move {
+            Self::validate_account_id(&account_id)?;
+            let table_id = self.table_id_for(&account_id, &table_name).await?;
+            let data_table = data::data_table_name(&table_id);
+            let path = ttl_json_path(&ttl_attribute);
+
+            let now = i64::try_from(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+            )
+            .unwrap_or(i64::MAX);
+            let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+
+            // Path bound as a parameter — TTL attribute never interpolated.
+            let sql = format!(
+                "SELECT item_data FROM {data_table} \
+                 WHERE CAST(json_extract(item_data, ?) AS INTEGER) BETWEEN 1 AND ? \
+                 ORDER BY CAST(json_extract(item_data, ?) AS INTEGER) LIMIT ?"
+            );
+            let rows: Vec<(String,)> = sqlx::query_as(&sql)
+                .bind(&path)
+                .bind(now)
+                .bind(&path)
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            rows.into_iter()
+                .map(|(s,)| {
+                    serde_json::from_str(&s).map_err(|e| StorageError::Internal(e.to_string()))
+                })
+                .collect()
+        })
+    }
+
+    fn refresh_table_size(
+        &self,
+        account_id: &str,
+        table_name: &str,
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        Box::pin(async move {
+            Self::validate_account_id(&account_id)?;
+            let table_id = self.table_id_for(&account_id, &table_name).await?;
+            let data_table = data::data_table_name(&table_id);
+            let (item_count, table_size): (i64, i64) = sqlx::query_as(&format!(
+                "SELECT COUNT(*), COALESCE(SUM(length(item_data)), 0) FROM {data_table}"
+            ))
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            sqlx::query(
+                "UPDATE tables SET item_count = ?, table_size_bytes = ? \
+                 WHERE account_id = ? AND table_name = ? AND table_status = 'ACTIVE'",
+            )
+            .bind(item_count)
+            .bind(table_size)
+            .bind(&account_id)
+            .bind(&table_name)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(())
+        })
+    }
+
+    fn list_active_table_names(
+        &self,
+        account_id: &str,
+    ) -> BoxFuture<'_, Result<Vec<String>, StorageError>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move {
+            let rows: Vec<(String,)> = sqlx::query_as(
+                "SELECT table_name FROM tables \
+                 WHERE account_id = ? AND table_status = 'ACTIVE' ORDER BY table_name",
+            )
+            .bind(&account_id)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(rows.into_iter().map(|(n,)| n).collect())
+        })
+    }
+
+    fn all_active_tables(&self) -> BoxFuture<'_, Result<Vec<(String, String)>, StorageError>> {
+        Box::pin(async move {
+            sqlx::query_as(
+                "SELECT account_id, table_name FROM tables \
+                 WHERE table_status = 'ACTIVE' ORDER BY account_id, table_name",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))
+        })
+    }
+}

--- a/crates/storage-sqlite/src/number_key.rs
+++ b/crates/storage-sqlite/src/number_key.rs
@@ -41,6 +41,11 @@ const NEG_TERMINATOR: char = ':';
 
 /// Encode a `BigDecimal` into an order-preserving ASCII string such that, for
 /// all `a`, `b`: `a.cmp(b) == encode(a).cmp(&encode(b))`.
+///
+/// Precondition: `value` is a finite decimal within DynamoDB's supported numeric
+/// range. `BigDecimal` cannot represent NaN or ±Infinity, and the protocol /
+/// validation layer rejects non-numeric, NaN, and Infinity inputs before they
+/// reach this encoder, so those cases are not handled here.
 pub(crate) fn encode_orderable_number(value: &BigDecimal) -> String {
     if value.is_zero() {
         return "1".to_owned();

--- a/crates/storage-sqlite/src/number_key.rs
+++ b/crates/storage-sqlite/src/number_key.rs
@@ -1,0 +1,220 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Order-preserving encoding of DynamoDB numbers for use as SQLite sort keys.
+//!
+//! SQLite has no arbitrary-precision numeric type, and storing a `N` sort key
+//! as `REAL` would truncate beyond ~15-17 significant digits, corrupting both
+//! ordering and equality. Instead we store `N` sort keys in a `TEXT` column
+//! holding a canonical, byte-lexicographically order-preserving encoding of the
+//! value, so SQLite's default BINARY collation yields exact DynamoDB numeric
+//! ordering. The full-precision value is always retained in the item JSON, so
+//! reads lose nothing — this column exists only for ordering/range/equality.
+//!
+//! # Encoding
+//!
+//! A value is written in canonical normalized form `± 0.d₁d₂… × 10^E` (leading
+//! digit non-zero, no trailing zeros), then encoded as:
+//!
+//! - **class byte** — `'0'` negative, `'1'` zero, `'2'` positive — so the three
+//!   classes order negative < zero < positive.
+//! - **exponent** — `E` biased into a fixed-width 6-digit field. Positive
+//!   numbers use `E + BIAS` (increasing in `E`); negative numbers use
+//!   `BIAS - E` (decreasing in `E`) so larger magnitudes sort earlier.
+//! - **mantissa digits** — written verbatim for positives. For negatives each
+//!   digit `d` is complemented to `9 - d`, and a high terminator (`':'`, which
+//!   sorts above any digit) is appended so a longer (more negative) value sorts
+//!   before its prefix.
+//!
+//! Canonical normalization makes numerically-equal inputs (`5`, `5.0`, `+5`)
+//! encode identically, matching DynamoDB's number normalization for key
+//! equality.
+
+use bigdecimal::{BigDecimal, Zero};
+
+/// Exponent bias. Comfortably covers DynamoDB's exponent range (≈ -130..=126)
+/// within a fixed 6-digit field with wide margin.
+const EXP_BIAS: i64 = 100_000;
+const EXP_WIDTH: usize = 6;
+/// Terminator that sorts above any decimal digit (`'9'` = 0x39 < `':'` = 0x3A).
+const NEG_TERMINATOR: char = ':';
+
+/// Encode a `BigDecimal` into an order-preserving ASCII string such that, for
+/// all `a`, `b`: `a.cmp(b) == encode(a).cmp(&encode(b))`.
+pub(crate) fn encode_orderable_number(value: &BigDecimal) -> String {
+    if value.is_zero() {
+        return "1".to_owned();
+    }
+
+    let negative = value < &BigDecimal::zero();
+    let magnitude = value.abs().normalized();
+
+    // value = mantissa_int * 10^(-scale); with no trailing zeros (normalized)
+    // and no leading zeros (decimal string), the normalized form is
+    // 0.<digits> × 10^E where E = digit_count - scale.
+    let (mantissa_int, scale) = magnitude.as_bigint_and_exponent();
+    let digits = mantissa_int.to_string();
+    let exponent = digits.len() as i64 - scale;
+
+    if negative {
+        let exp_code = format!("{:0width$}", EXP_BIAS - exponent, width = EXP_WIDTH);
+        let complemented: String = digits
+            .bytes()
+            .map(|b| char::from(b'9' - (b - b'0')))
+            .collect();
+        format!("0{exp_code}{complemented}{NEG_TERMINATOR}")
+    } else {
+        let exp_code = format!("{:0width$}", EXP_BIAS + exponent, width = EXP_WIDTH);
+        format!("2{exp_code}{digits}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cmp::Ordering;
+    use std::str::FromStr;
+
+    fn bd(s: &str) -> BigDecimal {
+        BigDecimal::from_str(s).expect("valid decimal")
+    }
+
+    fn enc(s: &str) -> String {
+        encode_orderable_number(&bd(s))
+    }
+
+    /// Core property: encoded byte order equals numeric order, for every pair.
+    fn assert_order_preserving(values: &[&str]) {
+        for a in values {
+            for b in values {
+                let numeric = bd(a).cmp(&bd(b));
+                let encoded = enc(a).cmp(&enc(b));
+                assert_eq!(
+                    numeric,
+                    encoded,
+                    "order mismatch for {a} vs {b}: numeric={numeric:?} encoded={encoded:?} \
+                     (enc(a)={:?}, enc(b)={:?})",
+                    enc(a),
+                    enc(b),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn ascending_sequence_spanning_sign_and_scale() {
+        // Deliberately spans negatives, zero, fractions, integers, and large
+        // and small magnitudes, listed in true numeric ascending order.
+        let ordered = [
+            "-1000000000000000000000000000000",
+            "-100",
+            "-10.5",
+            "-10",
+            "-1.0001",
+            "-1",
+            "-0.5",
+            "-0.05",
+            "-0.0000001",
+            "0",
+            "0.0000001",
+            "0.05",
+            "0.5",
+            "1",
+            "1.0001",
+            "10",
+            "10.5",
+            "100",
+            "1000000000000000000000000000000",
+        ];
+        // Each strictly less than the next.
+        for w in ordered.windows(2) {
+            assert!(
+                enc(w[0]) < enc(w[1]),
+                "expected enc({}) < enc({}) but got {:?} >= {:?}",
+                w[0],
+                w[1],
+                enc(w[0]),
+                enc(w[1]),
+            );
+        }
+        assert_order_preserving(&ordered);
+    }
+
+    #[test]
+    fn canonical_equality_for_equal_values() {
+        // Numerically equal values must encode identically (DynamoDB number
+        // normalization), so they compare Equal as sort keys.
+        for (a, b) in [
+            ("5", "5.0"),
+            ("5", "5.00"),
+            ("5", "+5"),
+            ("0", "0.0"),
+            ("0", "-0"),
+            ("-7.5", "-7.50"),
+            ("100", "1E2"),
+            ("0.1", "1E-1"),
+            ("12300", "1.23E4"),
+        ] {
+            assert_eq!(enc(a), enc(b), "{a} and {b} should encode identically");
+            assert_eq!(bd(a).cmp(&bd(b)), Ordering::Equal);
+        }
+    }
+
+    #[test]
+    fn full_precision_38_digit_extremes() {
+        // 38 significant digits differing only in the last digit must order
+        // correctly — the case that REAL/f64 silently corrupts.
+        let lo = "1.2345678901234567890123456789012345678";
+        let hi = "1.2345678901234567890123456789012345679";
+        assert!(bd(lo) < bd(hi));
+        assert!(enc(lo) < enc(hi));
+
+        let neg_lo = "-1.2345678901234567890123456789012345679";
+        let neg_hi = "-1.2345678901234567890123456789012345678";
+        assert!(bd(neg_lo) < bd(neg_hi));
+        assert!(enc(neg_lo) < enc(neg_hi));
+
+        assert_order_preserving(&[lo, hi, neg_lo, neg_hi, "0"]);
+    }
+
+    #[test]
+    fn dynamodb_magnitude_bounds() {
+        // Near DynamoDB's documented positive/negative magnitude limits.
+        let vals = [
+            "-9.9999999999999999999999999999999999999E+125",
+            "-1E-130",
+            "0",
+            "1E-130",
+            "9.9999999999999999999999999999999999999E+125",
+        ];
+        for w in vals.windows(2) {
+            assert!(bd(w[0]) < bd(w[1]));
+            assert!(
+                enc(w[0]) < enc(w[1]),
+                "enc order failed at {} vs {}",
+                w[0],
+                w[1]
+            );
+        }
+        assert_order_preserving(&vals);
+    }
+
+    #[test]
+    fn same_exponent_varying_mantissa_length() {
+        // Prefix relationships within one decade, both signs.
+        assert_order_preserving(&[
+            "0.12", "0.123", "0.1234", "0.2", "-0.12", "-0.123", "-0.1234", "-0.2",
+        ]);
+        // Positive: shorter prefix is smaller (0.12 < 0.123).
+        assert!(enc("0.12") < enc("0.123"));
+        // Negative: more-negative (longer magnitude) is smaller (-0.123 < -0.12).
+        assert!(enc("-0.123") < enc("-0.12"));
+    }
+
+    #[test]
+    fn zero_sits_between_smallest_negative_and_smallest_positive() {
+        assert!(enc("-0.0000000001") < enc("0"));
+        assert!(enc("0") < enc("0.0000000001"));
+        assert_eq!(enc("0"), "1");
+    }
+}

--- a/crates/storage-sqlite/src/operations.rs
+++ b/crates/storage-sqlite/src/operations.rs
@@ -1,0 +1,62 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `OperationsEngine` implementation for the SQLite backend.
+//!
+//! Provides the backend-specific CLI helpers (connection-string parsing,
+//! redaction, identifier validation, catalog version) used by `extenddb`
+//! lifecycle commands. SQLite connection strings are filesystem paths with no
+//! embedded credentials, so redaction is a no-op.
+
+use extenddb_storage::error::StorageError;
+use extenddb_storage::operations::{ConnectionParts, OperationsEngine};
+
+use crate::schema::CATALOG_VERSION;
+
+/// Backend operations for the SQLite engine.
+pub(crate) struct SqliteOperationsEngine;
+
+impl OperationsEngine for SqliteOperationsEngine {
+    fn parse_connection_string(&self, s: &str) -> Result<ConnectionParts, StorageError> {
+        // A SQLite "connection string" is just a file path (or :memory:).
+        Ok(ConnectionParts {
+            host: s.to_owned(),
+            port: 0,
+            user: String::new(),
+            password: String::new(),
+            database: s.to_owned(),
+        })
+    }
+
+    fn redact_connection_string(&self, s: &str) -> String {
+        s.to_owned() // No credentials in a SQLite path.
+    }
+
+    fn validate_identifier(&self, name: &str, label: &str) -> Result<(), StorageError> {
+        if name.is_empty() {
+            return Err(StorageError::Internal(format!("{label} must not be empty")));
+        }
+        // Defense-in-depth for any identifier interpolated into DDL. Backend
+        // table identifiers are `_ddb_<uuid>` (engine-controlled), but reject
+        // characters that could break a quoted identifier regardless.
+        if name.contains('"') || name.contains('\0') {
+            return Err(StorageError::Internal(format!(
+                "{label} contains characters invalid for a SQL identifier"
+            )));
+        }
+        if !name.is_ascii() {
+            return Err(StorageError::Internal(format!(
+                "{label} must contain only ASCII characters"
+            )));
+        }
+        Ok(())
+    }
+
+    fn catalog_version(&self) -> String {
+        CATALOG_VERSION.to_string()
+    }
+
+    fn is_sensitive_key(&self, _key: &str) -> bool {
+        false // SQLite config carries no secrets.
+    }
+}

--- a/crates/storage-sqlite/src/schema.rs
+++ b/crates/storage-sqlite/src/schema.rs
@@ -1,0 +1,404 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Authoritative SQLite catalog schema.
+//!
+//! Mirrors the semantics of the reference PostgreSQL catalog schema
+//! (`crates/storage-postgres/migrations/001_schema.sql`, catalog version
+//! 0.0.2). Table and column names are kept identical to PostgreSQL so the
+//! catalog/management stores remain portable across backends.
+//!
+//! Type mapping PostgreSQL → SQLite:
+//! - `JSONB`        → `TEXT` (JSON serialized as a string)
+//! - `BYTEA`        → `BLOB`
+//! - `BOOLEAN`      → `INTEGER` (0/1)
+//! - `BIGINT`       → `INTEGER`
+//! - `DOUBLE PRECISION` → `REAL` (`±9e999` literals store as `±Infinity`)
+//! - `TIMESTAMPTZ`  → `TEXT` in RFC 3339 UTC (`YYYY-MM-DDTHH:MM:SS.sssZ`)
+//! - `SEQUENCE`     → a `seq_counters` row updated inside the write transaction
+//!
+//! Per-DynamoDB-table data tables (`_ddb_<table_id>`) are NOT created here; they
+//! are created dynamically by `create_table`, exactly as in the PostgreSQL
+//! backend.
+
+use extenddb_storage::management_store::{OpError, OpResult};
+use sqlx::SqlitePool;
+
+/// Compiled-in catalog version. Single source of truth for the SQLite backend;
+/// mirrors the PostgreSQL backend's `CATALOG_VERSION`.
+pub const CATALOG_VERSION: extenddb_core::version::CatalogVersion =
+    extenddb_core::version::CatalogVersion::new(0, 0, 2);
+
+/// Complete catalog schema, applied once on a fresh database.
+///
+/// Every object uses `IF NOT EXISTS` so re-application is harmless. Foreign-key
+/// enforcement requires `PRAGMA foreign_keys = ON` on each connection (set in
+/// the engine's `after_connect` hook).
+pub const SCHEMA_SQL: &str = r#"
+-- Accounts — multi-account support (REQ-AUTH-005).
+CREATE TABLE IF NOT EXISTS accounts (
+    account_id TEXT PRIMARY KEY,
+    account_name TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+-- Table metadata.
+CREATE TABLE IF NOT EXISTS tables (
+    account_id TEXT NOT NULL REFERENCES accounts(account_id) ON DELETE CASCADE,
+    table_name TEXT NOT NULL,
+    key_schema TEXT NOT NULL,
+    attribute_definitions TEXT NOT NULL,
+    billing_mode TEXT NOT NULL DEFAULT 'PAY_PER_REQUEST',
+    provisioned_throughput TEXT,
+    stream_specification TEXT,
+    table_status TEXT NOT NULL DEFAULT 'CREATING',
+    creation_date_time TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    table_size_bytes INTEGER NOT NULL DEFAULT 0,
+    item_count INTEGER NOT NULL DEFAULT 0,
+    table_arn TEXT NOT NULL,
+    table_id TEXT NOT NULL,
+    ttl_attribute TEXT,
+    deletion_protection_enabled INTEGER NOT NULL DEFAULT 0,
+    status_transition_at TEXT,
+    stream_label TEXT,
+    ttl_index_ready INTEGER NOT NULL DEFAULT 0,
+    table_class TEXT,
+    sse_specification TEXT,
+    on_demand_throughput TEXT,
+    PRIMARY KEY (account_id, table_name),
+    CONSTRAINT tables_table_id_unique UNIQUE (table_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tables_pending_transition
+    ON tables (status_transition_at)
+    WHERE status_transition_at IS NOT NULL;
+
+-- Index metadata. index_id is always supplied by the engine (no DB-side UUID).
+CREATE TABLE IF NOT EXISTS indexes (
+    table_id TEXT NOT NULL,
+    index_id TEXT NOT NULL,
+    index_name TEXT NOT NULL,
+    index_type TEXT NOT NULL,
+    key_schema TEXT NOT NULL,
+    projection TEXT NOT NULL,
+    index_status TEXT NOT NULL DEFAULT 'ACTIVE',
+    provisioned_throughput TEXT,
+    propagation_delay_ms INTEGER,
+    PRIMARY KEY (table_id, index_name),
+    CONSTRAINT indexes_table_id_fkey
+        FOREIGN KEY (table_id) REFERENCES tables(table_id) ON DELETE CASCADE,
+    CONSTRAINT chk_propagation_delay_ms_non_negative
+        CHECK (propagation_delay_ms IS NULL OR propagation_delay_ms >= 0)
+);
+
+-- Resource tags.
+CREATE TABLE IF NOT EXISTS tags (
+    resource_arn TEXT NOT NULL,
+    tag_key TEXT NOT NULL,
+    tag_value TEXT NOT NULL,
+    PRIMARY KEY (resource_arn, tag_key)
+);
+
+-- Migration tracking.
+CREATE TABLE IF NOT EXISTS schema_history (
+    filename TEXT PRIMARY KEY,
+    applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+-- Settings (catalog version, data database name, runtime config).
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+-- Stream shards.
+CREATE TABLE IF NOT EXISTS stream_shards (
+    shard_id TEXT PRIMARY KEY,
+    table_id TEXT NOT NULL REFERENCES tables(table_id) ON DELETE CASCADE,
+    parent_shard_id TEXT,
+    starting_sequence_number TEXT NOT NULL,
+    ending_sequence_number TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_stream_shards_table ON stream_shards (table_id);
+
+-- Stream records.
+CREATE TABLE IF NOT EXISTS stream_records (
+    shard_id TEXT NOT NULL REFERENCES stream_shards(shard_id) ON DELETE CASCADE,
+    sequence_number TEXT NOT NULL,
+    table_id TEXT NOT NULL,
+    event_name TEXT NOT NULL,
+    record_data TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (shard_id, sequence_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_stream_records_created ON stream_records (created_at);
+
+-- Admin users.
+CREATE TABLE IF NOT EXISTS admin_users (
+    admin_name TEXT PRIMARY KEY,
+    password_hash TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+-- IAM users.
+CREATE TABLE IF NOT EXISTS iam_users (
+    account_id TEXT NOT NULL REFERENCES accounts(account_id) ON DELETE CASCADE,
+    user_name TEXT NOT NULL,
+    user_arn TEXT NOT NULL UNIQUE,
+    password_hash TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (account_id, user_name)
+);
+
+-- IAM user tags.
+CREATE TABLE IF NOT EXISTS iam_user_tags (
+    account_id TEXT NOT NULL,
+    user_name TEXT NOT NULL,
+    tag_key TEXT NOT NULL,
+    tag_value TEXT NOT NULL,
+    PRIMARY KEY (account_id, user_name, tag_key),
+    FOREIGN KEY (account_id, user_name)
+        REFERENCES iam_users(account_id, user_name) ON DELETE CASCADE
+);
+
+-- Access keys.
+CREATE TABLE IF NOT EXISTS access_keys (
+    access_key_id TEXT PRIMARY KEY,
+    secret_key_encrypted BLOB NOT NULL,
+    account_id TEXT NOT NULL,
+    user_name TEXT NOT NULL,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    FOREIGN KEY (account_id, user_name)
+        REFERENCES iam_users(account_id, user_name) ON DELETE CASCADE
+);
+
+-- IAM groups.
+CREATE TABLE IF NOT EXISTS iam_groups (
+    account_id TEXT NOT NULL REFERENCES accounts(account_id) ON DELETE CASCADE,
+    group_name TEXT NOT NULL,
+    group_arn TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (account_id, group_name)
+);
+
+-- IAM group membership.
+CREATE TABLE IF NOT EXISTS iam_group_members (
+    account_id TEXT NOT NULL,
+    group_name TEXT NOT NULL,
+    user_name TEXT NOT NULL,
+    PRIMARY KEY (account_id, group_name, user_name),
+    FOREIGN KEY (account_id, group_name)
+        REFERENCES iam_groups(account_id, group_name) ON DELETE CASCADE,
+    FOREIGN KEY (account_id, user_name)
+        REFERENCES iam_users(account_id, user_name) ON DELETE CASCADE
+);
+
+-- IAM roles.
+CREATE TABLE IF NOT EXISTS iam_roles (
+    account_id TEXT NOT NULL REFERENCES accounts(account_id) ON DELETE CASCADE,
+    role_name TEXT NOT NULL,
+    role_arn TEXT NOT NULL UNIQUE,
+    trust_policy TEXT NOT NULL,
+    permissions_boundary_arn TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (account_id, role_name)
+);
+
+-- IAM role tags.
+CREATE TABLE IF NOT EXISTS iam_role_tags (
+    account_id TEXT NOT NULL,
+    role_name TEXT NOT NULL,
+    tag_key TEXT NOT NULL,
+    tag_value TEXT NOT NULL,
+    PRIMARY KEY (account_id, role_name, tag_key),
+    FOREIGN KEY (account_id, role_name)
+        REFERENCES iam_roles(account_id, role_name) ON DELETE CASCADE
+);
+
+-- IAM sessions.
+CREATE TABLE IF NOT EXISTS iam_sessions (
+    session_token TEXT PRIMARY KEY,
+    access_key_id TEXT NOT NULL UNIQUE,
+    secret_key_encrypted BLOB NOT NULL,
+    account_id TEXT NOT NULL,
+    role_name TEXT NOT NULL,
+    session_name TEXT NOT NULL,
+    session_tags TEXT,
+    session_policy TEXT,
+    expires_at TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    FOREIGN KEY (account_id, role_name)
+        REFERENCES iam_roles(account_id, role_name) ON DELETE CASCADE
+);
+
+-- IAM policies.
+CREATE TABLE IF NOT EXISTS iam_policies (
+    account_id TEXT NOT NULL REFERENCES accounts(account_id) ON DELETE CASCADE,
+    principal_type TEXT NOT NULL CHECK (principal_type IN ('user', 'group', 'role')),
+    principal_name TEXT NOT NULL,
+    policy_name TEXT NOT NULL,
+    policy_document TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (account_id, principal_type, principal_name, policy_name)
+);
+
+-- IAM permissions boundaries.
+CREATE TABLE IF NOT EXISTS iam_permissions_boundaries (
+    account_id TEXT NOT NULL REFERENCES accounts(account_id) ON DELETE CASCADE,
+    principal_type TEXT NOT NULL CHECK (principal_type IN ('user', 'role')),
+    principal_name TEXT NOT NULL,
+    policy_document TEXT NOT NULL,
+    PRIMARY KEY (account_id, principal_type, principal_name)
+);
+
+-- Idempotency tokens for TransactWriteItems.
+CREATE TABLE IF NOT EXISTS idempotency_tokens (
+    account_id  TEXT NOT NULL,
+    token       TEXT NOT NULL,
+    fingerprint TEXT NOT NULL,
+    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (account_id, token)
+);
+
+CREATE INDEX IF NOT EXISTS idx_idempotency_tokens_created ON idempotency_tokens (created_at);
+
+-- Metrics (1-minute aggregation). ±9e999 store as ±Infinity in SQLite REAL,
+-- matching PostgreSQL's Infinity / -Infinity seed for min / max.
+CREATE TABLE IF NOT EXISTS metrics (
+    bucket TEXT NOT NULL,
+    metric TEXT NOT NULL,
+    table_name TEXT NOT NULL DEFAULT '',
+    index_name TEXT NOT NULL DEFAULT '',
+    operation TEXT NOT NULL DEFAULT '',
+    sum REAL NOT NULL DEFAULT 0,
+    count INTEGER NOT NULL DEFAULT 0,
+    min REAL NOT NULL DEFAULT 9e999,
+    max REAL NOT NULL DEFAULT -9e999,
+    PRIMARY KEY (bucket, metric, table_name, index_name, operation)
+);
+
+CREATE INDEX IF NOT EXISTS idx_metrics_bucket ON metrics (bucket);
+
+-- Login attempt tracking.
+CREATE TABLE IF NOT EXISTS login_attempts (
+    principal     TEXT NOT NULL,
+    attempted_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    success       INTEGER NOT NULL,
+    source_ip     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_login_attempts_principal_time
+    ON login_attempts (principal, attempted_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_login_attempts_source_ip_time
+    ON login_attempts (source_ip, attempted_at DESC)
+    WHERE source_ip IS NOT NULL;
+
+-- Backup metadata.
+CREATE TABLE IF NOT EXISTS backups (
+    backup_arn TEXT PRIMARY KEY,
+    backup_name TEXT NOT NULL,
+    table_id TEXT NOT NULL,
+    table_name TEXT NOT NULL,
+    account_id TEXT NOT NULL,
+    backup_status TEXT NOT NULL DEFAULT 'AVAILABLE',
+    backup_type TEXT NOT NULL DEFAULT 'USER',
+    backup_size_bytes INTEGER NOT NULL DEFAULT 0,
+    item_count INTEGER NOT NULL DEFAULT 0,
+    key_schema TEXT NOT NULL,
+    attribute_definitions TEXT NOT NULL,
+    billing_mode TEXT NOT NULL DEFAULT 'PAY_PER_REQUEST',
+    provisioned_throughput TEXT,
+    stream_specification TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_backups_table ON backups (account_id, table_name);
+
+-- Backup items.
+CREATE TABLE IF NOT EXISTS backup_items (
+    backup_arn TEXT NOT NULL REFERENCES backups(backup_arn) ON DELETE CASCADE,
+    pk TEXT NOT NULL,
+    sk TEXT,
+    item_data TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_backup_items_arn ON backup_items (backup_arn);
+
+-- Continuous backups / PITR status.
+CREATE TABLE IF NOT EXISTS continuous_backups (
+    account_id TEXT NOT NULL,
+    table_name TEXT NOT NULL,
+    pitr_enabled INTEGER NOT NULL DEFAULT 0,
+    earliest_restorable TEXT,
+    latest_restorable TEXT,
+    PRIMARY KEY (account_id, table_name)
+);
+
+-- Persistent queue for async GSI propagation. A row is inserted inside the
+-- base write transaction (zero crash window) and consumed by a background
+-- worker once `ready_at` has passed; survives process crash/restart.
+--
+-- One row per async index: each row is self-describing — `index_context`
+-- carries the base key schema, attribute definitions, and the single target
+-- index definition captured at enqueue, so the worker applies with zero
+-- catalog reads. `worker_partition` is a stable hash of the base table key;
+-- all updates to a given base item share a partition and `ready_at` is kept
+-- monotonically non-decreasing within it, so the worker (which drains in `id`
+-- order) preserves per-key FIFO even with randomized propagation jitter.
+CREATE TABLE IF NOT EXISTS gsi_pending (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    table_id TEXT NOT NULL,
+    worker_partition INTEGER NOT NULL,
+    old_item TEXT,
+    new_item TEXT,
+    index_context TEXT NOT NULL,
+    ready_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_gsi_pending_claim
+    ON gsi_pending (worker_partition, ready_at, id);
+
+-- Monotonic counters. Replaces PostgreSQL sequences. The stream counter is
+-- seeded to the current epoch in microseconds so sequence numbers are
+-- time-ordered and survive restarts (mirrors the PostgreSQL setval seed).
+CREATE TABLE IF NOT EXISTS seq_counters (
+    name TEXT PRIMARY KEY,
+    value INTEGER NOT NULL DEFAULT 0
+);
+
+INSERT OR IGNORE INTO seq_counters (name, value)
+    VALUES ('stream', CAST(strftime('%s','now') AS INTEGER) * 1000000);
+
+-- Seed settings (mirror PostgreSQL defaults).
+INSERT OR IGNORE INTO settings (key, value) VALUES ('catalog_version', '0.0.2');
+INSERT OR IGNORE INTO settings (key, value) VALUES ('control_plane_delay_seconds', '0.25');
+INSERT OR IGNORE INTO settings (key, value) VALUES ('gsi_propagation_delay_ms', '10');
+"#;
+
+/// Apply the full catalog schema to a fresh (or existing) database.
+///
+/// Idempotent: every statement uses `IF NOT EXISTS` / `INSERT OR IGNORE`.
+pub async fn apply(pool: &SqlitePool) -> OpResult<()> {
+    sqlx::raw_sql(SCHEMA_SQL)
+        .execute(pool)
+        .await
+        .map_err(|e| OpError::Internal(format!("apply catalog schema: {e}")))?;
+    Ok(())
+}
+
+/// Return whether a table with the given name exists in the catalog.
+pub async fn table_exists(pool: &SqlitePool, name: &str) -> OpResult<bool> {
+    let exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?)",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .map_err(|e| OpError::Internal(format!("table_exists({name}): {e}")))?;
+    Ok(exists)
+}

--- a/crates/storage-sqlite/src/sqlite_util.rs
+++ b/crates/storage-sqlite/src/sqlite_util.rs
@@ -1,0 +1,92 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared helpers for the SQLite backend: connection-URL building, RFC 3339
+//! timestamp conversion, and constraint-violation classification.
+
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+
+/// Normalize a configured path or connection string into a sqlx-openable
+/// SQLite URL.
+///
+/// Accepts a value that is already a `sqlite:` URL (returned unchanged), the
+/// in-memory sentinel `:memory:`, or a filesystem path (wrapped as a
+/// read-write-create file URL).
+pub(crate) fn sqlite_url(path_or_url: &str) -> String {
+    if path_or_url.starts_with("sqlite:") {
+        path_or_url.to_owned()
+    } else if path_or_url == ":memory:" {
+        "sqlite::memory:".to_owned()
+    } else {
+        format!("sqlite://{path_or_url}?mode=rwc")
+    }
+}
+
+/// Format a timestamp as RFC 3339 UTC, matching the catalog's stored format.
+pub(crate) fn format_timestamp(ts: OffsetDateTime) -> String {
+    ts.to_offset(time::UtcOffset::UTC)
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| ts.to_string())
+}
+
+/// Parse a catalog timestamp string into an `OffsetDateTime`.
+///
+/// Accepts RFC 3339 (the canonical stored form, e.g. `2026-06-08T12:00:00.123Z`)
+/// and tolerates SQLite's bare `datetime()` form (`YYYY-MM-DD HH:MM:SS`, assumed
+/// UTC) for robustness against rows written by older tooling.
+pub(crate) fn parse_timestamp(s: &str) -> Result<OffsetDateTime, time::error::Parse> {
+    if let Ok(dt) = OffsetDateTime::parse(s, &Rfc3339) {
+        return Ok(dt);
+    }
+    // Fallback: "YYYY-MM-DD HH:MM:SS" (SQLite datetime('now')), interpret as UTC.
+    let normalized = format!("{}Z", s.replace(' ', "T"));
+    OffsetDateTime::parse(&normalized, &Rfc3339)
+}
+
+/// True if the error is a SQLite UNIQUE / PRIMARY KEY constraint violation.
+pub(crate) fn is_unique_violation(e: &sqlx::Error) -> bool {
+    matches!(e, sqlx::Error::Database(db) if {
+        let msg = db.message();
+        msg.contains("UNIQUE constraint failed") || msg.contains("PRIMARY KEY constraint failed")
+    })
+}
+
+/// True if the error is a SQLite FOREIGN KEY constraint violation.
+pub(crate) fn is_fk_violation(e: &sqlx::Error) -> bool {
+    matches!(e, sqlx::Error::Database(db) if db.message().contains("FOREIGN KEY constraint failed"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sqlite_url_variants() {
+        assert_eq!(sqlite_url(":memory:"), "sqlite::memory:");
+        assert_eq!(
+            sqlite_url("extenddb.sqlite"),
+            "sqlite://extenddb.sqlite?mode=rwc"
+        );
+        assert_eq!(
+            sqlite_url("sqlite://already.db?mode=rwc"),
+            "sqlite://already.db?mode=rwc"
+        );
+    }
+
+    #[test]
+    fn timestamp_round_trips_rfc3339() {
+        let now = OffsetDateTime::now_utc();
+        let s = format_timestamp(now);
+        let parsed = parse_timestamp(&s).expect("parse RFC3339");
+        // Equal to at least second precision.
+        assert_eq!(parsed.unix_timestamp(), now.unix_timestamp());
+    }
+
+    #[test]
+    fn timestamp_parses_bare_datetime() {
+        let parsed = parse_timestamp("2026-06-08 12:00:00").expect("parse bare datetime");
+        assert_eq!(parsed.year(), 2026);
+        assert_eq!(parsed.offset(), time::UtcOffset::UTC);
+    }
+}

--- a/crates/storage-sqlite/src/store.rs
+++ b/crates/storage-sqlite/src/store.rs
@@ -1,0 +1,311 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Central SQLite storage engine: connection pool, write serialization, and
+//! construction.
+//!
+//! # Concurrency model (design decision D1)
+//!
+//! WAL mode allows many concurrent readers alongside a single writer. SQLite
+//! offers no `SERIALIZABLE` isolation knob, so to make condition-check-then-
+//! write atomic and free of write-skew the engine serializes all writers
+//! through `write_lock` and opens every write transaction with `BEGIN
+//! IMMEDIATE` via `pool.begin_with("BEGIN IMMEDIATE")`, so the condition read
+//! and its write hold SQLite's reserved write lock up front. This is
+//! multi-pool-safe: the catalog/credential store opens a second pool over the
+//! same file, and `BEGIN IMMEDIATE` + `busy_timeout` prevent
+//! `SQLITE_BUSY_SNAPSHOT` (a deferred read-then-write whose snapshot is
+//! invalidated by another pool committing) rather than surfacing it as a 500.
+//! Reads run concurrently from the pool against WAL snapshots and take no lock.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+
+use extenddb_storage::error::StorageError;
+use sqlx::SqlitePool;
+use sqlx::sqlite::SqlitePoolOptions;
+use tokio::sync::Mutex;
+
+use crate::schema::CATALOG_VERSION;
+use crate::sqlite_util::sqlite_url;
+
+/// The SQLite storage engine. Implements `StorageEngine` (all data/metadata/
+/// stream/worker/backup traits) over a single SQLite database.
+#[derive(Clone)]
+pub struct SqliteEngine {
+    pub(crate) pool: SqlitePool,
+    pub(crate) region: String,
+    pub(crate) max_item_size_bytes: usize,
+    /// Wakes the control-plane poller when a table enters CREATING / DELETING.
+    pub(crate) control_plane_notify: Arc<tokio::sync::Notify>,
+    /// Cached default GSI propagation delay (ms); refreshed by a worker and
+    /// read on the write path to decide sync-vs-async index maintenance.
+    pub(crate) gsi_default_delay_ms: Arc<AtomicU64>,
+    /// Wakes the GSI propagation worker when a write enqueues into `gsi_pending`.
+    pub(crate) gsi_notify: Arc<tokio::sync::Notify>,
+    /// Serializes all writers (design decision D1). Held for the duration of
+    /// every write transaction so condition checks and writes are atomic and
+    /// `SQLITE_BUSY` cannot arise from competing writers.
+    pub(crate) write_lock: Arc<Mutex<()>>,
+}
+
+impl SqliteEngine {
+    /// Open (creating if necessary) the SQLite database and build the engine.
+    ///
+    /// `path_or_url` accepts a filesystem path, `:memory:`, or a `sqlite:` URL.
+    pub async fn new(
+        path_or_url: &str,
+        pool_size: u32,
+        region: &str,
+        max_item_size_bytes: usize,
+    ) -> Result<Self, StorageError> {
+        let url = sqlite_url(path_or_url);
+        // An in-memory database lives only inside its own connection: a second
+        // connection opens a *separate* empty database. So for `:memory:` we pin
+        // the pool to a single connection that is never recycled (idle and
+        // lifetime timeouts disabled), guaranteeing one shared database for the
+        // process lifetime. Writes are already serialized by `write_lock`, so a
+        // single connection costs only read concurrency — acceptable for the
+        // ephemeral in-memory use case. File-backed databases keep the full WAL
+        // pool (concurrent readers alongside a single writer).
+        let in_memory = url.contains(":memory:") || url.contains("mode=memory");
+        let mut opts = SqlitePoolOptions::new()
+            .max_connections(if in_memory { 1 } else { pool_size.max(1) })
+            .min_connections(1);
+        if in_memory {
+            opts = opts.idle_timeout(None).max_lifetime(None);
+        }
+        let pool = opts
+            .after_connect(|conn, _| {
+                Box::pin(async move {
+                    use sqlx::Executor;
+                    conn.execute("PRAGMA journal_mode = WAL").await?;
+                    conn.execute("PRAGMA foreign_keys = ON").await?;
+                    conn.execute("PRAGMA synchronous = NORMAL").await?;
+                    conn.execute("PRAGMA busy_timeout = 5000").await?;
+                    conn.execute("PRAGMA cache_size = -32000").await?;
+                    Ok(())
+                })
+            })
+            .connect(&url)
+            .await
+            .map_err(|e| StorageError::Connection(e.to_string()))?;
+
+        // The database file stores the AES encryption key alongside the data it
+        // protects (encrypted access-key secrets, password hashes). Restrict the
+        // file and its WAL/SHM sidecars to owner read/write so other local users
+        // or processes cannot read it and decrypt secrets. In-memory databases
+        // have no file to protect.
+        #[cfg(unix)]
+        if !in_memory {
+            use std::os::unix::fs::PermissionsExt;
+            for suffix in ["", "-wal", "-shm"] {
+                let f = format!("{path_or_url}{suffix}");
+                if std::path::Path::new(&f).exists() {
+                    let _ = std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o600));
+                }
+            }
+        }
+
+        let initial_gsi_delay: u64 = sqlx::query_as::<_, (String,)>(
+            "SELECT value FROM settings WHERE key = 'gsi_propagation_delay_ms'",
+        )
+        .fetch_optional(&pool)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|(v,)| v.parse::<u64>().ok())
+        .unwrap_or(10);
+
+        Ok(Self {
+            pool,
+            region: region.to_owned(),
+            max_item_size_bytes,
+            control_plane_notify: Arc::new(tokio::sync::Notify::new()),
+            gsi_default_delay_ms: Arc::new(AtomicU64::new(initial_gsi_delay)),
+            gsi_notify: Arc::new(tokio::sync::Notify::new()),
+            write_lock: Arc::new(Mutex::new(())),
+        })
+    }
+
+    /// Handle to the control-plane notifier, for the background poller.
+    pub(crate) fn control_plane_notify(&self) -> Arc<tokio::sync::Notify> {
+        Arc::clone(&self.control_plane_notify)
+    }
+
+    /// Bootstrap an ephemeral catalog on the engine's own (shared) connection,
+    /// at serve time. Used for in-memory databases, whose state does not
+    /// survive the `init` process, so schema, encryption key, default account,
+    /// and admin user must be created when the server starts. Idempotent.
+    ///
+    /// Returns `Some(password)` when a new admin user was created with a
+    /// generated password (so the caller can surface it once), or `None` when
+    /// the admin already existed or the password came from the environment.
+    pub(crate) async fn bootstrap_ephemeral(
+        &self,
+        admin_user: Option<&str>,
+        admin_password: Option<&str>,
+    ) -> Result<Option<String>, StorageError> {
+        use extenddb_storage::bootstrapper::helpers;
+
+        let internal = |e: String| StorageError::Internal(e);
+
+        // Schema (creates settings, accounts, admin_users, … and seeds
+        // catalog_version + gsi_propagation_delay_ms).
+        crate::schema::apply(&self.pool)
+            .await
+            .map_err(|e| internal(format!("apply schema: {e:?}")))?;
+
+        // Encryption key.
+        let key_exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM settings WHERE key = 'encryption_key')",
+        )
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| internal(format!("check encryption key: {e}")))?;
+        if !key_exists {
+            let key = helpers::generate_encryption_key();
+            sqlx::query("INSERT OR IGNORE INTO settings (key, value) VALUES ('encryption_key', ?)")
+                .bind(&key)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| internal(format!("store encryption key: {e}")))?;
+        }
+
+        // Default account + canonical marker. Record the default account id in
+        // settings (idempotent, backfill-safe) so callers resolve it explicitly
+        // rather than inferring it from account-list ordering.
+        let account_id: String = match sqlx::query_scalar(
+            "SELECT account_id FROM accounts ORDER BY account_id LIMIT 1",
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| internal(format!("check accounts: {e}")))?
+        {
+            Some(id) => id,
+            None => {
+                let id = helpers::generate_account_id();
+                sqlx::query(
+                    "INSERT OR IGNORE INTO accounts (account_id, account_name) VALUES (?, 'default')",
+                )
+                .bind(&id)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| internal(format!("create default account: {e}")))?;
+                id
+            }
+        };
+        sqlx::query("INSERT OR IGNORE INTO settings (key, value) VALUES ('default_account_id', ?)")
+            .bind(&account_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| internal(format!("record default account id: {e}")))?;
+
+        // Admin user.
+        let username = admin_user
+            .filter(|s| !s.is_empty())
+            .unwrap_or("admin")
+            .to_owned();
+        let admin_exists: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM admin_users WHERE admin_name = ?)")
+                .bind(&username)
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|e| internal(format!("check admin user: {e}")))?;
+        if admin_exists {
+            return Ok(None);
+        }
+        let (password, from_env) = match admin_password.filter(|s| !s.is_empty()) {
+            Some(p) => (p.to_owned(), true),
+            None => (helpers::generate_random_password(), false),
+        };
+        let password_hash = helpers::hash_password_async(password.clone())
+            .await
+            .map_err(|e| internal(format!("hash admin password: {e:?}")))?;
+        sqlx::query("INSERT INTO admin_users (admin_name, password_hash) VALUES (?, ?)")
+            .bind(&username)
+            .bind(&password_hash)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| internal(format!("create admin user: {e}")))?;
+
+        Ok(if from_env { None } else { Some(password) })
+    }
+
+    /// Current cached GSI propagation delay (ms); `0` means synchronous.
+    pub(crate) fn gsi_default_delay(&self) -> u64 {
+        self.gsi_default_delay_ms
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Handle to the GSI propagation notifier, woken after an enqueue.
+    pub(crate) fn gsi_notify(&self) -> Arc<tokio::sync::Notify> {
+        Arc::clone(&self.gsi_notify)
+    }
+
+    /// Defense-in-depth: reject `account_id` values unsafe for interpolation
+    /// into quoted SQL identifiers (`_ddb_*` data-table names embed `table_id`,
+    /// but `account_id` flows through the catalog and must stay clean).
+    /// See `docs/adr/0002-sql-injection-defense.md` in the extenddb repo.
+    pub(crate) fn validate_account_id(account_id: &str) -> Result<(), StorageError> {
+        if account_id.contains('"') || account_id.contains('\0') || !account_id.is_ascii() {
+            return Err(StorageError::Internal(
+                "account_id contains invalid characters for use in SQL identifiers".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Validate the on-disk catalog version matches the compiled expectation.
+    ///
+    /// # Errors
+    /// - [`StorageError::CatalogNotInitialized`] if the catalog is absent.
+    /// - [`StorageError::CatalogVersionMismatch`] if versions differ.
+    /// - [`StorageError::Internal`] if the stored version is malformed.
+    pub async fn check_catalog_version(&self) -> Result<(), StorageError> {
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'settings')",
+        )
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| StorageError::Connection(e.to_string()))?;
+
+        if !exists {
+            return Err(StorageError::CatalogNotInitialized);
+        }
+
+        let found_str = sqlx::query_as::<_, (String,)>(
+            "SELECT value FROM settings WHERE key = 'catalog_version'",
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::Connection(e.to_string()))?
+        .ok_or(StorageError::CatalogNotInitialized)?
+        .0;
+
+        let found = found_str
+            .parse::<extenddb_core::version::CatalogVersion>()
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        if found != CATALOG_VERSION {
+            return Err(StorageError::CatalogVersionMismatch {
+                expected: CATALOG_VERSION.to_string(),
+                found: found_str,
+            });
+        }
+        Ok(())
+    }
+
+    /// Read the configured data database name (the file path) for the startup
+    /// banner. Returns `"(not configured)"` when unset.
+    pub async fn data_database_info(&self) -> String {
+        sqlx::query_as::<_, (String,)>(
+            "SELECT value FROM settings WHERE key = 'data_database_name'",
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .ok()
+        .flatten()
+        .map_or_else(|| "(not configured)".to_owned(), |(v,)| v)
+    }
+}

--- a/crates/storage-sqlite/src/stream.rs
+++ b/crates/storage-sqlite/src/stream.rs
@@ -1,0 +1,493 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `StreamEngine` trait implementation for `SqliteEngine`.
+//!
+//! Shards, records, and the sequence counter all live in the one SQLite file,
+//! so `init_stream_shards` runs in the caller's catalog transaction.
+//! Monotonic sequence numbers come from the `seq_counters` table (there is no
+//! PostgreSQL sequence). Retention cleanup compares an RFC 3339 cutoff computed
+//! in Rust.
+
+use extenddb_core::types::{
+    DescribeStreamInput, SequenceNumberRange, Shard, StreamDescription, StreamRecord, StreamStatus,
+    StreamSummary, StreamViewType,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::{parse_stream_arn, stream_arn};
+use extenddb_storage::{StreamEngine, StreamListResult, StreamRecordsResult};
+use futures::future::BoxFuture;
+
+use crate::sqlite_util::format_timestamp;
+use crate::store::SqliteEngine;
+
+/// Fixed shards per stream (hash-based partition-key assignment).
+const SHARDS_PER_STREAM: u32 = 4;
+
+impl SqliteEngine {
+    /// Initialize stream shards and set `stream_label`, within the caller's
+    /// transaction. Returns the assigned stream label.
+    pub(crate) async fn init_stream_shards(
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        account_id: &str,
+        table_name: &str,
+        table_id: &str,
+    ) -> Result<String, StorageError> {
+        let label: String = sqlx::query_scalar(
+            "UPDATE tables SET stream_label = strftime('%Y-%m-%dT%H:%M:%S','now') \
+             WHERE account_id = ? AND table_name = ? RETURNING stream_label",
+        )
+        .bind(account_id)
+        .bind(table_name)
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        for i in 0..SHARDS_PER_STREAM {
+            let shard_id = format!("shardId-{table_name}-{i:012}");
+            let start_seq = format!("{:021}", 0);
+            sqlx::query(
+                "INSERT INTO stream_shards (shard_id, table_id, starting_sequence_number) \
+                 VALUES (?, ?, ?)",
+            )
+            .bind(&shard_id)
+            .bind(table_id)
+            .bind(&start_seq)
+            .execute(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        }
+        Ok(label)
+    }
+}
+
+impl StreamEngine for SqliteEngine {
+    fn write_stream_record(
+        &self,
+        account_id: &str,
+        record: &StreamRecord,
+        shard_id: &str,
+        table_name: &str,
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let account_id = account_id.to_owned();
+        let record = record.clone();
+        let shard_id = shard_id.to_owned();
+        let table_name = table_name.to_owned();
+        Box::pin(async move {
+            let record_json = serde_json::to_string(&record)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let table_id: String = sqlx::query_scalar(
+                "SELECT table_id FROM tables WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let _writer = self.write_lock.lock().await;
+            sqlx::query(
+                "INSERT INTO stream_records (sequence_number, shard_id, table_id, event_name, record_data) \
+                 VALUES (?, ?, ?, ?, ?)",
+            )
+            .bind(&record.dynamodb.sequence_number)
+            .bind(&shard_id)
+            .bind(&table_id)
+            .bind(format!("{:?}", record.event_name))
+            .bind(&record_json)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(())
+        })
+    }
+
+    fn get_stream_records(
+        &self,
+        account_id: &str,
+        shard_id: &str,
+        after_sequence: Option<&str>,
+        limit: i64,
+    ) -> BoxFuture<'_, StreamRecordsResult> {
+        let account_id = account_id.to_owned();
+        let shard_id = shard_id.to_owned();
+        let after = after_sequence.map(str::to_owned);
+        Box::pin(async move {
+            // Ownership guard: only return records if the shard's backing table
+            // belongs to the calling account. SQLite keeps shards and the table
+            // catalog in the same database, so ownership resolves in one join.
+            // A shard iterator resolves to a shard the caller does not own or
+            // one that does not exist. Real DynamoDB returns
+            // `ValidationException: Invalid ShardIterator` for a GetRecords
+            // iterator it did not issue, and does NOT distinguish "exists but
+            // not yours" from "does not exist" — so neither do we (both
+            // collapse here). Verified against DynamoDB Streams (us-east-1).
+            let owned: Option<(i32,)> = sqlx::query_as(
+                "SELECT 1 FROM stream_shards s \
+                 JOIN tables t ON t.table_id = s.table_id \
+                 WHERE s.shard_id = ? AND t.account_id = ?",
+            )
+            .bind(&shard_id)
+            .bind(&account_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if owned.is_none() {
+                return Err(StorageError::Validation("Invalid ShardIterator".to_owned()));
+            }
+
+            let rows: Vec<(String,)> = if let Some(after) = after {
+                sqlx::query_as(
+                    "SELECT record_data FROM stream_records \
+                     WHERE shard_id = ? AND sequence_number > ? ORDER BY sequence_number LIMIT ?",
+                )
+                .bind(&shard_id)
+                .bind(&after)
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await
+            } else {
+                sqlx::query_as(
+                    "SELECT record_data FROM stream_records \
+                     WHERE shard_id = ? ORDER BY sequence_number LIMIT ?",
+                )
+                .bind(&shard_id)
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await
+            }
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let records: Vec<StreamRecord> = rows
+                .into_iter()
+                .map(|(d,)| {
+                    serde_json::from_str(&d).map_err(|e| StorageError::Internal(e.to_string()))
+                })
+                .collect::<Result<_, _>>()?;
+            let last = records.last().map(|r| r.dynamodb.sequence_number.clone());
+            Ok((records, last))
+        })
+    }
+
+    fn describe_stream(
+        &self,
+        account_id: &str,
+        input: &DescribeStreamInput,
+    ) -> BoxFuture<'_, Result<StreamDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        let stream_arn = input.stream_arn.clone();
+        let limit = input.limit.unwrap_or(100);
+        let start = input.exclusive_start_shard_id.clone();
+        Box::pin(async move {
+            let (table_name, stream_label) = parse_stream_arn(&stream_arn)?;
+            let row: Option<(String, Option<String>, String, String)> = sqlx::query_as(
+                "SELECT key_schema, stream_specification, table_status, table_id \
+                 FROM tables WHERE account_id = ? AND table_name = ? AND stream_label = ?",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .bind(&stream_label)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let (ks_json, stream_spec_json, table_status, table_id) = row.ok_or_else(|| {
+                StorageError::TableNotFound(format!(
+                    "Requested resource not found: Stream: {stream_arn} not found."
+                ))
+            })?;
+
+            let key_schema = serde_json::from_str(&ks_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let stream_view_type = stream_spec_json
+                .as_deref()
+                .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+                .and_then(|v| {
+                    v.get("StreamViewType")
+                        .and_then(|sv| serde_json::from_value::<StreamViewType>(sv.clone()).ok())
+                })
+                .unwrap_or(StreamViewType::KeysOnly);
+
+            let shard_rows: Vec<(String, Option<String>, String, Option<String>)> =
+                if let Some(ref s) = start {
+                    sqlx::query_as(
+                        "SELECT shard_id, parent_shard_id, starting_sequence_number, ending_sequence_number \
+                         FROM stream_shards WHERE table_id = ? AND shard_id > ? \
+                         ORDER BY shard_id LIMIT ?",
+                    )
+                    .bind(&table_id)
+                    .bind(s)
+                    .bind(limit + 1)
+                    .fetch_all(&self.pool)
+                    .await
+                } else {
+                    sqlx::query_as(
+                        "SELECT shard_id, parent_shard_id, starting_sequence_number, ending_sequence_number \
+                         FROM stream_shards WHERE table_id = ? ORDER BY shard_id LIMIT ?",
+                    )
+                    .bind(&table_id)
+                    .bind(limit + 1)
+                    .fetch_all(&self.pool)
+                    .await
+                }
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            #[allow(clippy::cast_sign_loss)]
+            let limit_usize = limit.max(0) as usize;
+            let last_shard =
+                (shard_rows.len() > limit_usize).then(|| shard_rows[limit_usize - 1].0.clone());
+            let shards: Vec<Shard> = shard_rows
+                .into_iter()
+                .take(limit_usize)
+                .map(|(id, parent, start, end)| Shard {
+                    shard_id: id,
+                    parent_shard_id: parent,
+                    sequence_number_range: SequenceNumberRange {
+                        starting_sequence_number: start,
+                        ending_sequence_number: end,
+                    },
+                })
+                .collect();
+
+            let stream_status = if table_status == "DELETING" {
+                StreamStatus::Disabling
+            } else {
+                StreamStatus::Enabled
+            };
+
+            Ok(StreamDescription {
+                stream_arn,
+                stream_label,
+                stream_status,
+                stream_view_type,
+                table_name,
+                key_schema,
+                shards,
+                last_evaluated_shard_id: last_shard,
+            })
+        })
+    }
+
+    fn list_streams(
+        &self,
+        account_id: &str,
+        table_name: Option<&str>,
+        limit: i64,
+        exclusive_start_stream_arn: Option<&str>,
+    ) -> BoxFuture<'_, StreamListResult> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.map(str::to_owned);
+        let start_arn = exclusive_start_stream_arn.map(str::to_owned);
+        Box::pin(async move {
+            let rows: Vec<(String, String)> = match (table_name.as_deref(), start_arn.as_deref()) {
+                (Some(tn), Some(arn)) => {
+                    let (_, start_label) = parse_stream_arn(arn)?;
+                    sqlx::query_as(
+                        "SELECT table_name, stream_label FROM tables \
+                         WHERE account_id = ? AND stream_label IS NOT NULL AND table_name = ? \
+                           AND stream_label > ? ORDER BY stream_label LIMIT ?",
+                    )
+                    .bind(&account_id)
+                    .bind(tn)
+                    .bind(&start_label)
+                    .bind(limit + 1)
+                    .fetch_all(&self.pool)
+                    .await
+                }
+                (Some(tn), None) => {
+                    sqlx::query_as(
+                        "SELECT table_name, stream_label FROM tables \
+                     WHERE account_id = ? AND stream_label IS NOT NULL AND table_name = ? \
+                     ORDER BY stream_label LIMIT ?",
+                    )
+                    .bind(&account_id)
+                    .bind(tn)
+                    .bind(limit + 1)
+                    .fetch_all(&self.pool)
+                    .await
+                }
+                (None, Some(arn)) => {
+                    let (start_table, start_label) = parse_stream_arn(arn)?;
+                    sqlx::query_as(
+                        "SELECT table_name, stream_label FROM tables \
+                         WHERE account_id = ? AND stream_label IS NOT NULL \
+                           AND (table_name, stream_label) > (?, ?) \
+                         ORDER BY table_name, stream_label LIMIT ?",
+                    )
+                    .bind(&account_id)
+                    .bind(&start_table)
+                    .bind(&start_label)
+                    .bind(limit + 1)
+                    .fetch_all(&self.pool)
+                    .await
+                }
+                (None, None) => {
+                    sqlx::query_as(
+                        "SELECT table_name, stream_label FROM tables \
+                     WHERE account_id = ? AND stream_label IS NOT NULL \
+                     ORDER BY table_name, stream_label LIMIT ?",
+                    )
+                    .bind(&account_id)
+                    .bind(limit + 1)
+                    .fetch_all(&self.pool)
+                    .await
+                }
+            }
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            #[allow(clippy::cast_sign_loss)]
+            let limit_usize = limit.max(0) as usize;
+            let summaries: Vec<StreamSummary> = rows
+                .iter()
+                .take(limit_usize)
+                .map(|(tn, label)| StreamSummary {
+                    stream_arn: stream_arn(&self.region, &account_id, tn, label),
+                    stream_label: label.clone(),
+                    table_name: tn.clone(),
+                })
+                .collect();
+            let last = (rows.len() > limit_usize)
+                .then(|| summaries.last().map(|s| s.stream_arn.clone()))
+                .flatten();
+            Ok((summaries, last))
+        })
+    }
+
+    fn cleanup_expired_stream_records(
+        &self,
+        retention_hours: i64,
+    ) -> BoxFuture<'_, Result<u64, StorageError>> {
+        Box::pin(async move {
+            let cutoff = format_timestamp(
+                time::OffsetDateTime::now_utc() - time::Duration::hours(retention_hours),
+            );
+            let result = sqlx::query("DELETE FROM stream_records WHERE created_at < ?")
+                .bind(&cutoff)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(result.rows_affected())
+        })
+    }
+
+    fn assign_shard(
+        &self,
+        account_id: &str,
+        table_name: &str,
+        partition_key: &str,
+    ) -> BoxFuture<'_, Result<String, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        let partition_key = partition_key.to_owned();
+        Box::pin(async move {
+            let table_id: String = sqlx::query_scalar(
+                "SELECT table_id FROM tables WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let shards: Vec<(String,)> = sqlx::query_as(
+                "SELECT shard_id FROM stream_shards WHERE table_id = ? ORDER BY shard_id",
+            )
+            .bind(&table_id)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if shards.is_empty() {
+                return Err(StorageError::Internal(format!(
+                    "No stream shards for table {table_name}"
+                )));
+            }
+            let idx = (crc32fast::hash(partition_key.as_bytes()) as usize) % shards.len();
+            Ok(shards[idx].0.clone())
+        })
+    }
+
+    fn next_sequence_number(&self, _shard_id: &str) -> BoxFuture<'_, Result<String, StorageError>> {
+        Box::pin(async move {
+            let _writer = self.write_lock.lock().await;
+            let mut tx = self
+                .pool
+                .begin_with("BEGIN IMMEDIATE")
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            sqlx::query("UPDATE seq_counters SET value = value + 1 WHERE name = 'stream'")
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let value: i64 =
+                sqlx::query_scalar("SELECT value FROM seq_counters WHERE name = 'stream'")
+                    .fetch_one(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            tx.commit()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(format!("{value:021}"))
+        })
+    }
+
+    fn validate_shard(
+        &self,
+        account_id: &str,
+        stream_arn: &str,
+        shard_id: &str,
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let account_id = account_id.to_owned();
+        let stream_arn = stream_arn.to_owned();
+        let shard_id = shard_id.to_owned();
+        Box::pin(async move {
+            let (table_name, stream_label) = parse_stream_arn(&stream_arn)?;
+            let table_id: Option<String> = sqlx::query_scalar(
+                "SELECT table_id FROM tables \
+                 WHERE account_id = ? AND table_name = ? AND stream_label = ?",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .bind(&stream_label)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let Some(table_id) = table_id else {
+                return Err(StorageError::TableNotFound(format!(
+                    "Requested resource not found: Stream: {stream_arn} not found."
+                )));
+            };
+            let exists: Option<(i64,)> =
+                sqlx::query_as("SELECT 1 FROM stream_shards WHERE shard_id = ? AND table_id = ?")
+                    .bind(&shard_id)
+                    .bind(&table_id)
+                    .fetch_optional(&self.pool)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if exists.is_none() {
+                return Err(StorageError::TableNotFound(format!(
+                    "Requested resource not found: Stream: {stream_arn} not found."
+                )));
+            }
+            Ok(())
+        })
+    }
+
+    fn latest_sequence_number(
+        &self,
+        shard_id: &str,
+    ) -> BoxFuture<'_, Result<Option<String>, StorageError>> {
+        let shard_id = shard_id.to_owned();
+        Box::pin(async move {
+            let row: Option<(String,)> = sqlx::query_as(
+                "SELECT sequence_number FROM stream_records \
+                 WHERE shard_id = ? ORDER BY sequence_number DESC LIMIT 1",
+            )
+            .bind(&shard_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(row.map(|(s,)| s))
+        })
+    }
+}

--- a/crates/storage-sqlite/src/table_engine.rs
+++ b/crates/storage-sqlite/src/table_engine.rs
@@ -1,0 +1,143 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `TableEngine` trait implementation for `SqliteEngine`.
+
+use extenddb_core::types::{
+    CreateTableInput, DeleteTableInput, DescribeTableInput, IndexInfo, ListTablesInput,
+    ListTablesOutput, TableDescription, TableKeyInfo, UpdateTableInput,
+};
+use extenddb_storage::TableEngine;
+use extenddb_storage::error::StorageError;
+use futures::future::BoxFuture;
+
+use crate::store::SqliteEngine;
+
+impl TableEngine for SqliteEngine {
+    fn create_table(
+        &self,
+        account_id: &str,
+        input: CreateTableInput,
+    ) -> BoxFuture<'_, Result<TableDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.create_table_impl(&account_id, input).await })
+    }
+
+    fn delete_table(
+        &self,
+        account_id: &str,
+        input: DeleteTableInput,
+    ) -> BoxFuture<'_, Result<TableDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.delete_table_impl(&account_id, input).await })
+    }
+
+    fn describe_table(
+        &self,
+        account_id: &str,
+        input: DescribeTableInput,
+    ) -> BoxFuture<'_, Result<TableDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move {
+            self.build_table_description(&account_id, &input.table_name)
+                .await
+        })
+    }
+
+    fn list_tables(
+        &self,
+        account_id: &str,
+        input: ListTablesInput,
+    ) -> BoxFuture<'_, Result<ListTablesOutput, StorageError>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move {
+            let limit = i64::from(input.limit.unwrap_or(100));
+            // SQLite's default BINARY collation matches DynamoDB's UTF-8 byte
+            // order, so no COLLATE clause is needed. Fetch one extra to detect
+            // a continuation.
+            let rows: Vec<(String,)> = if let Some(start) = &input.exclusive_start_table_name {
+                sqlx::query_as(
+                    "SELECT table_name FROM tables WHERE account_id = ? AND table_name > ? \
+                     ORDER BY table_name LIMIT ?",
+                )
+                .bind(&account_id)
+                .bind(start)
+                .bind(limit + 1)
+                .fetch_all(&self.pool)
+                .await
+            } else {
+                sqlx::query_as(
+                    "SELECT table_name FROM tables WHERE account_id = ? \
+                     ORDER BY table_name LIMIT ?",
+                )
+                .bind(&account_id)
+                .bind(limit + 1)
+                .fetch_all(&self.pool)
+                .await
+            }
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let names: Vec<String> = rows.into_iter().map(|(n,)| n).collect();
+            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+            let limit_usize = limit.max(0) as usize;
+            if names.len() > limit_usize {
+                Ok(ListTablesOutput {
+                    last_evaluated_table_name: Some(names[limit_usize - 1].clone()),
+                    table_names: names[..limit_usize].to_vec(),
+                })
+            } else {
+                Ok(ListTablesOutput {
+                    table_names: names,
+                    last_evaluated_table_name: None,
+                })
+            }
+        })
+    }
+
+    fn update_table(
+        &self,
+        account_id: &str,
+        input: UpdateTableInput,
+    ) -> BoxFuture<'_, Result<TableDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.update_table_impl(&account_id, input).await })
+    }
+
+    fn table_key_info(
+        &self,
+        account_id: &str,
+        table_name: &str,
+    ) -> BoxFuture<'_, Result<TableKeyInfo, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        Box::pin(async move { self.fetch_table_key_info(&account_id, &table_name).await })
+    }
+
+    fn index_info(
+        &self,
+        account_id: &str,
+        table_name: &str,
+        index_name: &str,
+    ) -> BoxFuture<'_, Result<IndexInfo, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        let index_name = index_name.to_owned();
+        Box::pin(async move {
+            self.fetch_index_info(&account_id, &table_name, &index_name)
+                .await
+        })
+    }
+
+    fn index_info_by_table_id(
+        &self,
+        table_id: &str,
+        index_name: &str,
+    ) -> BoxFuture<'_, Result<IndexInfo, StorageError>> {
+        let table_id = table_id.to_owned();
+        let index_name = index_name.to_owned();
+        Box::pin(async move {
+            self.fetch_index_info_by_table_id(&table_id, &index_name)
+                .await
+        })
+    }
+}

--- a/crates/storage-sqlite/src/table_helpers.rs
+++ b/crates/storage-sqlite/src/table_helpers.rs
@@ -1,0 +1,322 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Row types and helpers for `TableEngine`: catalog row mapping, building a
+//! `TableDescription`, and GSI backfill. JSON columns are stored as TEXT, so
+//! they are fetched as `String` and parsed here.
+
+use extenddb_core::types::{
+    AttributeDefinition, BillingMode, BillingModeSummary, GsiDescription, KeySchemaElement,
+    LsiDescription, Projection, ProvisionedThroughput, ProvisionedThroughputDescription,
+    SseDescription, SseType, TableDescription, TableStatus,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::{index_arn, stream_arn};
+
+use crate::data;
+use crate::sqlite_util::parse_timestamp;
+use crate::store::SqliteEngine;
+
+/// Catalog `tables` row (JSON columns as TEXT, timestamp as RFC 3339 TEXT).
+#[derive(sqlx::FromRow)]
+pub(crate) struct TableRow {
+    pub table_name: String,
+    pub key_schema: String,
+    pub attribute_definitions: String,
+    pub billing_mode: String,
+    pub provisioned_throughput: Option<String>,
+    pub stream_specification: Option<String>,
+    pub table_status: String,
+    pub creation_date_time: String,
+    pub table_size_bytes: i64,
+    pub item_count: i64,
+    pub table_arn: String,
+    pub table_id: String,
+    pub deletion_protection_enabled: bool,
+    pub stream_label: Option<String>,
+    pub table_class: Option<String>,
+    pub sse_specification: Option<String>,
+    pub on_demand_throughput: Option<String>,
+}
+
+/// Catalog `indexes` row.
+#[derive(sqlx::FromRow)]
+pub(crate) struct IndexRow {
+    pub index_name: String,
+    #[allow(dead_code)]
+    pub index_id: String,
+    pub index_type: String,
+    pub key_schema: String,
+    pub projection: String,
+    pub index_status: String,
+    pub provisioned_throughput: Option<String>,
+}
+
+/// Columns selected for a `TableRow`, in `FromRow` field order.
+pub(crate) const TABLE_COLUMNS: &str = "table_name, key_schema, attribute_definitions, \
+     billing_mode, provisioned_throughput, stream_specification, table_status, \
+     creation_date_time, table_size_bytes, item_count, table_arn, table_id, \
+     deletion_protection_enabled, stream_label, table_class, sse_specification, \
+     on_demand_throughput";
+
+/// Columns selected for an `IndexRow`, in `FromRow` field order.
+pub(crate) const INDEX_COLUMNS: &str = "index_name, index_id, index_type, key_schema, \
+     projection, index_status, provisioned_throughput";
+
+fn parse_json<T: serde::de::DeserializeOwned>(s: &str, ctx: &str) -> Result<T, StorageError> {
+    serde_json::from_str(s).map_err(|e| StorageError::Internal(format!("{ctx}: {e}")))
+}
+
+impl SqliteEngine {
+    /// Build a `TableDescription` by reading the catalog.
+    pub(crate) async fn build_table_description(
+        &self,
+        account_id: &str,
+        table_name: &str,
+    ) -> Result<TableDescription, StorageError> {
+        let row: Option<TableRow> = sqlx::query_as(&format!(
+            "SELECT {TABLE_COLUMNS} FROM tables WHERE account_id = ? AND table_name = ?"
+        ))
+        .bind(account_id)
+        .bind(table_name)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let row = row.ok_or_else(|| StorageError::TableNotFound(table_name.to_owned()))?;
+
+        let index_rows: Vec<IndexRow> = sqlx::query_as(&format!(
+            "SELECT {INDEX_COLUMNS} FROM indexes WHERE table_id = ?"
+        ))
+        .bind(&row.table_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        self.build_table_description_from_row(account_id, row, index_rows)
+    }
+
+    pub(crate) fn build_table_description_from_row(
+        &self,
+        account_id: &str,
+        row: TableRow,
+        index_rows: Vec<IndexRow>,
+    ) -> Result<TableDescription, StorageError> {
+        let mut gsis: Vec<GsiDescription> = Vec::new();
+        let mut lsis: Vec<LsiDescription> = Vec::new();
+
+        for idx in index_rows {
+            let ks = parse_json(&idx.key_schema, "index key_schema")?;
+            let proj = parse_json(&idx.projection, "index projection")?;
+            if idx.index_type == "GSI" {
+                let pt = idx
+                    .provisioned_throughput
+                    .as_deref()
+                    .map(|s| parse_json::<ProvisionedThroughputDescription>(s, "index pt"))
+                    .transpose()?;
+                gsis.push(GsiDescription {
+                    index_name: idx.index_name.clone(),
+                    key_schema: ks,
+                    projection: proj,
+                    index_status: idx.index_status,
+                    provisioned_throughput: pt.or(Some(zero_throughput())),
+                    index_size_bytes: 0,
+                    item_count: 0,
+                    index_arn: index_arn(
+                        &self.region,
+                        account_id,
+                        &row.table_name,
+                        &idx.index_name,
+                    ),
+                });
+            } else {
+                lsis.push(LsiDescription {
+                    index_name: idx.index_name.clone(),
+                    key_schema: ks,
+                    projection: proj,
+                    index_size_bytes: 0,
+                    item_count: 0,
+                    index_arn: index_arn(
+                        &self.region,
+                        account_id,
+                        &row.table_name,
+                        &idx.index_name,
+                    ),
+                });
+            }
+        }
+
+        let key_schema = parse_json(&row.key_schema, "key_schema")?;
+        let attr_defs = parse_json(&row.attribute_definitions, "attribute_definitions")?;
+        let stream_spec = row
+            .stream_specification
+            .as_deref()
+            .map(|s| parse_json(s, "stream_specification"))
+            .transpose()?;
+
+        let (rcu, wcu) = match &row.provisioned_throughput {
+            Some(s) => {
+                let pt: ProvisionedThroughput = parse_json(s, "provisioned_throughput")?;
+                (pt.read_capacity_units, pt.write_capacity_units)
+            }
+            None => (0, 0),
+        };
+
+        let table_status = match row.table_status.as_str() {
+            "ACTIVE" => TableStatus::Active,
+            "CREATING" => TableStatus::Creating,
+            "DELETING" => TableStatus::Deleting,
+            "UPDATING" => TableStatus::Updating,
+            other => {
+                return Err(StorageError::Internal(format!(
+                    "unknown table status in database: {other}"
+                )));
+            }
+        };
+
+        let creation_epoch = parse_timestamp(&row.creation_date_time)
+            .map(|dt| dt.unix_timestamp() as f64)
+            .unwrap_or(0.0);
+
+        let billing_mode_summary = if row.billing_mode == "PAY_PER_REQUEST" {
+            Some(BillingModeSummary {
+                billing_mode: BillingMode::PayPerRequest,
+                last_update_to_pay_per_request_date_time: Some(creation_epoch),
+            })
+        } else {
+            None
+        };
+
+        let latest_stream_arn = row
+            .stream_label
+            .as_ref()
+            .map(|label| stream_arn(&self.region, account_id, &row.table_name, label));
+
+        let sse_description = row.sse_specification.as_deref().and_then(|spec| {
+            let enabled = serde_json::from_str::<serde_json::Value>(spec)
+                .ok()
+                .and_then(|v| v.get("Enabled").and_then(serde_json::Value::as_bool))
+                .unwrap_or(false);
+            enabled.then(|| SseDescription {
+                status: "ENABLED".to_owned(),
+                sse_type: Some(SseType::KMS),
+                kms_master_key_arn: Some(format!(
+                    "arn:aws:kms:{}:{}:key/default",
+                    self.region, account_id
+                )),
+            })
+        });
+
+        Ok(TableDescription {
+            table_name: row.table_name,
+            key_schema,
+            attribute_definitions: attr_defs,
+            table_status,
+            creation_date_time: creation_epoch,
+            table_size_bytes: row.table_size_bytes,
+            item_count: row.item_count,
+            table_arn: row.table_arn,
+            table_id: row.table_id,
+            provisioned_throughput: ProvisionedThroughputDescription {
+                read_capacity_units: rcu,
+                write_capacity_units: wcu,
+                number_of_decreases_today: 0,
+                last_increase_date_time: None,
+                last_decrease_date_time: None,
+            },
+            billing_mode_summary,
+            global_secondary_indexes: (!gsis.is_empty()).then_some(gsis),
+            local_secondary_indexes: (!lsis.is_empty()).then_some(lsis),
+            stream_specification: stream_spec,
+            latest_stream_arn,
+            latest_stream_label: row.stream_label,
+            deletion_protection_enabled: row.deletion_protection_enabled,
+            sse_description,
+            table_class_summary: row
+                .table_class
+                .as_ref()
+                .map(|tc| serde_json::json!({ "TableClass": tc })),
+            on_demand_throughput: row
+                .on_demand_throughput
+                .as_deref()
+                .and_then(|s| serde_json::from_str(s).ok()),
+        })
+    }
+
+    /// Backfill existing base-table items into a newly created GSI, batched to
+    /// bound memory.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn backfill_gsi(
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        table_id: &str,
+        index_id: &str,
+        index_key_schema: &[KeySchemaElement],
+        attr_defs: &[AttributeDefinition],
+        base_key_schema: &[KeySchemaElement],
+        base_attr_defs: &[AttributeDefinition],
+        projection: &Projection,
+    ) -> Result<(), StorageError> {
+        const BATCH: i64 = 500;
+        let base_table = data::data_table_name(table_id);
+        let idx_table = data::index_table_name(index_id);
+        let idx_sks = data::all_sort_key_info(index_key_schema, attr_defs);
+        let base_sks = data::all_sort_key_info(base_key_schema, base_attr_defs);
+
+        let sql = format!("SELECT item_data FROM {base_table} ORDER BY pk LIMIT ? OFFSET ?");
+        let mut offset: i64 = 0;
+        loop {
+            let rows: Vec<(String,)> = sqlx::query_as(&sql)
+                .bind(BATCH)
+                .bind(offset)
+                .fetch_all(&mut **tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if rows.is_empty() {
+                break;
+            }
+            let len = rows.len() as i64;
+            for (item_json,) in rows {
+                let item: extenddb_core::types::Item = serde_json::from_str(&item_json)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                if !index_key_schema
+                    .iter()
+                    .all(|ks| item.contains_key(&ks.attribute_name))
+                {
+                    continue;
+                }
+                let projected = data::project_item_for_index(
+                    &item,
+                    index_key_schema,
+                    base_key_schema,
+                    projection,
+                );
+                data::insert_index_row_multi(
+                    tx,
+                    &idx_table,
+                    &item,
+                    &projected,
+                    index_key_schema,
+                    base_key_schema,
+                    &idx_sks,
+                    &base_sks,
+                )
+                .await?;
+            }
+            if len < BATCH {
+                break;
+            }
+            offset += len;
+        }
+        Ok(())
+    }
+}
+
+fn zero_throughput() -> ProvisionedThroughputDescription {
+    ProvisionedThroughputDescription {
+        read_capacity_units: 0,
+        write_capacity_units: 0,
+        number_of_decreases_today: 0,
+        last_increase_date_time: None,
+        last_decrease_date_time: None,
+    }
+}

--- a/crates/storage-sqlite/src/update_table.rs
+++ b/crates/storage-sqlite/src/update_table.rs
@@ -1,0 +1,581 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `update_table` implementation for `SqliteEngine` (REQ-CTRL-003).
+//!
+//! Mirrors the PostgreSQL backend: billing mode, provisioned throughput,
+//! deletion protection, stream specification, table class, on-demand
+//! throughput, and GSI create/delete. Single-pool; the engine write lock
+//! replaces `FOR UPDATE`. GSI data tables are created (and backfilled) or
+//! dropped after the catalog transaction commits, with catalog cleanup on
+//! a data-DDL failure.
+
+use extenddb_core::types::{
+    AttributeDefinition, BillingMode, KeySchemaElement, TableDescription, UpdateTableInput,
+};
+use extenddb_storage::error::StorageError;
+
+use crate::store::SqliteEngine;
+
+impl SqliteEngine {
+    pub(crate) async fn update_table_impl(
+        &self,
+        account_id: &str,
+        input: UpdateTableInput,
+    ) -> Result<TableDescription, StorageError> {
+        Self::validate_account_id(account_id)?;
+
+        let _writer = self.write_lock.lock().await;
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let row: Option<(String, String, String, String)> = sqlx::query_as(
+            "SELECT table_status, table_id, key_schema, attribute_definitions \
+             FROM tables WHERE account_id = ? AND table_name = ?",
+        )
+        .bind(account_id)
+        .bind(&input.table_name)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let (status, table_id, ks_json, ad_json) =
+            row.ok_or_else(|| StorageError::TableNotFound(input.table_name.clone()))?;
+        if status != "ACTIVE" {
+            return Err(StorageError::TableNotActive(input.table_name.clone()));
+        }
+
+        // Reject ProvisionedThroughput when the effective billing mode is
+        // PAY_PER_REQUEST. The effective mode is the requested billing_mode when
+        // the request changes it, otherwise the table's current mode. Real
+        // DynamoDB returns "Neither ReadCapacityUnits nor WriteCapacityUnits can
+        // be specified when BillingMode is PAY_PER_REQUEST". Checked here, under
+        // the write transaction, because it depends on the table's current
+        // billing mode. Mirrors the PostgreSQL backend.
+        if input.provisioned_throughput.is_some() {
+            let effective_ppr = match input.billing_mode {
+                Some(BillingMode::PayPerRequest) => true,
+                Some(BillingMode::Provisioned) => false,
+                None => {
+                    let current_bm: Option<Option<String>> = sqlx::query_scalar(
+                        "SELECT billing_mode FROM tables WHERE account_id = ? AND table_name = ?",
+                    )
+                    .bind(account_id)
+                    .bind(&input.table_name)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    current_bm.flatten().as_deref() == Some("PAY_PER_REQUEST")
+                }
+            };
+            if effective_ppr {
+                return Err(StorageError::Validation(
+                    "One or more parameter values were invalid: Neither ReadCapacityUnits nor WriteCapacityUnits can be specified when BillingMode is PAY_PER_REQUEST".to_owned(),
+                ));
+            }
+        }
+
+        // No-op rejection: same PROVISIONED throughput.
+        if matches!(input.billing_mode, Some(BillingMode::Provisioned))
+            && let Some(ref pt) = input.provisioned_throughput
+        {
+            let current: Option<(Option<String>, Option<String>)> = sqlx::query_as(
+                "SELECT billing_mode, provisioned_throughput FROM tables \
+                 WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(account_id)
+            .bind(&input.table_name)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if let Some((bm, cur_pt)) = current {
+                let is_prov = bm.as_deref() == Some("PROVISIONED") || bm.is_none();
+                let cur: serde_json::Value = cur_pt
+                    .as_deref()
+                    .and_then(|s| serde_json::from_str(s).ok())
+                    .unwrap_or_else(|| serde_json::json!({}));
+                let cur_rcu = cur
+                    .get("ReadCapacityUnits")
+                    .or_else(|| cur.get("read_capacity_units"))
+                    .and_then(serde_json::Value::as_i64)
+                    .unwrap_or(0);
+                let cur_wcu = cur
+                    .get("WriteCapacityUnits")
+                    .or_else(|| cur.get("write_capacity_units"))
+                    .and_then(serde_json::Value::as_i64)
+                    .unwrap_or(0);
+                if is_prov
+                    && cur_rcu == pt.read_capacity_units
+                    && cur_wcu == pt.write_capacity_units
+                {
+                    return Err(StorageError::NoOpUpdate(format!(
+                        "The provisioned throughput for the table will not change. \
+                         The requested value equals the current value. \
+                         Current ReadCapacityUnits provisioned for the table: {cur_rcu}. \
+                         Requested ReadCapacityUnits: {}. \
+                         Current WriteCapacityUnits provisioned for the table: {cur_wcu}. \
+                         Requested WriteCapacityUnits: {}.",
+                        pt.read_capacity_units, pt.write_capacity_units
+                    )));
+                }
+            }
+        }
+
+        if let Some(bm) = &input.billing_mode {
+            let s = match bm {
+                BillingMode::Provisioned => "PROVISIONED",
+                BillingMode::PayPerRequest => "PAY_PER_REQUEST",
+            };
+            update_col(&mut tx, account_id, &input.table_name, "billing_mode", s).await?;
+        }
+        if let Some(pt) = &input.provisioned_throughput {
+            let j = serde_json::to_string(pt).map_err(|e| StorageError::Internal(e.to_string()))?;
+            update_col(
+                &mut tx,
+                account_id,
+                &input.table_name,
+                "provisioned_throughput",
+                &j,
+            )
+            .await?;
+        }
+        if let Some(dp) = input.deletion_protection_enabled {
+            sqlx::query(
+                "UPDATE tables SET deletion_protection_enabled = ? \
+                 WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(dp)
+            .bind(account_id)
+            .bind(&input.table_name)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        }
+        if let Some(tc) = &input.table_class {
+            update_col(&mut tx, account_id, &input.table_name, "table_class", tc).await?;
+        }
+        if let Some(odt) = &input.on_demand_throughput {
+            let j =
+                serde_json::to_string(odt).map_err(|e| StorageError::Internal(e.to_string()))?;
+            update_col(
+                &mut tx,
+                account_id,
+                &input.table_name,
+                "on_demand_throughput",
+                &j,
+            )
+            .await?;
+        }
+        if let Some(spec) = &input.stream_specification {
+            let j =
+                serde_json::to_string(spec).map_err(|e| StorageError::Internal(e.to_string()))?;
+            update_col(
+                &mut tx,
+                account_id,
+                &input.table_name,
+                "stream_specification",
+                &j,
+            )
+            .await?;
+            if spec.stream_enabled {
+                let existing: Option<(String,)> =
+                    sqlx::query_as("SELECT shard_id FROM stream_shards WHERE table_id = ? LIMIT 1")
+                        .bind(&table_id)
+                        .fetch_optional(&mut *tx)
+                        .await
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                if existing.is_none() {
+                    Self::init_stream_shards(&mut tx, account_id, &input.table_name, &table_id)
+                        .await?;
+                } else {
+                    let label: Option<String> = sqlx::query_scalar(
+                        "SELECT stream_label FROM tables WHERE account_id = ? AND table_name = ?",
+                    )
+                    .bind(account_id)
+                    .bind(&input.table_name)
+                    .fetch_one(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    if label.is_none() {
+                        sqlx::query(
+                            "UPDATE tables SET stream_label = strftime('%Y-%m-%dT%H:%M:%S','now') \
+                             WHERE account_id = ? AND table_name = ?",
+                        )
+                        .bind(account_id)
+                        .bind(&input.table_name)
+                        .execute(&mut *tx)
+                        .await
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    }
+                }
+            }
+        }
+
+        // GSI create/delete.
+        let mut created: Vec<String> = Vec::new();
+        let mut deleted: Vec<String> = Vec::new();
+        if let Some(updates) = &input.global_secondary_index_updates {
+            for update in updates {
+                if let Some(create) = &update.create {
+                    let dup: Option<(String,)> = sqlx::query_as(
+                        "SELECT index_name FROM indexes WHERE table_id = ? AND index_name = ?",
+                    )
+                    .bind(&table_id)
+                    .bind(&create.index_name)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    if dup.is_some() {
+                        return Err(StorageError::IndexAlreadyExists(create.index_name.clone()));
+                    }
+                    let ks = serde_json::to_string(&create.key_schema)
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    let proj = serde_json::to_string(&create.projection)
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    let pt = create
+                        .provisioned_throughput
+                        .as_ref()
+                        .map(serde_json::to_string)
+                        .transpose()
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    let index_id = uuid::Uuid::new_v4().to_string();
+                    sqlx::query(
+                        "INSERT INTO indexes \
+                         (table_id, index_name, index_id, index_type, key_schema, projection, \
+                          index_status, provisioned_throughput) \
+                         VALUES (?, ?, ?, 'GSI', ?, ?, 'CREATING', ?)",
+                    )
+                    .bind(&table_id)
+                    .bind(&create.index_name)
+                    .bind(&index_id)
+                    .bind(&ks)
+                    .bind(&proj)
+                    .bind(&pt)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    created.push(index_id);
+                }
+                if let Some(delete) = &update.delete {
+                    let existing: Option<(String,)> = sqlx::query_as(
+                        "SELECT index_id FROM indexes WHERE table_id = ? AND index_name = ?",
+                    )
+                    .bind(&table_id)
+                    .bind(&delete.index_name)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    let (del_id,) = existing
+                        .ok_or_else(|| StorageError::IndexNotFound(delete.index_name.clone()))?;
+                    sqlx::query("DELETE FROM indexes WHERE table_id = ? AND index_name = ?")
+                        .bind(&table_id)
+                        .bind(&delete.index_name)
+                        .execute(&mut *tx)
+                        .await
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    deleted.push(del_id);
+                }
+            }
+            if let Some(new_attr_defs) = &input.attribute_definitions {
+                let j = serde_json::to_string(new_attr_defs)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                update_col(
+                    &mut tx,
+                    account_id,
+                    &input.table_name,
+                    "attribute_definitions",
+                    &j,
+                )
+                .await?;
+            }
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        // Data DDL after catalog commit.
+        if let Some(updates) = &input.global_secondary_index_updates {
+            let base_ks: Vec<KeySchemaElement> = serde_json::from_str(&ks_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let base_ad: Vec<AttributeDefinition> = serde_json::from_str(&ad_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let effective_ad = input.attribute_definitions.as_deref().unwrap_or(&base_ad);
+
+            let mut ci = 0usize;
+            let mut di = 0usize;
+            for update in updates {
+                if let Some(create) = &update.create {
+                    let idx_id = created[ci].clone();
+                    ci += 1;
+                    let result = async {
+                        let mut data_tx = self
+                            .pool
+                            .begin_with("BEGIN IMMEDIATE")
+                            .await
+                            .map_err(|e| StorageError::Internal(e.to_string()))?;
+                        Self::create_index_data_table(
+                            &mut data_tx,
+                            &idx_id,
+                            &create.key_schema,
+                            effective_ad,
+                            &base_ks,
+                            &base_ad,
+                        )
+                        .await?;
+                        Self::backfill_gsi(
+                            &mut data_tx,
+                            &table_id,
+                            &idx_id,
+                            &create.key_schema,
+                            effective_ad,
+                            &base_ks,
+                            &base_ad,
+                            &create.projection,
+                        )
+                        .await?;
+                        data_tx
+                            .commit()
+                            .await
+                            .map_err(|e| StorageError::Internal(e.to_string()))?;
+                        Ok::<(), StorageError>(())
+                    }
+                    .await;
+                    if let Err(e) = result {
+                        tracing::error!(
+                            "Failed to build GSI '{}' on '{}', cleaning up catalog: {e}",
+                            create.index_name,
+                            input.table_name
+                        );
+                        let _ = sqlx::query(
+                            "DELETE FROM indexes WHERE table_id = ? AND index_name = ?",
+                        )
+                        .bind(&table_id)
+                        .bind(&create.index_name)
+                        .execute(&self.pool)
+                        .await;
+                        return Err(e);
+                    }
+                    // Backfill succeeded and the data table is populated, so the
+                    // index is now queryable: flip CREATING -> ACTIVE. DescribeTable
+                    // reports CREATING until this point (matching DynamoDB), so a
+                    // Query never hits a not-yet-populated index, and a crash before
+                    // here leaves a CREATING row the startup reconciler rebuilds.
+                    sqlx::query(
+                        "UPDATE indexes SET index_status = 'ACTIVE' \
+                         WHERE table_id = ? AND index_id = ?",
+                    )
+                    .bind(&table_id)
+                    .bind(&idx_id)
+                    .execute(&self.pool)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                }
+                if update.delete.is_some() {
+                    let idx_id = deleted[di].clone();
+                    di += 1;
+                    let mut data_tx = self
+                        .pool
+                        .begin_with("BEGIN IMMEDIATE")
+                        .await
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    Self::drop_index_data_table(&mut data_tx, &idx_id).await?;
+                    data_tx
+                        .commit()
+                        .await
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                }
+            }
+        }
+
+        self.build_table_description(account_id, &input.table_name)
+            .await
+    }
+
+    /// Rebuild any GSI left in `CREATING` by a crash between the catalog commit
+    /// and the completion of its data-table backfill. Runs once at startup: for
+    /// each such index it drops any partial data table, recreates and backfills
+    /// it, then flips the catalog row to `ACTIVE`. This closes the non-atomic
+    /// create+backfill gap (an `ACTIVE` index with no/partial data table can
+    /// never be observed, and nothing is left permanently stuck in `CREATING`).
+    pub(crate) async fn reconcile_incomplete_gsis(&self) -> Result<usize, StorageError> {
+        let rows: Vec<(String, String, String, String, String, String)> = sqlx::query_as(
+            "SELECT i.index_id, i.table_id, i.key_schema, i.projection, \
+                    t.key_schema, t.attribute_definitions \
+             FROM indexes i JOIN tables t ON i.table_id = t.table_id \
+             WHERE i.index_status = 'CREATING' AND i.index_type = 'GSI'",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let mut rebuilt = 0usize;
+        for (index_id, table_id, idx_ks_json, proj_json, base_ks_json, base_ad_json) in rows {
+            let index_key_schema: Vec<KeySchemaElement> = serde_json::from_str(&idx_ks_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let projection: extenddb_core::types::Projection = serde_json::from_str(&proj_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let base_key_schema: Vec<KeySchemaElement> = serde_json::from_str(&base_ks_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let attr_defs: Vec<AttributeDefinition> = serde_json::from_str(&base_ad_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let _writer = self.write_lock.lock().await;
+            let mut data_tx = self
+                .pool
+                .begin_with("BEGIN IMMEDIATE")
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Self::drop_index_data_table(&mut data_tx, &index_id).await?;
+            Self::create_index_data_table(
+                &mut data_tx,
+                &index_id,
+                &index_key_schema,
+                &attr_defs,
+                &base_key_schema,
+                &attr_defs,
+            )
+            .await?;
+            Self::backfill_gsi(
+                &mut data_tx,
+                &table_id,
+                &index_id,
+                &index_key_schema,
+                &attr_defs,
+                &base_key_schema,
+                &attr_defs,
+                &projection,
+            )
+            .await?;
+            data_tx
+                .commit()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            sqlx::query(
+                "UPDATE indexes SET index_status = 'ACTIVE' \
+                 WHERE table_id = ? AND index_id = ?",
+            )
+            .bind(&table_id)
+            .bind(&index_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            rebuilt += 1;
+            tracing::info!("Reconciled incomplete GSI {index_id} on table {table_id}");
+        }
+        Ok(rebuilt)
+    }
+}
+
+/// Update a single string column on the `tables` row.
+async fn update_col(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    account_id: &str,
+    table_name: &str,
+    column: &str,
+    value: &str,
+) -> Result<(), StorageError> {
+    // `column` is a compile-time constant from this module, never user input.
+    let sql = format!("UPDATE tables SET {column} = ? WHERE account_id = ? AND table_name = ?");
+    sqlx::query(&sql)
+        .bind(value)
+        .bind(account_id)
+        .bind(table_name)
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod reconciler_tests {
+    use crate::SqliteEngine;
+    use serde_json::json;
+
+    /// A GSI left in `CREATING` by a crash (catalog row committed, but its data
+    /// table never finished backfilling) must be rebuilt on startup: the
+    /// reconciler recreates + backfills the data table and flips the row to
+    /// `ACTIVE`. A second run is a no-op (idempotent). The `ACTIVE` flip only
+    /// happens after create+backfill both succeed, so asserting `ACTIVE` proves
+    /// the full rebuild ran.
+    #[tokio::test]
+    async fn reconcile_rebuilds_creating_gsi_to_active() {
+        let engine = SqliteEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+
+        let account = "000000000000";
+        sqlx::query("INSERT INTO accounts (account_id, account_name) VALUES (?, 'default')")
+            .bind(account)
+            .execute(&engine.pool)
+            .await
+            .expect("account");
+
+        // Create the base table via the real path (this also creates its
+        // `_ddb_<table_id>` data table that backfill will scan).
+        let input: extenddb_core::types::CreateTableInput = serde_json::from_value(json!({
+            "TableName": "t",
+            "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "gsipk", "AttributeType": "S"}
+            ],
+            "BillingMode": "PAY_PER_REQUEST"
+        }))
+        .expect("input");
+        engine
+            .create_table_impl(account, input)
+            .await
+            .expect("create table");
+
+        let (table_id,): (String,) =
+            sqlx::query_as("SELECT table_id FROM tables WHERE account_id = ? AND table_name = 't'")
+                .bind(account)
+                .fetch_one(&engine.pool)
+                .await
+                .expect("table_id");
+
+        // Simulate a crash mid-build: a CREATING GSI catalog row whose data table
+        // was never created.
+        let ks = json!([{"AttributeName": "gsipk", "KeyType": "HASH"}]).to_string();
+        let proj = json!({"ProjectionType": "ALL"}).to_string();
+        sqlx::query(
+            "INSERT INTO indexes \
+             (table_id, index_id, index_name, index_type, key_schema, projection, index_status) \
+             VALUES (?, 'idx-1', 'gsi1', 'GSI', ?, ?, 'CREATING')",
+        )
+        .bind(&table_id)
+        .bind(&ks)
+        .bind(&proj)
+        .execute(&engine.pool)
+        .await
+        .expect("insert CREATING index");
+
+        // Reconcile rebuilds it.
+        let rebuilt = engine.reconcile_incomplete_gsis().await.expect("reconcile");
+        assert_eq!(rebuilt, 1, "one CREATING GSI should be rebuilt");
+
+        let (status,): (String,) = sqlx::query_as(
+            "SELECT index_status FROM indexes WHERE table_id = ? AND index_id = 'idx-1'",
+        )
+        .bind(&table_id)
+        .fetch_one(&engine.pool)
+        .await
+        .expect("status");
+        assert_eq!(status, "ACTIVE", "reconciled GSI must be flipped to ACTIVE");
+
+        // Idempotent: nothing left in CREATING, so a second run rebuilds nothing.
+        assert_eq!(
+            engine
+                .reconcile_incomplete_gsis()
+                .await
+                .expect("second reconcile"),
+            0,
+            "reconciler must be idempotent"
+        );
+    }
+}

--- a/crates/storage-sqlite/src/worker.rs
+++ b/crates/storage-sqlite/src/worker.rs
@@ -1,0 +1,109 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `WorkerStore` trait implementation and control-plane transition processing.
+//!
+//! Tables in CREATING whose `status_transition_at` has passed become ACTIVE;
+//! tables in DELETING whose time has passed are removed (catalog row cascades
+//! to indexes/shards/records) and their `_ddb_*` data tables dropped. The
+//! engine write lock replaces PostgreSQL's `FOR UPDATE SKIP LOCKED`, and the
+//! `<= now` comparison binds an RFC 3339 cutoff computed in Rust.
+
+use extenddb_storage::WorkerStore;
+use extenddb_storage::error::StorageError;
+use futures::future::BoxFuture;
+
+use crate::sqlite_util::format_timestamp;
+use crate::store::SqliteEngine;
+
+impl WorkerStore for SqliteEngine {
+    fn process_control_plane_transitions(
+        &self,
+    ) -> BoxFuture<'_, Result<Vec<(String, &'static str)>, StorageError>> {
+        Box::pin(async move { Self::process_control_plane_transitions(self).await })
+    }
+}
+
+impl SqliteEngine {
+    /// Process due control-plane transitions. Returns `(table_name, change)`
+    /// pairs for logging. Called by the background poller and at startup.
+    pub async fn process_control_plane_transitions(
+        &self,
+    ) -> Result<Vec<(String, &'static str)>, StorageError> {
+        let _writer = self.write_lock.lock().await;
+        let now = format_timestamp(time::OffsetDateTime::now_utc());
+        let mut transitions = Vec::new();
+
+        // CREATING → ACTIVE.
+        let activated: Vec<(String,)> = sqlx::query_as(
+            "UPDATE tables SET table_status = 'ACTIVE', status_transition_at = NULL \
+             WHERE table_status = 'CREATING' AND status_transition_at IS NOT NULL \
+               AND status_transition_at <= ? RETURNING table_name",
+        )
+        .bind(&now)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+        for (name,) in activated {
+            transitions.push((name, "CREATING → active"));
+        }
+
+        // DELETING → removed.
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let candidates: Vec<(String, String, String)> = sqlx::query_as(
+            "SELECT table_name, table_arn, table_id FROM tables \
+             WHERE table_status = 'DELETING' AND status_transition_at IS NOT NULL \
+               AND status_transition_at <= ?",
+        )
+        .bind(&now)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        for (name, arn, table_id) in &candidates {
+            // Collect index ids before deleting the table row (CASCADE removes them).
+            let index_ids: Vec<(String,)> =
+                sqlx::query_as("SELECT index_id FROM indexes WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_all(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            sqlx::query("DELETE FROM tags WHERE resource_arn = ?")
+                .bind(arn)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            sqlx::query("DELETE FROM tables WHERE table_id = ?")
+                .bind(table_id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            for (idx_id,) in &index_ids {
+                Self::drop_index_data_table(&mut tx, idx_id).await?;
+            }
+            Self::drop_data_table(&mut tx, table_id).await?;
+            // Remove orphaned pending GSI rows in the same drop transaction.
+            sqlx::query("DELETE FROM gsi_pending WHERE table_id = ?")
+                .bind(table_id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            transitions.push((name.clone(), "DELETING → deleted"));
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        Ok(transitions)
+    }
+}

--- a/crates/storage-sqlite/src/workers.rs
+++ b/crates/storage-sqlite/src/workers.rs
@@ -1,0 +1,622 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! SQLite background workers: control-plane transition poller, table-size
+//! refresh, stream-record cleanup, idempotency-token cleanup, TTL sweep, the
+//! persistent GSI propagation worker, and the GSI-delay setting poller.
+//!
+//! GSI updates with a non-zero effective propagation delay are applied
+//! asynchronously via the `gsi_pending` queue (drained by an event-driven
+//! worker); LSIs and zero-delay GSIs are applied synchronously on the write
+//! path. There is a single connection pool (catalog and data co-locate).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use extenddb_core::metrics::{MetricsCollector, QuerySource};
+use extenddb_core::types::UserIdentity;
+use extenddb_storage::error::StorageError;
+use extenddb_storage::hooks::{CancellationToken, sleep_or_shutdown};
+use extenddb_storage::management_store::SettingsStore;
+use extenddb_storage::{DataEngine, MetadataEngine, StreamEngine, TableEngine};
+
+use crate::store::SqliteEngine;
+
+pub(crate) async fn poll_control_plane_transitions<S: SettingsStore + ?Sized>(
+    storage: Arc<SqliteEngine>,
+    notify: Arc<tokio::sync::Notify>,
+    settings: Arc<S>,
+    token: CancellationToken,
+) {
+    const ACTIVE_POLL: Duration = Duration::from_secs(1);
+    const IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+    const MARGIN_SECS: f64 = 5.0;
+
+    loop {
+        // Idle: wait for a wake signal, an idle timeout (defensive sweep), or
+        // shutdown.
+        let shutting_down = tokio::select! {
+            () = token.cancelled() => true,
+            _ = tokio::time::timeout(IDLE_TIMEOUT, notify.notified()) => false,
+        };
+        if shutting_down {
+            return;
+        }
+        let delay = settings
+            .get_setting("control_plane_delay_seconds")
+            .await
+            .ok()
+            .flatten()
+            .and_then(|v| v.parse::<f64>().ok())
+            .filter(|&v| v >= 0.0)
+            .unwrap_or(0.25);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs_f64(delay + MARGIN_SECS);
+        loop {
+            match storage.process_control_plane_transitions().await {
+                Ok(transitions) => {
+                    for (name, transition) in &transitions {
+                        tracing::info!("Table '{name}': {transition}");
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("Control plane transition poll failed: {e}");
+                    break;
+                }
+            }
+            if tokio::time::Instant::now() >= deadline {
+                break;
+            }
+            if !sleep_or_shutdown(&token, ACTIVE_POLL).await {
+                return;
+            }
+        }
+    }
+}
+
+pub(crate) async fn table_size_refresh_worker(
+    storage: Arc<SqliteEngine>,
+    token: CancellationToken,
+) {
+    const INTERVAL: Duration = Duration::from_secs(300);
+    while sleep_or_shutdown(&token, INTERVAL).await {
+        let tables = match MetadataEngine::all_active_tables(&*storage).await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!("Size refresh worker: list tables failed: {e}");
+                continue;
+            }
+        };
+        for (account_id, table_name) in &tables {
+            if let Err(e) =
+                MetadataEngine::refresh_table_size(&*storage, account_id, table_name).await
+            {
+                tracing::warn!("Size refresh worker: {table_name}: {e}");
+            }
+        }
+    }
+}
+
+pub(crate) async fn stream_record_cleanup_worker(
+    storage: Arc<SqliteEngine>,
+    metrics: Arc<MetricsCollector>,
+    token: CancellationToken,
+) {
+    const INTERVAL: Duration = Duration::from_secs(3600);
+    const RETENTION_HOURS: i64 = 24;
+    while sleep_or_shutdown(&token, INTERVAL).await {
+        let start = std::time::Instant::now();
+        match StreamEngine::cleanup_expired_stream_records(&*storage, RETENTION_HOURS).await {
+            Ok(n) => {
+                if n > 0 {
+                    tracing::info!("Stream cleanup worker: deleted {n} expired record(s)");
+                }
+                #[allow(clippy::cast_precision_loss)]
+                metrics.record_worker_success(
+                    QuerySource::StreamCleanup,
+                    start.elapsed().as_micros() as f64,
+                );
+            }
+            Err(e) => {
+                tracing::error!("Stream record cleanup failed: {e}");
+                metrics.record_worker_error(QuerySource::StreamCleanup);
+            }
+        }
+    }
+}
+
+pub(crate) async fn idempotency_token_cleanup_worker(
+    storage: Arc<SqliteEngine>,
+    metrics: Arc<MetricsCollector>,
+    token: CancellationToken,
+) {
+    const INTERVAL: Duration = Duration::from_secs(600);
+    const MAX_AGE_SECONDS: i64 = 600;
+    while sleep_or_shutdown(&token, INTERVAL).await {
+        let start = std::time::Instant::now();
+        match DataEngine::cleanup_expired_idempotency_tokens(&*storage, MAX_AGE_SECONDS).await {
+            Ok(n) => {
+                if n > 0 {
+                    tracing::info!("Idempotency cleanup worker: deleted {n} expired token(s)");
+                }
+                #[allow(clippy::cast_precision_loss)]
+                metrics.record_worker_success(
+                    QuerySource::IdempotencyCleanup,
+                    start.elapsed().as_micros() as f64,
+                );
+            }
+            Err(e) => {
+                tracing::error!("Idempotency token cleanup failed: {e}");
+                metrics.record_worker_error(QuerySource::IdempotencyCleanup);
+            }
+        }
+    }
+}
+
+const TTL_SCAN_INTERVAL: Duration = Duration::from_secs(60);
+const TTL_BATCH: usize = 100;
+
+pub(crate) async fn ttl_cleanup_worker(
+    storage: Arc<SqliteEngine>,
+    metrics: Arc<MetricsCollector>,
+    token: CancellationToken,
+) {
+    let region: Arc<str> = Arc::from(storage.region.as_str());
+    while sleep_or_shutdown(&token, TTL_SCAN_INTERVAL).await {
+        retry_pending_indexes(&storage).await;
+        sweep_expired_items(&storage, &metrics, &region).await;
+    }
+}
+
+async fn retry_pending_indexes(storage: &SqliteEngine) {
+    let (Ok(pending), Ok(ready)) = (
+        MetadataEngine::all_tables_with_ttl(storage).await,
+        MetadataEngine::all_tables_with_ttl_index_ready(storage).await,
+    ) else {
+        return;
+    };
+    let ready_set: std::collections::HashSet<(&str, &str)> = ready
+        .iter()
+        .map(|(a, t, _)| (a.as_str(), t.as_str()))
+        .collect();
+    for (account_id, table_name, ttl_attr) in &pending {
+        if !ready_set.contains(&(account_id.as_str(), table_name.as_str()))
+            && let Err(e) =
+                MetadataEngine::create_ttl_index(storage, account_id, table_name, ttl_attr).await
+        {
+            tracing::debug!("TTL worker: index retry failed for {table_name}: {e}");
+        }
+    }
+}
+
+async fn sweep_expired_items(
+    storage: &SqliteEngine,
+    metrics: &MetricsCollector,
+    region: &Arc<str>,
+) {
+    let ttl_identity = UserIdentity {
+        identity_type: "Service".to_owned(),
+        principal_id: "dynamodb.amazonaws.com".to_owned(),
+    };
+
+    let tables = match MetadataEngine::all_tables_with_ttl_index_ready(storage).await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!("TTL worker: list tables failed: {e}");
+            return;
+        }
+    };
+
+    let now_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    for (account_id, table_name, ttl_attribute) in &tables {
+        let items = match MetadataEngine::find_expired_items_indexed(
+            storage,
+            account_id,
+            table_name,
+            ttl_attribute,
+            TTL_BATCH,
+        )
+        .await
+        {
+            Ok(items) => items,
+            Err(e) => {
+                tracing::warn!("TTL worker: find expired failed for {table_name}: {e}");
+                continue;
+            }
+        };
+        if items.is_empty() {
+            continue;
+        }
+        let key_info = match TableEngine::table_key_info(storage, account_id, table_name).await {
+            Ok(ki) => ki,
+            Err(e) => {
+                tracing::warn!("TTL worker: key info failed for {table_name}: {e}");
+                continue;
+            }
+        };
+        let view_type = key_info.stream_specification.as_ref().and_then(|s| {
+            if s.stream_enabled {
+                s.stream_view_type
+            } else {
+                None
+            }
+        });
+        let (condition_expr, maps) = build_ttl_condition(ttl_attribute, now_epoch);
+
+        let mut deleted = 0usize;
+        for item in &items {
+            let staleness = item
+                .get(ttl_attribute.as_str())
+                .and_then(|av| match av {
+                    extenddb_core::types::AttributeValue::N(n) => n.parse::<u64>().ok(),
+                    _ => None,
+                })
+                .map(|ttl_val| now_epoch.saturating_sub(ttl_val));
+
+            let key: extenddb_core::types::Item = key_info
+                .key_schema
+                .iter()
+                .filter_map(|ks| {
+                    item.get(&ks.attribute_name)
+                        .map(|v| (ks.attribute_name.clone(), v.clone()))
+                })
+                .collect();
+
+            let stream = view_type.map(|vt| extenddb_storage::StreamCapture {
+                view_type: vt,
+                user_identity: Some(ttl_identity.clone()),
+                region: region.clone(),
+            });
+            match DataEngine::delete_item(
+                storage,
+                &key_info,
+                &key,
+                view_type.is_some(),
+                Some(&condition_expr),
+                &maps,
+                stream.as_ref(),
+            )
+            .await
+            {
+                Err(StorageError::ConditionFailed(_)) => {}
+                Err(e) => tracing::warn!("TTL worker: delete failed for {table_name}: {e}"),
+                Ok(_) => {
+                    deleted += 1;
+                    metrics.record_ttl_deletion(table_name);
+                    if let Some(s) = staleness {
+                        #[allow(clippy::cast_precision_loss)]
+                        metrics.record_ttl_staleness(table_name, s as f64);
+                    }
+                }
+            }
+        }
+        if deleted > 0 {
+            tracing::info!("TTL worker: deleted {deleted} expired item(s) from {table_name}");
+        }
+    }
+}
+
+/// `attribute_exists(#ttl) AND #ttl <= :now` — guards against deleting an item
+/// whose TTL was cleared or moved into the future between scan and delete.
+fn build_ttl_condition(
+    ttl_attribute: &str,
+    now_epoch: u64,
+) -> (
+    extenddb_core::expression::Expr,
+    extenddb_core::expression::ExpressionMaps,
+) {
+    use extenddb_core::expression::{CompareOp, Expr, ExpressionMaps, PathElement};
+    use std::collections::HashMap;
+
+    let ttl_path = vec![PathElement::Attribute("#ttl".to_owned())];
+    let condition = Expr::And(
+        Box::new(Expr::Function {
+            name: "attribute_exists".to_owned(),
+            args: vec![Expr::Path(ttl_path.clone())],
+        }),
+        Box::new(Expr::Compare {
+            left: Box::new(Expr::Path(ttl_path)),
+            op: CompareOp::Le,
+            right: Box::new(Expr::Placeholder("now".to_owned())),
+        }),
+    );
+    let mut names = HashMap::new();
+    names.insert("ttl".to_owned(), ttl_attribute.to_owned());
+    let mut values = HashMap::new();
+    values.insert(
+        "now".to_owned(),
+        extenddb_core::types::AttributeValue::N(now_epoch.to_string()),
+    );
+    (condition, ExpressionMaps::new(names, values))
+}
+
+/// Maximum `gsi_pending` rows claimed per worker batch.
+const GSI_BATCH: i64 = 100;
+
+/// Drains the persistent `gsi_pending` queue, applying async GSI updates whose
+/// `ready_at` has passed. A single worker suffices: all writes (and the
+/// claim+apply transaction) are serialized by the engine write lock.
+///
+/// The worker is event-driven — it wakes exactly when the next row becomes due
+/// (`MIN(ready_at)`) or when a write notifies it, never on a blind interval —
+/// so async GSI application latency tracks the configured propagation delay and
+/// the write path pays nothing beyond the in-transaction `gsi_pending` insert.
+pub(crate) async fn gsi_propagation_worker(
+    engine: Arc<SqliteEngine>,
+    notify: Arc<tokio::sync::Notify>,
+    token: CancellationToken,
+) {
+    // Defensive cap on idle sleep so a missed notification can never strand a
+    // pending row indefinitely. Matches the PostgreSQL persistent-queue worker's
+    // 1s backstop (PR #128) so recovery from a missed wake is identical across
+    // backends; the worker is otherwise notify-driven and sleeps to MIN(ready_at).
+    const MAX_SLEEP: Duration = Duration::from_secs(1);
+    // Backoff after an error so a poison row cannot hot-loop the worker.
+    const ERROR_BACKOFF: Duration = Duration::from_secs(1);
+    loop {
+        // Drain everything currently due.
+        let mut errored = false;
+        loop {
+            match process_gsi_batch(&engine).await {
+                Ok(n) if n > 0 => continue,
+                Ok(_) => break,
+                Err(e) => {
+                    tracing::error!("GSI propagation worker: batch error: {e}");
+                    errored = true;
+                    break;
+                }
+            }
+        }
+        // Sleep until the next row is due (or a write wakes us early).
+        let wait = if errored {
+            ERROR_BACKOFF
+        } else {
+            match next_ready_delay(&engine).await {
+                Ok(Some(d)) => d.min(MAX_SLEEP),
+                Ok(None) => MAX_SLEEP,
+                Err(e) => {
+                    tracing::debug!("GSI worker: next_ready_delay error: {e}");
+                    MAX_SLEEP
+                }
+            }
+        };
+        // Sleep, waking early on a write notification, and return on shutdown.
+        // The queue is persistent (`gsi_pending`) and reconciled at startup, so
+        // stopping between drains loses nothing.
+        let shutting_down = tokio::select! {
+            () = token.cancelled() => true,
+            _ = tokio::time::timeout(wait, notify.notified()) => false,
+        };
+        if shutting_down {
+            return;
+        }
+    }
+}
+
+/// Time until the earliest pending row becomes due. `Some(ZERO)` means a row is
+/// already due (drain again immediately); `None` means the queue is empty.
+/// Runs on the shared read pool (no write lock, indexed `MIN` on
+/// `idx_gsi_pending_ready`) so it stays off the write path.
+async fn next_ready_delay(engine: &SqliteEngine) -> Result<Option<Duration>, StorageError> {
+    let min_ready: Option<String> = sqlx::query_scalar("SELECT MIN(ready_at) FROM gsi_pending")
+        .fetch_one(&engine.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let Some(ready_at) = min_ready else {
+        return Ok(None);
+    };
+    let ready = crate::sqlite_util::parse_timestamp(&ready_at)
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let now = time::OffsetDateTime::now_utc();
+    if ready <= now {
+        Ok(Some(Duration::ZERO))
+    } else {
+        // Positive remainder; convert time::Duration → std::time::Duration.
+        Ok(Some((ready - now).try_into().unwrap_or(Duration::ZERO)))
+    }
+}
+
+/// Parse a claimed `gsi_pending` row and apply its index update within `tx`.
+/// Any error (malformed context or a non-recoverable apply failure) is returned
+/// to the caller, which drops the row rather than stalling the queue. A
+/// dropped-index race is handled inside `apply_claimed_row` (returns `Ok`).
+async fn apply_pending_row(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    old_json: &Option<String>,
+    new_json: &Option<String>,
+    ctx_json: &str,
+) -> Result<(), StorageError> {
+    let old: Option<extenddb_core::types::Item> = old_json
+        .as_deref()
+        .map(serde_json::from_str)
+        .transpose()
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let new: Option<extenddb_core::types::Item> = new_json
+        .as_deref()
+        .map(serde_json::from_str)
+        .transpose()
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let context: crate::data::GsiApplyContext =
+        serde_json::from_str(ctx_json).map_err(|e| StorageError::Internal(e.to_string()))?;
+    crate::data::apply_claimed_row(tx, old.as_ref(), new.as_ref(), &context).await
+}
+
+/// Claim and apply one batch of due `gsi_pending` rows in a single transaction
+/// (under the write lock). Claim + apply share the transaction, so a crash
+/// rolls back and the rows are retried — at-least-once, and the index writes
+/// are idempotent. Returns the number of rows processed.
+async fn process_gsi_batch(engine: &SqliteEngine) -> Result<usize, StorageError> {
+    let _writer = engine.write_lock.lock().await;
+    let mut tx = engine
+        .pool
+        .begin_with("BEGIN IMMEDIATE")
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    let now = crate::sqlite_util::format_timestamp(time::OffsetDateTime::now_utc());
+    // Drain in `id` order; per-partition `ready_at` is monotonic, so this
+    // preserves per-key FIFO. Each row is self-describing via `index_context`.
+    let rows: Vec<(Option<String>, Option<String>, String)> = sqlx::query_as(
+        "DELETE FROM gsi_pending WHERE id IN ( \
+             SELECT id FROM gsi_pending WHERE ready_at <= ? ORDER BY id LIMIT ? \
+         ) RETURNING old_item, new_item, index_context",
+    )
+    .bind(&now)
+    .bind(GSI_BATCH)
+    .fetch_all(&mut *tx)
+    .await
+    .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    if rows.is_empty() {
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        return Ok(0);
+    }
+
+    let count = rows.len();
+    for (old_json, new_json, ctx_json) in &rows {
+        // Guard each row with a SAVEPOINT. A row that cannot be applied (bad
+        // context, or a persistent apply error) is undone and DROPPED — it was
+        // already removed from `gsi_pending` by the batch DELETE above, so the
+        // commit consumes it. This matches the PostgreSQL backend's log-and-drop:
+        // one poison row must not roll back the whole batch and get re-claimed
+        // forever, which would stall ALL GSI propagation instance-wide.
+        // (A dropped-index race is handled inside apply_claimed_row and returns
+        // Ok, so it is applied-as-skip, not dropped here.)
+        sqlx::query("SAVEPOINT gsi_row")
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        match apply_pending_row(&mut tx, old_json, new_json, ctx_json).await {
+            Ok(()) => {
+                sqlx::query("RELEASE gsi_row")
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            }
+            Err(e) => {
+                tracing::error!("GSI worker: dropping unprocessable gsi_pending row: {e}");
+                sqlx::query("ROLLBACK TO gsi_row")
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                sqlx::query("RELEASE gsi_row")
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            }
+        }
+    }
+
+    tx.commit()
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    Ok(count)
+}
+
+/// Refresh the cached GSI propagation delay from the `gsi_propagation_delay_ms`
+/// runtime setting, so changes take effect without restart.
+pub(crate) async fn poll_gsi_delay<S: SettingsStore + ?Sized>(
+    settings: Arc<S>,
+    gsi_default: Arc<std::sync::atomic::AtomicU64>,
+    token: CancellationToken,
+) {
+    use std::sync::atomic::Ordering;
+    const POLL: Duration = Duration::from_secs(30);
+    while sleep_or_shutdown(&token, POLL).await {
+        match settings.get_setting("gsi_propagation_delay_ms").await {
+            Ok(Some(v)) => {
+                if let Ok(ms) = v.parse::<u64>() {
+                    gsi_default.store(ms, Ordering::Relaxed);
+                }
+            }
+            Ok(None) => gsi_default.store(10, Ordering::Relaxed),
+            Err(e) => tracing::debug!("poll_gsi_delay: {e:?}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod poison_row_tests {
+    use super::process_gsi_batch;
+    use crate::SqliteEngine;
+
+    /// A `gsi_pending` row that cannot be applied (here: `index_context` is not
+    /// valid JSON) must be logged-and-DROPPED so the batch commits and the queue
+    /// drains. Before the per-row SAVEPOINT fix, the apply error rolled back the
+    /// whole batch including the claim DELETE, so the same row was re-claimed
+    /// forever and ALL GSI propagation stalled instance-wide.
+    #[tokio::test]
+    async fn poison_row_is_dropped_not_stalled() {
+        let engine = SqliteEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+
+        // Poison row: malformed index_context. ready_at defaults to now (due).
+        sqlx::query(
+            "INSERT INTO gsi_pending \
+             (table_id, worker_partition, old_item, new_item, index_context, ready_at) \
+             VALUES ('t-poison', 0, NULL, '{\"pk\":{\"S\":\"x\"}}', 'not-valid-json', \
+                     '2000-01-01T00:00:00.000Z')",
+        )
+        .execute(&engine.pool)
+        .await
+        .expect("insert poison row");
+
+        // The batch claims and consumes the row (returns Ok, count = 1).
+        let processed = process_gsi_batch(&engine).await.expect("batch drains");
+        assert_eq!(processed, 1, "poison row should be claimed and consumed");
+
+        // The poison row is gone, not rolled back into the queue.
+        let remaining: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM gsi_pending")
+            .fetch_one(&engine.pool)
+            .await
+            .expect("count");
+        assert_eq!(remaining.0, 0, "poison row must be dropped, not re-queued");
+
+        // A second pass has nothing left to do (proves it was not re-claimed).
+        assert_eq!(
+            process_gsi_batch(&engine).await.expect("second pass"),
+            0,
+            "queue must stay empty (no infinite re-claim)"
+        );
+    }
+
+    /// A well-formed row alongside a poison row is still applied-as-skip when its
+    /// target index no longer exists (dropped-index race handled inside
+    /// apply_claimed_row), and both rows are consumed — one bad row does not
+    /// block the rest of the batch.
+    #[tokio::test]
+    async fn poison_row_does_not_block_sibling_rows() {
+        let engine = SqliteEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+
+        // Poison row (bad context) + a second poison row: both must drain.
+        sqlx::query(
+            "INSERT INTO gsi_pending \
+             (table_id, worker_partition, old_item, new_item, index_context, ready_at) \
+             VALUES \
+             ('t-a', 0, NULL, '{\"pk\":{\"S\":\"1\"}}', 'not-json', '2000-01-01T00:00:00.000Z'), \
+             ('t-b', 1, NULL, '{\"pk\":{\"S\":\"2\"}}', 'also-not-json', '2000-01-01T00:00:00.000Z')",
+        )
+        .execute(&engine.pool)
+        .await
+        .expect("insert rows");
+
+        let processed = process_gsi_batch(&engine).await.expect("batch drains");
+        assert_eq!(processed, 2, "both rows claimed in one batch");
+
+        let remaining: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM gsi_pending")
+            .fetch_one(&engine.pool)
+            .await
+            .expect("count");
+        assert_eq!(remaining.0, 0, "both poison rows dropped");
+    }
+}

--- a/crates/storage-sqlite/src/workers.rs
+++ b/crates/storage-sqlite/src/workers.rs
@@ -110,6 +110,8 @@ pub(crate) async fn stream_record_cleanup_worker(
                 if n > 0 {
                     tracing::info!("Stream cleanup worker: deleted {n} expired record(s)");
                 }
+                // Elapsed microseconds fit exactly in f64's 53-bit mantissa for
+                // the latency ranges recorded here (telemetry, not exact math).
                 #[allow(clippy::cast_precision_loss)]
                 metrics.record_worker_success(
                     QuerySource::StreamCleanup,
@@ -138,6 +140,8 @@ pub(crate) async fn idempotency_token_cleanup_worker(
                 if n > 0 {
                     tracing::info!("Idempotency cleanup worker: deleted {n} expired token(s)");
                 }
+                // Elapsed microseconds fit exactly in f64's 53-bit mantissa for
+                // the latency ranges recorded here (telemetry, not exact math).
                 #[allow(clippy::cast_precision_loss)]
                 metrics.record_worker_success(
                     QuerySource::IdempotencyCleanup,
@@ -287,6 +291,8 @@ async fn sweep_expired_items(
                     deleted += 1;
                     metrics.record_ttl_deletion(table_name);
                     if let Some(s) = staleness {
+                        // Staleness seconds are small and well within f64's
+                        // exact-integer range; used only for telemetry.
                         #[allow(clippy::cast_precision_loss)]
                         metrics.record_ttl_staleness(table_name, s as f64);
                     }

--- a/crates/storage/src/management_store/mod.rs
+++ b/crates/storage/src/management_store/mod.rs
@@ -157,6 +157,12 @@ pub trait ManagementStore: Send + Sync {
     /// List all accounts as `(account_id, account_name)`.
     fn list_all_accounts(&self) -> BoxFuture<'_, OpResult<Vec<(String, String)>>>;
 
+    /// Return the deployment's canonical default account id, recorded at
+    /// bootstrap. Callers must use this rather than inferring the default from
+    /// `list_all_accounts` ordering. Returns `None` if not recorded (catalog
+    /// not bootstrapped by a version that records it).
+    fn default_account_id(&self) -> BoxFuture<'_, OpResult<Option<String>>>;
+
     /// List all accounts with `created_at` as `(account_id, account_name, created_at)`.
     fn list_all_accounts_full(
         &self,

--- a/crates/storage/src/server_components.rs
+++ b/crates/storage/src/server_components.rs
@@ -83,14 +83,27 @@ impl std::fmt::Display for BackendError {
 
 impl std::error::Error for BackendError {}
 
+/// Options for server-component creation, beyond the storage config itself.
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct ServerComponentsOptions {
+    /// Bootstrap the catalog at serve time when it is not initialized,
+    /// instead of failing with `InitializationFailed`. Set by dev-mode builds
+    /// so `serve` works with no prior `init` (zero-config local/CI use).
+    /// Backends whose bootstrap requires operator input ignore this and fail
+    /// as usual; backends with a self-contained bootstrap (SQLite) honor it.
+    pub bootstrap_if_uninitialized: bool,
+}
+
 /// Factory function type for creating server components.
 ///
-/// Takes a `StorageConfig` trait object and region string, returns a Future
-/// that resolves to `ServerComponents` or `BackendError`.
+/// Takes a `StorageConfig` trait object, region string, and options; returns
+/// a Future that resolves to `ServerComponents` or `BackendError`.
 pub type ServerComponentsFactory =
     fn(
         &dyn StorageConfig,
         &str,
+        ServerComponentsOptions,
     ) -> Pin<Box<dyn Future<Output = Result<ServerComponents, BackendError>> + Send>>;
 
 /// Create server components using the installed backend.
@@ -101,7 +114,8 @@ pub type ServerComponentsFactory =
 pub async fn create_server_components(
     config: &dyn StorageConfig,
     region: &str,
+    options: ServerComponentsOptions,
 ) -> Result<ServerComponents, BackendError> {
     let backend = crate::backend::try_backend().ok_or(BackendError::BackendNotInstalled)?;
-    (backend.server_components)(config, region).await
+    (backend.server_components)(config, region, options).await
 }

--- a/devtools/run-tests
+++ b/devtools/run-tests
@@ -310,24 +310,26 @@ if $NEEDS_INTEGRATION && [[ "$TARGET" != "real-dynamodb" ]]; then
         fi
     fi
 
-    # Import/export paths
+    # Import/export paths. The Python tests write fixtures via tempfile, which
+    # honours $TMPDIR — on macOS that is under /var/folders, not /tmp. Allow
+    # whatever tempfile will use so exported/imported file paths validate on
+    # every platform (Linux leaves TMPDIR unset, so this is /tmp there).
+    TMP_ALLOWED="${TMPDIR:-/tmp}"; TMP_ALLOWED="${TMP_ALLOWED%/}"
     if [[ -f "$CONFIG_FOR_SETTINGS" ]]; then
         NEED_RESTART=false
-        if ! grep -qE '^\[import\]' "$CONFIG_FOR_SETTINGS" || \
-           ! grep -A1 '^\[import\]' "$CONFIG_FOR_SETTINGS" | grep -q '/tmp'; then
+        if ! grep -A1 '^\[import\]' "$CONFIG_FOR_SETTINGS" 2>/dev/null | grep -qF "$TMP_ALLOWED"; then
             sed '/^# \[import\]/d; /^# paths = \[\].*import/d' "$CONFIG_FOR_SETTINGS" > "$CONFIG_FOR_SETTINGS.tmp" \
                 && mv "$CONFIG_FOR_SETTINGS.tmp" "$CONFIG_FOR_SETTINGS"
-            printf '\n[import]\npaths = ["/tmp"]\n' >> "$CONFIG_FOR_SETTINGS"
+            printf '\n[import]\npaths = ["%s"]\n' "$TMP_ALLOWED" >> "$CONFIG_FOR_SETTINGS"
             NEED_RESTART=true
-            echo "  ✓ [import] paths configured for /tmp"
+            echo "  ✓ [import] paths configured for $TMP_ALLOWED"
         fi
-        if ! grep -qE '^\[export\]' "$CONFIG_FOR_SETTINGS" || \
-           ! grep -A1 '^\[export\]' "$CONFIG_FOR_SETTINGS" | grep -q '/tmp'; then
+        if ! grep -A1 '^\[export\]' "$CONFIG_FOR_SETTINGS" 2>/dev/null | grep -qF "$TMP_ALLOWED"; then
             sed '/^# \[export\]/d; /^# paths = \[\].*export/d' "$CONFIG_FOR_SETTINGS" > "$CONFIG_FOR_SETTINGS.tmp" \
                 && mv "$CONFIG_FOR_SETTINGS.tmp" "$CONFIG_FOR_SETTINGS"
-            printf '\n[export]\npaths = ["/tmp"]\n' >> "$CONFIG_FOR_SETTINGS"
+            printf '\n[export]\npaths = ["%s"]\n' "$TMP_ALLOWED" >> "$CONFIG_FOR_SETTINGS"
             NEED_RESTART=true
-            echo "  ✓ [export] paths configured for /tmp"
+            echo "  ✓ [export] paths configured for $TMP_ALLOWED"
         fi
         if $NEED_RESTART && [[ -x "$BINARY" ]]; then
             echo "  Restarting server to pick up import/export config..."

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -104,6 +104,34 @@ To bind the server to a specific address (e.g., for remote access), pass `--bind
 
 This generates a certificate with SANs: `localhost`, `127.0.0.1`, and `10.0.1.5`.
 
+### SQLite backend (developer mode)
+
+For local development and CI, extenddb can run against a SQLite backend instead
+of PostgreSQL. Select it at init time with `--backend sqlite`:
+
+```bash
+./target/release/extenddb init --backend sqlite
+```
+
+This writes a config with a `[storage.sqlite]` section where the database
+location is configured (default `extenddb.sqlite`):
+
+```toml
+[storage.sqlite]
+path = "extenddb.sqlite"   # or ":memory:" for an ephemeral in-memory database
+```
+
+At serve time the path can be overridden with `--sqlite-path`. The resolution
+order is: the `--sqlite-path` flag, then `[storage.sqlite].path` in the config,
+then the default `extenddb.sqlite`:
+
+```bash
+./target/release/extenddb serve --config extenddb.toml --sqlite-path /data/extenddb.sqlite
+```
+
+Use `:memory:` (in the config or via `--sqlite-path`) for an ephemeral database
+that is discarded on shutdown.
+
 ### Generating a self-signed certificate manually
 
 `extenddb init` auto-generates a self-signed TLS certificate at `~/.extenddb/tls/`. If you need a certificate with different SANs (e.g., binding to `0.0.0.0` and connecting via a specific hostname), generate one manually with `openssl`:

--- a/extenddb.sample.toml
+++ b/extenddb.sample.toml
@@ -29,7 +29,15 @@
 # run_dir = "~/.extenddb/run"  # Directory for PID file (~ is expanded to $HOME)
 
 [storage]
-# backend = "postgres"         # Storage backend (only "postgres" supported)
+# backend = "postgres"         # Storage backend: "postgres" (default) or "sqlite".
+
+# --- SQLite backend (developer mode) ---
+# Select with `extenddb init --backend sqlite`. The database path can be given
+# at serve time (`extenddb serve --sqlite-path <path>`) or here. Resolution order:
+#   --sqlite-path flag  ->  [storage.sqlite].path  ->  default "extenddb.sqlite".
+# Use ":memory:" for an ephemeral in-memory database (data lost on shutdown).
+# [storage.sqlite]
+# path = "extenddb.sqlite"
 
 [storage.postgres]
 # Connection string points to the CATALOG database.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,31 @@ def wait_for_active(client, table_name: str, timeout: float = 120.0) -> None:
             return
         time.sleep(interval)
     raise TimeoutError(f"Table {table_name} did not become ACTIVE within {timeout}s")
+
+
+def wait_for_gsi_items(paginate, expected: int, timeout: float = 15.0):
+    """Poll a paginated GSI query/scan until it yields at least ``expected`` items.
+
+    GSIs are eventually consistent: an item written to the base table is not
+    guaranteed to be visible through a secondary index immediately — ExtendDB
+    applies the configured ``gsi_propagation_delay_ms`` (like real DynamoDB), so
+    a read-back through a GSI right after the write can legitimately be short.
+    Tests that write then page a GSI must poll rather than read once.
+
+    ``paginate`` is a zero-arg callable that runs the *entire* pagination and
+    returns the collected list; it is retried until it returns at least
+    ``expected`` items or the timeout elapses. The last collected list is
+    returned so the caller's ordering/dedup assertions run on the converged
+    result.
+    """
+    interval = _poll_interval()
+    deadline = time.monotonic() + timeout
+    items = paginate()
+    while len(items) < expected and time.monotonic() < deadline:
+        time.sleep(interval)
+        items = paginate()
+    return items
+
 @pytest.fixture()
 def create_and_cleanup_table(dynamodb_client, unique_table_name):
     """Create a table and ensure it's deleted after the test (REQ-TEST-005)."""

--- a/tests/rust/src/concurrency.rs
+++ b/tests/rust/src/concurrency.rs
@@ -1,0 +1,111 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Concurrency regression tests.
+//!
+//! Many clients issuing read-then-write operations in parallel must never
+//! surface `InternalServerError` (500). This guards the SQLite write path,
+//! where a deferred `BEGIN` whose read snapshot is invalidated by another
+//! connection pool (the catalog/credential pool shares the same database file)
+//! returns `SQLITE_BUSY_SNAPSHOT` (517) — which `busy_timeout` cannot retry.
+//! Opening every write transaction with `BEGIN IMMEDIATE` takes the reserved
+//! write lock up front, eliminating that race. Backend-agnostic: passes against
+//! real DynamoDB as well.
+
+use crate::test_base::*;
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition, BillingMode, KeySchemaElement, KeyType, ScalarAttributeType,
+};
+
+const TASKS: usize = 16;
+const PER_TASK: usize = 64;
+
+async fn make_simple_table(c: &aws_sdk_dynamodb::Client, name: &str) {
+    let _ = c
+        .create_table()
+        .table_name(name)
+        .billing_mode(BillingMode::PayPerRequest)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await;
+    wait_for_active(c, name).await;
+}
+
+/// Concurrent conditional puts (read-then-write) followed by parallel deletes
+/// across many tasks — the Rust analogue of the Python `test_parallel_deletes`
+/// that exposed the 517-as-500 regression under load.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn parallel_writes_then_deletes_no_internal_error() {
+    let c = client();
+    let table = format!("ConcurrencyRegression_{}", ts());
+    make_simple_table(c, &table).await;
+
+    // Phase 1 — concurrent conditional puts on distinct keys. Each put reads
+    // (attribute_not_exists) then writes inside one transaction.
+    let mut handles = Vec::new();
+    for t in 0..TASKS {
+        let c = c.clone();
+        let table = table.clone();
+        handles.push(tokio::spawn(async move {
+            for i in 0..PER_TASK {
+                let key = format!("t{t}-{i}");
+                c.put_item()
+                    .table_name(&table)
+                    .item("pk", s(&key))
+                    .item("v", n(i as i64))
+                    .condition_expression("attribute_not_exists(pk)")
+                    .send()
+                    .await
+                    .unwrap_or_else(|e| panic!("put {key} failed: {}", err_msg(&e)));
+            }
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+
+    // Phase 2 — parallel deletes of every key across all tasks.
+    let mut handles = Vec::new();
+    for t in 0..TASKS {
+        let c = c.clone();
+        let table = table.clone();
+        handles.push(tokio::spawn(async move {
+            for i in 0..PER_TASK {
+                let key = format!("t{t}-{i}");
+                c.delete_item()
+                    .table_name(&table)
+                    .key("pk", s(&key))
+                    .send()
+                    .await
+                    .unwrap_or_else(|e| panic!("delete {key} failed: {}", err_msg(&e)));
+            }
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+
+    // All keys must be gone.
+    let scan = c
+        .scan()
+        .table_name(&table)
+        .send()
+        .await
+        .expect("scan failed");
+    assert_eq!(scan.count(), 0, "all items should have been deleted");
+
+    let _ = c.delete_table().table_name(&table).send().await;
+}

--- a/tests/rust/src/main.rs
+++ b/tests/rust/src/main.rs
@@ -28,6 +28,8 @@ mod capacity_throttling;
 #[cfg(test)]
 mod composite_keys;
 #[cfg(test)]
+mod concurrency;
+#[cfg(test)]
 mod condition_expressions;
 #[cfg(test)]
 mod condition_expressions_more;

--- a/tests/test_gsi_async_queue_sqlite.py
+++ b/tests/test_gsi_async_queue_sqlite.py
@@ -156,6 +156,22 @@ class _Deployment:
         _patch_port(self.config, self.port)
         # Set the system GSI delay before serving (read at startup).
         self._run("settings", "set", "gsi_propagation_delay_ms", str(gsi_delay_ms))
+        # Assert the delay is persisted as expected BEFORE the server starts.
+        # These tests run isolated, file-backed servers with their own database,
+        # so the main devtools/run-tests setting of gsi_propagation_delay_ms=0 on
+        # the shared server cannot race or clobber this value. The read-back pins
+        # that invariant rather than relying on it implicitly.
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT value FROM settings WHERE key = 'gsi_propagation_delay_ms'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None and row[0] == str(gsi_delay_ms), (
+            f"expected gsi_propagation_delay_ms={gsi_delay_ms} persisted at startup, "
+            f"got {row!r}"
+        )
 
     def start(self) -> None:
         self.proc = subprocess.Popen(
@@ -174,16 +190,31 @@ class _Deployment:
         self.proc = None
 
     def stop(self) -> None:
-        if self.proc is not None:
-            try:
-                self._run("stop", check=False)
-            except Exception:
-                pass
-            try:
-                self.proc.send_signal(signal.SIGKILL)
-                self.proc.wait(timeout=10)
-            except Exception:
-                pass
+        if self.proc is None:
+            return
+        # Graceful shutdown is the only acceptable path in normal teardown.
+        # `extenddb stop` drains the queue and exits; we wait for that exit and
+        # escalate to a hard signal ONLY if it fails to exit within the timeout,
+        # and even then loudly (a warning) rather than silently.
+        try:
+            self._run("stop", check=False)
+        except Exception:
+            # The stop command itself timed out/failed; fall through and observe
+            # the process directly before deciding whether to escalate.
+            pass
+        try:
+            self.proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            import warnings
+
+            warnings.warn(
+                f"`extenddb stop` did not exit within 30s (pid {self.proc.pid}); "
+                "escalating to SIGKILL as a last resort.",
+                stacklevel=2,
+            )
+            self.proc.send_signal(signal.SIGKILL)
+            self.proc.wait(timeout=10)
+        finally:
             self.proc = None
 
     def _provision(self) -> dict:

--- a/tests/test_gsi_async_queue_sqlite.py
+++ b/tests/test_gsi_async_queue_sqlite.py
@@ -1,0 +1,432 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for the SQLite persistent GSI propagation queue (``gsi_pending``).
+
+The SQLite mirror of ``test_gsi_async_queue.py`` (PostgreSQL). Each test drives
+the real server lifecycle (``init --backend sqlite`` -> ``serve`` -> optional
+``SIGKILL`` -> restart) and inspects/manipulates ``gsi_pending`` and ``indexes``
+directly via the SQLite database file. Covers:
+
+  * **crash recovery** — committed-but-unpropagated updates survive ``SIGKILL``
+    and are applied after restart;
+  * **per-key FIFO ordering** — successive updates to one base item converge to
+    the latest state with no stale index entries;
+  * **dropped-index handling** — rows whose target index table was dropped are
+    consumed, not retried forever;
+  * **per-index propagation delay** — a GSI's own ``propagation_delay_ms`` is
+    honored over the system default;
+  * **orphan cleanup** — a table delete removes that table's pending rows.
+
+SQLite-specific. Self-skips unless the ``extenddb`` binary is a SQLite build
+(probed once), so it is inert under the PostgreSQL/agnostic suites.
+
+CRITICAL (crash recovery): the crash must be ``SIGKILL`` — never a graceful
+``extenddb stop``, which drains the queue before exiting and would let the test
+pass even with a non-persistent queue (a false positive).
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import sqlite3
+import ssl
+import subprocess
+import time
+import urllib.request
+import uuid
+
+import boto3
+import pytest
+import urllib3
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+ADMIN_PASSWORD = "TestPass1!"
+_DEVTOOLS = os.path.join(os.path.dirname(__file__), "..", "devtools")
+EXTENDDB_BINARY = os.environ.get(
+    "EXTENDDB_BINARY",
+    os.path.join(os.path.dirname(__file__), "..", "target", "release", "extenddb"),
+)
+
+
+# --------------------------------------------------------------------------- #
+# Lifecycle helpers
+# --------------------------------------------------------------------------- #
+def _free_port() -> int:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_health(port: int, timeout: float = 20.0) -> bool:
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(
+                f"https://127.0.0.1:{port}/health", context=ctx, timeout=2
+            ) as resp:
+                if resp.status == 200:
+                    return True
+        except Exception:
+            time.sleep(0.3)
+    return False
+
+
+def _patch_port(config_path: str, port: int) -> None:
+    import re
+
+    with open(config_path) as f:
+        content = f.read()
+    new, n = re.subn(
+        r"(?m)^[ \t]*#?[ \t]*port[ \t]*=[ \t]*\d+.*$", f"port = {port}", content, count=1
+    )
+    if n == 0:
+        new = content.replace(
+            'bind_addr = "127.0.0.1"', f'bind_addr = "127.0.0.1"\nport = {port}', 1
+        )
+    with open(config_path, "w") as f:
+        f.write(new)
+
+
+@pytest.fixture(scope="session")
+def _sqlite_supported(tmp_path_factory) -> bool:
+    """Probe once that the binary is a SQLite build; skip the module otherwise."""
+    if not os.path.isfile(EXTENDDB_BINARY):
+        pytest.skip(f"extenddb binary not found at {EXTENDDB_BINARY}")
+    probe = tmp_path_factory.mktemp("sqlite-probe")
+    res = subprocess.run(
+        [EXTENDDB_BINARY, "init", "--backend", "sqlite", "--config", "extenddb.toml"],
+        cwd=probe,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        timeout=30,
+    )
+    if res.returncode != 0 or "Unknown backend" in (res.stdout + res.stderr):
+        pytest.skip("extenddb binary was not built with the SQLite backend")
+    return True
+
+
+class _Deployment:
+    """An isolated, file-backed SQLite deployment under the test's tmp dir."""
+
+    def __init__(self, tmp_dir: str, gsi_delay_ms: int):
+        self.dir = tmp_dir
+        self.config = os.path.join(tmp_dir, "extenddb.toml")
+        self.db_path = os.path.join(tmp_dir, "extenddb.sqlite")
+        self.port = _free_port()
+        self.proc: subprocess.Popen | None = None
+        self._init(gsi_delay_ms)
+        self.start()
+        self.creds = self._provision()
+        self.ddb = self._client()
+
+    def _run(self, *args, check=True, env=None):
+        # `--config` goes right after the subcommand: the `settings` CLI requires
+        # it before the `set`/`get` action, and it is order-independent elsewhere.
+        cmd = [EXTENDDB_BINARY, args[0], "--config", self.config, *args[1:]]
+        return subprocess.run(
+            cmd,
+            cwd=self.dir,
+            capture_output=True,
+            text=True,
+            stdin=subprocess.DEVNULL,
+            timeout=30,
+            check=check,
+            env=env,
+        )
+
+    def _init(self, gsi_delay_ms: int) -> None:
+        env = os.environ.copy()
+        env["EXTENDDB_ADMIN_PASSWORD"] = ADMIN_PASSWORD
+        out = self._run("init", "--backend", "sqlite", env=env).stdout
+        self.admin_password = ADMIN_PASSWORD
+        # Best-effort capture if init generated its own password.
+        for line in out.splitlines():
+            line = line.strip()
+            if line.startswith("Password:"):
+                self.admin_password = line.split("Password:", 1)[1].strip()
+        _patch_port(self.config, self.port)
+        # Set the system GSI delay before serving (read at startup).
+        self._run("settings", "set", "gsi_propagation_delay_ms", str(gsi_delay_ms))
+
+    def start(self) -> None:
+        self.proc = subprocess.Popen(
+            [EXTENDDB_BINARY, "serve", "--config", self.config, "--foreground"],
+            cwd=self.dir,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+        )
+        assert _wait_for_health(self.port), "server did not become healthy"
+
+    def sigkill(self) -> None:
+        assert self.proc is not None
+        self.proc.send_signal(signal.SIGKILL)
+        self.proc.wait(timeout=10)
+        self.proc = None
+
+    def stop(self) -> None:
+        if self.proc is not None:
+            try:
+                self._run("stop", check=False)
+            except Exception:
+                pass
+            try:
+                self.proc.send_signal(signal.SIGKILL)
+                self.proc.wait(timeout=10)
+            except Exception:
+                pass
+            self.proc = None
+
+    def _provision(self) -> dict:
+        env = os.environ.copy()
+        env.update(
+            {
+                "EXTENDDB_TEST_ENDPOINT": f"https://127.0.0.1:{self.port}",
+                "EXTENDDB_ADMIN_USER": "admin",
+                "EXTENDDB_ADMIN_PASSWORD": self.admin_password,
+                "EXTENDDB_CA_CERT": os.path.join(self.dir, ".extenddb", "tls", "cert.pem"),
+            }
+        )
+        res = subprocess.run(
+            ["python3", os.path.join(_DEVTOOLS, "provision-test-credentials")],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=True,
+            timeout=30,
+        )
+        creds = {}
+        for line in res.stdout.splitlines():
+            line = line.strip()
+            if line.startswith("export "):
+                k, _, v = line[len("export ") :].partition("=")
+                creds[k] = v.strip().strip('"').strip("'")
+        assert "AWS_ACCESS_KEY_ID" in creds, f"provisioning failed: {res.stdout}\n{res.stderr}"
+        return creds
+
+    def _client(self):
+        return boto3.client(
+            "dynamodb",
+            endpoint_url=f"https://127.0.0.1:{self.port}",
+            region_name="us-east-1",
+            aws_access_key_id=self.creds["AWS_ACCESS_KEY_ID"],
+            aws_secret_access_key=self.creds["AWS_SECRET_ACCESS_KEY"],
+            verify=False,
+        )
+
+    # --- direct DB inspection / manipulation (WAL allows concurrent access) ---
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path, timeout=10)
+        conn.execute("PRAGMA busy_timeout = 10000")
+        return conn
+
+    def gsi_pending_count(self) -> int:
+        conn = self._connect()
+        try:
+            return conn.execute("SELECT count(*) FROM gsi_pending").fetchone()[0]
+        finally:
+            conn.close()
+
+    def index_id(self, table_name: str, index_name: str = "gsi1") -> str:
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT i.index_id FROM indexes i JOIN tables t ON t.table_id = i.table_id "
+                "WHERE t.table_name = ? AND i.index_name = ?",
+                (table_name, index_name),
+            ).fetchone()
+            assert row, f"index_id not found for {table_name}.{index_name}"
+            return row[0]
+        finally:
+            conn.close()
+
+    def set_index_delay(self, table_name: str, ms: int, index_name: str = "gsi1") -> None:
+        conn = self._connect()
+        try:
+            cur = conn.execute(
+                "UPDATE indexes SET propagation_delay_ms = ? WHERE index_name = ? AND table_id = "
+                "(SELECT table_id FROM tables WHERE table_name = ?)",
+                (ms, index_name, table_name),
+            )
+            conn.commit()
+            assert cur.rowcount == 1, "failed to set per-index delay"
+        finally:
+            conn.close()
+
+    def drop_index_table(self, index_id: str) -> None:
+        conn = self._connect()
+        try:
+            conn.execute(f'DROP TABLE IF EXISTS "_ddb_{index_id}"')
+            conn.commit()
+        finally:
+            conn.close()
+
+
+@pytest.fixture()
+def deploy(_sqlite_supported, tmp_path):
+    """Factory yielding started SQLite deployments; all are stopped on teardown."""
+    created: list[_Deployment] = []
+
+    def _make(gsi_delay_ms: int) -> _Deployment:
+        sub = tmp_path / f"d{len(created)}"
+        sub.mkdir()
+        d = _Deployment(str(sub), gsi_delay_ms)
+        created.append(d)
+        return d
+
+    yield _make
+    for d in created:
+        d.stop()
+
+
+# --------------------------------------------------------------------------- #
+# DynamoDB helpers
+# --------------------------------------------------------------------------- #
+def _create_gsi_table(ddb) -> str:
+    table = f"gsiq_{uuid.uuid4().hex[:8]}"
+    ddb.create_table(
+        TableName=table,
+        AttributeDefinitions=[
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "gpk", "AttributeType": "S"},
+        ],
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "gsi1",
+                "KeySchema": [{"AttributeName": "gpk", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    ddb.get_waiter("table_exists").wait(TableName=table)
+    return table
+
+
+def _gsi_count(ddb, table: str, gpk: str) -> int:
+    return ddb.query(
+        TableName=table,
+        IndexName="gsi1",
+        KeyConditionExpression="gpk = :g",
+        ExpressionAttributeValues={":g": {"S": gpk}},
+    )["Count"]
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+class TestGsiAsyncQueueSqlite:
+    """Correctness of the SQLite persistent GSI propagation queue."""
+
+    def test_pending_gsi_updates_survive_sigkill(self, deploy):
+        """Committed-but-unpropagated GSI updates survive a hard crash."""
+        d = deploy(5000)  # long delay so writes stay pending
+        table = _create_gsi_table(d.ddb)
+        n_items = 5
+        for i in range(n_items):
+            d.ddb.put_item(
+                TableName=table, Item={"pk": {"S": f"pk{i}"}, "gpk": {"S": f"g{i}"}}
+            )
+
+        # Genuinely pending (durably queued, not yet applied).
+        assert d.gsi_pending_count() >= 1, "writes were not queued"
+        assert _gsi_count(d.ddb, table, "g0") == 0, "delay did not take effect"
+
+        d.sigkill()  # HARD crash — never `extenddb stop`.
+
+        d.start()
+        d.ddb = d._client()
+        recovered = {}
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            recovered = {i: _gsi_count(d.ddb, table, f"g{i}") for i in range(n_items)}
+            if all(c == 1 for c in recovered.values()):
+                break
+            time.sleep(0.5)
+        assert all(recovered.get(i) == 1 for i in range(n_items)), (
+            f"GSI updates lost across crash: {recovered}"
+        )
+
+    def test_same_base_key_updates_apply_in_order(self, deploy):
+        """Successive updates to one base item converge to the latest state."""
+        d = deploy(1500)
+        table = _create_gsi_table(d.ddb)
+        values = [f"v{i}" for i in range(6)]
+        for v in values:
+            d.ddb.put_item(TableName=table, Item={"pk": {"S": "X"}, "gpk": {"S": v}})
+
+        latest, stale = values[-1], values[:-1]
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if _gsi_count(d.ddb, table, latest) == 1 and d.gsi_pending_count() == 0:
+                break
+            time.sleep(0.5)
+        assert _gsi_count(d.ddb, table, latest) == 1, "latest GSI entry missing after drain"
+        for v in stale:
+            assert _gsi_count(d.ddb, table, v) == 0, (
+                f"stale GSI entry for {v} survived — updates applied out of order"
+            )
+        item = d.ddb.get_item(TableName=table, Key={"pk": {"S": "X"}})["Item"]
+        assert item["gpk"]["S"] == latest
+
+    def test_dropped_index_rows_are_consumed(self, deploy):
+        """Rows whose target index table was dropped are consumed, not retried."""
+        d = deploy(3000)
+        table = _create_gsi_table(d.ddb)
+        for i in range(3):
+            d.ddb.put_item(
+                TableName=table, Item={"pk": {"S": f"pk{i}"}, "gpk": {"S": f"g{i}"}}
+            )
+        assert d.gsi_pending_count() == 3, "writes were not queued"
+
+        d.drop_index_table(d.index_id(table))
+
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if d.gsi_pending_count() == 0:
+                break
+            time.sleep(0.5)
+        assert d.gsi_pending_count() == 0, "queue did not drain after index drop"
+        assert _wait_for_health(d.port, timeout=5), "server wedged on a poison row"
+
+    def test_per_index_delay_overrides_system_default(self, deploy):
+        """A GSI's own propagation delay is honored over the system default."""
+        d = deploy(0)  # system default: synchronous
+        table = _create_gsi_table(d.ddb)
+        d.set_index_delay(table, 5000)  # gsi1 gets its own 5s delay
+
+        d.ddb.put_item(TableName=table, Item={"pk": {"S": "X"}, "gpk": {"S": "g0"}})
+
+        # With jitter the effective delay is in [2500ms, 5000ms]; at 1.5s the
+        # update is still queued, not applied. (With the bug — enqueue using the
+        # system default of 0 — it would have applied synchronously.)
+        time.sleep(1.5)
+        assert _gsi_count(d.ddb, table, "g0") == 0, (
+            "per-index delay ignored — applied at the system default"
+        )
+        assert d.gsi_pending_count() == 1, "update was not queued under the per-index delay"
+
+    def test_pending_rows_cleared_on_table_delete(self, deploy):
+        """Deleting a table removes its still-pending gsi_pending rows."""
+        d = deploy(5000)
+        table = _create_gsi_table(d.ddb)
+        for i in range(4):
+            d.ddb.put_item(
+                TableName=table, Item={"pk": {"S": f"pk{i}"}, "gpk": {"S": f"g{i}"}}
+            )
+        assert d.gsi_pending_count() >= 1, "writes were not queued"
+
+        d.ddb.delete_table(TableName=table)
+        d.ddb.get_waiter("table_not_exists").wait(TableName=table)
+
+        assert d.gsi_pending_count() == 0, "pending rows not cleared on table delete"

--- a/tests/test_query_scan.py
+++ b/tests/test_query_scan.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import pytest
 from botocore.exceptions import ClientError
 
-from conftest import wait_for_active, scoped_table
+from conftest import wait_for_active, wait_for_gsi_items, scoped_table
 @pytest.fixture(scope="class")
 def query_table(dynamodb_client):
     """Create a hash+range (S,N) table with 10 items for query tests."""
@@ -1065,27 +1065,30 @@ class TestHashOnlyGSIPagination:
 
     def test_paginate_all_items_with_limit(self, dynamodb_client, gsi_hash_only_table):
         """Paginating through all items on a hash-only GSI returns all 10 items."""
-        all_items = []
-        exclusive_start_key = None
+        def _collect():
+            all_items = []
+            exclusive_start_key = None
+            while True:
+                kwargs = {
+                    "TableName": gsi_hash_only_table,
+                    "IndexName": "StatusGSI",
+                    "KeyConditionExpression": "nodeStatus = :s",
+                    "ExpressionAttributeValues": {":s": {"S": "ACTIVE"}},
+                    "Limit": 3,
+                }
+                if exclusive_start_key:
+                    kwargs["ExclusiveStartKey"] = exclusive_start_key
 
-        while True:
-            kwargs = {
-                "TableName": gsi_hash_only_table,
-                "IndexName": "StatusGSI",
-                "KeyConditionExpression": "nodeStatus = :s",
-                "ExpressionAttributeValues": {":s": {"S": "ACTIVE"}},
-                "Limit": 3,
-            }
-            if exclusive_start_key:
-                kwargs["ExclusiveStartKey"] = exclusive_start_key
+                resp = dynamodb_client.query(**kwargs)
+                all_items.extend(resp["Items"])
 
-            resp = dynamodb_client.query(**kwargs)
-            all_items.extend(resp["Items"])
+                if "LastEvaluatedKey" not in resp:
+                    break
+                exclusive_start_key = resp["LastEvaluatedKey"]
+            return all_items
 
-            if "LastEvaluatedKey" not in resp:
-                break
-            exclusive_start_key = resp["LastEvaluatedKey"]
-
+        # GSI is eventually consistent — poll until all writes have propagated.
+        all_items = wait_for_gsi_items(_collect, 10)
         assert len(all_items) == 10
         ids = sorted(item["instanceId"]["S"] for item in all_items)
         expected = sorted(f"node-{i}" for i in range(1, 11))
@@ -1190,27 +1193,30 @@ class TestGSIOnHashOnlyBaseTable:
 
     def test_paginate_duplicate_gsi_sort_keys(self, dynamodb_client, gsi_on_hash_only_base_table):
         """All 7 items with same GSI sort key are returned through pagination."""
-        all_items = []
-        exclusive_start_key = None
+        def _collect():
+            all_items = []
+            exclusive_start_key = None
+            while True:
+                kwargs = {
+                    "TableName": gsi_on_hash_only_base_table,
+                    "IndexName": "CategoryPriorityGSI",
+                    "KeyConditionExpression": "category = :c",
+                    "ExpressionAttributeValues": {":c": {"S": "urgent"}},
+                    "Limit": 2,
+                }
+                if exclusive_start_key:
+                    kwargs["ExclusiveStartKey"] = exclusive_start_key
 
-        while True:
-            kwargs = {
-                "TableName": gsi_on_hash_only_base_table,
-                "IndexName": "CategoryPriorityGSI",
-                "KeyConditionExpression": "category = :c",
-                "ExpressionAttributeValues": {":c": {"S": "urgent"}},
-                "Limit": 2,
-            }
-            if exclusive_start_key:
-                kwargs["ExclusiveStartKey"] = exclusive_start_key
+                resp = dynamodb_client.query(**kwargs)
+                all_items.extend(resp["Items"])
 
-            resp = dynamodb_client.query(**kwargs)
-            all_items.extend(resp["Items"])
+                if "LastEvaluatedKey" not in resp:
+                    break
+                exclusive_start_key = resp["LastEvaluatedKey"]
+            return all_items
 
-            if "LastEvaluatedKey" not in resp:
-                break
-            exclusive_start_key = resp["LastEvaluatedKey"]
-
+        # GSI is eventually consistent — poll until all writes have propagated.
+        all_items = wait_for_gsi_items(_collect, 7)
         assert len(all_items) == 7
         ids = sorted(item["itemId"]["S"] for item in all_items)
         assert ids == sorted(f"item-{i}" for i in range(1, 8))
@@ -1477,22 +1483,26 @@ class TestHashOnlyGsiCompositeBaseScan:
     def test_scan_paginate_returns_all(
         self, dynamodb_client, hash_only_gsi_on_composite_base
     ):
-        all_ts = []
-        exclusive_start_key = None
-        while True:
-            kwargs = {
-                "TableName": hash_only_gsi_on_composite_base,
-                "IndexName": "StatusGSI",
-                "Limit": 2,
-            }
-            if exclusive_start_key:
-                kwargs["ExclusiveStartKey"] = exclusive_start_key
-            resp = dynamodb_client.scan(**kwargs)
-            all_ts.extend(item["ts"]["N"] for item in resp["Items"])
-            if "LastEvaluatedKey" not in resp:
-                break
-            exclusive_start_key = resp["LastEvaluatedKey"]
+        def _collect():
+            all_ts = []
+            exclusive_start_key = None
+            while True:
+                kwargs = {
+                    "TableName": hash_only_gsi_on_composite_base,
+                    "IndexName": "StatusGSI",
+                    "Limit": 2,
+                }
+                if exclusive_start_key:
+                    kwargs["ExclusiveStartKey"] = exclusive_start_key
+                resp = dynamodb_client.scan(**kwargs)
+                all_ts.extend(item["ts"]["N"] for item in resp["Items"])
+                if "LastEvaluatedKey" not in resp:
+                    break
+                exclusive_start_key = resp["LastEvaluatedKey"]
+            return all_ts
 
+        # GSI is eventually consistent — poll until all writes have propagated.
+        all_ts = wait_for_gsi_items(_collect, 7)
         assert len(all_ts) == 7, f"expected 7 items, got {len(all_ts)}"
         assert sorted(all_ts, key=int) == [str(i) for i in range(1, 8)]
 


### PR DESCRIPTION
Bring the SQLite storage backend into the workspace as crates/storage-sqlite, per RFC-0002 (backends as in-tree crates). PostgreSQL remains the default; SQLite is selected by Cargo feature. Targets local development, CI, and embedded/air-gapped use.

Consolidation:
- crates/storage-sqlite as a workspace member using workspace dependencies.
- bin features: `sqlite` and `sqlite-memory` (zero-config ephemeral in-memory).
- Uniform backend linking: each backend exposes `link()` and the bin's `backends::link_all()` references every enabled backend, so inventory registrations are never dead-stripped.

Developer mode (build-time `dev-mode` feature):
- Plain HTTP on loopback and open IAM authorization, with SigV4 still verified.
- Credential adopted from the standard AWS_* env, else AWS's documented example.
- A compile_error guard makes `dev-mode` + the Postgres backend fail to build, so an insecure production binary cannot exist.

Fixes found bringing the backend to parity:
- Resolve a relative SQLite path to absolute before daemonizing (chdir to / otherwise breaks file-backed serve in the default daemon mode).
- Remove a stale PID file before daemonizing (spurious "failed to start").
- Generate extenddb-prefixed access keys/secrets; reject non-ASCII identifiers (matches PostgreSQL).
- Hash-only GSI scan pagination on a composite-key base table no longer skips rows (include the base sort key in ORDER BY and the pagination predicate).
- Seed a self-service IAM policy on user creation.
- Restrict the database file (and WAL/SHM sidecars) to 0600.
- Parse session tags in array and object form; treat expired sessions as absent.
- Mark a restored table ACTIVE immediately.
- Bind every placeholder in delete_index_row_multi.

Testing:
- SQLite integration job added to CI, mirroring the Postgres job.
- run-tests works with non-Postgres backends; import/export allowed paths use $TMPDIR.
- Conformance green against SQLite: 721 pytest + 326 comprehensive, plus fmt, clippy -D warnings, and cargo test --workspace.

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] All tests pass (`cargo test --workspace`)
- [ ] Code is formatted (`cargo fmt --check`)
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [ ] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: <!-- link or "n/a" -->

## Breaking changes

<!-- If this PR introduces breaking changes, describe them here. Otherwise delete this section. -->

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
