### PR TITLE
Fix/number validation and txn key errors

### DIFF
--- a/crates/core/src/validation/number.rs
+++ b/crates/core/src/validation/number.rs
@@ -9,7 +9,10 @@ const MIN_EXPONENT: i32 = -130;
 
 /// Validate and normalize a `DynamoDB` number string.
 pub fn validate_and_normalize_number(s: &str) -> Result<String, DynamoDbError> {
-    let s = s.trim();
+    // DynamoDB does not trim: leading or trailing whitespace makes the number
+    // malformed rather than acceptable (e.g. " 5" and "5 " are rejected). A
+    // genuinely empty string is reported with a distinct message from a
+    // malformed-but-non-empty one.
     if s.is_empty() {
         return Err(number_err());
     }
@@ -20,12 +23,19 @@ pub fn validate_and_normalize_number(s: &str) -> Result<String, DynamoDbError> {
     };
 
     let (mantissa_str, explicit_exp) = match rest.split_once(['e', 'E']) {
-        Some((m, e)) => (m, e.parse::<i32>().map_err(|_| number_err())?),
+        Some((m, e)) => (m, e.parse::<i32>().map_err(|_| numeric_value_err(s))?),
         None => (rest, 0),
     };
 
     if mantissa_str.is_empty() || !mantissa_str.chars().all(|c| c.is_ascii_digit() || c == '.') {
-        return Err(number_err());
+        return Err(numeric_value_err(s));
+    }
+
+    // The mantissa must contain at least one digit. A bare "." (also "+.",
+    // ".e5") passes the character check above since '.' is allowed, but has no
+    // digits and is not a valid number.
+    if !mantissa_str.bytes().any(|b| b.is_ascii_digit()) {
+        return Err(numeric_value_err(s));
     }
 
     // Split into integer and fractional parts
@@ -37,7 +47,7 @@ pub fn validate_and_normalize_number(s: &str) -> Result<String, DynamoDbError> {
     if !int_part.chars().all(|c| c.is_ascii_digit())
         || !frac_part.chars().all(|c| c.is_ascii_digit())
     {
-        return Err(number_err());
+        return Err(numeric_value_err(s));
     }
 
     // Combine into a single digit string and track where the decimal point is.
@@ -140,6 +150,15 @@ fn number_err() -> DynamoDbError {
     )
 }
 
+/// Error for a non-empty but malformed number string. Mirrors real DynamoDB,
+/// which reports `The parameter cannot be converted to a numeric value: <input>`
+/// for syntactically invalid numbers, distinct from the empty-value message.
+fn numeric_value_err(s: &str) -> DynamoDbError {
+    DynamoDbError::ValidationException(format!(
+        "The parameter cannot be converted to a numeric value: {s}"
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -230,5 +249,38 @@ mod tests {
     #[test]
     fn negative_decimal() {
         assert_eq!(validate_and_normalize_number("-0.5").unwrap(), "-0.5");
+    }
+
+    #[test]
+    fn rejects_surrounding_whitespace() {
+        // DynamoDB does not trim; whitespace makes the value malformed.
+        assert!(validate_and_normalize_number(" 5").is_err());
+        assert!(validate_and_normalize_number("5 ").is_err());
+        assert!(validate_and_normalize_number("1 5").is_err());
+    }
+
+    #[test]
+    fn rejects_bare_dot() {
+        assert!(validate_and_normalize_number(".").is_err());
+        assert!(validate_and_normalize_number("+.").is_err());
+    }
+
+    #[test]
+    fn malformed_uses_numeric_value_message() {
+        for bad in [
+            "+e2", "1+2", "1.2.3", "0x5", "NaN", "Infinity", "1_000", "1e",
+        ] {
+            let err = validate_and_normalize_number(bad).unwrap_err();
+            assert!(
+                err.to_string().contains("numeric value"),
+                "expected numeric-value message for {bad:?}, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_uses_empty_value_message() {
+        let err = validate_and_normalize_number("").unwrap_err();
+        assert!(err.to_string().contains("Supplied AttributeValue is empty"));
     }
 }

--- a/crates/engine/src/transact_write_items.rs
+++ b/crates/engine/src/transact_write_items.rs
@@ -254,6 +254,10 @@ async fn prepare_write_op(
             .table_key_info(&ctx.account_id, &del.table_name)
             .await
             .map_err(storage_err_to_dynamo)?;
+        // Empty or oversize key values are up-front input validation in
+        // DynamoDB (a top-level ValidationException), unlike a key type
+        // mismatch which surfaces as a per-item cancellation reason.
+        validate_key_sizes(&del.key, &key_info.key_schema, &ctx.limits)?;
         let maps = build_expression_maps(
             del.expression_attribute_names.as_ref(),
             del.expression_attribute_values.as_ref(),
@@ -292,6 +296,10 @@ async fn prepare_write_op(
             .table_key_info(&ctx.account_id, &upd.table_name)
             .await
             .map_err(storage_err_to_dynamo)?;
+        // Empty or oversize key values are up-front input validation in
+        // DynamoDB (a top-level ValidationException), unlike a key type
+        // mismatch which surfaces as a per-item cancellation reason.
+        validate_key_sizes(&upd.key, &key_info.key_schema, &ctx.limits)?;
         let maps = build_expression_maps(
             upd.expression_attribute_names.as_ref(),
             upd.expression_attribute_values.as_ref(),
@@ -349,6 +357,10 @@ async fn prepare_write_op(
             .table_key_info(&ctx.account_id, &cc.table_name)
             .await
             .map_err(storage_err_to_dynamo)?;
+        // Empty or oversize key values are up-front input validation in
+        // DynamoDB (a top-level ValidationException), unlike a key type
+        // mismatch which surfaces as a per-item cancellation reason.
+        validate_key_sizes(&cc.key, &key_info.key_schema, &ctx.limits)?;
         let maps = build_expression_maps(
             cc.expression_attribute_names.as_ref(),
             cc.expression_attribute_values.as_ref(),

--- a/crates/storage-postgres/src/data/transactions.rs
+++ b/crates/storage-postgres/src/data/transactions.rs
@@ -339,7 +339,7 @@ async fn execute_transact_write_op(
             return_values_on_ccf,
             ..
         } => {
-            validation::validate_key_only(
+            validation::validate_batch_key_only(
                 key,
                 &key_info.key_schema,
                 &key_info.attribute_definitions,
@@ -384,7 +384,7 @@ async fn execute_transact_write_op(
             return_values_on_ccf,
             ..
         } => {
-            validation::validate_key_only(
+            validation::validate_batch_key_only(
                 key,
                 &key_info.key_schema,
                 &key_info.attribute_definitions,
@@ -440,7 +440,7 @@ async fn execute_transact_write_op(
             maps,
             return_values_on_ccf,
         } => {
-            validation::validate_key_only(
+            validation::validate_batch_key_only(
                 key,
                 &key_info.key_schema,
                 &key_info.attribute_definitions,


### PR DESCRIPTION
## What

Three parity fixes to error reporting in number-value validation and transactional key validation:

1. **`N` attribute validation** (`crates/core/src/validation/number.rs`)
   - No longer trims input: leading/trailing whitespace (`" 5"`, `"5 "`) is
     now rejected, matching DynamoDB (previously silently accepted).
   - A bare `"."` (and `"+."`, `".e5"`) is now rejected instead of being
     accepted as `0`.
   - Malformed-but-non-empty numbers now return
     `The parameter cannot be converted to a numeric value: <input>` instead of
     reusing the empty-value message ("Supplied AttributeValue is empty, ...").
     The empty-value message is retained only for a genuinely empty string.

2. **Key-only transaction validation** (`crates/storage-postgres/src/data/transactions.rs`)
   - `TransactWriteItems` Delete/Update/ConditionCheck now validate their `Key`
     via `validate_batch_key_only`, so a key type mismatch surfaces as
     `The provided key element does not match the schema` (the batch/transaction
     form) instead of the single-item "Type mismatch for key attribute ..."
     string. The Put item-key path is intentionally left on `validate_item_keys`.

3. **Up-front empty/oversize key validation** (`crates/engine/src/transact_write_items.rs`)
   - Delete/Update/ConditionCheck now run `validate_key_sizes` during the
     prepare pass (as Put already did), so an empty or oversize key is reported
     as a top-level `ValidationException` rather than a per-item cancellation
     reason — matching DynamoDB's up-front input validation.

## Why

ExtendDB diverged from real DynamoDB on the error type/message/placement for
several invalid-input cases. Emulator consumers rely on these being faithful
(error name, exact message, and whether a fault is top-level vs a transaction
cancellation reason), so the divergences cause incorrect client behaviour in
code paths that branch on DynamoDB errors.

Closes # <!-- add issue number if one exists, else delete this line -->

## Testing done

- Added Rust unit tests in `number.rs` covering whitespace rejection, bare-dot
  rejection, the malformed-vs-empty message split, and the empty-value message.
- `cargo test --workspace` — 562 passed, 0 failed.
- Manually validated against a local ExtendDB instance backed by PostgreSQL,
  exercising the affected operations and confirming the exact error name,
  message text, and top-level-vs-cancellation placement now match real DynamoDB
  (`us-east-1`):
  - `PutItem` with malformed `N` values (whitespace, bare-dot, `+e2`, `1+2`,
    `NaN`, etc.).
  - `TransactWriteItems` Update/Delete/ConditionCheck with wrong-typed,
    non-scalar, and empty-string keys.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed (n/a — no documented
      behaviour changed; error strings now match DynamoDB)
- [x] Breaking changes are noted below (none)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a — error-message and input-validation parity fixes only; no
change to the wire protocol, `Storage` trait, auth model, on-disk format, or
CLI surface.

## Breaking changes

None. Error names and HTTP status codes are unchanged; only error *message
text* and the top-level-vs-cancellation placement of certain key-validation
failures change, bringing them in line with real DynamoDB.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.