### PR TITLE
Validate secondary-index key attributes on writes

### DIFF
--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -736,6 +736,162 @@ fn validate_no_empty_key_value(
     Ok(())
 }
 
+/// A secondary index's name and key schema, for index-key validation.
+///
+/// Decouples [`validate_index_keys`] from the storage layer's index metadata
+/// type: callers build these refs from whatever index representation they hold.
+pub struct IndexKeyRef<'a> {
+    pub index_name: &'a str,
+    pub key_schema: &'a [KeySchemaElement],
+}
+
+/// The `DynamoDB` type tag for an `AttributeValue`, used in `Actual: <tag>`
+/// error text (e.g. `N`, `L`, `BOOL`).
+fn attribute_value_type_tag(v: &AttributeValue) -> &'static str {
+    match v {
+        AttributeValue::S(_) => "S",
+        AttributeValue::N(_) => "N",
+        AttributeValue::B(_) => "B",
+        AttributeValue::SS(_) => "SS",
+        AttributeValue::NS(_) => "NS",
+        AttributeValue::BS(_) => "BS",
+        AttributeValue::Bool(_) => "BOOL",
+        AttributeValue::Null => "NULL",
+        AttributeValue::L(_) => "L",
+        AttributeValue::M(_) => "M",
+    }
+}
+
+/// The scalar type tag (`S`, `N`, or `B`) for a declared attribute type.
+fn scalar_type_tag(t: ScalarAttributeType) -> &'static str {
+    match t {
+        ScalarAttributeType::S => "S",
+        ScalarAttributeType::N => "N",
+        ScalarAttributeType::B => "B",
+    }
+}
+
+/// Context for a secondary-index empty-key error, selecting the message form.
+#[derive(Debug, Clone, Copy)]
+pub enum SecondaryIndexEmptyContext {
+    /// The value came directly from a written item (PutItem / Put transaction).
+    Item,
+    /// The value was produced by an UpdateExpression (Update transaction).
+    UpdateExpression,
+}
+
+/// Validate that secondary-index key attributes present in `item` match their
+/// declared scalar type.
+///
+/// Indexes are checked in name order, so when an attribute keys more than one
+/// index the alphabetically-first index name is the one reported (matching
+/// observed `DynamoDB` behaviour).
+///
+/// # Errors
+///
+/// Returns `DynamoDbError::ValidationException` on the first index key attribute
+/// whose value type does not match its declared scalar type.
+pub fn validate_index_key_types(
+    item: &Item,
+    indexes: &[IndexKeyRef<'_>],
+    attr_defs: &[AttributeDefinition],
+) -> Result<(), DynamoDbError> {
+    for idx in ordered_indexes(indexes) {
+        for ks in idx.key_schema {
+            let Some(value) = item.get(&ks.attribute_name) else {
+                continue;
+            };
+            let Some(expected) = attr_defs
+                .iter()
+                .find(|ad| ad.attribute_name == ks.attribute_name)
+                .map(|ad| ad.attribute_type)
+            else {
+                continue;
+            };
+            let matches = matches!(
+                (expected, value),
+                (ScalarAttributeType::S, AttributeValue::S(_))
+                    | (ScalarAttributeType::N, AttributeValue::N(_))
+                    | (ScalarAttributeType::B, AttributeValue::B(_))
+            );
+            if !matches {
+                return Err(DynamoDbError::ValidationException(format!(
+                    "One or more parameter values were invalid: Type mismatch for Index Key {} Expected: {} Actual: {} IndexName: {}",
+                    ks.attribute_name,
+                    scalar_type_tag(expected),
+                    attribute_value_type_tag(value),
+                    idx.index_name
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate that no secondary-index key attribute in `item` is an empty string
+/// or empty binary value.
+///
+/// # Errors
+///
+/// Returns `DynamoDbError::ValidationException` naming the alphabetically-first
+/// index for the first empty index key attribute found. The message form is
+/// selected by `ctx`.
+pub fn validate_index_key_not_empty(
+    item: &Item,
+    indexes: &[IndexKeyRef<'_>],
+    ctx: SecondaryIndexEmptyContext,
+) -> Result<(), DynamoDbError> {
+    for idx in ordered_indexes(indexes) {
+        for ks in idx.key_schema {
+            let Some(value) = item.get(&ks.attribute_name) else {
+                continue;
+            };
+            let empty = matches!(value, AttributeValue::S(s) if s.is_empty())
+                || matches!(value, AttributeValue::B(b) if b.is_empty());
+            if empty {
+                let msg = match ctx {
+                    SecondaryIndexEmptyContext::Item => format!(
+                        "One or more parameter values are not valid. A value specified for a secondary index key is not supported. \
+                         The AttributeValue for a key attribute cannot contain an empty string value. IndexName: {}, IndexKey: {}",
+                        idx.index_name, ks.attribute_name
+                    ),
+                    SecondaryIndexEmptyContext::UpdateExpression =>
+                        "One or more parameter values are not valid. The update expression attempted to update a secondary index key to a value that is not supported. \
+                         The AttributeValue for a key attribute cannot contain an empty string value."
+                            .to_owned(),
+                };
+                return Err(DynamoDbError::ValidationException(msg));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate secondary-index key attributes for a written item: scalar type match
+/// first, then non-empty. Convenience wrapper over [`validate_index_key_types`]
+/// and [`validate_index_key_not_empty`] for the PutItem / BatchWriteItem paths,
+/// where both faults are reported as a top-level `ValidationException`.
+///
+/// # Errors
+///
+/// Returns `DynamoDbError::ValidationException` on the first offending index key.
+pub fn validate_index_keys(
+    item: &Item,
+    indexes: &[IndexKeyRef<'_>],
+    attr_defs: &[AttributeDefinition],
+) -> Result<(), DynamoDbError> {
+    validate_index_key_types(item, indexes, attr_defs)?;
+    validate_index_key_not_empty(item, indexes, SecondaryIndexEmptyContext::Item)
+}
+
+/// Indexes sorted by name, so the alphabetically-first index that uses a
+/// violating attribute is the one reported.
+fn ordered_indexes<'b, 'a>(indexes: &'b [IndexKeyRef<'a>]) -> Vec<&'b IndexKeyRef<'a>> {
+    let mut ordered: Vec<&IndexKeyRef<'_>> = indexes.iter().collect();
+    ordered.sort_by(|a, b| a.index_name.cmp(b.index_name));
+    ordered
+}
+
 /// Validate partition key and sort key sizes against limits.
 ///
 /// # Errors
@@ -1437,5 +1593,98 @@ mod tests {
                 .contains("Nesting Levels have exceeded supported limits"),
             "unexpected error: {err}"
         );
+    }
+
+    fn idx<'a>(name: &'a str, attr: &'a str) -> (String, Vec<KeySchemaElement>) {
+        (name.to_owned(), vec![make_ks(attr, KeyType::Hash)])
+    }
+
+    #[test]
+    fn index_key_type_mismatch_names_alphabetically_first_index() {
+        // lsi1sk keys both gsi1 and lsi1; declared S but written as N.
+        let owned = [idx("lsi1", "lsi1sk"), idx("gsi1", "lsi1sk")];
+        let refs: Vec<IndexKeyRef<'_>> = owned
+            .iter()
+            .map(|(n, ks)| IndexKeyRef {
+                index_name: n,
+                key_schema: ks,
+            })
+            .collect();
+        let attr_defs = vec![make_ad("lsi1sk", ScalarAttributeType::S)];
+        let mut item = Item::new();
+        item.insert("lsi1sk".to_owned(), AttributeValue::N("5".to_owned()));
+
+        let err = validate_index_key_types(&item, &refs, &attr_defs).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "One or more parameter values were invalid: Type mismatch for Index Key lsi1sk Expected: S Actual: N IndexName: gsi1"
+        );
+    }
+
+    #[test]
+    fn index_key_non_scalar_reports_actual_l() {
+        let owned = [idx("gsi1", "lsi1sk")];
+        let refs: Vec<IndexKeyRef<'_>> = owned
+            .iter()
+            .map(|(n, ks)| IndexKeyRef {
+                index_name: n,
+                key_schema: ks,
+            })
+            .collect();
+        let attr_defs = vec![make_ad("lsi1sk", ScalarAttributeType::S)];
+        let mut item = Item::new();
+        item.insert("lsi1sk".to_owned(), AttributeValue::L(vec![]));
+        let err = validate_index_key_types(&item, &refs, &attr_defs).unwrap_err();
+        assert!(err.to_string().contains("Actual: L"), "got: {err}");
+    }
+
+    #[test]
+    fn index_key_empty_messages_by_context() {
+        let owned = [idx("gsi1", "lsi1sk")];
+        let refs: Vec<IndexKeyRef<'_>> = owned
+            .iter()
+            .map(|(n, ks)| IndexKeyRef {
+                index_name: n,
+                key_schema: ks,
+            })
+            .collect();
+        let mut item = Item::new();
+        item.insert("lsi1sk".to_owned(), AttributeValue::S(String::new()));
+
+        let put_err = validate_index_key_not_empty(&item, &refs, SecondaryIndexEmptyContext::Item)
+            .unwrap_err();
+        assert_eq!(
+            put_err.to_string(),
+            "One or more parameter values are not valid. A value specified for a secondary index key is not supported. \
+             The AttributeValue for a key attribute cannot contain an empty string value. IndexName: gsi1, IndexKey: lsi1sk"
+        );
+
+        let upd_err = validate_index_key_not_empty(
+            &item,
+            &refs,
+            SecondaryIndexEmptyContext::UpdateExpression,
+        )
+        .unwrap_err();
+        assert_eq!(
+            upd_err.to_string(),
+            "One or more parameter values are not valid. The update expression attempted to update a secondary index key to a value that is not supported. \
+             The AttributeValue for a key attribute cannot contain an empty string value."
+        );
+    }
+
+    #[test]
+    fn valid_index_key_passes() {
+        let owned = [idx("gsi1", "lsi1sk")];
+        let refs: Vec<IndexKeyRef<'_>> = owned
+            .iter()
+            .map(|(n, ks)| IndexKeyRef {
+                index_name: n,
+                key_schema: ks,
+            })
+            .collect();
+        let attr_defs = vec![make_ad("lsi1sk", ScalarAttributeType::S)];
+        let mut item = Item::new();
+        item.insert("lsi1sk".to_owned(), AttributeValue::S("ok".to_owned()));
+        assert!(validate_index_keys(&item, &refs, &attr_defs).is_ok());
     }
 }

--- a/crates/storage-postgres/src/data/put_item.rs
+++ b/crates/storage-postgres/src/data/put_item.rs
@@ -35,6 +35,27 @@ impl PostgresEngine {
 
         // Fetch indexes for GSI/LSI updates (D-4: sync + async split).
         let indexes = fetch_indexes_for_table(&key_info.table_id, &self.pool).await?;
+
+        // Index key attributes present in the item must match their declared
+        // scalar type and be non-empty, matching real DynamoDB. This is up-front
+        // input validation (a top-level ValidationException), so it runs before
+        // any write work.
+        if !indexes.is_empty() {
+            let index_refs: Vec<extenddb_core::validation::IndexKeyRef<'_>> = indexes
+                .iter()
+                .map(|idx| extenddb_core::validation::IndexKeyRef {
+                    index_name: &idx.index_name,
+                    key_schema: &idx.key_schema,
+                })
+                .collect();
+            extenddb_core::validation::validate_index_keys(
+                &item,
+                &index_refs,
+                &key_info.attribute_definitions,
+            )
+            .map_err(|e| StorageError::Validation(e.to_string()))?;
+        }
+
         let sys_delay = if indexes.is_empty() {
             0
         } else {

--- a/crates/storage-postgres/src/data/transactions.rs
+++ b/crates/storage-postgres/src/data/transactions.rs
@@ -127,6 +127,12 @@ impl PostgresEngine {
                     any_failed = true;
                     reasons.push(r);
                 }
+                Err(TxnOpError::Validation(msg)) => {
+                    // Up-front input validation (e.g. empty secondary-index key):
+                    // abort the whole transaction with a top-level
+                    // ValidationException, not a per-item cancellation reason.
+                    return Err(StorageError::Validation(msg));
+                }
                 Err(TxnOpError::Storage(e)) => {
                     // Infrastructure error — abort the entire transaction
                     // without leaking internal details into cancellation reasons.
@@ -257,9 +263,24 @@ fn transact_op_table_id<'a>(op: &'a TransactWriteOp<'_>) -> &'a str {
 /// from infrastructure errors (PG connection failures, serialization errors).
 /// This prevents internal error details from leaking into client-visible
 /// cancellation reasons (BLOCKER #3 fix).
+/// Build [`validation::IndexKeyRef`] views over the table's indexes for
+/// secondary-index key validation.
+fn index_key_refs(indexes: &[IndexMeta]) -> Vec<validation::IndexKeyRef<'_>> {
+    indexes
+        .iter()
+        .map(|idx| validation::IndexKeyRef {
+            index_name: &idx.index_name,
+            key_schema: &idx.key_schema,
+        })
+        .collect()
+}
+
 enum TxnOpError {
     /// User-driven failure — becomes a per-item cancellation reason.
     Cancel(CancellationReason),
+    /// Up-front input validation failure — aborts the whole transaction with a
+    /// top-level `ValidationException` (not a per-item cancellation reason).
+    Validation(String),
     /// Infrastructure failure — bubbles up as `StorageError::Internal`.
     Storage(StorageError),
 }
@@ -301,6 +322,20 @@ async fn execute_transact_write_op(
                 &key_info.attribute_definitions,
             )
             .map_err(|e| TxnOpError::Cancel(CancellationReason::validation_error(e.to_string())))?;
+            // Secondary-index key faults split by kind: a type mismatch is a
+            // per-item cancellation reason; an empty index key is up-front input
+            // validation (a top-level ValidationException).
+            let idx_refs = index_key_refs(indexes);
+            validation::validate_index_key_types(item, &idx_refs, &key_info.attribute_definitions)
+                .map_err(|e| {
+                    TxnOpError::Cancel(CancellationReason::validation_error(e.to_string()))
+                })?;
+            validation::validate_index_key_not_empty(
+                item,
+                &idx_refs,
+                validation::SecondaryIndexEmptyContext::Item,
+            )
+            .map_err(|e| TxnOpError::Validation(e.to_string()))?;
             let existing = fetch_item_for_update(tx, key_info, item)
                 .await
                 .map_err(TxnOpError::Storage)?;
@@ -414,6 +449,20 @@ async fn execute_transact_write_op(
             validation::validate_item_size(&item, max_item_size_bytes).map_err(|e| {
                 TxnOpError::Cancel(CancellationReason::validation_error(e.to_string()))
             })?;
+            // Secondary-index key validation on the post-update item: a type
+            // mismatch is a cancellation reason; setting an index key to an
+            // empty value is a top-level ValidationException.
+            let idx_refs = index_key_refs(indexes);
+            validation::validate_index_key_types(&item, &idx_refs, &key_info.attribute_definitions)
+                .map_err(|e| {
+                    TxnOpError::Cancel(CancellationReason::validation_error(e.to_string()))
+                })?;
+            validation::validate_index_key_not_empty(
+                &item,
+                &idx_refs,
+                validation::SecondaryIndexEmptyContext::UpdateExpression,
+            )
+            .map_err(|e| TxnOpError::Validation(e.to_string()))?;
             upsert_item_in_tx(tx, key_info, &item)
                 .await
                 .map_err(TxnOpError::Storage)?;


### PR DESCRIPTION
## What

Adds secondary-index key attribute validation on writes, matching real DynamoDB. Previously ExtendDB did not validate index key attributes, so a write whose GSI/LSI key attribute had the wrong type, a non-scalar value, or an empty string/binary value was accepted (or surfaced with an incorrect error) instead of being rejected the way DynamoDB rejects it.

Behaviour added:

- **Type mismatch / non-scalar index key** → rejected with
  `One or more parameter values were invalid: Type mismatch for Index Key <attr> Expected: <E> Actual: <A> IndexName: <idx>`.
  When an attribute keys more than one index, the alphabetically-first index
  is named (matching observed DynamoDB behaviour).
- **Empty string/binary index key** → up-front input validation: a top-level
  `ValidationException`. The message form depends on origin — a written item
  (`A value specified for a secondary index key is not supported …`) vs an
  `UpdateExpression` (`The update expression attempted to update a secondary
  index key …`).

Wiring:
- **PutItem / BatchWriteItem** (storage put path): both faults surface as a
  top-level `ValidationException`.
- **TransactWriteItems**: a type mismatch becomes a per-item cancellation
  reason; an empty index key aborts the whole transaction with a top-level
  `ValidationException`, via a new `TxnOpError::Validation` variant.

New core helpers: `validate_index_key_types`, `validate_index_key_not_empty`
(with a `SecondaryIndexEmptyContext` message selector), and a combined
`validate_index_keys` convenience for the item-write paths.

## Why

Index key validation is observable behaviour that clients depend on: a write that would corrupt or mis-type a secondary index must fail with the same error name, message, and placement (top-level vs transaction cancellation) as real DynamoDB. Without it, emulator consumers branching on these errors behave incorrectly, and invalid index keys could reach the index materialisation path.

Closes # <!-- add issue number if one exists, else delete this line -->

## Testing done

- Added Rust unit tests in `validation` for: index-key type mismatch with
  alphabetically-first index naming, non-scalar (`Actual: L`), empty-key
  messages in both contexts, and the valid-key pass-through.
- `cargo test --workspace` — 562 passed, 0 failed.
- Manually validated against a local ExtendDB instance backed by PostgreSQL,
  exercising PutItem, BatchWriteItem, and TransactWriteItems (Put + Update)
  with wrong-typed, non-scalar, and empty index key values, confirming the
  exact error name, message, and top-level-vs-cancellation placement match
  real DynamoDB (`us-east-1`).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed (n/a — no documented
      behaviour changed; new validation matches DynamoDB)
- [x] Breaking changes are noted below (none)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a — additive input-validation parity. No change to the wire
protocol, `Storage` trait, auth model, on-disk format, or CLI surface. (Adds a
private `TxnOpError::Validation` variant internal to the Postgres backend.)

## Breaking changes

None. Writes that were previously (incorrectly) accepted with invalid secondary
-index keys are now rejected with a `ValidationException`, matching DynamoDB —
a correctness change, not an API-contract break. Error names and status codes
are unchanged.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.