### PR TITLE
Validate Select against ProjectionExpression and IndexName for Query …

### DIFF
--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -7,7 +7,7 @@ use crate::limits::LimitsConfig;
 use crate::types::{
     AttributeDefinition, AttributeValue, BillingMode, CreateTableInput, DeleteItemInput,
     GetItemInput, Item, KeySchemaElement, KeyType, PutItemInput, ReturnValues, ScalarAttributeType,
-    UpdateItemInput, item_size_bytes,
+    Select, UpdateItemInput, item_size_bytes,
 };
 
 /// Validate a table name per Virtual `DynamoDB` rules.
@@ -736,6 +736,55 @@ fn validate_no_empty_key_value(
     Ok(())
 }
 
+/// Validate the `Select` value against `ProjectionExpression` / `AttributesToGet`
+/// presence and `IndexName`. Shared by Query and Scan so both reject the same
+/// invalid combinations with the same messages.
+///
+/// Rules (matching real DynamoDB, in this order):
+/// 1. A `ProjectionExpression` with `ALL_ATTRIBUTES`, `ALL_PROJECTED_ATTRIBUTES`,
+///    or `COUNT` is rejected (reported before the `IndexName` requirement).
+/// 2. `SPECIFIC_ATTRIBUTES` requires a `ProjectionExpression` (or legacy
+///    `AttributesToGet`).
+/// 3. `ALL_PROJECTED_ATTRIBUTES` requires an `IndexName`.
+///
+/// # Errors
+///
+/// Returns `DynamoDbError::ValidationException` for any of the above.
+pub fn validate_select_projection(
+    select: Option<Select>,
+    has_projection: bool,
+    has_attributes_to_get: bool,
+    has_index_name: bool,
+) -> Result<(), DynamoDbError> {
+    if has_projection {
+        let incompatible = match select {
+            Some(Select::AllAttributes) => Some("ALL_ATTRIBUTES"),
+            Some(Select::AllProjectedAttributes) => Some("ALL_PROJECTED_ATTRIBUTES"),
+            Some(Select::Count) => Some("only the Count"),
+            _ => None,
+        };
+        if let Some(what) = incompatible {
+            return Err(DynamoDbError::ValidationException(format!(
+                "Cannot specify the ProjectionExpression when choosing to get {what}"
+            )));
+        }
+    }
+    if matches!(select, Some(Select::SpecificAttributes))
+        && !has_projection
+        && !has_attributes_to_get
+    {
+        return Err(DynamoDbError::ValidationException(
+            "1 validation error detected: Must specify the AttributesToGet or ProjectionExpression when choosing to get SPECIFIC_ATTRIBUTES".to_owned(),
+        ));
+    }
+    if matches!(select, Some(Select::AllProjectedAttributes)) && !has_index_name {
+        return Err(DynamoDbError::ValidationException(
+            "ALL_PROJECTED_ATTRIBUTES can be used only when Querying using an IndexName".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
 /// Validate partition key and sort key sizes against limits.
 ///
 /// # Errors
@@ -1436,6 +1485,72 @@ mod tests {
             err.to_string()
                 .contains("Nesting Levels have exceeded supported limits"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn select_projection_incompatible_messages() {
+        let cases = [
+            (Select::AllAttributes, "ALL_ATTRIBUTES"),
+            (Select::AllProjectedAttributes, "ALL_PROJECTED_ATTRIBUTES"),
+            (Select::Count, "only the Count"),
+        ];
+        for (select, what) in cases {
+            let err = validate_select_projection(Some(select), true, false, true).unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                format!("Cannot specify the ProjectionExpression when choosing to get {what}")
+            );
+        }
+    }
+
+    #[test]
+    fn select_specific_attributes_requires_projection() {
+        // No projection and no AttributesToGet -> rejected.
+        assert!(
+            validate_select_projection(Some(Select::SpecificAttributes), false, false, false)
+                .is_err()
+        );
+        // A projection satisfies it.
+        assert!(
+            validate_select_projection(Some(Select::SpecificAttributes), true, false, false)
+                .is_ok()
+        );
+        // Legacy AttributesToGet satisfies it.
+        assert!(
+            validate_select_projection(Some(Select::SpecificAttributes), false, true, false)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn select_all_projected_requires_index() {
+        let err =
+            validate_select_projection(Some(Select::AllProjectedAttributes), false, false, false)
+                .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "ALL_PROJECTED_ATTRIBUTES can be used only when Querying using an IndexName"
+        );
+        assert!(
+            validate_select_projection(Some(Select::AllProjectedAttributes), false, false, true)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn select_projection_rule_precedes_index_rule() {
+        // ALL_PROJECTED_ATTRIBUTES + ProjectionExpression + no IndexName: the
+        // ProjectionExpression rule is reported, not the IndexName one.
+        let err =
+            validate_select_projection(Some(Select::AllProjectedAttributes), true, false, false)
+                .unwrap_err();
+        assert!(
+            err.to_string().contains("ALL_PROJECTED_ATTRIBUTES")
+                && err
+                    .to_string()
+                    .contains("Cannot specify the ProjectionExpression"),
+            "got: {err}"
         );
     }
 }

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -335,28 +335,20 @@ pub async fn handle_query(
         )?;
     }
 
-    // Validate Select vs ProjectionExpression and index requirements
-    if let Some(Select::SpecificAttributes) = input.select
-        && effective_projection_str.is_none()
-    {
-        return Err(DynamoDbError::ValidationException(
-                "1 validation error detected: Must specify the AttributesToGet or ProjectionExpression when choosing to get SPECIFIC_ATTRIBUTES".to_owned(),
-            ));
-    }
-    if let Some(Select::AllProjectedAttributes) = input.select
-        && index_info.is_none()
-    {
-        return Err(DynamoDbError::ValidationException(
-            "ALL_PROJECTED_ATTRIBUTES can be used only when Querying using an IndexName".to_owned(),
-        ));
-    }
-    if let Some(Select::Count) = input.select
-        && effective_projection_str.is_some()
-    {
-        return Err(DynamoDbError::ValidationException(
-            "Cannot specify the ProjectionExpression when Select is COUNT".to_owned(),
-        ));
-    }
+    // Validate Select vs ProjectionExpression and index requirements (shared
+    // with Scan so both reject the same combinations identically).
+    extenddb_core::validation::validate_select_projection(
+        input.select,
+        input
+            .projection_expression
+            .as_deref()
+            .is_some_and(|s| !s.is_empty()),
+        input
+            .attributes_to_get
+            .as_ref()
+            .is_some_and(|a| !a.is_empty()),
+        input.index_name.is_some(),
+    )?;
 
     // When Select=ALL_PROJECTED_ATTRIBUTES, capture the index info for post-read filtering.
     let index_proj = if matches!(input.select, Some(Select::AllProjectedAttributes)) {

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -250,6 +250,21 @@ pub async fn handle_scan(
         None => None,
     };
 
+    // Validate Select vs ProjectionExpression and index requirements (shared
+    // with Query so both reject the same combinations identically).
+    extenddb_core::validation::validate_select_projection(
+        input.select,
+        input
+            .projection_expression
+            .as_deref()
+            .is_some_and(|s| !s.is_empty()),
+        input
+            .attributes_to_get
+            .as_ref()
+            .is_some_and(|a| !a.is_empty()),
+        input.index_name.is_some(),
+    )?;
+
     // Validate unused expression attributes
     {
         let exprs: Vec<&extenddb_core::expression::Expr> = filter.iter().collect();


### PR DESCRIPTION
## What

Adds `Select` / `ProjectionExpression` validation for Query and Scan, matching real DynamoDB. Query previously had only partial validation (with one mis-worded message), and Scan had none, so several invalid combinations were
accepted or rejected with the wrong error. A single shared validator now backs both operations:

- A `ProjectionExpression` combined with `Select=ALL_ATTRIBUTES`,
  `ALL_PROJECTED_ATTRIBUTES`, or `COUNT` is rejected with
  `Cannot specify the ProjectionExpression when choosing to get <X>`
  (reported before the `IndexName` requirement, matching AWS ordering).
- `Select=SPECIFIC_ATTRIBUTES` requires a `ProjectionExpression` (or legacy
  `AttributesToGet`).
- `Select=ALL_PROJECTED_ATTRIBUTES` requires an `IndexName`
  (`ALL_PROJECTED_ATTRIBUTES can be used only when Querying using an IndexName`).

Replaces Query's inline checks — which used the wrong `COUNT` message (`when Select is COUNT`) and did not handle `ALL_ATTRIBUTES` / `ALL_PROJECTED_ATTRIBUTES` with a `ProjectionExpression` — with the new
`validate_select_projection` core helper, and adds the same validation to Scan.

## Why

`Select` and `ProjectionExpression` are mutually constrained in DynamoDB, and clients rely on invalid combinations being rejected up front with the documented message. Without parity here, Scan silently accepted contradictory requests and
Query returned an incorrect error string, so emulator consumers that assert on these errors behaved differently than against real DynamoDB.

Closes # <!-- add issue number if one exists, else delete this line -->

## Testing done

- Added Rust unit tests for each rule: the three ProjectionExpression-incompatible
  Select values, SPECIFIC_ATTRIBUTES requiring a projection (and the legacy
  AttributesToGet path), ALL_PROJECTED_ATTRIBUTES requiring an IndexName, and the
  projection-rule-before-index-rule ordering.
- `cargo test --workspace` — 562 passed, 0 failed.
- Manually validated against a local ExtendDB instance backed by PostgreSQL,
  exercising Query and Scan with each invalid Select/ProjectionExpression
  combination and confirming the error name and exact message match real
  DynamoDB (`us-east-1`).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed (n/a — no documented
      behaviour changed; validation now matches DynamoDB)
- [x] Breaking changes are noted below (none)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a — request-level input-validation parity for Query/Scan. No change
to the wire protocol, `Storage` trait, auth model, on-disk format, or CLI surface.

## Breaking changes

None. Query/Scan requests with contradictory `Select` + `ProjectionExpression`
that were previously accepted (Scan) or rejected with a different message
(Query) are now rejected with DynamoDB's exact `ValidationException` — a
correctness change, not an API-contract break. Error names and status codes are
unchanged.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.