### PR TITLE
Validate INCLUDE projections and stream specification in CreateTable

### DIFF
--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -101,6 +101,67 @@ pub fn validate_create_table(
     validate_lsi_count(input, limits)?;
     validate_lsi_requires_range_key(input)?;
     validate_unique_index_names(input)?;
+    validate_index_projections(input)?;
+    validate_stream_specification(input)?;
+    Ok(())
+}
+
+/// Validate that INCLUDE-projection secondary indexes specify `NonKeyAttributes`.
+///
+/// Real `DynamoDB` rejects a GSI or LSI whose `ProjectionType` is `INCLUDE`
+/// without a non-empty `NonKeyAttributes` list.
+///
+/// # Errors
+///
+/// Returns `DynamoDbError::ValidationException` for any such index.
+fn validate_index_projections(input: &CreateTableInput) -> Result<(), DynamoDbError> {
+    fn include_without_attrs(projection: &crate::types::Projection) -> bool {
+        matches!(
+            projection.projection_type,
+            crate::types::ProjectionType::Include
+        ) && projection
+            .non_key_attributes
+            .as_ref()
+            .is_none_or(|attrs| attrs.is_empty())
+    }
+    let err = || {
+        DynamoDbError::ValidationException(
+            "One or more parameter values were invalid: ProjectionType is INCLUDE, but NonKeyAttributes is not specified".to_owned(),
+        )
+    };
+    if let Some(gsis) = &input.global_secondary_indexes {
+        for gsi in gsis {
+            if include_without_attrs(&gsi.projection) {
+                return Err(err());
+            }
+        }
+    }
+    if let Some(lsis) = &input.local_secondary_indexes {
+        for lsi in lsis {
+            if include_without_attrs(&lsi.projection) {
+                return Err(err());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate the `StreamSpecification`: a disabled stream must not also specify a
+/// `StreamViewType`.
+///
+/// # Errors
+///
+/// Returns `DynamoDbError::ValidationException` when `StreamEnabled` is false
+/// but a `StreamViewType` is present.
+fn validate_stream_specification(input: &CreateTableInput) -> Result<(), DynamoDbError> {
+    if let Some(stream) = &input.stream_specification
+        && !stream.stream_enabled
+        && stream.stream_view_type.is_some()
+    {
+        return Err(DynamoDbError::ValidationException(
+            "One or more parameter values were invalid: Table is being created with a stream disabled, UpdateViewType should not be specified".to_owned(),
+        ));
+    }
     Ok(())
 }
 
@@ -1437,5 +1498,73 @@ mod tests {
                 .contains("Nesting Levels have exceeded supported limits"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn gsi_include_projection_requires_non_key_attributes() {
+        use crate::types::{GsiInput, Projection, ProjectionType};
+        let mut input = base_input(
+            vec![make_ks("pk", KeyType::Hash)],
+            vec![
+                make_ad("pk", ScalarAttributeType::S),
+                make_ad("gsipk", ScalarAttributeType::S),
+            ],
+        );
+        let gsi = |non_key: Option<Vec<String>>| GsiInput {
+            index_name: "gsi_inc".to_owned(),
+            key_schema: vec![make_ks("gsipk", KeyType::Hash)],
+            projection: Projection {
+                projection_type: ProjectionType::Include,
+                non_key_attributes: non_key,
+            },
+            provisioned_throughput: None,
+        };
+
+        input.global_secondary_indexes = Some(vec![gsi(None)]);
+        let err = validate_create_table(&input, &LimitsConfig::default()).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "One or more parameter values were invalid: ProjectionType is INCLUDE, but NonKeyAttributes is not specified"
+        );
+
+        // Empty NonKeyAttributes is also rejected.
+        input.global_secondary_indexes = Some(vec![gsi(Some(vec![]))]);
+        assert!(validate_create_table(&input, &LimitsConfig::default()).is_err());
+
+        // A non-empty NonKeyAttributes list is accepted.
+        input.global_secondary_indexes = Some(vec![gsi(Some(vec!["extra".to_owned()]))]);
+        assert!(validate_create_table(&input, &LimitsConfig::default()).is_ok());
+    }
+
+    #[test]
+    fn stream_disabled_with_view_type_is_rejected() {
+        use crate::types::{StreamSpecification, StreamViewType};
+        let mut input = base_input(
+            vec![make_ks("pk", KeyType::Hash)],
+            vec![make_ad("pk", ScalarAttributeType::S)],
+        );
+        input.stream_specification = Some(StreamSpecification {
+            stream_enabled: false,
+            stream_view_type: Some(StreamViewType::NewAndOldImages),
+        });
+        let err = validate_create_table(&input, &LimitsConfig::default()).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "One or more parameter values were invalid: Table is being created with a stream disabled, UpdateViewType should not be specified"
+        );
+
+        // Disabled with no view type is fine.
+        input.stream_specification = Some(StreamSpecification {
+            stream_enabled: false,
+            stream_view_type: None,
+        });
+        assert!(validate_create_table(&input, &LimitsConfig::default()).is_ok());
+
+        // Enabled with a view type is fine.
+        input.stream_specification = Some(StreamSpecification {
+            stream_enabled: true,
+            stream_view_type: Some(StreamViewType::NewImage),
+        });
+        assert!(validate_create_table(&input, &LimitsConfig::default()).is_ok());
     }
 }

--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -109,38 +109,50 @@ pub fn validate_create_table(
 /// Validate that INCLUDE-projection secondary indexes specify `NonKeyAttributes`.
 ///
 /// Real `DynamoDB` rejects a GSI or LSI whose `ProjectionType` is `INCLUDE`
-/// without a non-empty `NonKeyAttributes` list.
+/// without a non-empty `NonKeyAttributes` list, and conversely rejects a
+/// `KEYS_ONLY` or `ALL` projection that carries `NonKeyAttributes`.
 ///
 /// # Errors
 ///
 /// Returns `DynamoDbError::ValidationException` for any such index.
 fn validate_index_projections(input: &CreateTableInput) -> Result<(), DynamoDbError> {
-    fn include_without_attrs(projection: &crate::types::Projection) -> bool {
-        matches!(
-            projection.projection_type,
-            crate::types::ProjectionType::Include
-        ) && projection
+    use crate::types::{Projection, ProjectionType};
+
+    // Validates a single index projection against real DynamoDB rules:
+    // `INCLUDE` requires a non-empty `NonKeyAttributes`, while `KEYS_ONLY`
+    // and `ALL` must not carry `NonKeyAttributes`.
+    fn check(projection: &Projection) -> Result<(), DynamoDbError> {
+        let has_attrs = projection
             .non_key_attributes
             .as_ref()
-            .is_none_or(|attrs| attrs.is_empty())
+            .is_some_and(|attrs| !attrs.is_empty());
+        let message = match projection.projection_type {
+            ProjectionType::Include if !has_attrs => {
+                Some("ProjectionType is INCLUDE, but NonKeyAttributes is not specified")
+            }
+            ProjectionType::KeysOnly if has_attrs => {
+                Some("ProjectionType is KEYS_ONLY, but NonKeyAttributes is specified")
+            }
+            ProjectionType::All if has_attrs => {
+                Some("ProjectionType is ALL, but NonKeyAttributes is specified")
+            }
+            _ => None,
+        };
+        if let Some(message) = message {
+            return Err(DynamoDbError::ValidationException(format!(
+                "One or more parameter values were invalid: {message}"
+            )));
+        }
+        Ok(())
     }
-    let err = || {
-        DynamoDbError::ValidationException(
-            "One or more parameter values were invalid: ProjectionType is INCLUDE, but NonKeyAttributes is not specified".to_owned(),
-        )
-    };
     if let Some(gsis) = &input.global_secondary_indexes {
         for gsi in gsis {
-            if include_without_attrs(&gsi.projection) {
-                return Err(err());
-            }
+            check(&gsi.projection)?;
         }
     }
     if let Some(lsis) = &input.local_secondary_indexes {
         for lsi in lsis {
-            if include_without_attrs(&lsi.projection) {
-                return Err(err());
-            }
+            check(&lsi.projection)?;
         }
     }
     Ok(())
@@ -1534,6 +1546,105 @@ mod tests {
         // A non-empty NonKeyAttributes list is accepted.
         input.global_secondary_indexes = Some(vec![gsi(Some(vec!["extra".to_owned()]))]);
         assert!(validate_create_table(&input, &LimitsConfig::default()).is_ok());
+    }
+
+    #[test]
+    fn keys_only_and_all_projections_reject_non_key_attributes() {
+        use crate::types::{GsiInput, LsiInput, Projection, ProjectionType};
+
+        // GSI cases: table keyed on `pk`, GSI keyed on `gsipk`.
+        let gsi_input = |ptype: ProjectionType, non_key: Option<Vec<String>>| {
+            let mut input = base_input(
+                vec![make_ks("pk", KeyType::Hash)],
+                vec![
+                    make_ad("pk", ScalarAttributeType::S),
+                    make_ad("gsipk", ScalarAttributeType::S),
+                ],
+            );
+            input.global_secondary_indexes = Some(vec![GsiInput {
+                index_name: "gsi1".to_owned(),
+                key_schema: vec![make_ks("gsipk", KeyType::Hash)],
+                projection: Projection {
+                    projection_type: ptype,
+                    non_key_attributes: non_key,
+                },
+                provisioned_throughput: None,
+            }]);
+            input
+        };
+
+        // LSI case: table keyed on `pk`+`sk`, LSI alternate sort key `lsisk`.
+        let lsi_input = |ptype: ProjectionType, non_key: Option<Vec<String>>| {
+            let mut input = base_input(
+                vec![make_ks("pk", KeyType::Hash), make_ks("sk", KeyType::Range)],
+                vec![
+                    make_ad("pk", ScalarAttributeType::S),
+                    make_ad("sk", ScalarAttributeType::S),
+                    make_ad("lsisk", ScalarAttributeType::S),
+                ],
+            );
+            input.local_secondary_indexes = Some(vec![LsiInput {
+                index_name: "lsi1".to_owned(),
+                key_schema: vec![
+                    make_ks("pk", KeyType::Hash),
+                    make_ks("lsisk", KeyType::Range),
+                ],
+                projection: Projection {
+                    projection_type: ptype,
+                    non_key_attributes: non_key,
+                },
+            }]);
+            input
+        };
+
+        // GSI KEYS_ONLY + NonKeyAttributes -> rejected.
+        let err = validate_create_table(
+            &gsi_input(ProjectionType::KeysOnly, Some(vec!["x".to_owned()])),
+            &LimitsConfig::default(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "One or more parameter values were invalid: ProjectionType is KEYS_ONLY, but NonKeyAttributes is specified"
+        );
+
+        // GSI ALL + NonKeyAttributes -> rejected.
+        let err = validate_create_table(
+            &gsi_input(ProjectionType::All, Some(vec!["x".to_owned()])),
+            &LimitsConfig::default(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "One or more parameter values were invalid: ProjectionType is ALL, but NonKeyAttributes is specified"
+        );
+
+        // LSI KEYS_ONLY + NonKeyAttributes -> rejected.
+        let err = validate_create_table(
+            &lsi_input(ProjectionType::KeysOnly, Some(vec!["x".to_owned()])),
+            &LimitsConfig::default(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "One or more parameter values were invalid: ProjectionType is KEYS_ONLY, but NonKeyAttributes is specified"
+        );
+
+        // KEYS_ONLY / ALL without NonKeyAttributes are accepted.
+        assert!(
+            validate_create_table(
+                &gsi_input(ProjectionType::KeysOnly, None),
+                &LimitsConfig::default()
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_create_table(
+                &gsi_input(ProjectionType::All, Some(vec![])),
+                &LimitsConfig::default()
+            )
+            .is_ok()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds two missing CreateTable input validations, matching real DynamoDB:

- **INCLUDE projection requires NonKeyAttributes.** A GSI or LSI with `ProjectionType: INCLUDE` must specify a non-empty `NonKeyAttributes` list. ExtendDB previously accepted `INCLUDE` with no `NonKeyAttributes`; it now rejects with
  `One or more parameter values were invalid: ProjectionType is INCLUDE, but NonKeyAttributes is not specified`.
- **Disabled stream must not specify a view type.** A `StreamSpecification` with `StreamEnabled: false` must not also carry a `StreamViewType`. ExtendDB previously accepted the contradictory pair; it now rejects with
  `One or more parameter values were invalid: Table is being created with a stream disabled, UpdateViewType should not be specified`.

Implemented as two helpers (`validate_index_projections`, `validate_stream_specification`) added to `validate_create_table`.

## Why

These are up-front input validations DynamoDB performs on CreateTable. Without them ExtendDB accepted malformed table definitions (an INCLUDE index with no projected attributes, or a disabled stream with a stray view type), diverging
from real DynamoDB and letting through configurations a real client would be prevented from creating.

Closes # <!-- add issue number if one exists, else delete this line -->

## Testing done

- Added Rust unit tests: GSI INCLUDE without / with / empty `NonKeyAttributes`, and StreamSpecification disabled+view-type / disabled-only / enabled+view-type.
- `cargo test --workspace` — 560 passed, 0 failed.
- Manually validated against a local ExtendDB instance backed by PostgreSQL, confirming both rejections return the exact error name and message produced by real DynamoDB (`us-east-1`), and that valid tables (INCLUDE with attributes, enabled stream with a view type, disabled stream with no view type) still create successfully.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed (n/a — no documented
      behaviour changed; validation now matches DynamoDB)
- [x] Breaking changes are noted below (none)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a — CreateTable input-validation parity only. No change to the wire
protocol, `Storage` trait, auth model, on-disk format, or CLI surface.

## Breaking changes

None. CreateTable requests that were previously (incorrectly) accepted with an
INCLUDE projection lacking NonKeyAttributes, or a disabled stream carrying a
StreamViewType, are now rejected with DynamoDB's exact `ValidationException` — a
correctness change, not an API-contract break. Error names and status codes are
unchanged.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.