### PR TITLE
fix: include base sort key in hash-only GSI scan pagination on a comp…

### DIFF
--- a/crates/storage-postgres/src/data/query_scan.rs
+++ b/crates/storage-postgres/src/data/query_scan.rs
@@ -438,8 +438,25 @@ impl PostgresEngine {
                             p1 = param_idx, p2 = param_idx + 1, p3 = param_idx + 2
                         ));
                     }
+                } else if let Some((_, base_sk_type)) = &base_sk_info {
+                    // Hash-only index on a composite-key base table: rows that
+                    // share the same index hash AND base partition key differ
+                    // only by the base sort key, so it must be part of the
+                    // pagination tie-breaker (matching the ORDER BY below).
+                    let base_sk_col = format!("base_{}", sk_column(*base_sk_type));
+                    let base_collate = if *base_sk_type == ScalarAttributeType::S {
+                        " COLLATE \"C\""
+                    } else {
+                        ""
+                    };
+                    conditions.push(format!(
+                        "(pk, base_pk COLLATE \"C\", {base_sk_col}{base_collate}) > (${p1}, ${p2}, ${p3})",
+                        p1 = param_idx,
+                        p2 = param_idx + 1,
+                        p3 = param_idx + 2
+                    ));
                 } else {
-                    // Hash-only index scan
+                    // Hash-only index on a hash-only base table.
                     conditions.push(format!(
                         "(pk, base_pk COLLATE \"C\") > (${p1}, ${p2})",
                         p1 = param_idx,
@@ -497,6 +514,17 @@ impl PostgresEngine {
                         " ORDER BY pk, {sk_col}{collate}, base_pk COLLATE \"C\""
                     );
                 }
+            } else if let Some((_, base_sk_type)) = &base_sk_info {
+                let base_sk_col = format!("base_{}", sk_column(*base_sk_type));
+                let base_collate = if *base_sk_type == ScalarAttributeType::S {
+                    " COLLATE \"C\""
+                } else {
+                    ""
+                };
+                let _ = write!(
+                    sql,
+                    " ORDER BY pk, base_pk COLLATE \"C\", {base_sk_col}{base_collate}"
+                );
             } else {
                 let _ = write!(sql, " ORDER BY pk, base_pk COLLATE \"C\"");
             }

--- a/tests/test_query_scan.py
+++ b/tests/test_query_scan.py
@@ -1347,3 +1347,70 @@ class TestBaseKeySchemaFlow:
         assert len(all_items) == 12
         item_keys = [(i["pk"]["S"], i["sk"]["N"]) for i in all_items]
         assert len(item_keys) == len(set(item_keys))
+
+
+
+@pytest.fixture
+def hash_only_gsi_on_composite_base(dynamodb_client):
+    """Composite-key base table (HASH+RANGE) with a hash-only GSI.
+
+    Multiple items share the same GSI hash AND the same base partition key,
+    differing only by the base sort key — the case where index rows collide on
+    (gsi_hash, base_pk) and pagination must order by the base sort key too.
+    """
+    with scoped_table(
+        dynamodb_client,
+        attribute_definitions=[
+            {"AttributeName": "deviceId", "AttributeType": "S"},
+            {"AttributeName": "ts", "AttributeType": "N"},
+            {"AttributeName": "status", "AttributeType": "S"},
+        ],
+        key_schema=[
+            {"AttributeName": "deviceId", "KeyType": "HASH"},
+            {"AttributeName": "ts", "KeyType": "RANGE"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "StatusGSI",
+                "KeySchema": [{"AttributeName": "status", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+    ) as name:
+        for i in range(1, 8):
+            dynamodb_client.put_item(
+                TableName=name,
+                Item={
+                    "deviceId": {"S": "d1"},
+                    "ts": {"N": str(i)},
+                    "status": {"S": "ACTIVE"},
+                },
+            )
+        yield name
+
+
+class TestHashOnlyGsiCompositeBaseScan:
+    """Scanning a hash-only GSI on a composite-key base table must not drop
+    rows that share a (gsi_hash, base_pk) prefix across page boundaries."""
+
+    def test_scan_paginate_returns_all(
+        self, dynamodb_client, hash_only_gsi_on_composite_base
+    ):
+        all_ts = []
+        exclusive_start_key = None
+        while True:
+            kwargs = {
+                "TableName": hash_only_gsi_on_composite_base,
+                "IndexName": "StatusGSI",
+                "Limit": 2,
+            }
+            if exclusive_start_key:
+                kwargs["ExclusiveStartKey"] = exclusive_start_key
+            resp = dynamodb_client.scan(**kwargs)
+            all_ts.extend(item["ts"]["N"] for item in resp["Items"])
+            if "LastEvaluatedKey" not in resp:
+                break
+            exclusive_start_key = resp["LastEvaluatedKey"]
+
+        assert len(all_ts) == 7, f"expected 7 items, got {len(all_ts)}"
+        assert sorted(all_ts, key=int) == [str(i) for i in range(1, 8)]


### PR DESCRIPTION
## What

A paginated `Scan` of a hash-only GSI whose base table has a composite (HASH+RANGE) key dropped every row past the first page when multiple rows shared the same index hash and the same base partition key. The index-scan pagination predicate and `ORDER BY` only tie-broke on `(index_hash, base_pk)`, which are identical for such rows, so the next page's row-value comparison excluded all of them and pagination stopped early.

This includes the base sort key as the final tie-breaker in both the pagination predicate and the `ORDER BY` for the hash-only-index branch, matching the index-with-sort-key branch and the `Query` path. Extends #146, which took the
tie-breaker only as far as `base_pk`.

Scope: `crates/storage-postgres/src/data/query_scan.rs` (read path only). No changes to the write path, storage trait, or wire protocol.

## Why

Conformance gap found by comparing ExtendDB against Amazon DynamoDB: a hash-only GSI on a composite base table is a valid, common shape (e.g. a status GSI over a `deviceId`+`ts` table), and paginating a `Scan` of it silently lost rows after
the first page.

Closes # 

## Testing done

New regression test `tests/test_query_scan.py::TestHashOnlyGsiCompositeBaseScan::test_scan_paginate_returns_all`
(7 rows sharing base partition key and GSI hash, paginated with `Limit=2`). Verified against Amazon DynamoDB, which returns all 7.

- Before the fix: `AssertionError: expected 7 items, got 2`.
- After the fix: passes 3/3 across repeated runs (synchronous GSI).
- `tests/test_query_scan.py` — 66/66 pass against PostgreSQL, no regressions.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p extenddb-storage-postgres -- -D warnings` — clean.
- `cargo build --release` — clean.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
    format, or public CLI surface, an RFC has been accepted or is linked
    below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a (bug fix; no protocol, storage-trait, auth, on-disk, or CLI change)

## Breaking changes

None.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.