### PR TITLE
Reject empty KeyConditionExpression and enforce nesting limit on all …

### DIFF
--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -132,6 +132,10 @@ pub async fn handle_query(
         ));
     }
 
+    // An explicitly empty KeyConditionExpression is rejected up front, before
+    // the expression-parameter-usage checks (matching real DynamoDB).
+    reject_empty_key_condition_expression(input.key_condition_expression.as_deref())?;
+
     // Build expression maps from request (used for expression-based parameters)
     let maps = build_expression_maps(
         input.expression_attribute_names.as_ref(),
@@ -546,5 +550,46 @@ fn validate_name_refs_in_expr(
             validate_name_refs_in_expr(right, names, expr_type)
         }
         Expr::Placeholder(_) => Ok(()),
+    }
+}
+
+/// Reject an explicitly empty `KeyConditionExpression` with DynamoDB's exact
+/// message. An absent expression (`None`) is allowed here; required-ness is
+/// enforced later. Only the empty-string case (`Some("")`) is rejected, and it
+/// is rejected up front — before expression-parameter-usage checks — to match
+/// real DynamoDB's ordering.
+fn reject_empty_key_condition_expression(expr: Option<&str>) -> Result<(), DynamoDbError> {
+    if expr == Some("") {
+        return Err(DynamoDbError::ValidationException(
+            "Invalid KeyConditionExpression: The expression can not be empty;".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod empty_key_condition_tests {
+    use super::reject_empty_key_condition_expression;
+    use extenddb_core::error::DynamoDbError;
+
+    #[test]
+    fn empty_string_is_rejected_with_canonical_message() {
+        match reject_empty_key_condition_expression(Some("")) {
+            Err(DynamoDbError::ValidationException(msg)) => assert_eq!(
+                msg,
+                "Invalid KeyConditionExpression: The expression can not be empty;"
+            ),
+            other => panic!("expected ValidationException, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn absent_expression_is_allowed_here() {
+        assert!(reject_empty_key_condition_expression(None).is_ok());
+    }
+
+    #[test]
+    fn non_empty_expression_is_allowed() {
+        assert!(reject_empty_key_condition_expression(Some("pk = :v")).is_ok());
     }
 }

--- a/crates/engine/src/update_item.rs
+++ b/crates/engine/src/update_item.rs
@@ -143,21 +143,13 @@ pub async fn handle_update_item(
         Vec::new()
     };
 
-    // Amazon DynamoDB enforces nesting depth on values that are stored as item
-    // attributes. For UpdateExpression, walk each SET action's RHS to find the
-    // EAV placeholders it references, resolve them against `maps.values`, and
-    // validate those values' depth. Condition-only EAV is left alone.
+    // Amazon DynamoDB enforces the 32-level nesting limit on every provided
+    // ExpressionAttributeValue up front — before the condition is evaluated —
+    // not only those stored via a SET action. Validate all of them so a deeply
+    // nested condition-only value is a ValidationException rather than surfacing
+    // as a ConditionalCheckFailedException.
     {
-        let mut placeholders: Vec<String> = Vec::new();
-        for action in &actions {
-            if let UpdateAction::Set { value, .. } = action {
-                extenddb_core::expression::collect_value_placeholders(value, &mut placeholders);
-            }
-        }
-        let stored: Vec<&extenddb_core::types::AttributeValue> = placeholders
-            .iter()
-            .filter_map(|name| maps.values.get(name))
-            .collect();
+        let stored: Vec<&extenddb_core::types::AttributeValue> = maps.values.values().collect();
         extenddb_core::validation::validate_attribute_values_nesting_depth(stored)?;
     }
 

--- a/tests/test_conditional_writes.py
+++ b/tests/test_conditional_writes.py
@@ -399,3 +399,31 @@ class TestBetweenBoundsValidation:
         err = exc_info.value.response["Error"]
         assert err["Code"] == "ValidationException"
         assert "BETWEEN" in err["Message"]
+
+
+def test_update_item_condition_only_deep_eav_is_validation_error(
+    dynamodb_client, condition_table
+):
+    """A >32-level nested EAV referenced only by the ConditionExpression (never by
+    a SET action) must be rejected up front as a ValidationException — not surface
+    as a ConditionalCheckFailedException.
+
+    Verified against real DynamoDB (us-east-1): nesting limit is enforced on every
+    provided ExpressionAttributeValue before the condition is evaluated.
+    """
+    # Build a 33-level-deep nested list value (exceeds the 32-level limit).
+    deep = {"S": "x"}
+    for _ in range(33):
+        deep = {"L": [deep]}
+
+    with pytest.raises(ClientError) as exc:
+        dynamodb_client.update_item(
+            TableName=condition_table,
+            Key={"pk": {"S": "p"}, "sk": {"S": "s"}},
+            UpdateExpression="SET v = :new",
+            ConditionExpression="c = :deep",
+            ExpressionAttributeValues={":new": {"N": "1"}, ":deep": deep},
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ValidationException", err
+    assert "Nesting Levels have exceeded supported limits" in err["Message"], err

--- a/tests/test_query_scan.py
+++ b/tests/test_query_scan.py
@@ -1347,3 +1347,20 @@ class TestBaseKeySchemaFlow:
         assert len(all_items) == 12
         item_keys = [(i["pk"]["S"], i["sk"]["N"]) for i in all_items]
         assert len(item_keys) == len(set(item_keys))
+
+
+def test_query_empty_key_condition_expression_rejected(dynamodb_client):
+    """Query with an explicitly empty KeyConditionExpression is a ValidationException.
+
+    Verified against real DynamoDB (us-east-1): the exact message is
+    "Invalid KeyConditionExpression: The expression can not be empty;".
+    """
+    with scoped_table(dynamodb_client) as name:
+        with pytest.raises(ClientError) as exc:
+            dynamodb_client.query(TableName=name, KeyConditionExpression="")
+        err = exc.value.response["Error"]
+        assert err["Code"] == "ValidationException", err
+        assert (
+            err["Message"]
+            == "Invalid KeyConditionExpression: The expression can not be empty;"
+        ), err


### PR DESCRIPTION
## What

Two request-validation correctness fixes that align ExtendDB with real DynamoDB:

**Query:** an explicitly empty `KeyConditionExpression` (`""`) is now rejected up front with DynamoDB's exact message — `"Invalid KeyConditionExpression: The expression can not be empty;"` — before the expression-parameter-usage checks, matching real DynamoDB's ordering. Extracted `reject_empty_key_condition_expression` with unit coverage.

**UpdateItem:** the 32-level attribute-value nesting limit is now enforced on every provided `ExpressionAttributeValue` up front, not only those referenced by a `SET` action. A deeply nested value used solely in a `ConditionExpression` now returns a `ValidationException` instead of surfacing as a `ConditionalCheckFailedException`.

## Why

`Query` previously accepted an empty `KeyConditionExpression` and `UpdateItem` only depth-checked SET-referenced values, so a deeply nested condition-only value leaked through as a `ConditionalCheckFailedException` instead of being rejected. Both diverged from real DynamoDB's behavior and error contract.

Closes #

## Testing done

Both behaviors verified against real DynamoDB (us-east-1).

- Unit (query): `reject_empty_key_condition_expression` — empty rejected with canonical message, `None` allowed, non-empty allowed.
- Integration (live server):
- `tests/test_query_scan.py::test_query_empty_key_condition_expression_rejected`
- `tests/test_conditional_writes.py::test_update_item_condition_only_deep_eav_is_validation_error`
- cargo test --workspace        # unit, green
- cargo fmt --all --check        # clean
- cargo clippy -p extenddb-engine --all-targets   # cleaninteg: EXTENDDB_TEST_ENDPOINT=https://127.0.0.1:18443 pytest (2/2 pass)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface, an RFC has been accepted or is linked below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a — error-message/validation parity fix, no protocol/trait/format change.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.