### PR TITLE
fix: validate request parameters before the table-existence check

### DIFF
--- a/crates/engine/src/batch_get_item.rs
+++ b/crates/engine/src/batch_get_item.rs
@@ -91,21 +91,11 @@ pub async fn handle_batch_get_item(
         ));
     }
 
-    let mut responses: HashMap<String, Vec<Item>> = HashMap::new();
-    let mut total_rcu: f64 = 0.0;
-    let mut total_pre_proj_bytes: usize = 0;
-    let mut returned_count: u64 = 0;
-    let mut per_table_rcu: HashMap<String, f64> = HashMap::new();
-
+    // Validate every table's projection and duplicate keys before
+    // any existence lookup (Amazon DynamoDB validates the whole request first).
+    // Compiled projections are reused below; per-key schema check stays in the loop.
+    let mut table_projections: HashMap<String, Option<Projection>> = HashMap::new();
     for (table_name, ka) in &input.request_items {
-        let key_info = ctx
-            .storage
-            .table_key_info(&ctx.account_id, table_name)
-            .await
-            .map_err(storage_err_to_dynamo)?;
-
-        // Parse per-table projection. AttributesToGet is desugared into a
-        // ProjectionExpression with synthetic name placeholders.
         extenddb_core::expression::validate_expression_param_usage(
             ka.expression_attribute_names.as_ref(),
             ka.projection_expression
@@ -173,15 +163,36 @@ pub async fn handle_batch_get_item(
             )?;
         }
 
-        let mut table_items: Vec<Item> = Vec::new();
+        // Reject duplicate keys (pre-existence on Amazon DynamoDB).
         let mut seen_keys: HashSet<Vec<u8>> = HashSet::with_capacity(ka.keys.len());
         for key in &ka.keys {
-            let key_bytes = serialize_key_for_dedup(key);
-            if !seen_keys.insert(key_bytes) {
+            if !seen_keys.insert(serialize_key_for_dedup(key)) {
                 return Err(DynamoDbError::ValidationException(
                     "Provided list of item keys contains duplicates".to_owned(),
                 ));
             }
+        }
+
+        table_projections.insert(table_name.clone(), projection);
+    }
+
+    let mut responses: HashMap<String, Vec<Item>> = HashMap::new();
+    let mut total_rcu: f64 = 0.0;
+    let mut total_pre_proj_bytes: usize = 0;
+    let mut returned_count: u64 = 0;
+    let mut per_table_rcu: HashMap<String, f64> = HashMap::new();
+
+    for (table_name, ka) in &input.request_items {
+        let key_info = ctx
+            .storage
+            .table_key_info(&ctx.account_id, table_name)
+            .await
+            .map_err(storage_err_to_dynamo)?;
+
+        let projection = table_projections.get(table_name).and_then(Option::as_ref);
+
+        let mut table_items: Vec<Item> = Vec::new();
+        for key in &ka.keys {
             validate_batch_key_only(key, &key_info.key_schema, &key_info.attribute_definitions)?;
             validate_key_sizes(key, &key_info.key_schema, &ctx.limits)?;
 
@@ -198,7 +209,7 @@ pub async fn handle_batch_get_item(
                 *per_table_rcu.entry(table_name.clone()).or_default() += item_rcu;
                 total_pre_proj_bytes += size;
                 returned_count += 1;
-                let item = if let Some(ref projection) = projection {
+                let item = if let Some(projection) = projection {
                     projection.apply(&item)
                 } else {
                     item

--- a/crates/engine/src/delete_item.rs
+++ b/crates/engine/src/delete_item.rs
@@ -42,18 +42,9 @@ pub async fn handle_delete_item(
 
     extenddb_core::validation::validate_table_name(&input.table_name, &ctx.limits)?;
 
-    let key_info = ctx
-        .table_key_info(&input.table_name)
-        .await
-        .map_err(storage_err_to_dynamo)?;
-
-    extenddb_core::validation::validate_delete_item(
-        &input,
-        &ctx.limits,
-        &key_info.key_schema,
-        &key_info.attribute_definitions,
-    )?;
-
+    // Validate expressions/`Expected` before the existence check,
+    // so a missing table returns ValidationException, not ResourceNotFoundException.
+    // Key validation stays after existence (it needs the table's key schema).
     let has_condition = input
         .condition_expression
         .as_ref()
@@ -91,6 +82,18 @@ pub async fn handle_delete_item(
             &std::collections::HashSet::new(),
         )?;
     }
+
+    let key_info = ctx
+        .table_key_info(&input.table_name)
+        .await
+        .map_err(storage_err_to_dynamo)?;
+
+    extenddb_core::validation::validate_delete_item(
+        &input,
+        &ctx.limits,
+        &key_info.key_schema,
+        &key_info.attribute_definitions,
+    )?;
 
     let return_old = input.return_values == ReturnValues::AllOld;
 

--- a/crates/engine/src/get_item.rs
+++ b/crates/engine/src/get_item.rs
@@ -36,17 +36,9 @@ pub async fn handle_get_item(
 ) -> Result<DispatchResult, DynamoDbError> {
     let input: GetItemInput = serde_json::from_value(body).map_err(crate::deserialize_error)?;
 
-    let key_info = ctx
-        .table_key_info(&input.table_name)
-        .await
-        .map_err(storage_err_to_dynamo)?;
-
-    extenddb_core::validation::validate_get_item(
-        &input,
-        &ctx.limits,
-        &key_info.key_schema,
-        &key_info.attribute_definitions,
-    )?;
+    // Validate the projection (and EAN usage) before the existence
+    // check, so a missing table returns ValidationException, not
+    // ResourceNotFoundException. Key validation stays after existence.
 
     // Reject ExpressionAttributeNames supplied with no ProjectionExpression
     // (legacy AttributesToGet does not count as an expression).
@@ -61,18 +53,6 @@ pub async fn handle_get_item(
         &[],
     )?;
 
-    let item = ctx
-        .storage
-        .get_item(&key_info, &input.key)
-        .await
-        .map_err(storage_err_to_dynamo)?;
-
-    // Capacity metering: full item size pre-projection, rounded up to 4 KB.
-    let pre_projection_bytes = item.as_ref().map_or(0, item_size_bytes);
-    let strongly_consistent = input.consistent_read == Some(true);
-    let rcu = capacity_helpers::read_capacity_units(pre_projection_bytes, strongly_consistent);
-
-    // Apply projection if requested.
     // M4: Mutual exclusivity — real DynamoDB rejects both at once.
     if input.projection_expression.is_some()
         && input
@@ -115,8 +95,8 @@ pub async fn handle_get_item(
         Some(merged)
     };
 
-    // Parse and validate the projection once, before the item fetch result
-    // matters, so validation runs whether or not the item exists.
+    // Parse and validate the projection once, before existence and before the
+    // item fetch, so validation runs whether or not the table or item exists.
     let projection = match effective_projection {
         Some(ref proj_str) => {
             let parsed = crate::expression_helpers::parse_projection_expr(proj_str, &ctx.limits)?;
@@ -139,6 +119,29 @@ pub async fn handle_get_item(
         }
         None => None,
     };
+
+    let key_info = ctx
+        .table_key_info(&input.table_name)
+        .await
+        .map_err(storage_err_to_dynamo)?;
+
+    extenddb_core::validation::validate_get_item(
+        &input,
+        &ctx.limits,
+        &key_info.key_schema,
+        &key_info.attribute_definitions,
+    )?;
+
+    let item = ctx
+        .storage
+        .get_item(&key_info, &input.key)
+        .await
+        .map_err(storage_err_to_dynamo)?;
+
+    // Capacity metering: full item size pre-projection, rounded up to 4 KB.
+    let pre_projection_bytes = item.as_ref().map_or(0, item_size_bytes);
+    let strongly_consistent = input.consistent_read == Some(true);
+    let rcu = capacity_helpers::read_capacity_units(pre_projection_bytes, strongly_consistent);
 
     let item = match (projection, item) {
         (Some(projection), Some(fetched)) => Some(projection.apply(&fetched)),

--- a/crates/engine/src/put_item.rs
+++ b/crates/engine/src/put_item.rs
@@ -100,18 +100,9 @@ pub async fn handle_put_item(
 
     extenddb_core::validation::validate_table_name(&input.table_name, &ctx.limits)?;
 
-    let key_info = ctx
-        .table_key_info(&input.table_name)
-        .await
-        .map_err(storage_err_to_dynamo)?;
-
-    extenddb_core::validation::validate_put_item(
-        &input,
-        &ctx.limits,
-        &key_info.key_schema,
-        &key_info.attribute_definitions,
-    )?;
-
+    // Validate expressions/`Expected` before the existence check,
+    // so a malformed request to a missing table returns ValidationException,
+    // not ResourceNotFoundException. Key/item-content checks stay after.
     let (condition, maps) = resolve_condition(
         input.condition_expression.as_deref(),
         input.expression_attribute_names.as_ref(),
@@ -137,6 +128,18 @@ pub async fn handle_put_item(
             &std::collections::HashSet::new(),
         )?;
     }
+
+    let key_info = ctx
+        .table_key_info(&input.table_name)
+        .await
+        .map_err(storage_err_to_dynamo)?;
+
+    extenddb_core::validation::validate_put_item(
+        &input,
+        &ctx.limits,
+        &key_info.key_schema,
+        &key_info.attribute_definitions,
+    )?;
 
     let return_old = input.return_values == ReturnValues::AllOld;
 

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -38,104 +38,8 @@ pub async fn handle_scan(
 ) -> Result<DispatchResult, DynamoDbError> {
     let input: ScanInput = serde_json::from_value(body).map_err(crate::deserialize_error)?;
 
-    // P118: Fetch key_info first so we can use table_id for index lookup.
-    let key_info = ctx
-        .table_key_info(&input.table_name)
-        .await
-        .map_err(storage_err_to_dynamo)?;
-
-    // GSI/LSI: resolve index metadata if scanning a secondary index.
-    // Uses table_id from pre-fetched key_info to skip redundant table lookup (P118 #4).
-    let index_info = if let Some(ref idx_name) = input.index_name {
-        Some(
-            ctx.storage
-                .index_info_by_table_id(&key_info.table_id, idx_name)
-                .await
-                .map_err(storage_err_to_dynamo)?,
-        )
-    } else {
-        None
-    };
-
-    // ConsistentRead is not supported on GSI scans (tenet 1: fidelity).
-    if input.consistent_read == Some(true)
-        && let Some(ref idx) = index_info
-        && idx.index_type == IndexType::Gsi
-    {
-        return Err(DynamoDbError::ValidationException(
-            "Consistent reads are not supported on global secondary indexes".to_owned(),
-        ));
-    }
-
-    // Validate Segment/TotalSegments — DynamoDB returns different messages per direction
-    match (input.segment, input.total_segments) {
-        (Some(_), None) => {
-            return Err(DynamoDbError::ValidationException(
-                "The TotalSegments parameter is required but was not present in the request when Segment parameter is present"
-                    .to_owned(),
-            ));
-        }
-        (None, Some(_)) => {
-            return Err(DynamoDbError::ValidationException(
-                "The Segment parameter is required but was not present in the request when parameter TotalSegments is present"
-                    .to_owned(),
-            ));
-        }
-        (Some(seg), Some(total)) => {
-            if total < 1 {
-                return Err(DynamoDbError::ValidationException(
-                    "The parameter TotalSegments should be greater than or equal to 1".to_owned(),
-                ));
-            }
-            if total > 1_000_000 {
-                return Err(DynamoDbError::ValidationException(format!(
-                    "1 validation error detected: Value '{total}' at 'totalSegments' failed to satisfy constraint: Member must have value less than or equal to 1000000"
-                )));
-            }
-            if seg < 0 {
-                return Err(DynamoDbError::ValidationException(format!(
-                    "1 validation error detected: Value '{seg}' at 'segment' failed to satisfy constraint: Member must have value greater than or equal to 0"
-                )));
-            }
-            if seg > 999_999 {
-                return Err(DynamoDbError::ValidationException(format!(
-                    "1 validation error detected: Value '{seg}' at 'segment' failed to satisfy constraint: Member must have value less than or equal to 999999"
-                )));
-            }
-            if seg >= total {
-                return Err(DynamoDbError::ValidationException(format!(
-                    "The Segment parameter is zero-based and must be less than parameter TotalSegments: \
-                     Segment: {seg} is not less than TotalSegments: {total}"
-                )));
-            }
-        }
-        (None, None) => {}
-    }
-
-    // Validate Limit >= 1
-    if let Some(limit) = input.limit
-        && limit < 1
-    {
-        return Err(DynamoDbError::ValidationException(format!(
-            "1 validation error detected: Value '{limit}' at 'limit' failed to satisfy constraint: Member must have value greater than or equal to 1"
-        )));
-    }
-
-    // For index scans, build a key_info that reflects the index's key schema.
-    let scan_key_info = if let Some(ref idx) = index_info {
-        TableKeyInfo {
-            table_name: key_info.table_name.clone(),
-            account_id: key_info.account_id.clone(),
-            table_id: key_info.table_id.clone(),
-            key_schema: idx.key_schema.clone(),
-            base_key_schema: key_info.key_schema.clone(),
-            attribute_definitions: key_info.attribute_definitions.clone(),
-            has_lsi: key_info.has_lsi,
-            stream_specification: None, // Scans don't capture stream records
-        }
-    } else {
-        key_info.clone()
-    };
+    // Validate Filter/Projection expressions before the existence
+    // check; index resolution, Segment/Limit/Select and key checks stay after.
 
     // --- Legacy vs expression mutual exclusivity checks ---
     let has_fe = input.filter_expression.is_some();
@@ -289,6 +193,105 @@ pub async fn handle_scan(
             &std::collections::HashSet::new(),
         )?;
     }
+
+    // P118: Fetch key_info first so we can use table_id for index lookup.
+    let key_info = ctx
+        .table_key_info(&input.table_name)
+        .await
+        .map_err(storage_err_to_dynamo)?;
+
+    // GSI/LSI: resolve index metadata if scanning a secondary index.
+    // Uses table_id from pre-fetched key_info to skip redundant table lookup (P118 #4).
+    let index_info = if let Some(ref idx_name) = input.index_name {
+        Some(
+            ctx.storage
+                .index_info_by_table_id(&key_info.table_id, idx_name)
+                .await
+                .map_err(storage_err_to_dynamo)?,
+        )
+    } else {
+        None
+    };
+
+    // ConsistentRead is not supported on GSI scans (tenet 1: fidelity).
+    if input.consistent_read == Some(true)
+        && let Some(ref idx) = index_info
+        && idx.index_type == IndexType::Gsi
+    {
+        return Err(DynamoDbError::ValidationException(
+            "Consistent reads are not supported on global secondary indexes".to_owned(),
+        ));
+    }
+
+    // Validate Segment/TotalSegments — DynamoDB returns different messages per direction
+    match (input.segment, input.total_segments) {
+        (Some(_), None) => {
+            return Err(DynamoDbError::ValidationException(
+                "The TotalSegments parameter is required but was not present in the request when Segment parameter is present"
+                    .to_owned(),
+            ));
+        }
+        (None, Some(_)) => {
+            return Err(DynamoDbError::ValidationException(
+                "The Segment parameter is required but was not present in the request when parameter TotalSegments is present"
+                    .to_owned(),
+            ));
+        }
+        (Some(seg), Some(total)) => {
+            if total < 1 {
+                return Err(DynamoDbError::ValidationException(
+                    "The parameter TotalSegments should be greater than or equal to 1".to_owned(),
+                ));
+            }
+            if total > 1_000_000 {
+                return Err(DynamoDbError::ValidationException(format!(
+                    "1 validation error detected: Value '{total}' at 'totalSegments' failed to satisfy constraint: Member must have value less than or equal to 1000000"
+                )));
+            }
+            if seg < 0 {
+                return Err(DynamoDbError::ValidationException(format!(
+                    "1 validation error detected: Value '{seg}' at 'segment' failed to satisfy constraint: Member must have value greater than or equal to 0"
+                )));
+            }
+            if seg > 999_999 {
+                return Err(DynamoDbError::ValidationException(format!(
+                    "1 validation error detected: Value '{seg}' at 'segment' failed to satisfy constraint: Member must have value less than or equal to 999999"
+                )));
+            }
+            if seg >= total {
+                return Err(DynamoDbError::ValidationException(format!(
+                    "The Segment parameter is zero-based and must be less than parameter TotalSegments: \
+                     Segment: {seg} is not less than TotalSegments: {total}"
+                )));
+            }
+        }
+        (None, None) => {}
+    }
+
+    // Validate Limit >= 1
+    if let Some(limit) = input.limit
+        && limit < 1
+    {
+        return Err(DynamoDbError::ValidationException(format!(
+            "1 validation error detected: Value '{limit}' at 'limit' failed to satisfy constraint: Member must have value greater than or equal to 1"
+        )));
+    }
+
+    // For index scans, build a key_info that reflects the index's key schema.
+    let scan_key_info = if let Some(ref idx) = index_info {
+        TableKeyInfo {
+            table_name: key_info.table_name.clone(),
+            account_id: key_info.account_id.clone(),
+            table_id: key_info.table_id.clone(),
+            key_schema: idx.key_schema.clone(),
+            base_key_schema: key_info.key_schema.clone(),
+            attribute_definitions: key_info.attribute_definitions.clone(),
+            has_lsi: key_info.has_lsi,
+            stream_specification: None, // Scans don't capture stream records
+        }
+    } else {
+        key_info.clone()
+    };
 
     // Validate Select vs ProjectionExpression and index requirements
     if let Some(Select::AllProjectedAttributes) = input.select

--- a/crates/engine/src/update_item.rs
+++ b/crates/engine/src/update_item.rs
@@ -56,10 +56,9 @@ pub async fn handle_update_item(
 
     extenddb_core::validation::validate_table_name(&input.table_name, &ctx.limits)?;
 
-    let key_info = ctx
-        .table_key_info(&input.table_name)
-        .await
-        .map_err(storage_err_to_dynamo)?;
+    // Validate Update/Condition expressions (and AttributeUpdates
+    // desugaring) before the existence check; key, item-content nesting, and
+    // the no-key-update checks stay after (post-existence on Amazon DynamoDB).
 
     // Desugar legacy AttributeUpdates into UpdateExpression if present.
     // N.B. The literal `{AttributeUpdates}` / `{UpdateExpression}` in the error message
@@ -102,13 +101,6 @@ pub async fn handle_update_item(
         Some(merged)
     };
 
-    extenddb_core::validation::validate_update_item(
-        &input,
-        &ctx.limits,
-        &key_info.key_schema,
-        &key_info.attribute_definitions,
-    )?;
-
     let has_update_expr = input
         .update_expression
         .as_ref()
@@ -143,24 +135,22 @@ pub async fn handle_update_item(
         Vec::new()
     };
 
-    // Amazon DynamoDB enforces nesting depth on values that are stored as item
-    // attributes. For UpdateExpression, walk each SET action's RHS to find the
-    // EAV placeholders it references, resolve them against `maps.values`, and
-    // validate those values' depth. Condition-only EAV is left alone — real
-    // DynamoDB does not apply the nesting limit to values used solely in a
-    // ConditionExpression (verified against the service).
-    {
-        let mut placeholders: Vec<String> = Vec::new();
-        for action in &actions {
-            if let UpdateAction::Set { value, .. } = action {
-                extenddb_core::expression::collect_value_placeholders(value, &mut placeholders);
+    // Reject an undefined #name before the existence check
+    // (otherwise it is only raised later, during execution).
+    for action in &actions {
+        let path = match action {
+            UpdateAction::Set { path, .. }
+            | UpdateAction::Remove { path }
+            | UpdateAction::Add { path, .. }
+            | UpdateAction::Delete { path, .. } => path,
+        };
+        for el in path {
+            if let PathElement::Attribute(name) = el
+                && let Some(ref_name) = name.strip_prefix('#')
+            {
+                maps.resolve_name(ref_name)?;
             }
         }
-        let stored: Vec<&extenddb_core::types::AttributeValue> = placeholders
-            .iter()
-            .filter_map(|name| maps.values.get(name))
-            .collect();
-        extenddb_core::validation::validate_attribute_values_nesting_depth(stored)?;
     }
 
     if input.expected.is_none()
@@ -178,6 +168,38 @@ pub async fn handle_update_item(
             &std::collections::HashSet::new(),
             &std::collections::HashSet::new(),
         )?;
+    }
+
+    let key_info = ctx
+        .table_key_info(&input.table_name)
+        .await
+        .map_err(storage_err_to_dynamo)?;
+
+    extenddb_core::validation::validate_update_item(
+        &input,
+        &ctx.limits,
+        &key_info.key_schema,
+        &key_info.attribute_definitions,
+    )?;
+
+    // Amazon DynamoDB enforces nesting depth on values that are stored as item
+    // attributes. For UpdateExpression, walk each SET action's RHS to find the
+    // EAV placeholders it references, resolve them against `maps.values`, and
+    // validate those values' depth. Condition-only EAV is left alone: real
+    // DynamoDB does not apply the nesting limit to values used solely in a
+    // ConditionExpression (verified against the service).
+    {
+        let mut placeholders: Vec<String> = Vec::new();
+        for action in &actions {
+            if let UpdateAction::Set { value, .. } = action {
+                extenddb_core::expression::collect_value_placeholders(value, &mut placeholders);
+            }
+        }
+        let stored: Vec<&extenddb_core::types::AttributeValue> = placeholders
+            .iter()
+            .filter_map(|name| maps.values.get(name))
+            .collect();
+        extenddb_core::validation::validate_attribute_values_nesting_depth(stored)?;
     }
 
     // Validate that no update action targets a key attribute (REQ-DATA-003)

--- a/tests/test_validation_precedence.py
+++ b/tests/test_validation_precedence.py
@@ -1,0 +1,200 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Request-validation precedence vs table existence.
+
+Amazon DynamoDB validates a documented subset of request parameters *before*
+it checks whether the target table exists. For a malformed request against a
+table that does not exist, those checks make DynamoDB return a
+``ValidationException`` rather than a ``ResourceNotFoundException``.
+
+The pre-existence subset (confirmed by capturing Amazon DynamoDB directly):
+
+* expression validation that ExtendDB performs (syntax / reserved-word /
+  undefined-name / overlapping-path) for ConditionExpression,
+  ProjectionExpression, UpdateExpression and FilterExpression;
+* legacy ``Expected`` structural validation (e.g. ComparisonOperator alone);
+* BatchGetItem request-structure validation (duplicate keys).
+
+Scope note: a few cases that the conformance suite groups with this ordering
+bug are actually *separate, missing-validation* bugs, not ordering bugs, so
+they are out of scope here and are tracked separately:
+
+* empty ConditionExpression / empty FilterExpression: ExtendDB accepts an empty
+  string as "no expression" even against an existing table (Amazon DynamoDB
+  rejects it). Root cause is the shared optional-expression parser, not
+  ordering.
+* legacy ``Expected`` with ``Exists: true`` and no ``Value``: ExtendDB accepts
+  it against an existing table (Amazon DynamoDB requires a Value).
+
+Some other checks are intentionally *post-existence* on Amazon DynamoDB and
+must keep returning ``ResourceNotFoundException`` for an absent table. The most
+visible one is the item-size limit (PutItem / BatchWriteItem). The control
+tests at the bottom pin that boundary so the fix does not over-correct.
+
+All expected behaviour here was captured from Amazon DynamoDB via the AWS CLI
+(profile ``asomasun-admin``, us-east-1).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from botocore.exceptions import ClientError
+
+# A table that is never created, so it does not exist on either target.
+ABSENT_TABLE = f"eddb-absent-{uuid.uuid4().hex[:12]}"
+
+
+def _error(excinfo) -> tuple[str, str]:
+    err = excinfo.value.response["Error"]
+    return err["Code"], err["Message"]
+
+
+def _assert_validation(excinfo, msg_contains: str) -> None:
+    code, message = _error(excinfo)
+    assert code == "ValidationException", f"expected ValidationException, got {code}: {message}"
+    assert msg_contains in message, f"{msg_contains!r} not in {message!r}"
+
+
+# Use the no-validation client so botocore does not reject the malformed
+# parameters client-side; we want the *service* to do the rejecting.
+@pytest.fixture()
+def client(dynamodb_client_no_validation):
+    return dynamodb_client_no_validation
+
+
+class TestValidationBeforeExistence:
+    """Malformed request to an absent table -> ValidationException."""
+
+    def test_put_item_expected_comparison_operator_alone(self, client):
+        with pytest.raises(ClientError) as ei:
+            client.put_item(
+                TableName=ABSENT_TABLE,
+                Item={"a": {"S": "k"}},
+                Expected={"a": {"ComparisonOperator": "EQ"}},
+            )
+        _assert_validation(ei, "One or more parameter values were invalid")
+
+    def test_get_item_empty_projection_expression(self, client):
+        with pytest.raises(ClientError) as ei:
+            client.get_item(
+                TableName=ABSENT_TABLE,
+                Key={"a": {"S": "k"}},
+                ProjectionExpression="",
+            )
+        _assert_validation(ei, "Invalid ProjectionExpression:")
+
+    def test_get_item_syntax_error_projection_expression(self, client):
+        with pytest.raises(ClientError) as ei:
+            client.get_item(
+                TableName=ABSENT_TABLE,
+                Key={"a": {"S": "k"}},
+                ProjectionExpression="a..b",
+            )
+        _assert_validation(ei, "Invalid ProjectionExpression:")
+
+    def test_get_item_overlapping_projection_paths(self, client):
+        with pytest.raises(ClientError) as ei:
+            client.get_item(
+                TableName=ABSENT_TABLE,
+                Key={"a": {"S": "k"}},
+                ProjectionExpression="a, a.b",
+            )
+        _assert_validation(ei, "Invalid ProjectionExpression:")
+
+    def test_delete_item_expected_comparison_operator_alone(self, client):
+        with pytest.raises(ClientError) as ei:
+            client.delete_item(
+                TableName=ABSENT_TABLE,
+                Key={"a": {"S": "k"}},
+                Expected={"a": {"ComparisonOperator": "EQ"}},
+            )
+        _assert_validation(ei, "One or more parameter values were invalid")
+
+    def test_update_item_empty_update_expression(self, client):
+        with pytest.raises(ClientError) as ei:
+            client.update_item(
+                TableName=ABSENT_TABLE,
+                Key={"a": {"S": "k"}},
+                UpdateExpression="",
+            )
+        _assert_validation(ei, "Invalid UpdateExpression:")
+
+    def test_update_item_syntax_error_update_expression(self, client):
+        with pytest.raises(ClientError) as ei:
+            client.update_item(
+                TableName=ABSENT_TABLE,
+                Key={"a": {"S": "k"}},
+                UpdateExpression="SET",
+            )
+        _assert_validation(ei, "Invalid UpdateExpression:")
+
+    def test_update_item_reserved_keyword(self, client):
+        with pytest.raises(ClientError) as ei:
+            client.update_item(
+                TableName=ABSENT_TABLE,
+                Key={"a": {"S": "k"}},
+                UpdateExpression="SET status = :v",
+                ExpressionAttributeValues={":v": {"S": "x"}},
+            )
+        _assert_validation(ei, "Invalid UpdateExpression:")
+
+    def test_update_item_undefined_attribute_name(self, client):
+        with pytest.raises(ClientError) as ei:
+            client.update_item(
+                TableName=ABSENT_TABLE,
+                Key={"a": {"S": "k"}},
+                UpdateExpression="SET #x = :v",
+                ExpressionAttributeValues={":v": {"S": "x"}},
+            )
+        # ExtendDB omits the "Invalid UpdateExpression:" prefix that Amazon
+        # DynamoDB adds here (a separate message-fidelity gap); assert on the
+        # shared substring instead. The point of this case is the error class.
+        _assert_validation(ei, "not defined")
+
+    def test_scan_syntax_error_filter_expression(self, client):
+        with pytest.raises(ClientError) as ei:
+            client.scan(
+                TableName=ABSENT_TABLE,
+                FilterExpression="a +",
+            )
+        _assert_validation(ei, "Invalid FilterExpression:")
+
+    def test_batch_get_item_duplicate_keys(self, client):
+        with pytest.raises(ClientError) as ei:
+            client.batch_get_item(
+                RequestItems={
+                    ABSENT_TABLE: {"Keys": [{"a": {"S": "k"}}, {"a": {"S": "k"}}]}
+                },
+            )
+        _assert_validation(ei, "duplicates")
+
+
+class TestValidationAfterExistence:
+    """Controls: checks that stay post-existence on Amazon DynamoDB.
+
+    These must keep returning ResourceNotFoundException for an absent table so
+    the precedence fix does not move item-content validation ahead of the
+    existence check.
+    """
+
+    def _big_item(self) -> dict:
+        return {"a": {"S": "k"}, "b": {"S": "x" * 400001}}
+
+    def test_put_item_too_big_is_resource_not_found(self, client):
+        with pytest.raises(ClientError) as ei:
+            client.put_item(TableName=ABSENT_TABLE, Item=self._big_item())
+        code, _ = _error(ei)
+        assert code == "ResourceNotFoundException", f"got {code}"
+
+    def test_batch_write_item_too_big_is_resource_not_found(self, client):
+        with pytest.raises(ClientError) as ei:
+            client.batch_write_item(
+                RequestItems={
+                    ABSENT_TABLE: [{"PutRequest": {"Item": self._big_item()}}]
+                },
+            )
+        code, _ = _error(ei)
+        assert code == "ResourceNotFoundException", f"got {code}"


### PR DESCRIPTION
## What

ExtendDB checked table existence before validating request parameters, so a malformed request to a missing table returned `ResourceNotFoundException` where Amazon DynamoDB returns `ValidationException`.

This runs the pre-existence validation subset before the existence check in the six affected handlers (`put_item`, `delete_item`, `get_item`, `update_item`, `scan`, `batch_get_item`). Schema and item-content checks stay after existence.

The subset is check-specific, captured via the AWS CLI against a missing table:

- **Pre-existence** (now fixed): expression syntax / reserved-word / overlap / undefined-name for Condition/Projection/Update/Filter; legacy `Expected` structural checks; `BatchGetItem` duplicate keys.
- **Post-existence** (already matched, unchanged): item size, numbers, nesting, key presence / type.

`update_item` also resolves `UpdateExpression` `#name` refs pre-existence;
`batch_get_item` validates all tables in a pre-pass before any table lookup.

## Behavior: today vs Amazon DynamoDB

Sent to a table that does not exist (captured from Amazon DynamoDB via the AWS CLI):

| Scenario | ExtendDB (before) | Amazon DynamoDB |
|---|---|---|
| `PutItem` `Expected={"a":{"ComparisonOperator":"EQ"}}` | `ResourceNotFoundException` | `ValidationException: One or more parameter values were invalid: ...` |
| `GetItem` `ProjectionExpression="a, a.b"` (overlap) | `ResourceNotFoundException` | `ValidationException: Invalid ProjectionExpression: Two document paths overlap ...` |
| `UpdateItem` `UpdateExpression="SET status = :v"` (reserved) | `ResourceNotFoundException` | `ValidationException: Invalid UpdateExpression: ... reserved keyword: status` |
| `UpdateItem` `UpdateExpression="SET #x = :v"` (undefined name) | `ResourceNotFoundException` | `ValidationException: ... attribute name: #x` |
| `Scan` `FilterExpression="a +"` (syntax) | `ResourceNotFoundException` | `ValidationException: Invalid FilterExpression: Syntax error; ...` |
| `BatchGetItem` duplicate keys | `ResourceNotFoundException` | `ValidationException: Provided list of item keys contains duplicates` |
| `PutItem` > 400 KB item (control) | `ResourceNotFoundException` | `ResourceNotFoundException` (item size is post-existence) |

The error class for a malformed request to a missing table changes from `ResourceNotFoundException` to `ValidationException`, matching Amazon DynamoDB.

## Why

Fix Conformance gaps.

## Testing done

- New `tests/test_validation_precedence.py`: 11 pre-existence cases + 2 controls.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: <!-- link or "n/a" -->

## Breaking changes

<!-- If this PR introduces breaking changes, describe them here. Otherwise delete this section. -->

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
