### PR TITLE
Disable some Rust integration tests that fail on both DynamoDB and ExtendDB

### DIFF
--- a/tests/rust/src/condition_expressions.rs
+++ b/tests/rust/src/condition_expressions.rs
@@ -146,6 +146,7 @@ async fn condition_equals_string() {
 }
 
 #[tokio::test]
+#[ignore = "reserved keyword validation too strict"]
 async fn condition_not_equals() {
     let c = client();
     let t = tables().await;

--- a/tests/rust/src/condition_expressions_more.rs
+++ b/tests/rust/src/condition_expressions_more.rs
@@ -59,6 +59,7 @@ async fn condition_contains_string() {
 }
 
 #[tokio::test]
+#[ignore = "reserved keyword validation too strict"]
 async fn condition_size_function() {
     let c = client();
     let t = tables().await;
@@ -171,6 +172,7 @@ async fn condition_or_one_true() {
 }
 
 #[tokio::test]
+#[ignore = "reserved keyword validation too strict"]
 async fn condition_not() {
     let c = client();
     let t = tables().await;
@@ -229,6 +231,7 @@ async fn put_item_if_not_exists() {
 // ========== attribute_type ==========
 
 #[tokio::test]
+#[ignore = "reserved keyword validation too strict"]
 async fn condition_attribute_type() {
     let c = client();
     let t = tables().await;

--- a/tests/rust/src/lsi.rs
+++ b/tests/rust/src/lsi.rs
@@ -381,6 +381,7 @@ async fn seed_gsi_items(table: &str, count: usize) {
 }
 
 #[tokio::test]
+#[ignore = "GSI hash-only pagination returns lexicographic order instead of expected order"]
 async fn gsi_hash_only_pagination() {
     let table = format!("GSIHashPag_{}", ts());
     create_hash_only_gsi_table(&table).await;

--- a/tests/rust/src/transaction_validation.rs
+++ b/tests/rust/src/transaction_validation.rs
@@ -157,6 +157,7 @@ async fn transact_write_condition_check_fails_cancels_all() {
 }
 
 #[tokio::test]
+#[ignore = "reserved keyword validation too strict"]
 async fn transact_write_update_with_expression() {
     let c = client();
     let t = tables().await;

--- a/tests/rust/src/update_expressions.rs
+++ b/tests/rust/src/update_expressions.rs
@@ -9,6 +9,7 @@ use crate::test_base::*;
 // ─── SET Expression ──────────────────────────────────────────
 
 #[tokio::test]
+#[ignore = "reserved keyword validation too strict"]
 async fn set_arithmetic_decrement() {
     let c = client();
     let t = tables().await;

--- a/tests/rust/src/update_expressions_more.rs
+++ b/tests/rust/src/update_expressions_more.rs
@@ -130,6 +130,7 @@ async fn add_and_delete_combined() {
 }
 
 #[tokio::test]
+#[ignore = "reserved keyword validation too strict"]
 async fn set_add_remove_delete_all_four() {
     let c = client();
     let t = tables().await;
@@ -180,6 +181,7 @@ async fn set_add_remove_delete_all_four() {
 // ─── SET with list index ─────────────────────────────────────
 
 #[tokio::test]
+#[ignore = "reserved keyword validation too strict"]
 async fn set_list_element_by_index() {
     let c = client();
     let t = tables().await;
@@ -224,6 +226,7 @@ async fn set_list_element_by_index() {
 // ─── REMOVE list element ─────────────────────────────────────
 
 #[tokio::test]
+#[ignore = "reserved keyword validation too strict"]
 async fn remove_list_element_by_index() {
     let c = client();
     let t = tables().await;


### PR DESCRIPTION
## What

Ignore certain tests that currently fail on both DynamoDB and ExtendDB. We'll likely remove them entirely at some point.

## Why

Simplify testing that DynamoDB and ExtendDB match behavior. Some of our integration tests are in Rust, but they've been largely ignored in favor of the Python ones. This is part of getting the Rust ones to parity.

## Testing done

Ran tests against both, confirmed these fail for both.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [n/a] I have added or updated tests for new functionality
- [n/a] I have updated documentation if behavior changed
- [n/a] Breaking changes are noted below (if any)
- [n/a] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

These are no worse off when run inside `tests/rust` than they were, we will need to do a separate cleanup pass on these

- [ ] Code is formatted (`cargo fmt --check`)
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)

ADR / RFC: n/a
---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
