### PR TITLE
fix: primary key size limit

### DIFF
--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -1211,6 +1211,78 @@ mod tests {
     }
 
     #[test]
+    fn validate_key_sizes_rejects_oversized_hash_key() {
+        let limits = LimitsConfig::default();
+        let mut item = Item::new();
+        let big = "a".repeat(limits.max_partition_key_size_bytes + 1);
+        item.insert("pk".to_owned(), AttributeValue::S(big));
+        let err = validate_key_sizes(&item, &[make_ks("pk", KeyType::Hash)], &limits).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Size of hashkey has exceeded the maximum size limit"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_key_sizes_rejects_oversized_range_key() {
+        let limits = LimitsConfig::default();
+        let mut item = Item::new();
+        let big = "b".repeat(limits.max_sort_key_size_bytes + 1);
+        item.insert("sk".to_owned(), AttributeValue::S(big));
+        let err = validate_key_sizes(&item, &[make_ks("sk", KeyType::Range)], &limits).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Aggregated size of all range keys has exceeded the size limit"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_key_sizes_accepts_key_at_limit() {
+        let limits = LimitsConfig::default();
+        let mut item = Item::new();
+        item.insert(
+            "pk".to_owned(),
+            AttributeValue::S("a".repeat(limits.max_partition_key_size_bytes)),
+        );
+        assert!(validate_key_sizes(&item, &[make_ks("pk", KeyType::Hash)], &limits).is_ok());
+    }
+
+    #[test]
+    fn validate_key_sizes_hash_message_matches_amazon_dynamodb() {
+        let limits = LimitsConfig::default();
+        let mut item = Item::new();
+        item.insert(
+            "pk".to_owned(),
+            AttributeValue::S("a".repeat(limits.max_partition_key_size_bytes + 1)),
+        );
+        let err = validate_key_sizes(&item, &[make_ks("pk", KeyType::Hash)], &limits).unwrap_err();
+        // Exact wording, including Amazon DynamoDB's missing space before the size.
+        assert_eq!(
+            err.to_string(),
+            "One or more parameter values were invalid: \
+             Size of hashkey has exceeded the maximum size limit of2048 bytes"
+        );
+    }
+
+    #[test]
+    fn validate_key_sizes_range_message_matches_amazon_dynamodb() {
+        let limits = LimitsConfig::default();
+        let mut item = Item::new();
+        item.insert(
+            "sk".to_owned(),
+            AttributeValue::S("b".repeat(limits.max_sort_key_size_bytes + 1)),
+        );
+        let err = validate_key_sizes(&item, &[make_ks("sk", KeyType::Range)], &limits).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "One or more parameter values were invalid: \
+             Aggregated size of all range keys has exceeded the size limit of 1024 bytes"
+        );
+    }
+
+    #[test]
     fn validate_key_only_rejects_empty_binary_key() {
         let mut key = Item::new();
         key.insert("pk".to_owned(), AttributeValue::B(Vec::new()));

--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -488,6 +488,7 @@ pub fn validate_get_item(
 ) -> Result<(), DynamoDbError> {
     validate_table_name(&input.table_name, limits)?;
     validate_key_only(&input.key, key_schema, attr_defs)?;
+    validate_key_sizes(&input.key, key_schema, limits)?;
     Ok(())
 }
 
@@ -517,6 +518,7 @@ pub fn validate_delete_item(
     }
 
     validate_key_only(&input.key, key_schema, attr_defs)?;
+    validate_key_sizes(&input.key, key_schema, limits)?;
     Ok(())
 }
 
@@ -536,6 +538,7 @@ pub fn validate_update_item(
 ) -> Result<(), DynamoDbError> {
     validate_table_name(&input.table_name, limits)?;
     validate_key_only(&input.key, key_schema, attr_defs)?;
+    validate_key_sizes(&input.key, key_schema, limits)?;
 
     if let Some(updates) = &input.attribute_updates {
         validate_attribute_values_nesting_depth(updates.values().filter_map(|u| u.value.as_ref()))?;
@@ -750,15 +753,24 @@ pub fn validate_key_sizes(
         if let Some(value) = item.get(&ks.attribute_name) {
             validate_no_empty_key_value(&ks.attribute_name, value)?;
             let size = key_value_byte_size(value);
-            let (max_size, key_label) = match ks.key_type {
-                KeyType::Hash => (limits.max_partition_key_size_bytes, "partition key"),
-                KeyType::Range => (limits.max_sort_key_size_bytes, "sort key"),
+            let max_size = match ks.key_type {
+                KeyType::Hash => limits.max_partition_key_size_bytes,
+                KeyType::Range => limits.max_sort_key_size_bytes,
             };
             if size > max_size {
-                return Err(DynamoDbError::ValidationException(format!(
-                    "One or more parameter values are not valid. \
-                     The {key_label} size must be between 1 and {max_size} bytes"
-                )));
+                // Hash and range use different wording, matching Amazon
+                // DynamoDB (the hash variant has no space before the size).
+                let msg = match ks.key_type {
+                    KeyType::Hash => format!(
+                        "One or more parameter values were invalid: \
+                         Size of hashkey has exceeded the maximum size limit of{max_size} bytes"
+                    ),
+                    KeyType::Range => format!(
+                        "One or more parameter values were invalid: \
+                         Aggregated size of all range keys has exceeded the size limit of {max_size} bytes"
+                    ),
+                };
+                return Err(DynamoDbError::ValidationException(msg));
             }
         }
     }
@@ -766,6 +778,10 @@ pub fn validate_key_sizes(
 }
 
 /// Get the byte size of a key attribute value.
+///
+/// For `N` keys this uses the digit-string length. Amazon DynamoDB caps a
+/// number at 38 significant digits, so the string length is always far below
+/// the key-size limit and the proxy is exact for the rejection decision.
 fn key_value_byte_size(value: &AttributeValue) -> usize {
     match value {
         AttributeValue::S(s) => s.len(),

--- a/crates/engine/src/batch_get_item.rs
+++ b/crates/engine/src/batch_get_item.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use extenddb_core::error::DynamoDbError;
 use extenddb_core::expression::Projection;
 use extenddb_core::types::{BatchGetItemInput, BatchGetItemOutput, Item, item_size_bytes};
-use extenddb_core::validation::validate_batch_key_only;
+use extenddb_core::validation::{validate_batch_key_only, validate_key_sizes};
 
 use crate::OperationContext;
 use crate::capacity_helpers;
@@ -183,6 +183,7 @@ pub async fn handle_batch_get_item(
                 ));
             }
             validate_batch_key_only(key, &key_info.key_schema, &key_info.attribute_definitions)?;
+            validate_key_sizes(key, &key_info.key_schema, &ctx.limits)?;
 
             if let Some(item) = ctx
                 .storage

--- a/tests/test_item_operations.py
+++ b/tests/test_item_operations.py
@@ -965,6 +965,161 @@ class TestEmptyKeyRejection:
 
 
 # ---------------------------------------------------------------------------
+# Primary-key size limit (hash > 2048 bytes, range > 1024 bytes)
+# ---------------------------------------------------------------------------
+
+_HASH_MAX = 2048
+_RANGE_MAX = 1024
+_HASH_TOO_BIG = "a" * (_HASH_MAX + 1)
+_HASH_AT_LIMIT = "a" * _HASH_MAX
+_RANGE_TOO_BIG = "b" * (_RANGE_MAX + 1)
+_RANGE_AT_LIMIT = "b" * _RANGE_MAX
+_HASH_MSG = "Size of hashkey has exceeded the maximum size limit"
+_RANGE_MSG = "Aggregated size of all range keys has exceeded the size limit"
+
+
+class TestPrimaryKeySizeRejection:
+    """DynamoDB rejects key values over the limit (hash 2048 B, range 1024 B).
+
+    Enforced on every key-bearing single-item / batch API. Boundary controls
+    pin that exactly-at-limit keys are accepted, and an oversized key against a
+    missing table stays ResourceNotFound (key-size is post-existence).
+    """
+
+    @pytest.fixture(scope="class")
+    def binary_hash_table(self, dynamodb_client):
+        with scoped_table(
+            dynamodb_client,
+            attribute_definitions=[{"AttributeName": "pk", "AttributeType": "B"}],
+            key_schema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        ) as name:
+            yield name
+
+    def test_get_item_rejects_oversized_hash_key(self, dynamodb_client, hash_range_table):
+        with pytest.raises(ClientError) as exc:
+            dynamodb_client.get_item(
+                TableName=hash_range_table,
+                Key={"pk": {"S": _HASH_TOO_BIG}, "sk": {"S": "s"}},
+            )
+        err = exc.value.response["Error"]
+        assert err["Code"] == "ValidationException", err["Message"]
+        assert _HASH_MSG in err["Message"], err["Message"]
+
+    def test_get_item_rejects_oversized_range_key(self, dynamodb_client, hash_range_table):
+        with pytest.raises(ClientError) as exc:
+            dynamodb_client.get_item(
+                TableName=hash_range_table,
+                Key={"pk": {"S": "h"}, "sk": {"S": _RANGE_TOO_BIG}},
+            )
+        err = exc.value.response["Error"]
+        assert err["Code"] == "ValidationException", err["Message"]
+        assert _RANGE_MSG in err["Message"], err["Message"]
+
+    def test_batch_get_item_rejects_oversized_hash_key(self, dynamodb_client, hash_range_table):
+        with pytest.raises(ClientError) as exc:
+            dynamodb_client.batch_get_item(
+                RequestItems={
+                    hash_range_table: {"Keys": [{"pk": {"S": _HASH_TOO_BIG}, "sk": {"S": "s"}}]}
+                }
+            )
+        err = exc.value.response["Error"]
+        assert err["Code"] == "ValidationException", err["Message"]
+        assert _HASH_MSG in err["Message"], err["Message"]
+
+    def test_batch_get_item_rejects_oversized_range_key(self, dynamodb_client, hash_range_table):
+        with pytest.raises(ClientError) as exc:
+            dynamodb_client.batch_get_item(
+                RequestItems={
+                    hash_range_table: {"Keys": [{"pk": {"S": "h"}, "sk": {"S": _RANGE_TOO_BIG}}]}
+                }
+            )
+        err = exc.value.response["Error"]
+        assert err["Code"] == "ValidationException", err["Message"]
+        assert _RANGE_MSG in err["Message"], err["Message"]
+
+    def test_delete_item_rejects_oversized_hash_key(self, dynamodb_client, hash_range_table):
+        with pytest.raises(ClientError) as exc:
+            dynamodb_client.delete_item(
+                TableName=hash_range_table,
+                Key={"pk": {"S": _HASH_TOO_BIG}, "sk": {"S": "s"}},
+            )
+        err = exc.value.response["Error"]
+        assert err["Code"] == "ValidationException", err["Message"]
+        assert _HASH_MSG in err["Message"], err["Message"]
+
+    def test_update_item_rejects_oversized_range_key(self, dynamodb_client, hash_range_table):
+        with pytest.raises(ClientError) as exc:
+            dynamodb_client.update_item(
+                TableName=hash_range_table,
+                Key={"pk": {"S": "h"}, "sk": {"S": _RANGE_TOO_BIG}},
+                UpdateExpression="SET x = :v",
+                ExpressionAttributeValues={":v": {"S": "1"}},
+            )
+        err = exc.value.response["Error"]
+        assert err["Code"] == "ValidationException", err["Message"]
+        assert _RANGE_MSG in err["Message"], err["Message"]
+
+    def test_put_item_rejects_oversized_hash_key(self, dynamodb_client, hash_range_table):
+        """Write path shares the validator; lock its wording too."""
+        with pytest.raises(ClientError) as exc:
+            dynamodb_client.put_item(
+                TableName=hash_range_table,
+                Item={"pk": {"S": _HASH_TOO_BIG}, "sk": {"S": "s"}},
+            )
+        err = exc.value.response["Error"]
+        assert err["Code"] == "ValidationException", err["Message"]
+        assert _HASH_MSG in err["Message"], err["Message"]
+
+    def test_get_item_rejects_oversized_hash_key_hash_only(self, dynamodb_client, hash_table):
+        with pytest.raises(ClientError) as exc:
+            dynamodb_client.get_item(
+                TableName=hash_table, Key={"pk": {"S": _HASH_TOO_BIG}},
+            )
+        err = exc.value.response["Error"]
+        assert err["Code"] == "ValidationException", err["Message"]
+        assert _HASH_MSG in err["Message"], err["Message"]
+
+    def test_get_item_rejects_oversized_binary_hash_key(self, dynamodb_client, binary_hash_table):
+        """Binary key limit is on the decoded byte length, not the base64 form."""
+        with pytest.raises(ClientError) as exc:
+            dynamodb_client.get_item(
+                TableName=binary_hash_table, Key={"pk": {"B": b"a" * (_HASH_MAX + 1)}},
+            )
+        err = exc.value.response["Error"]
+        assert err["Code"] == "ValidationException", err["Message"]
+        assert _HASH_MSG in err["Message"], err["Message"]
+
+    def test_get_item_accepts_binary_hash_key_at_limit(self, dynamodb_client, binary_hash_table):
+        resp = dynamodb_client.get_item(
+            TableName=binary_hash_table, Key={"pk": {"B": b"a" * _HASH_MAX}},
+        )
+        assert "Item" not in resp
+
+    def test_get_item_accepts_hash_key_at_limit(self, dynamodb_client, hash_range_table):
+        resp = dynamodb_client.get_item(
+            TableName=hash_range_table,
+            Key={"pk": {"S": _HASH_AT_LIMIT}, "sk": {"S": "s"}},
+        )
+        assert "Item" not in resp
+
+    def test_get_item_accepts_range_key_at_limit(self, dynamodb_client, hash_range_table):
+        resp = dynamodb_client.get_item(
+            TableName=hash_range_table,
+            Key={"pk": {"S": "h"}, "sk": {"S": _RANGE_AT_LIMIT}},
+        )
+        assert "Item" not in resp
+
+    def test_oversized_key_on_missing_table_is_resource_not_found(self, dynamodb_client):
+        """Key-size is post-existence: a missing table wins with ResourceNotFound."""
+        with pytest.raises(ClientError) as exc:
+            dynamodb_client.get_item(
+                TableName="extenddb-test-does-not-exist-keysize",
+                Key={"pk": {"S": _HASH_TOO_BIG}, "sk": {"S": "s"}},
+            )
+        assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+# ---------------------------------------------------------------------------
 # Duplicate values in NS and BS sets (c40478c)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

`GetItem`, `BatchGetItem`, `DeleteItem`, and `UpdateItem` accepted a primary-key value larger than the Amazon DynamoDB limit (hash key > 2,048 bytes, sort key > 1,024 bytes) and returned a normal result. The write path (`PutItem`, `BatchWriteItem`, `TransactWriteItems` Put, `ImportTable`) already enforced the limit via the shared `validate_key_sizes`; the read and key-only path never called it.

This wires `validate_key_sizes` into the read/key-bearing path: the `validate_get_item` / `validate_delete_item` / `validate_update_item` validators (after `validate_key_only`) and per key in `batch_get_item`.

Behavior, captured directly via the AWS CLI (HASH+RANGE table):

| Scenario | ExtendDB (before) | Amazon DynamoDB |
|---|---|---|
| `GetItem` hash key > 2,048 bytes | Accepted (200, no `Item`) | `ValidationException: One or more parameter values were invalid: Size of hashkey has exceeded the maximum size limit of2048 bytes` |
| `GetItem` sort key > 1,024 bytes | Accepted | `ValidationException: One or more parameter values were invalid: Aggregated size of all range keys has exceeded the size limit of 1024 bytes` |
| `BatchGetItem` / `DeleteItem` / `UpdateItem` oversized key | Accepted | same `ValidationException` messages |
| `PutItem` oversized hash key (write path) | `ValidationException`, ExtendDB wording (`The partition key size must be between 1 and 2048 bytes`) | `ValidationException: ... Size of hashkey has exceeded the maximum size limit of2048 bytes` |
| Key exactly 2,048 / 1,024 bytes (control) | Accepted | Accepted |
| Oversized key against a missing table (control) | `ResourceNotFoundException` | `ResourceNotFoundException` (key-size is post-existence) |

The two real-service templates are reproduced exactly, including the missing space before the size in the hash message (`of2048`) and its absence in the sort message (`of 1024`).

## Why

Conformance gap

## Testing done

- New pytest class `TestPrimaryKeySizeRejection` in `tests/test_item_operations.py` (13 cases)
- New Rust unit tests in `validate_key_sizes`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: <!-- link or "n/a" -->

## Breaking changes

N/A
---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
