### PR TITLE
(tests/rust): use credentials-process for aws-config to test against DynamoDB

### DIFF
--- a/tests/rust/Cargo.toml
+++ b/tests/rust/Cargo.toml
@@ -20,7 +20,7 @@ publish = false
 # See https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#paths-overrides
 [dependencies]
 aws-sdk-dynamodb = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"] }
-aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"] }
+aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client", "credentials-process"] }
 aws-credential-types = "1"
 aws-smithy-types = "1"
 aws-smithy-runtime-api = "1"


### PR DESCRIPTION
## What

This enables the credentials-process feature for aws-config in our Rust integration tests, so we can easily run those tests against DynamoDB.

## Testing done

Ran Rust integration tests locally against DynamoDB

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [ ] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
