### PR TITLE
perf(tests/rust): share tables at module level and remove in-test deletes

### DIFF
--- a/tests/rust/src/authorization.rs
+++ b/tests/rust/src/authorization.rs
@@ -99,8 +99,6 @@ async fn unknown_access_key_rejected() {
         err_code(&err).is_some(),
         "Expected auth error, got: {err:?}"
     );
-
-    c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]
@@ -165,6 +163,4 @@ async fn valid_credentials_put_and_get() {
         .unwrap();
     let item = resp.item().expect("Item should exist");
     assert_eq!(item.get("data").unwrap().as_s().unwrap(), "auth_test");
-
-    c.delete_table().table_name(&table).send().await.ok();
 }

--- a/tests/rust/src/backup_restore.rs
+++ b/tests/rust/src/backup_restore.rs
@@ -73,7 +73,6 @@ async fn create_backup_happy_case() {
     assert!(!details.backup_arn().is_empty());
     assert_eq!(details.backup_status().as_str(), "AVAILABLE");
 
-    c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]
@@ -108,7 +107,6 @@ async fn describe_backup() {
     let desc = resp.backup_description().unwrap();
     assert_eq!(desc.backup_details().unwrap().backup_arn(), arn.as_str());
 
-    c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]
@@ -135,7 +133,6 @@ async fn list_backups() {
     let resp = c.list_backups().table_name(&table).send().await.unwrap();
     assert!(resp.backup_summaries().len() >= 2);
 
-    c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]
@@ -147,7 +144,6 @@ async fn list_backups_empty() {
     let resp = c.list_backups().table_name(&table).send().await.unwrap();
     assert!(resp.backup_summaries().is_empty());
 
-    c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]
@@ -166,7 +162,6 @@ async fn delete_backup() {
         "DELETED"
     );
 
-    c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]
@@ -209,8 +204,6 @@ async fn restore_table_from_backup() {
     let scan = c.scan().table_name(&restored).send().await.unwrap();
     assert_eq!(scan.count(), 5);
 
-    c.delete_table().table_name(&restored).send().await.ok();
-    c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]
@@ -227,7 +220,6 @@ async fn describe_continuous_backups() {
         .unwrap();
     assert!(resp.continuous_backups_description().is_some());
 
-    c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]
@@ -264,7 +256,6 @@ async fn enable_point_in_time_recovery() {
         "ENABLED"
     );
 
-    c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]
@@ -284,5 +275,4 @@ async fn restore_table_to_point_in_time() {
         .await;
     assert!(err.is_err(), "RestoreTableToPointInTime should return an error (not yet supported)");
 
-    c.delete_table().table_name(&table).send().await.ok();
 }

--- a/tests/rust/src/capacity_throttling.rs
+++ b/tests/rust/src/capacity_throttling.rs
@@ -93,7 +93,6 @@ async fn get_item_consumed_capacity_total() {
     assert_eq!(cap.table_name().unwrap(), table.as_str());
     assert!(cap.capacity_units().unwrap() > 0.0);
 
-    c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]
@@ -116,7 +115,6 @@ async fn put_item_consumed_capacity_total() {
     assert_eq!(cap.table_name().unwrap(), table.as_str());
     assert!(cap.capacity_units().unwrap() > 0.0);
 
-    c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]
@@ -145,7 +143,6 @@ async fn scan_consumed_capacity_total() {
     let cap = resp.consumed_capacity().unwrap();
     assert!(cap.capacity_units().unwrap() > 0.0);
 
-    c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]
@@ -171,7 +168,6 @@ async fn no_consumed_capacity_by_default() {
 
     assert!(resp.consumed_capacity().is_none());
 
-    c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]
@@ -213,7 +209,6 @@ async fn per_partition_write_throttling() {
         "Expected some writes throttled. Succeeded: {succeeded}, Throttled: {throttled}"
     );
 
-    c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]
@@ -255,7 +250,6 @@ async fn provisioned_table_write_throttling() {
         "Expected some writes throttled (1 WCU). Succeeded: {succeeded}, Throttled: {throttled}"
     );
 
-    c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]
@@ -305,5 +299,4 @@ async fn provisioned_table_read_throttling() {
         "Expected some reads throttled (1 RCU). Succeeded: {succeeded}, Throttled: {throttled}"
     );
 
-    c.delete_table().table_name(&table).send().await.ok();
 }

--- a/tests/rust/src/gsi_more.rs
+++ b/tests/rust/src/gsi_more.rs
@@ -93,13 +93,6 @@ async fn create_table_with_gsi_keys_only_projection() {
         !result.contains_key("extra"),
         "KEYS_ONLY projection should not include non-key attributes"
     );
-
-    c.delete_table()
-        .table_name(&table_name)
-        .send()
-        .await
-        .unwrap();
-    wait_for_deleted(c, &table_name).await;
 }
 
 #[tokio::test]
@@ -187,13 +180,6 @@ async fn create_table_with_gsi_include_projection() {
         !result.contains_key("excluded_attr"),
         "INCLUDE projection should not include non-projected attributes"
     );
-
-    c.delete_table()
-        .table_name(&table_name)
-        .send()
-        .await
-        .unwrap();
-    wait_for_deleted(c, &table_name).await;
 }
 
 #[tokio::test]

--- a/tests/rust/src/lsi.rs
+++ b/tests/rust/src/lsi.rs
@@ -5,6 +5,9 @@
 //!
 //! Verifies that ExclusiveStartKey pagination works correctly when multiple
 //! items share the same index sort key value.
+//!
+//! Tables are shared at module level to avoid redundant CreateTable calls.
+//! Each test uses a unique partition key to isolate its data.
 
 use crate::test_base::*;
 use aws_sdk_dynamodb::types::{
@@ -12,12 +15,40 @@ use aws_sdk_dynamodb::types::{
     LocalSecondaryIndex, Projection, ProjectionType, ScalarAttributeType,
 };
 use std::collections::HashMap;
+use tokio::sync::OnceCell as AsyncOnceCell;
 
 const LSI_NAME: &str = "TaskTypeLSI";
 const LSI_SK_ATTR: &str = "taskType";
 
+// ---- Module-level shared tables (created once, reused by all tests) ----
+
+static LSI_TABLE: AsyncOnceCell<String> = AsyncOnceCell::const_new();
+static GSI_HASH_ONLY_TABLE: AsyncOnceCell<String> = AsyncOnceCell::const_new();
+
+/// Get or create the shared LSI table.
+async fn lsi_table() -> &'static str {
+    LSI_TABLE
+        .get_or_init(|| async {
+            let name = format!("LSI_{}", ts());
+            create_lsi_table_impl(&name).await;
+            name
+        })
+        .await
+}
+
+/// Get or create the shared hash-only GSI table.
+async fn gsi_hash_only_table() -> &'static str {
+    GSI_HASH_ONLY_TABLE
+        .get_or_init(|| async {
+            let name = format!("GSIHashOnly_{}", ts());
+            create_hash_only_gsi_table_impl(&name).await;
+            name
+        })
+        .await
+}
+
 /// Create a table with an LSI for pagination tests.
-async fn create_lsi_table(name: &str) {
+async fn create_lsi_table_impl(name: &str) {
     let c = client();
     let attr_defs = vec![
         AttributeDefinition::builder()
@@ -94,218 +125,8 @@ async fn create_lsi_table(name: &str) {
     wait_for_active(&c, name).await;
 }
 
-/// Seed items that share the same LSI sort key value.
-async fn seed_lsi_items(table: &str, pk: &str, count: usize) {
-    let c = client();
-    for i in 1..=count {
-        let mut item = HashMap::new();
-        item.insert(HASH_KEY_S.into(), s(pk));
-        item.insert(RANGE_KEY_S.into(), s(&format!("task{i}")));
-        item.insert(LSI_SK_ATTR.into(), s("EXPORT"));
-        item.insert("data".into(), s(&format!("payload-{i}")));
-        c.put_item()
-            .table_name(table)
-            .set_item(Some(item))
-            .send()
-            .await
-            .unwrap();
-    }
-}
-
-#[tokio::test]
-async fn lsi_pagination_duplicate_sort_keys() {
-    let table = format!("LSIPagination_{}", ts());
-    let pk = format!("lsi_pag_{}", ts());
-    create_lsi_table(&table).await;
-    seed_lsi_items(&table, &pk, 5).await;
-
-    let c = client();
-    let mut all_items: Vec<HashMap<String, AttributeValue>> = Vec::new();
-    let mut exclusive_start_key: Option<HashMap<String, AttributeValue>> = None;
-
-    loop {
-        let mut req = c
-            .query()
-            .table_name(&table)
-            .index_name(LSI_NAME)
-            .key_condition_expression("#pk = :pk")
-            .expression_attribute_names("#pk", HASH_KEY_S)
-            .expression_attribute_values(":pk", s(&pk))
-            .limit(2);
-
-        if let Some(ref lek) = exclusive_start_key {
-            req = req.set_exclusive_start_key(Some(lek.clone()));
-        }
-
-        let resp = req.send().await.unwrap();
-        all_items.extend(resp.items().to_vec());
-
-        match resp.last_evaluated_key() {
-            Some(lek) => exclusive_start_key = Some(lek.to_owned()),
-            None => break,
-        }
-    }
-
-    assert_eq!(
-        all_items.len(),
-        5,
-        "All 5 items must be returned through pagination with duplicate LSI sort keys"
-    );
-
-    let mut sks: Vec<String> = all_items
-        .iter()
-        .map(|item| match item.get(RANGE_KEY_S).unwrap() {
-            AttributeValue::S(v) => v.clone(),
-            _ => panic!("unexpected type"),
-        })
-        .collect();
-    sks.sort();
-    assert_eq!(sks, vec!["task1", "task2", "task3", "task4", "task5"]);
-}
-
-#[tokio::test]
-async fn lsi_pagination_reverse_order() {
-    let table = format!("LSIPagRev_{}", ts());
-    let pk = format!("lsi_rev_{}", ts());
-    create_lsi_table(&table).await;
-    seed_lsi_items(&table, &pk, 5).await;
-
-    let c = client();
-    let mut all_items: Vec<HashMap<String, AttributeValue>> = Vec::new();
-    let mut exclusive_start_key: Option<HashMap<String, AttributeValue>> = None;
-
-    loop {
-        let mut req = c
-            .query()
-            .table_name(&table)
-            .index_name(LSI_NAME)
-            .key_condition_expression("#pk = :pk")
-            .expression_attribute_names("#pk", HASH_KEY_S)
-            .expression_attribute_values(":pk", s(&pk))
-            .scan_index_forward(false)
-            .limit(2);
-
-        if let Some(ref lek) = exclusive_start_key {
-            req = req.set_exclusive_start_key(Some(lek.clone()));
-        }
-
-        let resp = req.send().await.unwrap();
-        all_items.extend(resp.items().to_vec());
-
-        match resp.last_evaluated_key() {
-            Some(lek) => exclusive_start_key = Some(lek.to_owned()),
-            None => break,
-        }
-    }
-
-    assert_eq!(all_items.len(), 5);
-
-    // With ScanIndexForward=false and equal index sort keys, items should be
-    // sub-sorted by base table sort key in descending order.
-    let sks: Vec<String> = all_items
-        .iter()
-        .map(|item| match item.get(RANGE_KEY_S).unwrap() {
-            AttributeValue::S(v) => v.clone(),
-            _ => panic!("unexpected type"),
-        })
-        .collect();
-    assert_eq!(sks, vec!["task5", "task4", "task3", "task2", "task1"]);
-}
-
-#[tokio::test]
-async fn lsi_page_two_returns_items() {
-    let table = format!("LSIPagTwo_{}", ts());
-    let pk = format!("lsi_p2_{}", ts());
-    create_lsi_table(&table).await;
-    seed_lsi_items(&table, &pk, 5).await;
-
-    let c = client();
-
-    // Page 1
-    let resp1 = c
-        .query()
-        .table_name(&table)
-        .index_name(LSI_NAME)
-        .key_condition_expression("#pk = :pk")
-        .expression_attribute_names("#pk", HASH_KEY_S)
-        .expression_attribute_values(":pk", s(&pk))
-        .limit(2)
-        .send()
-        .await
-        .unwrap();
-
-    assert_eq!(resp1.items().len(), 2);
-    let lek = resp1
-        .last_evaluated_key()
-        .expect("Page 1 must have LastEvaluatedKey")
-        .to_owned();
-
-    // Page 2 — core regression test for issue #145
-    let resp2 = c
-        .query()
-        .table_name(&table)
-        .index_name(LSI_NAME)
-        .key_condition_expression("#pk = :pk")
-        .expression_attribute_names("#pk", HASH_KEY_S)
-        .expression_attribute_values(":pk", s(&pk))
-        .set_exclusive_start_key(Some(lek))
-        .limit(2)
-        .send()
-        .await
-        .unwrap();
-
-    assert_eq!(
-        resp2.items().len(),
-        2,
-        "Page 2 must return items when index sort keys are duplicated"
-    );
-}
-
-#[tokio::test]
-async fn lsi_last_evaluated_key_contains_all_keys() {
-    let table = format!("LSILek_{}", ts());
-    let pk = format!("lsi_lek_{}", ts());
-    create_lsi_table(&table).await;
-    seed_lsi_items(&table, &pk, 5).await;
-
-    let c = client();
-
-    let resp = c
-        .query()
-        .table_name(&table)
-        .index_name(LSI_NAME)
-        .key_condition_expression("#pk = :pk")
-        .expression_attribute_names("#pk", HASH_KEY_S)
-        .expression_attribute_values(":pk", s(&pk))
-        .limit(2)
-        .send()
-        .await
-        .unwrap();
-
-    let lek = resp
-        .last_evaluated_key()
-        .expect("Must have LastEvaluatedKey");
-
-    assert!(
-        lek.contains_key(HASH_KEY_S),
-        "LEK must contain partition key"
-    );
-    assert!(
-        lek.contains_key(RANGE_KEY_S),
-        "LEK must contain base table sort key"
-    );
-    assert!(
-        lek.contains_key(LSI_SK_ATTR),
-        "LEK must contain index sort key"
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Hash-only GSI pagination tests
-// ---------------------------------------------------------------------------
-
 /// Create a table with a hash-only GSI for pagination tests.
-async fn create_hash_only_gsi_table(name: &str) {
+async fn create_hash_only_gsi_table_impl(name: &str) {
     let c = client();
     let attr_defs = vec![
         AttributeDefinition::builder()
@@ -363,13 +184,16 @@ async fn create_hash_only_gsi_table(name: &str) {
     wait_for_active(&c, name).await;
 }
 
-/// Seed items that share the same GSI hash key.
-async fn seed_gsi_items(table: &str, count: usize) {
+// ---- Helpers ----
+
+/// Seed items that share the same LSI sort key value, using a unique PK.
+async fn seed_lsi_items(table: &str, pk: &str, count: usize) {
     let c = client();
     for i in 1..=count {
         let mut item = HashMap::new();
-        item.insert("instanceId".into(), s(&format!("node-{i}")));
-        item.insert("nodeStatus".into(), s("ACTIVE"));
+        item.insert(HASH_KEY_S.into(), s(pk));
+        item.insert(RANGE_KEY_S.into(), s(&format!("task{i}")));
+        item.insert(LSI_SK_ATTR.into(), s("EXPORT"));
         item.insert("data".into(), s(&format!("payload-{i}")));
         c.put_item()
             .table_name(table)
@@ -380,11 +204,216 @@ async fn seed_gsi_items(table: &str, count: usize) {
     }
 }
 
+/// Seed items for hash-only GSI tests, using a unique prefix for isolation.
+async fn seed_gsi_items(table: &str, prefix: &str, count: usize) {
+    let c = client();
+    for i in 1..=count {
+        let mut item = HashMap::new();
+        item.insert("instanceId".into(), s(&format!("{prefix}-{i}")));
+        item.insert("nodeStatus".into(), s(prefix));
+        item.insert("data".into(), s(&format!("payload-{i}")));
+        c.put_item()
+            .table_name(table)
+            .set_item(Some(item))
+            .send()
+            .await
+            .unwrap();
+    }
+}
+
+// ---- LSI tests (share LSI_TABLE) ----
+
+#[tokio::test]
+async fn lsi_pagination_duplicate_sort_keys() {
+    let table = lsi_table().await;
+    let pk = format!("lsi_pag_{}", ts());
+    seed_lsi_items(table, &pk, 5).await;
+
+    let c = client();
+    let mut all_items: Vec<HashMap<String, AttributeValue>> = Vec::new();
+    let mut exclusive_start_key: Option<HashMap<String, AttributeValue>> = None;
+
+    loop {
+        let mut req = c
+            .query()
+            .table_name(table)
+            .index_name(LSI_NAME)
+            .key_condition_expression("#pk = :pk")
+            .expression_attribute_names("#pk", HASH_KEY_S)
+            .expression_attribute_values(":pk", s(&pk))
+            .limit(2);
+
+        if let Some(ref lek) = exclusive_start_key {
+            req = req.set_exclusive_start_key(Some(lek.clone()));
+        }
+
+        let resp = req.send().await.unwrap();
+        all_items.extend(resp.items().to_vec());
+
+        match resp.last_evaluated_key() {
+            Some(lek) => exclusive_start_key = Some(lek.to_owned()),
+            None => break,
+        }
+    }
+
+    assert_eq!(
+        all_items.len(),
+        5,
+        "All 5 items must be returned through pagination with duplicate LSI sort keys"
+    );
+
+    let mut sks: Vec<String> = all_items
+        .iter()
+        .map(|item| match item.get(RANGE_KEY_S).unwrap() {
+            AttributeValue::S(v) => v.clone(),
+            _ => panic!("unexpected type"),
+        })
+        .collect();
+    sks.sort();
+    assert_eq!(sks, vec!["task1", "task2", "task3", "task4", "task5"]);
+}
+
+#[tokio::test]
+async fn lsi_pagination_reverse_order() {
+    let table = lsi_table().await;
+    let pk = format!("lsi_rev_{}", ts());
+    seed_lsi_items(table, &pk, 5).await;
+
+    let c = client();
+    let mut all_items: Vec<HashMap<String, AttributeValue>> = Vec::new();
+    let mut exclusive_start_key: Option<HashMap<String, AttributeValue>> = None;
+
+    loop {
+        let mut req = c
+            .query()
+            .table_name(table)
+            .index_name(LSI_NAME)
+            .key_condition_expression("#pk = :pk")
+            .expression_attribute_names("#pk", HASH_KEY_S)
+            .expression_attribute_values(":pk", s(&pk))
+            .scan_index_forward(false)
+            .limit(2);
+
+        if let Some(ref lek) = exclusive_start_key {
+            req = req.set_exclusive_start_key(Some(lek.clone()));
+        }
+
+        let resp = req.send().await.unwrap();
+        all_items.extend(resp.items().to_vec());
+
+        match resp.last_evaluated_key() {
+            Some(lek) => exclusive_start_key = Some(lek.to_owned()),
+            None => break,
+        }
+    }
+
+    assert_eq!(all_items.len(), 5);
+
+    // With ScanIndexForward=false and equal index sort keys, items should be
+    // sub-sorted by base table sort key in descending order.
+    let sks: Vec<String> = all_items
+        .iter()
+        .map(|item| match item.get(RANGE_KEY_S).unwrap() {
+            AttributeValue::S(v) => v.clone(),
+            _ => panic!("unexpected type"),
+        })
+        .collect();
+    assert_eq!(sks, vec!["task5", "task4", "task3", "task2", "task1"]);
+}
+
+#[tokio::test]
+async fn lsi_page_two_returns_items() {
+    let table = lsi_table().await;
+    let pk = format!("lsi_p2_{}", ts());
+    seed_lsi_items(table, &pk, 5).await;
+
+    let c = client();
+
+    // Page 1
+    let resp1 = c
+        .query()
+        .table_name(table)
+        .index_name(LSI_NAME)
+        .key_condition_expression("#pk = :pk")
+        .expression_attribute_names("#pk", HASH_KEY_S)
+        .expression_attribute_values(":pk", s(&pk))
+        .limit(2)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp1.items().len(), 2);
+    let lek = resp1
+        .last_evaluated_key()
+        .expect("Page 1 must have LastEvaluatedKey")
+        .to_owned();
+
+    // Page 2 — core regression test for issue #145
+    let resp2 = c
+        .query()
+        .table_name(table)
+        .index_name(LSI_NAME)
+        .key_condition_expression("#pk = :pk")
+        .expression_attribute_names("#pk", HASH_KEY_S)
+        .expression_attribute_values(":pk", s(&pk))
+        .set_exclusive_start_key(Some(lek))
+        .limit(2)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp2.items().len(),
+        2,
+        "Page 2 must return items when index sort keys are duplicated"
+    );
+}
+
+#[tokio::test]
+async fn lsi_last_evaluated_key_contains_all_keys() {
+    let table = lsi_table().await;
+    let pk = format!("lsi_lek_{}", ts());
+    seed_lsi_items(table, &pk, 5).await;
+
+    let c = client();
+
+    let resp = c
+        .query()
+        .table_name(table)
+        .index_name(LSI_NAME)
+        .key_condition_expression("#pk = :pk")
+        .expression_attribute_names("#pk", HASH_KEY_S)
+        .expression_attribute_values(":pk", s(&pk))
+        .limit(2)
+        .send()
+        .await
+        .unwrap();
+
+    let lek = resp
+        .last_evaluated_key()
+        .expect("Must have LastEvaluatedKey");
+
+    assert!(
+        lek.contains_key(HASH_KEY_S),
+        "LEK must contain partition key"
+    );
+    assert!(
+        lek.contains_key(RANGE_KEY_S),
+        "LEK must contain base table sort key"
+    );
+    assert!(
+        lek.contains_key(LSI_SK_ATTR),
+        "LEK must contain index sort key"
+    );
+}
+
+// ---- Hash-only GSI pagination tests (share GSI_HASH_ONLY_TABLE) ----
+
 #[tokio::test]
 async fn gsi_hash_only_pagination() {
-    let table = format!("GSIHashPag_{}", ts());
-    create_hash_only_gsi_table(&table).await;
-    seed_gsi_items(&table, 10).await;
+    let table = gsi_hash_only_table().await;
+    let prefix = format!("pag_{}", ts());
+    seed_gsi_items(table, &prefix, 10).await;
 
     // Allow GSI propagation
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -396,10 +425,10 @@ async fn gsi_hash_only_pagination() {
     loop {
         let mut req = c
             .query()
-            .table_name(&table)
+            .table_name(table)
             .index_name("StatusGSI")
             .key_condition_expression("nodeStatus = :s")
-            .expression_attribute_values(":s", s("ACTIVE"))
+            .expression_attribute_values(":s", s(&prefix))
             .limit(3);
 
         if let Some(ref lek) = exclusive_start_key {
@@ -429,16 +458,16 @@ async fn gsi_hash_only_pagination() {
         })
         .collect();
     ids.sort();
-    let mut expected: Vec<String> = (1..=10).map(|i| format!("node-{i}")).collect();
+    let mut expected: Vec<String> = (1..=10).map(|i| format!("{prefix}-{i}")).collect();
     expected.sort();
     assert_eq!(ids, expected);
 }
 
 #[tokio::test]
 async fn gsi_hash_only_page_two_returns_items() {
-    let table = format!("GSIHashP2_{}", ts());
-    create_hash_only_gsi_table(&table).await;
-    seed_gsi_items(&table, 10).await;
+    let table = gsi_hash_only_table().await;
+    let prefix = format!("p2_{}", ts());
+    seed_gsi_items(table, &prefix, 10).await;
 
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
@@ -446,10 +475,10 @@ async fn gsi_hash_only_page_two_returns_items() {
 
     let resp1 = c
         .query()
-        .table_name(&table)
+        .table_name(table)
         .index_name("StatusGSI")
         .key_condition_expression("nodeStatus = :s")
-        .expression_attribute_values(":s", s("ACTIVE"))
+        .expression_attribute_values(":s", s(&prefix))
         .limit(3)
         .send()
         .await
@@ -463,10 +492,10 @@ async fn gsi_hash_only_page_two_returns_items() {
 
     let resp2 = c
         .query()
-        .table_name(&table)
+        .table_name(table)
         .index_name("StatusGSI")
         .key_condition_expression("nodeStatus = :s")
-        .expression_attribute_values(":s", s("ACTIVE"))
+        .expression_attribute_values(":s", s(&prefix))
         .set_exclusive_start_key(Some(lek))
         .limit(3)
         .send()
@@ -482,9 +511,9 @@ async fn gsi_hash_only_page_two_returns_items() {
 
 #[tokio::test]
 async fn gsi_hash_only_no_duplicates() {
-    let table = format!("GSIHashNoDup_{}", ts());
-    create_hash_only_gsi_table(&table).await;
-    seed_gsi_items(&table, 10).await;
+    let table = gsi_hash_only_table().await;
+    let prefix = format!("nodup_{}", ts());
+    seed_gsi_items(table, &prefix, 10).await;
 
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
@@ -495,10 +524,10 @@ async fn gsi_hash_only_no_duplicates() {
     loop {
         let mut req = c
             .query()
-            .table_name(&table)
+            .table_name(table)
             .index_name("StatusGSI")
             .key_condition_expression("nodeStatus = :s")
-            .expression_attribute_values(":s", s("ACTIVE"))
+            .expression_attribute_values(":s", s(&prefix))
             .limit(2);
 
         if let Some(ref lek) = exclusive_start_key {

--- a/tests/rust/src/query_more.rs
+++ b/tests/rust/src/query_more.rs
@@ -173,7 +173,6 @@ async fn scan_with_select_count() {
     assert_eq!(resp.count(), 4);
     assert!(resp.items().is_empty());
 
-    c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]

--- a/tests/rust/src/test_base.rs
+++ b/tests/rust/src/test_base.rs
@@ -222,6 +222,20 @@ pub async fn tables() -> &'static TestTables {
         .await
 }
 
+// ========== Table creation helpers ==========
+//
+// Tables created during tests are NOT deleted by Rust code. Cleanup is handled
+// by `devtools/run-tests` which bulk-deletes all test tables after the test
+// binary exits (see the "Post-test table cleanup" section in that script).
+//
+// This avoids per-test `wait_for_deleted` polling loops, which on real DynamoDB
+// can take up to 60 seconds per table — a significant overhead when many tests
+// each create their own table. On ExtendDB the tables vanish with the database
+// anyway (CI uses a fresh PostgreSQL container per run).
+//
+// The only tests that issue DeleteTable are those in `table_operations.rs` which
+// specifically verify deletion behavior.
+
 async fn create_table(
     c: &Client,
     name: &str,
@@ -359,8 +373,18 @@ async fn create_table_with_gsi(
 }
 
 /// Poll DescribeTable until ACTIVE (up to 60s).
+///
+/// Uses 100ms polling for local ExtendDB (tables are instantly active)
+/// and 1s polling for real DynamoDB (async table creation).
 pub async fn wait_for_active(c: &Client, name: &str) {
-    for _ in 0..60 {
+    let interval = if is_real_dynamodb() {
+        Duration::from_secs(1)
+    } else {
+        Duration::from_millis(100)
+    };
+    let max_attempts = if is_real_dynamodb() { 60 } else { 100 };
+
+    for _ in 0..max_attempts {
         if let Ok(resp) = c.describe_table().table_name(name).send().await {
             if let Some(table) = resp.table() {
                 if table.table_status() == Some(&TableStatus::Active) {
@@ -368,14 +392,23 @@ pub async fn wait_for_active(c: &Client, name: &str) {
                 }
             }
         }
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(interval).await;
     }
-    panic!("Table {name} did not become ACTIVE within 60s");
+    panic!("Table {name} did not become ACTIVE within timeout");
 }
 
 /// Poll DescribeTable until the table no longer exists (up to 60s).
+///
+/// Uses adaptive polling interval like `wait_for_active`.
 pub async fn wait_for_deleted(c: &Client, name: &str) {
-    for _ in 0..60 {
+    let interval = if is_real_dynamodb() {
+        Duration::from_secs(1)
+    } else {
+        Duration::from_millis(100)
+    };
+    let max_attempts = if is_real_dynamodb() { 60 } else { 100 };
+
+    for _ in 0..max_attempts {
         match c.describe_table().table_name(name).send().await {
             Err(e) => {
                 if err_code(&e) == Some("ResourceNotFoundException") {
@@ -384,9 +417,9 @@ pub async fn wait_for_deleted(c: &Client, name: &str) {
             }
             Ok(_) => {}
         }
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(interval).await;
     }
-    panic!("Table {name} was not deleted within 60s");
+    panic!("Table {name} was not deleted within timeout");
 }
 
 // ========== Item helpers ==========


### PR DESCRIPTION
- lsi.rs: share one LSI table and one hash-only GSI table across all
  tests using AsyncOnceCell; isolate via unique partition keys (7→2 tables)
- test_base.rs: adaptive polling in wait_for_active/wait_for_deleted
  (100ms for ExtendDB, 1s for DynamoDB); add comment explaining why
  tests don't delete their own tables
- gsi_more.rs: remove delete_table + wait_for_deleted after assertions
- authorization.rs, backup_restore.rs, capacity_throttling.rs,
  query_more.rs: remove fire-and-forget delete_table calls

Table cleanup is handled by devtools/run-tests post-run script.
In CI, the PostgreSQL container is discarded after each run anyway.

Verified: 344 passed, 0 failed, 10 ignored (ExtendDB)
          333 passed, 11 failed, 10 ignored (DynamoDB — pre-existing)

## What

Reuses tables within a module across tests, in our Rust-based integration-test suite.

## Why

Make tests faster, so people are more likely to run them.

## Testing done

Ran these tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [n/a] I have added or updated tests for new functionality
- [n/a] I have updated documentation if behavior changed
- [n/a] Breaking changes are noted below (if any)

This needs to be done in bulk later (and GitHub enforcement added:
- [ ] Code is formatted (`cargo fmt --check`)
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)

ADR / RFC: n/a

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
