### PR TITLE
fix: Report per-index consumed capacity for writes (excludes transact/batch APIs for now)

### DIFF
--- a/crates/core/src/types/capacity.rs
+++ b/crates/core/src/types/capacity.rs
@@ -245,6 +245,66 @@ impl ConsumedCapacity {
             local_secondary_indexes: None,
         }
     }
+
+    /// Build a write `ConsumedCapacity` whose aggregate total includes the base
+    /// table plus every affected secondary index.
+    ///
+    /// `base_cu` is the base-table write capacity. `gsi`/`lsi` map each affected
+    /// index name to its write capacity. DynamoDB reports the aggregate total as
+    /// `base + Σ(GSI) + Σ(LSI)` (confirmed against BigBird
+    /// `ReturnedIops_v2Tests.verifyConsumedCapacityValues`), and — in `INDEXES`
+    /// mode — the per-table `Table` capacity plus the two per-index maps.
+    ///
+    /// When `breakdown` is true (`INDEXES` mode) the `Table`,
+    /// `GlobalSecondaryIndexes` and `LocalSecondaryIndexes` fields are populated;
+    /// when false (`TOTAL` mode) only the aggregate is returned, but that
+    /// aggregate still reflects the index writes.
+    #[must_use]
+    pub fn write_indexed(
+        table_name: &str,
+        base_cu: f64,
+        gsi: HashMap<String, f64>,
+        lsi: HashMap<String, f64>,
+        breakdown: bool,
+    ) -> Self {
+        let total = base_cu + gsi.values().sum::<f64>() + lsi.values().sum::<f64>();
+        Self {
+            table_name: table_name.to_owned(),
+            capacity_units: total,
+            read_capacity_units: None,
+            write_capacity_units: Some(total),
+            table: breakdown.then(|| Capacity::write_units(base_cu)),
+            global_secondary_indexes: if breakdown { map_or_none(gsi) } else { None },
+            local_secondary_indexes: if breakdown { map_or_none(lsi) } else { None },
+        }
+    }
+}
+
+impl Capacity {
+    /// A write-only `Capacity` with the given units.
+    #[must_use]
+    pub fn write_units(cu: f64) -> Self {
+        Self {
+            capacity_units: cu,
+            read_capacity_units: None,
+            write_capacity_units: Some(cu),
+        }
+    }
+}
+
+/// Convert a per-index units map into `Some(map of Capacity)`, or `None` when
+/// empty so the field is omitted from the response.
+fn map_or_none(units: HashMap<String, f64>) -> Option<HashMap<String, Capacity>> {
+    if units.is_empty() {
+        None
+    } else {
+        Some(
+            units
+                .into_iter()
+                .map(|(name, cu)| (name, Capacity::write_units(cu)))
+                .collect(),
+        )
+    }
 }
 
 impl ItemCollectionMetrics {

--- a/crates/core/src/types/capacity.rs
+++ b/crates/core/src/types/capacity.rs
@@ -251,9 +251,8 @@ impl ConsumedCapacity {
     ///
     /// `base_cu` is the base-table write capacity. `gsi`/`lsi` map each affected
     /// index name to its write capacity. DynamoDB reports the aggregate total as
-    /// `base + Σ(GSI) + Σ(LSI)` (confirmed against BigBird
-    /// `ReturnedIops_v2Tests.verifyConsumedCapacityValues`), and — in `INDEXES`
-    /// mode — the per-table `Table` capacity plus the two per-index maps.
+    /// `base + Σ(GSI) + Σ(LSI)`, and — in `INDEXES` mode — the per-table `Table`
+    /// capacity plus the two per-index maps.
     ///
     /// When `breakdown` is true (`INDEXES` mode) the `Table`,
     /// `GlobalSecondaryIndexes` and `LocalSecondaryIndexes` fields are populated;

--- a/crates/core/src/types/capacity.rs
+++ b/crates/core/src/types/capacity.rs
@@ -271,8 +271,8 @@ impl ConsumedCapacity {
             table_name: table_name.to_owned(),
             capacity_units: total,
             read_capacity_units: None,
-            write_capacity_units: Some(total),
-            table: breakdown.then(|| Capacity::write_units(base_cu)),
+            write_capacity_units: None,
+            table: breakdown.then(|| Capacity::units(base_cu)),
             global_secondary_indexes: if breakdown { map_or_none(gsi) } else { None },
             local_secondary_indexes: if breakdown { map_or_none(lsi) } else { None },
         }
@@ -280,13 +280,13 @@ impl ConsumedCapacity {
 }
 
 impl Capacity {
-    /// A write-only `Capacity` with the given units.
+    /// Capacity for a single-item write, which reports only `CapacityUnits`.
     #[must_use]
-    pub fn write_units(cu: f64) -> Self {
+    fn units(cu: f64) -> Self {
         Self {
             capacity_units: cu,
             read_capacity_units: None,
-            write_capacity_units: Some(cu),
+            write_capacity_units: None,
         }
     }
 }
@@ -300,7 +300,7 @@ fn map_or_none(units: HashMap<String, f64>) -> Option<HashMap<String, Capacity>>
         Some(
             units
                 .into_iter()
-                .map(|(name, cu)| (name, Capacity::write_units(cu)))
+                .map(|(name, cu)| (name, Capacity::units(cu)))
                 .collect(),
         )
     }
@@ -314,5 +314,37 @@ impl ItemCollectionMetrics {
             item_collection_key: HashMap::from([(pk_name.to_owned(), pk_value.clone())]),
             size_estimate_range_gb: [0.0, 1.0],
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn indexed_write_omits_granular_write_capacity_units() {
+        let capacity = ConsumedCapacity::write_indexed(
+            "table",
+            1.0,
+            HashMap::from([("gsi".to_owned(), 1.0)]),
+            HashMap::from([("lsi".to_owned(), 1.0)]),
+            true,
+        );
+        let Ok(value) = serde_json::to_value(capacity) else {
+            panic!("indexed capacity should serialize");
+        };
+
+        assert!(value.get("WriteCapacityUnits").is_none());
+        assert!(value["Table"].get("WriteCapacityUnits").is_none());
+        assert!(
+            value["GlobalSecondaryIndexes"]["gsi"]
+                .get("WriteCapacityUnits")
+                .is_none()
+        );
+        assert!(
+            value["LocalSecondaryIndexes"]["lsi"]
+                .get("WriteCapacityUnits")
+                .is_none()
+        );
     }
 }

--- a/crates/core/src/types/key_schema.rs
+++ b/crates/core/src/types/key_schema.rs
@@ -87,6 +87,14 @@ pub struct TableKeyInfo {
     /// Whether the table has at least one local secondary index.
     /// Used to decide whether `ItemCollectionMetrics` should be returned.
     pub has_lsi: bool,
+    /// Global secondary indexes defined on the table (name, key schema, and
+    /// projection). Populated from the catalog and carried on the cached
+    /// `TableKeyInfo` so per-index consumed capacity can be computed without an
+    /// extra `describe_table` round-trip per write.
+    pub global_secondary_indexes: Vec<IndexInfo>,
+    /// Local secondary indexes defined on the table (name, key schema, and
+    /// projection). Same rationale as `global_secondary_indexes`.
+    pub local_secondary_indexes: Vec<IndexInfo>,
     /// Stream specification for the table, if streams are configured.
     /// Cached here to avoid an extra `describe_table` call per write operation.
     pub stream_specification: Option<super::StreamSpecification>,
@@ -260,6 +268,8 @@ mod tests {
             base_key_schema: schema.clone(),
             attribute_definitions: vec![],
             has_lsi: false,
+            global_secondary_indexes: vec![],
+            local_secondary_indexes: vec![],
             stream_specification: None,
         };
         assert_eq!(info.key_schema, info.base_key_schema);
@@ -277,6 +287,8 @@ mod tests {
             base_key_schema: base_schema.clone(),
             attribute_definitions: vec![],
             has_lsi: false,
+            global_secondary_indexes: vec![],
+            local_secondary_indexes: vec![],
             stream_specification: None,
         };
         assert_eq!(info.key_schema, index_schema);

--- a/crates/engine/src/batch_write_item.rs
+++ b/crates/engine/src/batch_write_item.rs
@@ -199,6 +199,9 @@ pub async fn handle_batch_write_item(
         }
     }
 
+    // NOTE: per-index (INDEXES) breakdown for batch writes is deferred to the
+    // storage-layer capacity-reporting follow-up (Delete requests lack the old
+    // item needed to attribute per-index capacity). Base-table aggregate only.
     let consumed_capacity = capacity_helpers::batch_write_capacity(
         input.return_consumed_capacity,
         per_table_wcu.iter().map(|(t, cu)| (t.as_str(), *cu)),

--- a/crates/engine/src/capacity_helpers.rs
+++ b/crates/engine/src/capacity_helpers.rs
@@ -10,8 +10,8 @@
 use std::sync::atomic::AtomicU64;
 
 use extenddb_core::types::{
-    ConsumedCapacity, Item, ItemCollectionMetrics, KeySchemaElement, ReturnConsumedCapacity,
-    ReturnItemCollectionMetrics,
+    ConsumedCapacity, Item, ItemCollectionMetrics, KeySchemaElement, Projection, ProjectionType,
+    ReturnConsumedCapacity, ReturnItemCollectionMetrics, TableDescription, item_size_bytes,
 };
 
 /// Global counter for requests that used approximate consumed capacity.
@@ -52,6 +52,133 @@ pub fn write_capacity(
     }
 }
 
+/// Build a write `ConsumedCapacity` with a per-index breakdown for `INDEXES`
+/// mode, or the plain table-level capacity otherwise.
+///
+/// `base_cu` is the base-table write capacity; `item` is the item being written
+/// (used to determine sparse index membership and per-index projected size);
+/// `desc` is the table description (source of GSI/LSI definitions). When the
+/// caller does not request `INDEXES`, `desc` is unused and this behaves exactly
+/// like [`write_capacity`].
+#[must_use]
+pub fn write_capacity_indexed(
+    rcc: ReturnConsumedCapacity,
+    table_name: &str,
+    base_cu: f64,
+    item: &Item,
+    desc: &TableDescription,
+) -> Option<ConsumedCapacity> {
+    match rcc {
+        ReturnConsumedCapacity::None => None,
+        rcc => {
+            CAPACITY_REQUEST_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let (gsi, lsi) = index_write_units(item, desc);
+            let breakdown = rcc == ReturnConsumedCapacity::Indexes;
+            Some(ConsumedCapacity::write_indexed(
+                table_name, base_cu, gsi, lsi, breakdown,
+            ))
+        }
+    }
+}
+
+/// Compute per-GSI and per-LSI write capacity units contributed by `item`.
+///
+/// Returns `(gsi_units, lsi_units)` keyed by index name. An index is charged
+/// only when the item projects into it — i.e. the item contains every one of
+/// the index's key attributes (sparse-index semantics). Per-index capacity is
+/// `ceil(projected_item_size / 1KB)`, where the projected item contains only
+/// the attributes the index materializes (per its projection type).
+#[must_use]
+pub fn index_write_units(
+    item: &Item,
+    desc: &TableDescription,
+) -> (
+    std::collections::HashMap<String, f64>,
+    std::collections::HashMap<String, f64>,
+) {
+    let base_keys: Vec<&str> = desc
+        .key_schema
+        .iter()
+        .map(|k| k.attribute_name.as_str())
+        .collect();
+
+    let mut gsi = std::collections::HashMap::new();
+    if let Some(gsis) = &desc.global_secondary_indexes {
+        for g in gsis {
+            if let Some(cu) = one_index_write_units(item, &g.key_schema, &base_keys, &g.projection)
+            {
+                gsi.insert(g.index_name.clone(), cu);
+            }
+        }
+    }
+
+    let mut lsi = std::collections::HashMap::new();
+    if let Some(lsis) = &desc.local_secondary_indexes {
+        for l in lsis {
+            if let Some(cu) = one_index_write_units(item, &l.key_schema, &base_keys, &l.projection)
+            {
+                lsi.insert(l.index_name.clone(), cu);
+            }
+        }
+    }
+
+    (gsi, lsi)
+}
+
+/// Write units for a single index, or `None` if the item is not projected into
+/// it (missing an index key attribute — sparse index).
+fn one_index_write_units(
+    item: &Item,
+    index_key_schema: &[KeySchemaElement],
+    base_keys: &[&str],
+    projection: &Projection,
+) -> Option<f64> {
+    for ks in index_key_schema {
+        if !item.contains_key(&ks.attribute_name) {
+            return None;
+        }
+    }
+    let projected = project_index_item(item, index_key_schema, base_keys, projection);
+    Some(write_capacity_units(item_size_bytes(&projected)))
+}
+
+/// Build the subset of `item` that an index materializes, per its projection.
+fn project_index_item(
+    item: &Item,
+    index_key_schema: &[KeySchemaElement],
+    base_keys: &[&str],
+    projection: &Projection,
+) -> Item {
+    match projection.projection_type {
+        // ALL projects the entire item.
+        ProjectionType::All => item.clone(),
+        // KEYS_ONLY and INCLUDE always project index keys + base table keys.
+        ProjectionType::KeysOnly | ProjectionType::Include => {
+            let mut out = Item::new();
+            for ks in index_key_schema {
+                if let Some(v) = item.get(&ks.attribute_name) {
+                    out.insert(ks.attribute_name.clone(), v.clone());
+                }
+            }
+            for k in base_keys {
+                if let Some(v) = item.get(*k) {
+                    out.insert((*k).to_owned(), v.clone());
+                }
+            }
+            if projection.projection_type == ProjectionType::Include
+                && let Some(non_key) = &projection.non_key_attributes
+            {
+                for a in non_key {
+                    if let Some(v) = item.get(a) {
+                        out.insert(a.clone(), v.clone());
+                    }
+                }
+            }
+            out
+        }
+    }
+}
+
 /// Build a `Vec<ConsumedCapacity>` for a batch/transaction read, or `None` if not requested.
 /// One entry per distinct table name with real CU values.
 #[must_use]
@@ -74,7 +201,7 @@ pub fn batch_read_capacity<'a>(
 }
 
 /// Build a `Vec<ConsumedCapacity>` for a batch/transaction write, or `None` if not requested.
-/// One entry per distinct table name with real CU values.
+/// One entry per distinct table name with real CU values (base-table aggregate only).
 #[must_use]
 pub fn batch_write_capacity<'a>(
     rcc: ReturnConsumedCapacity,

--- a/crates/engine/src/capacity_helpers.rs
+++ b/crates/engine/src/capacity_helpers.rs
@@ -55,24 +55,26 @@ pub fn write_capacity(
 /// Build a write `ConsumedCapacity` with a per-index breakdown for `INDEXES`
 /// mode, or the plain table-level capacity otherwise.
 ///
-/// `base_cu` is the base-table write capacity; `item` is the item being written
-/// (used to determine sparse index membership and per-index projected size);
-/// `desc` is the table description (source of GSI/LSI definitions). When the
-/// caller does not request `INDEXES`, `key_info` is unused and this behaves
-/// exactly like [`write_capacity`].
+/// `base_cu` is the base-table write capacity. `old_item` and `new_item`
+/// describe the index transition: inserts provide only the new item, deletes
+/// only the old item, and replacements/updates provide both. Index metadata
+/// comes from the cached `TableKeyInfo`.
 #[must_use]
 pub fn write_capacity_indexed(
     rcc: ReturnConsumedCapacity,
     table_name: &str,
     base_cu: f64,
-    item: &Item,
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+    charge_unchanged_projection: bool,
     key_info: &TableKeyInfo,
 ) -> Option<ConsumedCapacity> {
     match rcc {
         ReturnConsumedCapacity::None => None,
         rcc => {
             CAPACITY_REQUEST_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            let (gsi, lsi) = index_write_units(item, key_info);
+            let (gsi, lsi) =
+                index_write_units(old_item, new_item, charge_unchanged_projection, key_info);
             let breakdown = rcc == ReturnConsumedCapacity::Indexes;
             Some(ConsumedCapacity::write_indexed(
                 table_name, base_cu, gsi, lsi, breakdown,
@@ -81,19 +83,21 @@ pub fn write_capacity_indexed(
     }
 }
 
-/// Compute per-GSI and per-LSI write capacity units contributed by `item`.
+/// Compute per-GSI and per-LSI write capacity units for an item transition.
 ///
-/// Returns `(gsi_units, lsi_units)` keyed by index name. An index is charged
-/// only when the item projects into it — i.e. the item contains every one of
-/// the index's key attributes (sparse-index semantics). Per-index capacity is
-/// `ceil(projected_item_size / 1KB)`, where the projected item contains only
-/// the attributes the index materializes (per its projection type).
+/// Returns `(gsi_units, lsi_units)` keyed by index name. Sparse-index inserts
+/// and deletes are charged from the projection that exists. When both versions
+/// project into an index, a changed key is a delete plus an insert. With an
+/// unchanged key, updates skip identical projected entries while PutItem
+/// replacements still charge the index write.
 ///
-/// Index metadata is read from the (cached) `TableKeyInfo`, so no extra catalog
+/// Index metadata is read from the cached `TableKeyInfo`, so no extra catalog
 /// round-trip is needed.
 #[must_use]
 pub fn index_write_units(
-    item: &Item,
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+    charge_unchanged_projection: bool,
     key_info: &TableKeyInfo,
 ) -> (
     std::collections::HashMap<String, f64>,
@@ -106,37 +110,97 @@ pub fn index_write_units(
         .collect();
 
     let mut gsi = std::collections::HashMap::new();
-    for g in &key_info.global_secondary_indexes {
-        if let Some(cu) = one_index_write_units(item, &g.key_schema, &base_keys, &g.projection) {
-            gsi.insert(g.index_name.clone(), cu);
+    for index in &key_info.global_secondary_indexes {
+        if let Some(cu) = one_index_write_units(
+            old_item,
+            new_item,
+            charge_unchanged_projection,
+            &index.key_schema,
+            &base_keys,
+            &index.projection,
+        ) {
+            gsi.insert(index.index_name.clone(), cu);
         }
     }
 
     let mut lsi = std::collections::HashMap::new();
-    for l in &key_info.local_secondary_indexes {
-        if let Some(cu) = one_index_write_units(item, &l.key_schema, &base_keys, &l.projection) {
-            lsi.insert(l.index_name.clone(), cu);
+    for index in &key_info.local_secondary_indexes {
+        if let Some(cu) = one_index_write_units(
+            old_item,
+            new_item,
+            charge_unchanged_projection,
+            &index.key_schema,
+            &base_keys,
+            &index.projection,
+        ) {
+            lsi.insert(index.index_name.clone(), cu);
         }
     }
 
     (gsi, lsi)
 }
 
-/// Write units for a single index, or `None` if the item is not projected into
-/// it (missing an index key attribute — sparse index).
+/// Write units for one index transition, or `None` when neither item projects
+/// into the sparse index.
 fn one_index_write_units(
-    item: &Item,
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+    charge_unchanged_projection: bool,
     index_key_schema: &[KeySchemaElement],
     base_keys: &[&str],
     projection: &Projection,
 ) -> Option<f64> {
-    for ks in index_key_schema {
-        if !item.contains_key(&ks.attribute_name) {
-            return None;
+    let old_projection = old_item
+        .and_then(|item| sparse_index_projection(item, index_key_schema, base_keys, projection));
+    let new_projection = new_item
+        .and_then(|item| sparse_index_projection(item, index_key_schema, base_keys, projection));
+
+    match (old_projection, new_projection) {
+        (None, None) => None,
+        (Some(projected), None) | (None, Some(projected)) => {
+            Some(write_capacity_units(item_size_bytes(&projected)))
+        }
+        (Some(old_projected), Some(new_projected)) => {
+            let same_key = old_item.zip(new_item).is_some_and(|(old, new)| {
+                index_key_schema
+                    .iter()
+                    .all(|key| old.get(&key.attribute_name) == new.get(&key.attribute_name))
+            });
+            if same_key && !charge_unchanged_projection && old_projected == new_projected {
+                return None;
+            }
+
+            let old_cu = write_capacity_units(item_size_bytes(&old_projected));
+            let new_cu = write_capacity_units(item_size_bytes(&new_projected));
+            Some(if same_key {
+                old_cu.max(new_cu)
+            } else {
+                old_cu + new_cu
+            })
         }
     }
-    let projected = project_index_item(item, index_key_schema, base_keys, projection);
-    Some(write_capacity_units(item_size_bytes(&projected)))
+}
+
+/// Project an item into one index, or return `None` when the item is not a
+/// member of the sparse index.
+fn sparse_index_projection(
+    item: &Item,
+    index_key_schema: &[KeySchemaElement],
+    base_keys: &[&str],
+    projection: &Projection,
+) -> Option<Item> {
+    if index_key_schema
+        .iter()
+        .any(|key| !item.contains_key(&key.attribute_name))
+    {
+        return None;
+    }
+    Some(project_index_item(
+        item,
+        index_key_schema,
+        base_keys,
+        projection,
+    ))
 }
 
 /// Build the subset of `item` that an index materializes, per its projection.
@@ -312,4 +376,93 @@ pub fn item_metrics(
         .find(|ks| ks.key_type == extenddb_core::types::KeyType::Hash)?;
     let pk_value = item_or_key.get(&pk.attribute_name)?;
     Some(ItemCollectionMetrics::stub(&pk.attribute_name, pk_value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use extenddb_core::types::{AttributeValue, KeyType};
+
+    fn key(name: &str) -> KeySchemaElement {
+        KeySchemaElement {
+            attribute_name: name.to_owned(),
+            key_type: KeyType::Hash,
+        }
+    }
+
+    fn item(pk: &str, index_key: Option<&str>) -> Item {
+        let mut item = Item::new();
+        item.insert("pk".to_owned(), AttributeValue::S(pk.to_owned()));
+        if let Some(value) = index_key {
+            item.insert("gsi_pk".to_owned(), AttributeValue::S(value.to_owned()));
+        }
+        item
+    }
+
+    fn keys_only() -> Projection {
+        Projection {
+            projection_type: ProjectionType::KeysOnly,
+            non_key_attributes: None,
+        }
+    }
+
+    #[test]
+    fn charges_deleted_sparse_index_projection() {
+        let old = item("item", Some("old"));
+        let new = item("item", None);
+        let units = one_index_write_units(
+            Some(&old),
+            Some(&new),
+            false,
+            &[key("gsi_pk")],
+            &["pk"],
+            &keys_only(),
+        );
+        assert_eq!(units, Some(1.0));
+    }
+
+    #[test]
+    fn changing_index_key_charges_delete_and_insert() {
+        let old = item("item", Some("old"));
+        let new = item("item", Some("new"));
+        let units = one_index_write_units(
+            Some(&old),
+            Some(&new),
+            false,
+            &[key("gsi_pk")],
+            &["pk"],
+            &keys_only(),
+        );
+        assert_eq!(units, Some(2.0));
+    }
+
+    #[test]
+    fn update_skips_unchanged_projection_but_replacement_charges_it() {
+        let mut old = item("item", Some("index"));
+        old.insert("other".to_owned(), AttributeValue::S("old".to_owned()));
+        let mut new = item("item", Some("index"));
+        new.insert("other".to_owned(), AttributeValue::S("new".to_owned()));
+        let key_schema = [key("gsi_pk")];
+        let projection = keys_only();
+
+        let update_units = one_index_write_units(
+            Some(&old),
+            Some(&new),
+            false,
+            &key_schema,
+            &["pk"],
+            &projection,
+        );
+        assert_eq!(update_units, None);
+
+        let replacement_units = one_index_write_units(
+            Some(&old),
+            Some(&new),
+            true,
+            &key_schema,
+            &["pk"],
+            &projection,
+        );
+        assert_eq!(replacement_units, Some(1.0));
+    }
 }

--- a/crates/engine/src/capacity_helpers.rs
+++ b/crates/engine/src/capacity_helpers.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::AtomicU64;
 
 use extenddb_core::types::{
     ConsumedCapacity, Item, ItemCollectionMetrics, KeySchemaElement, Projection, ProjectionType,
-    ReturnConsumedCapacity, ReturnItemCollectionMetrics, TableDescription, item_size_bytes,
+    ReturnConsumedCapacity, ReturnItemCollectionMetrics, TableKeyInfo, item_size_bytes,
 };
 
 /// Global counter for requests that used approximate consumed capacity.
@@ -58,21 +58,21 @@ pub fn write_capacity(
 /// `base_cu` is the base-table write capacity; `item` is the item being written
 /// (used to determine sparse index membership and per-index projected size);
 /// `desc` is the table description (source of GSI/LSI definitions). When the
-/// caller does not request `INDEXES`, `desc` is unused and this behaves exactly
-/// like [`write_capacity`].
+/// caller does not request `INDEXES`, `key_info` is unused and this behaves
+/// exactly like [`write_capacity`].
 #[must_use]
 pub fn write_capacity_indexed(
     rcc: ReturnConsumedCapacity,
     table_name: &str,
     base_cu: f64,
     item: &Item,
-    desc: &TableDescription,
+    key_info: &TableKeyInfo,
 ) -> Option<ConsumedCapacity> {
     match rcc {
         ReturnConsumedCapacity::None => None,
         rcc => {
             CAPACITY_REQUEST_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            let (gsi, lsi) = index_write_units(item, desc);
+            let (gsi, lsi) = index_write_units(item, key_info);
             let breakdown = rcc == ReturnConsumedCapacity::Indexes;
             Some(ConsumedCapacity::write_indexed(
                 table_name, base_cu, gsi, lsi, breakdown,
@@ -88,37 +88,34 @@ pub fn write_capacity_indexed(
 /// the index's key attributes (sparse-index semantics). Per-index capacity is
 /// `ceil(projected_item_size / 1KB)`, where the projected item contains only
 /// the attributes the index materializes (per its projection type).
+///
+/// Index metadata is read from the (cached) `TableKeyInfo`, so no extra catalog
+/// round-trip is needed.
 #[must_use]
 pub fn index_write_units(
     item: &Item,
-    desc: &TableDescription,
+    key_info: &TableKeyInfo,
 ) -> (
     std::collections::HashMap<String, f64>,
     std::collections::HashMap<String, f64>,
 ) {
-    let base_keys: Vec<&str> = desc
-        .key_schema
+    let base_keys: Vec<&str> = key_info
+        .base_key_schema
         .iter()
         .map(|k| k.attribute_name.as_str())
         .collect();
 
     let mut gsi = std::collections::HashMap::new();
-    if let Some(gsis) = &desc.global_secondary_indexes {
-        for g in gsis {
-            if let Some(cu) = one_index_write_units(item, &g.key_schema, &base_keys, &g.projection)
-            {
-                gsi.insert(g.index_name.clone(), cu);
-            }
+    for g in &key_info.global_secondary_indexes {
+        if let Some(cu) = one_index_write_units(item, &g.key_schema, &base_keys, &g.projection) {
+            gsi.insert(g.index_name.clone(), cu);
         }
     }
 
     let mut lsi = std::collections::HashMap::new();
-    if let Some(lsis) = &desc.local_secondary_indexes {
-        for l in lsis {
-            if let Some(cu) = one_index_write_units(item, &l.key_schema, &base_keys, &l.projection)
-            {
-                lsi.insert(l.index_name.clone(), cu);
-            }
+    for l in &key_info.local_secondary_indexes {
+        if let Some(cu) = one_index_write_units(item, &l.key_schema, &base_keys, &l.projection) {
+            lsi.insert(l.index_name.clone(), cu);
         }
     }
 

--- a/crates/engine/src/delete_item.rs
+++ b/crates/engine/src/delete_item.rs
@@ -122,13 +122,18 @@ pub async fn handle_delete_item(
         region: ctx.region.clone(),
     });
     let need_old_for_stream = stream.is_some();
+    // Consumed capacity — when requested, the total includes base + affected
+    // GSIs; INDEXES additionally returns the per-index breakdown. The deleted
+    // (old) item is needed to determine which indexes the delete propagated to.
+    let need_old_for_capacity =
+        input.return_consumed_capacity != extenddb_core::types::ReturnConsumedCapacity::None;
 
     let old_item = ctx
         .storage
         .delete_item(
             &key_info,
             &input.key,
-            return_old || need_old_for_stream,
+            return_old || need_old_for_stream || need_old_for_capacity,
             condition.as_ref(),
             &maps,
             stream.as_ref(),
@@ -147,13 +152,37 @@ pub async fn handle_delete_item(
             .map_or_else(|| item_size_bytes(&input.key), item_size_bytes),
     );
 
-    let output = DeleteItemOutput {
-        attributes: if return_old { old_item } else { None },
-        consumed_capacity: capacity_helpers::write_capacity(
+    // Consumed capacity — INDEXES mode uses the deleted (old) item to determine
+    // which indexes the delete propagated to, via one describe_table read. If
+    // nothing was deleted, only base-table capacity is reported.
+    let consumed_capacity = if input.return_consumed_capacity
+        != extenddb_core::types::ReturnConsumedCapacity::None
+        && let Some(cc_item) = old_item.as_ref()
+    {
+        let desc = ctx
+            .storage
+            .describe_table(
+                &ctx.account_id,
+                extenddb_core::types::DescribeTableInput {
+                    table_name: input.table_name.clone(),
+                },
+            )
+            .await
+            .map_err(storage_err_to_dynamo)?;
+        capacity_helpers::write_capacity_indexed(
             input.return_consumed_capacity,
             &input.table_name,
             wcu,
-        ),
+            cc_item,
+            &desc,
+        )
+    } else {
+        capacity_helpers::write_capacity(input.return_consumed_capacity, &input.table_name, wcu)
+    };
+
+    let output = DeleteItemOutput {
+        attributes: if return_old { old_item } else { None },
+        consumed_capacity,
         item_collection_metrics: capacity_helpers::item_metrics(
             input.return_item_collection_metrics,
             &key_info.key_schema,

--- a/crates/engine/src/delete_item.rs
+++ b/crates/engine/src/delete_item.rs
@@ -161,7 +161,9 @@ pub async fn handle_delete_item(
             input.return_consumed_capacity,
             &input.table_name,
             wcu,
-            cc_item,
+            Some(cc_item),
+            None,
+            false,
             &key_info,
         ),
         None => {

--- a/crates/engine/src/delete_item.rs
+++ b/crates/engine/src/delete_item.rs
@@ -153,31 +153,20 @@ pub async fn handle_delete_item(
     );
 
     // Consumed capacity — INDEXES mode uses the deleted (old) item to determine
-    // which indexes the delete propagated to, via one describe_table read. If
+    // which indexes the delete propagated to. Index metadata comes from the
+    // (cached) `TableKeyInfo`, so no extra catalog round-trip is needed. If
     // nothing was deleted, only base-table capacity is reported.
-    let consumed_capacity = if input.return_consumed_capacity
-        != extenddb_core::types::ReturnConsumedCapacity::None
-        && let Some(cc_item) = old_item.as_ref()
-    {
-        let desc = ctx
-            .storage
-            .describe_table(
-                &ctx.account_id,
-                extenddb_core::types::DescribeTableInput {
-                    table_name: input.table_name.clone(),
-                },
-            )
-            .await
-            .map_err(storage_err_to_dynamo)?;
-        capacity_helpers::write_capacity_indexed(
+    let consumed_capacity = match old_item.as_ref() {
+        Some(cc_item) => capacity_helpers::write_capacity_indexed(
             input.return_consumed_capacity,
             &input.table_name,
             wcu,
             cc_item,
-            &desc,
-        )
-    } else {
-        capacity_helpers::write_capacity(input.return_consumed_capacity, &input.table_name, wcu)
+            &key_info,
+        ),
+        None => {
+            capacity_helpers::write_capacity(input.return_consumed_capacity, &input.table_name, wcu)
+        }
     };
 
     let output = DeleteItemOutput {

--- a/crates/engine/src/put_item.rs
+++ b/crates/engine/src/put_item.rs
@@ -161,22 +161,16 @@ pub async fn handle_put_item(
     )?;
 
     let return_old = input.return_values == ReturnValues::AllOld;
+    let capacity_requested =
+        input.return_consumed_capacity != extenddb_core::types::ReturnConsumedCapacity::None;
+    let needs_index_capacity = capacity_requested
+        && (!key_info.global_secondary_indexes.is_empty()
+            || !key_info.local_secondary_indexes.is_empty());
 
-    // Capacity metering: full item size, rounded up to 1 KB.
-    let item_bytes = item_size_bytes(&input.item);
-    let wcu = capacity_helpers::write_capacity_units(item_bytes);
-
-    // Consumed capacity is computed before `input.item` is moved into storage.
-    // Consumed capacity, computed before `input.item` is moved into storage.
-    // Per-index (INDEXES) breakdown uses the index metadata already carried on
-    // the (cached) `TableKeyInfo`, so no extra catalog round-trip is needed.
-    let consumed_capacity = capacity_helpers::write_capacity_indexed(
-        input.return_consumed_capacity,
-        &input.table_name,
-        wcu,
-        &input.item,
-        &key_info,
-    );
+    // Preserve the new item only when per-index accounting needs to compare it
+    // with the replaced item after storage takes ownership.
+    let new_item_for_capacity = needs_index_capacity.then(|| input.item.clone());
+    let new_item_bytes = item_size_bytes(&input.item);
 
     // Extract item collection metrics before item is moved into storage.
     let icm = capacity_helpers::item_metrics(
@@ -194,16 +188,18 @@ pub async fn handle_put_item(
         user_identity: None,
         region: ctx.region.clone(),
     });
-    // When streams are enabled, always request old item so the storage layer
-    // can determine Insert vs Modify and build old images.
+    // Capacity uses the larger old/new base item and must include index entries
+    // deleted by an overwrite, so request the old item whenever capacity is
+    // requested. Indexed writes already read it inside the storage transaction.
     let need_old_for_stream = stream.is_some();
+    let need_old_for_capacity = capacity_requested;
 
     let old_item = ctx
         .storage
         .put_item(
             &key_info,
             input.item,
-            return_old || need_old_for_stream,
+            return_old || need_old_for_stream || need_old_for_capacity,
             condition.as_ref(),
             &maps,
             stream.as_ref(),
@@ -214,6 +210,23 @@ pub async fn handle_put_item(
         })?;
 
     // Stream records are now captured atomically within the storage transaction.
+
+    let old_item_bytes = old_item.as_ref().map_or(0, item_size_bytes);
+    let wcu = capacity_helpers::write_capacity_units(new_item_bytes.max(old_item_bytes));
+    let consumed_capacity = match new_item_for_capacity.as_ref() {
+        Some(new_item) => capacity_helpers::write_capacity_indexed(
+            input.return_consumed_capacity,
+            &input.table_name,
+            wcu,
+            old_item.as_ref(),
+            Some(new_item),
+            true,
+            &key_info,
+        ),
+        None => {
+            capacity_helpers::write_capacity(input.return_consumed_capacity, &input.table_name, wcu)
+        }
+    };
 
     let output = PutItemOutput {
         attributes: if return_old { old_item } else { None },

--- a/crates/engine/src/put_item.rs
+++ b/crates/engine/src/put_item.rs
@@ -167,31 +167,16 @@ pub async fn handle_put_item(
     let wcu = capacity_helpers::write_capacity_units(item_bytes);
 
     // Consumed capacity is computed before `input.item` is moved into storage.
-    // INDEXES mode additionally needs the item and index metadata to build the
-    // per-index breakdown, which requires one describe_table catalog read (only
-    // taken when INDEXES is requested).
-    let consumed_capacity =
-        if input.return_consumed_capacity != extenddb_core::types::ReturnConsumedCapacity::None {
-            let desc = ctx
-                .storage
-                .describe_table(
-                    &ctx.account_id,
-                    extenddb_core::types::DescribeTableInput {
-                        table_name: input.table_name.clone(),
-                    },
-                )
-                .await
-                .map_err(storage_err_to_dynamo)?;
-            capacity_helpers::write_capacity_indexed(
-                input.return_consumed_capacity,
-                &input.table_name,
-                wcu,
-                &input.item,
-                &desc,
-            )
-        } else {
-            capacity_helpers::write_capacity(input.return_consumed_capacity, &input.table_name, wcu)
-        };
+    // Consumed capacity, computed before `input.item` is moved into storage.
+    // Per-index (INDEXES) breakdown uses the index metadata already carried on
+    // the (cached) `TableKeyInfo`, so no extra catalog round-trip is needed.
+    let consumed_capacity = capacity_helpers::write_capacity_indexed(
+        input.return_consumed_capacity,
+        &input.table_name,
+        wcu,
+        &input.item,
+        &key_info,
+    );
 
     // Extract item collection metrics before item is moved into storage.
     let icm = capacity_helpers::item_metrics(

--- a/crates/engine/src/put_item.rs
+++ b/crates/engine/src/put_item.rs
@@ -166,6 +166,33 @@ pub async fn handle_put_item(
     let item_bytes = item_size_bytes(&input.item);
     let wcu = capacity_helpers::write_capacity_units(item_bytes);
 
+    // Consumed capacity is computed before `input.item` is moved into storage.
+    // INDEXES mode additionally needs the item and index metadata to build the
+    // per-index breakdown, which requires one describe_table catalog read (only
+    // taken when INDEXES is requested).
+    let consumed_capacity =
+        if input.return_consumed_capacity != extenddb_core::types::ReturnConsumedCapacity::None {
+            let desc = ctx
+                .storage
+                .describe_table(
+                    &ctx.account_id,
+                    extenddb_core::types::DescribeTableInput {
+                        table_name: input.table_name.clone(),
+                    },
+                )
+                .await
+                .map_err(storage_err_to_dynamo)?;
+            capacity_helpers::write_capacity_indexed(
+                input.return_consumed_capacity,
+                &input.table_name,
+                wcu,
+                &input.item,
+                &desc,
+            )
+        } else {
+            capacity_helpers::write_capacity(input.return_consumed_capacity, &input.table_name, wcu)
+        };
+
     // Extract item collection metrics before item is moved into storage.
     let icm = capacity_helpers::item_metrics(
         input.return_item_collection_metrics,
@@ -205,11 +232,7 @@ pub async fn handle_put_item(
 
     let output = PutItemOutput {
         attributes: if return_old { old_item } else { None },
-        consumed_capacity: capacity_helpers::write_capacity(
-            input.return_consumed_capacity,
-            &input.table_name,
-            wcu,
-        ),
+        consumed_capacity,
         item_collection_metrics: icm,
     };
     let body = serialize_output(&output)?;

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -89,6 +89,8 @@ pub async fn handle_query(
             base_key_schema: key_info.key_schema.clone(),
             attribute_definitions: key_info.attribute_definitions.clone(),
             has_lsi: key_info.has_lsi,
+            global_secondary_indexes: key_info.global_secondary_indexes.clone(),
+            local_secondary_indexes: key_info.local_secondary_indexes.clone(),
             stream_specification: None, // Queries don't capture stream records
         }
     } else {

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -289,6 +289,8 @@ pub async fn handle_scan(
             base_key_schema: key_info.key_schema.clone(),
             attribute_definitions: key_info.attribute_definitions.clone(),
             has_lsi: key_info.has_lsi,
+            global_secondary_indexes: key_info.global_secondary_indexes.clone(),
+            local_secondary_indexes: key_info.local_secondary_indexes.clone(),
             stream_specification: None, // Scans don't capture stream records
         }
     } else {

--- a/crates/engine/src/transact_write_items.rs
+++ b/crates/engine/src/transact_write_items.rs
@@ -169,6 +169,11 @@ pub async fn handle_transact_write_items(
         })
         .sum();
 
+    // NOTE: per-index (INDEXES) consumed-capacity breakdown for transactions is
+    // deferred to the storage-layer capacity-reporting follow-up: the engine has
+    // no resulting/old item for Update/Delete sub-ops, but DynamoDB requires a
+    // non-null GSI breakdown for those ops on GSI tables. Base-table aggregate
+    // only for now.
     let consumed_capacity = capacity_helpers::transact_write_capacity(
         input.return_consumed_capacity,
         per_table_wcu.iter().map(|(t, cu)| (t.as_str(), *cu)),

--- a/crates/engine/src/transact_write_items.rs
+++ b/crates/engine/src/transact_write_items.rs
@@ -171,8 +171,8 @@ pub async fn handle_transact_write_items(
 
     // NOTE: per-index (INDEXES) consumed-capacity breakdown for transactions is
     // deferred to the storage-layer capacity-reporting follow-up: the engine has
-    // no resulting/old item for Update/Delete sub-ops, but DynamoDB requires a
-    // non-null GSI breakdown for those ops on GSI tables. Base-table aggregate
+    // no resulting/old item for Update/Delete sub-ops, but DynamoDB reports a
+    // per-index breakdown for those ops on GSI tables. Base-table aggregate
     // only for now.
     let consumed_capacity = capacity_helpers::transact_write_capacity(
         input.return_consumed_capacity,

--- a/crates/engine/src/update_item.rs
+++ b/crates/engine/src/update_item.rs
@@ -230,6 +230,8 @@ pub async fn handle_update_item(
         region: ctx.region.clone(),
     });
     let need_old_for_stream = stream.is_some();
+    let need_old_for_capacity =
+        input.return_consumed_capacity != extenddb_core::types::ReturnConsumedCapacity::None;
 
     let (old_item, new_item) = ctx
         .storage
@@ -237,7 +239,7 @@ pub async fn handle_update_item(
             &key_info,
             &input.key,
             &actions,
-            return_old || need_old_for_stream,
+            return_old || need_old_for_stream || need_old_for_capacity,
             true, // always fetch new item for WCU calculation
             condition.as_ref(),
             &maps,
@@ -255,22 +257,19 @@ pub async fn handle_update_item(
     let new_bytes = new_item.as_ref().map_or(0, item_size_bytes);
     let wcu = capacity_helpers::write_capacity_units(old_bytes.max(new_bytes));
 
-    // Consumed capacity — computed before old/new items are moved below. The
-    // per-index breakdown uses the resulting item (new, or old for pure deletes)
-    // for sparse index membership; index metadata comes from the (cached)
-    // `TableKeyInfo`, so no extra catalog round-trip is needed.
-    let consumed_capacity = match new_item.as_ref().or(old_item.as_ref()) {
-        Some(cc_item) => capacity_helpers::write_capacity_indexed(
-            input.return_consumed_capacity,
-            &input.table_name,
-            wcu,
-            cc_item,
-            &key_info,
-        ),
-        None => {
-            capacity_helpers::write_capacity(input.return_consumed_capacity, &input.table_name, wcu)
-        }
-    };
+    // Index capacity follows the old-to-new transition, so removing a sparse
+    // index key charges the deleted projection and changing an index key charges
+    // both the old deletion and new insertion. Metadata comes from cached
+    // `TableKeyInfo`; no describe-table round-trip is needed.
+    let consumed_capacity = capacity_helpers::write_capacity_indexed(
+        input.return_consumed_capacity,
+        &input.table_name,
+        wcu,
+        old_item.as_ref(),
+        new_item.as_ref(),
+        false,
+        &key_info,
+    );
 
     // Select the appropriate return value.
     // UPDATED_OLD and UPDATED_NEW return only the attributes that were

--- a/crates/engine/src/update_item.rs
+++ b/crates/engine/src/update_item.rs
@@ -255,6 +255,34 @@ pub async fn handle_update_item(
     let new_bytes = new_item.as_ref().map_or(0, item_size_bytes);
     let wcu = capacity_helpers::write_capacity_units(old_bytes.max(new_bytes));
 
+    // Consumed capacity — computed before old/new items are moved below.
+    // INDEXES mode uses the resulting item (new, or old for pure deletes) to
+    // determine sparse index membership, via one describe_table read.
+    let consumed_capacity = if input.return_consumed_capacity
+        != extenddb_core::types::ReturnConsumedCapacity::None
+        && let Some(cc_item) = new_item.as_ref().or(old_item.as_ref())
+    {
+        let desc = ctx
+            .storage
+            .describe_table(
+                &ctx.account_id,
+                extenddb_core::types::DescribeTableInput {
+                    table_name: input.table_name.clone(),
+                },
+            )
+            .await
+            .map_err(storage_err_to_dynamo)?;
+        capacity_helpers::write_capacity_indexed(
+            input.return_consumed_capacity,
+            &input.table_name,
+            wcu,
+            cc_item,
+            &desc,
+        )
+    } else {
+        capacity_helpers::write_capacity(input.return_consumed_capacity, &input.table_name, wcu)
+    };
+
     // Select the appropriate return value.
     // UPDATED_OLD and UPDATED_NEW return only the attributes that were
     // targeted by the update expression (top-level attribute of each action path).
@@ -272,11 +300,7 @@ pub async fn handle_update_item(
 
     let output = UpdateItemOutput {
         attributes,
-        consumed_capacity: capacity_helpers::write_capacity(
-            input.return_consumed_capacity,
-            &input.table_name,
-            wcu,
-        ),
+        consumed_capacity,
         item_collection_metrics: capacity_helpers::item_metrics(
             input.return_item_collection_metrics,
             &key_info.key_schema,

--- a/crates/engine/src/update_item.rs
+++ b/crates/engine/src/update_item.rs
@@ -255,32 +255,21 @@ pub async fn handle_update_item(
     let new_bytes = new_item.as_ref().map_or(0, item_size_bytes);
     let wcu = capacity_helpers::write_capacity_units(old_bytes.max(new_bytes));
 
-    // Consumed capacity — computed before old/new items are moved below.
-    // INDEXES mode uses the resulting item (new, or old for pure deletes) to
-    // determine sparse index membership, via one describe_table read.
-    let consumed_capacity = if input.return_consumed_capacity
-        != extenddb_core::types::ReturnConsumedCapacity::None
-        && let Some(cc_item) = new_item.as_ref().or(old_item.as_ref())
-    {
-        let desc = ctx
-            .storage
-            .describe_table(
-                &ctx.account_id,
-                extenddb_core::types::DescribeTableInput {
-                    table_name: input.table_name.clone(),
-                },
-            )
-            .await
-            .map_err(storage_err_to_dynamo)?;
-        capacity_helpers::write_capacity_indexed(
+    // Consumed capacity — computed before old/new items are moved below. The
+    // per-index breakdown uses the resulting item (new, or old for pure deletes)
+    // for sparse index membership; index metadata comes from the (cached)
+    // `TableKeyInfo`, so no extra catalog round-trip is needed.
+    let consumed_capacity = match new_item.as_ref().or(old_item.as_ref()) {
+        Some(cc_item) => capacity_helpers::write_capacity_indexed(
             input.return_consumed_capacity,
             &input.table_name,
             wcu,
             cc_item,
-            &desc,
-        )
-    } else {
-        capacity_helpers::write_capacity(input.return_consumed_capacity, &input.table_name, wcu)
+            &key_info,
+        ),
+        None => {
+            capacity_helpers::write_capacity(input.return_consumed_capacity, &input.table_name, wcu)
+        }
     };
 
     // Select the appropriate return value.

--- a/crates/storage-postgres/src/data/ddl.rs
+++ b/crates/storage-postgres/src/data/ddl.rs
@@ -13,14 +13,13 @@ use extenddb_storage::util::{sk_column, sk_column_n};
 use super::{all_sort_key_info, data_table_name, index_table_name};
 use crate::PostgresEngine;
 
-/// Row shape returned by the table-info query: (`key_schema`, `attr_defs`, status, `table_id`, `stream_spec`, `has_lsi`).
+/// Row shape returned by the table-info query: (`key_schema`, `attr_defs`, status, `table_id`, `stream_spec`).
 type TableInfoRow = (
     serde_json::Value,
     serde_json::Value,
     String,
     String,
     Option<serde_json::Value>,
-    Option<bool>,
 );
 
 impl PostgresEngine {
@@ -263,8 +262,7 @@ impl PostgresEngine {
     ) -> Result<TableKeyInfo, StorageError> {
         let row: Option<TableInfoRow> = sqlx::query_as(
             "SELECT key_schema, attribute_definitions, table_status, table_id, \
-             stream_specification, \
-             EXISTS(SELECT 1 FROM indexes WHERE table_id = tables.table_id AND index_type = 'LSI') AS has_lsi \
+             stream_specification \
              FROM tables \
              WHERE account_id = $1 AND table_name = $2",
         )
@@ -274,7 +272,7 @@ impl PostgresEngine {
         .await
         .map_err(|e| StorageError::Internal(e.to_string()))?;
 
-        let (ks_json, ad_json, status, table_id, stream_spec_json, has_lsi) =
+        let (ks_json, ad_json, status, table_id, stream_spec_json) =
             row.ok_or_else(|| StorageError::TableNotFound(table_name.to_owned()))?;
 
         match status.as_str() {
@@ -298,6 +296,14 @@ impl PostgresEngine {
             .transpose()
             .map_err(|e| StorageError::Internal(e.to_string()))?;
 
+        // Fetch all secondary indexes once and carry their metadata on the
+        // (cached) TableKeyInfo. This lets per-index consumed-capacity accounting
+        // avoid a separate describe_table round-trip on every write, and also
+        // supplies `has_lsi`.
+        let (global_secondary_indexes, local_secondary_indexes) =
+            self.fetch_all_index_info(&table_id).await?;
+        let has_lsi = !local_secondary_indexes.is_empty();
+
         Ok(TableKeyInfo {
             table_name: table_name.to_owned(),
             account_id: account_id.to_owned(),
@@ -305,9 +311,58 @@ impl PostgresEngine {
             base_key_schema: key_schema.clone(),
             key_schema,
             attribute_definitions,
-            has_lsi: has_lsi.unwrap_or(false),
+            has_lsi,
+            global_secondary_indexes,
+            local_secondary_indexes,
             stream_specification,
         })
+    }
+
+    /// Fetch every secondary index defined on a table, split into
+    /// `(global_secondary_indexes, local_secondary_indexes)`.
+    async fn fetch_all_index_info(
+        &self,
+        table_id: &str,
+    ) -> Result<(Vec<IndexInfo>, Vec<IndexInfo>), StorageError> {
+        let rows: Vec<(String, String, String, serde_json::Value, serde_json::Value)> =
+            sqlx::query_as(
+                "SELECT index_name, index_type, index_id, key_schema, projection \
+                 FROM indexes WHERE table_id = $1",
+            )
+            .bind(table_id)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let mut gsis = Vec::new();
+        let mut lsis = Vec::new();
+        for (index_name, idx_type_str, index_id, ks_json, proj_json) in rows {
+            let index_type = match idx_type_str.as_str() {
+                "GSI" => IndexType::Gsi,
+                "LSI" => IndexType::Lsi,
+                other => {
+                    return Err(StorageError::Internal(format!(
+                        "unknown index type in database: {other}"
+                    )));
+                }
+            };
+            let key_schema: Vec<KeySchemaElement> = serde_json::from_value(ks_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let projection: Projection = serde_json::from_value(proj_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let info = IndexInfo {
+                index_name,
+                index_id,
+                index_type,
+                key_schema,
+                projection,
+            };
+            match index_type {
+                IndexType::Gsi => gsis.push(info),
+                IndexType::Lsi => lsis.push(info),
+            }
+        }
+        Ok((gsis, lsis))
     }
 
     /// Fetch metadata for a secondary index from the catalog.

--- a/crates/storage-postgres/src/data/update_item.rs
+++ b/crates/storage-postgres/src/data/update_item.rs
@@ -93,7 +93,11 @@ impl PostgresEngine {
             None
         };
 
-        let old_item = if return_old { Some(item.clone()) } else { None };
+        let old_item = if return_old && old_json.is_some() {
+            Some(item.clone())
+        } else {
+            None
+        };
 
         // Evaluate condition against the existing item (empty if non-existent).
         // DynamoDB treats a non-existent item as having no attributes at all.

--- a/tests/test_item_operations.py
+++ b/tests/test_item_operations.py
@@ -1488,6 +1488,77 @@ class TestConsumedCapacityIndexes:
         assert cc["CapacityUnits"] == 3.0
         assert set(cc["GlobalSecondaryIndexes"]) == {"gsi1", "gsi2"}
 
+    def test_keys_only_gsi_charges_projected_size(self, dynamodb_client):
+        """A KEYS_ONLY GSI is charged on the projected (keys-only) size, not the
+        full base item.
+
+        The base item carries a ~2 KB non-key attribute (2 WCU), but the
+        KEYS_ONLY GSI projects only the key attributes, so it costs 1 WCU. Total
+        is base(2) + gsi(1) = 3 — proving per-index size uses the projection, not
+        the whole item.
+        """
+        with scoped_table(
+            dynamodb_client,
+            attribute_definitions=[
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "g1", "AttributeType": "S"},
+            ],
+            key_schema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "gsi_ko",
+                    "KeySchema": [{"AttributeName": "g1", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "KEYS_ONLY"},
+                }
+            ],
+        ) as table:
+            resp = dynamodb_client.put_item(
+                TableName=table,
+                Item={"pk": {"S": "a"}, "g1": {"S": "gv"}, "big": {"S": "x" * 2000}},
+                ReturnConsumedCapacity="INDEXES",
+            )
+            cc = resp["ConsumedCapacity"]
+            assert cc["Table"]["CapacityUnits"] == 2.0  # ~2 KB base item
+            assert cc["GlobalSecondaryIndexes"]["gsi_ko"]["CapacityUnits"] == 1.0  # keys only
+            assert cc["CapacityUnits"] == 3.0
+
+    def test_lsi_write_reports_local_secondary_index_breakdown(self, dynamodb_client):
+        """An LSI is reported under LocalSecondaryIndexes and added to the total.
+
+        Base (pk, sk) + LSI on (pk, ls). Small item → base 1 + lsi 1 = 2.
+        """
+        with scoped_table(
+            dynamodb_client,
+            attribute_definitions=[
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "sk", "AttributeType": "S"},
+                {"AttributeName": "ls", "AttributeType": "S"},
+            ],
+            key_schema=[
+                {"AttributeName": "pk", "KeyType": "HASH"},
+                {"AttributeName": "sk", "KeyType": "RANGE"},
+            ],
+            LocalSecondaryIndexes=[
+                {
+                    "IndexName": "lsi1",
+                    "KeySchema": [
+                        {"AttributeName": "pk", "KeyType": "HASH"},
+                        {"AttributeName": "ls", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+        ) as table:
+            resp = dynamodb_client.put_item(
+                TableName=table,
+                Item={"pk": {"S": "a"}, "sk": {"S": "s1"}, "ls": {"S": "l1"}},
+                ReturnConsumedCapacity="INDEXES",
+            )
+            cc = resp["ConsumedCapacity"]
+            assert cc["LocalSecondaryIndexes"]["lsi1"]["CapacityUnits"] == 1.0
+            assert cc["Table"]["CapacityUnits"] == 1.0
+            assert cc["CapacityUnits"] == 2.0  # base + LSI
+
 
 # ---------------------------------------------------------------------------
 # Number sizing uses DynamoDB formula (a787349)

--- a/tests/test_item_operations.py
+++ b/tests/test_item_operations.py
@@ -1448,6 +1448,82 @@ class TestConsumedCapacityIndexes:
         assert cc["CapacityUnits"] == 2.0
         assert set(cc["GlobalSecondaryIndexes"]) == {"gsi1"}
 
+    def test_index_breakdown_omits_granular_write_units(
+        self, dynamodb_client, two_gsi_table
+    ):
+        """Single-item writes expose CapacityUnits only, including index entries."""
+        resp = dynamodb_client.put_item(
+            TableName=two_gsi_table,
+            Item={"pk": {"S": "shape"}, "g1": {"S": "x"}, "g2": {"S": "y"}},
+            ReturnConsumedCapacity="INDEXES",
+        )
+        cc = resp["ConsumedCapacity"]
+        assert "WriteCapacityUnits" not in cc
+        for capacity in [cc["Table"], *cc["GlobalSecondaryIndexes"].values()]:
+            assert "WriteCapacityUnits" not in capacity
+            assert "ReadCapacityUnits" not in capacity
+
+    def test_put_item_overwrite_charges_deleted_sparse_index(
+        self, dynamodb_client, two_gsi_table
+    ):
+        """Overwriting an indexed item charges an old index entry that is removed."""
+        dynamodb_client.put_item(
+            TableName=two_gsi_table,
+            Item={"pk": {"S": "overwrite"}, "g1": {"S": "x"}, "g2": {"S": "y"}},
+        )
+        resp = dynamodb_client.put_item(
+            TableName=two_gsi_table,
+            Item={"pk": {"S": "overwrite"}, "g1": {"S": "x"}},
+            ReturnConsumedCapacity="INDEXES",
+        )
+        cc = resp["ConsumedCapacity"]
+        assert cc["GlobalSecondaryIndexes"]["gsi2"]["CapacityUnits"] == 1.0
+        assert cc["CapacityUnits"] == 3.0  # base + retained gsi1 + deleted gsi2
+
+    def test_update_item_charges_deleted_sparse_index(
+        self, dynamodb_client, two_gsi_table
+    ):
+        """Removing an index key still charges deletion of the old projection."""
+        dynamodb_client.put_item(
+            TableName=two_gsi_table,
+            Item={"pk": {"S": "remove-index"}, "g1": {"S": "x"}, "g2": {"S": "y"}},
+        )
+        resp = dynamodb_client.update_item(
+            TableName=two_gsi_table,
+            Key={"pk": {"S": "remove-index"}},
+            UpdateExpression="REMOVE g2",
+            ReturnConsumedCapacity="INDEXES",
+        )
+        cc = resp["ConsumedCapacity"]
+        assert cc["GlobalSecondaryIndexes"]["gsi2"]["CapacityUnits"] == 1.0
+        assert cc["CapacityUnits"] >= 2.0  # base + deleted gsi2
+
+    def test_update_upsert_charges_new_index_on_base_key(self, dynamodb_client):
+        """A missing item has no old GSI entry even when the GSI reuses its base key."""
+        with scoped_table(
+            dynamodb_client,
+            attribute_definitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+            key_schema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "gsi_pk",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "KEYS_ONLY"},
+                }
+            ],
+        ) as table:
+            resp = dynamodb_client.update_item(
+                TableName=table,
+                Key={"pk": {"S": "upsert"}},
+                UpdateExpression="SET #attr = :value",
+                ExpressionAttributeNames={"#attr": "other"},
+                ExpressionAttributeValues={":value": {"S": "created"}},
+                ReturnConsumedCapacity="INDEXES",
+            )
+            cc = resp["ConsumedCapacity"]
+            assert cc["GlobalSecondaryIndexes"]["gsi_pk"]["CapacityUnits"] == 1.0
+            assert cc["CapacityUnits"] == 2.0  # base insert + GSI insert
+
     def test_put_item_total_aggregate_includes_gsis(self, dynamodb_client, two_gsi_table):
         """TOTAL: aggregate counts base + affected GSIs, but no breakdown maps."""
         resp = dynamodb_client.put_item(
@@ -1521,6 +1597,17 @@ class TestConsumedCapacityIndexes:
             assert cc["Table"]["CapacityUnits"] == 2.0  # ~2 KB base item
             assert cc["GlobalSecondaryIndexes"]["gsi_ko"]["CapacityUnits"] == 1.0  # keys only
             assert cc["CapacityUnits"] == 3.0
+
+            update = dynamodb_client.update_item(
+                TableName=table,
+                Key={"pk": {"S": "a"}},
+                UpdateExpression="SET big = :value",
+                ExpressionAttributeValues={":value": {"S": "y" * 2000}},
+                ReturnConsumedCapacity="INDEXES",
+            )
+            update_cc = update["ConsumedCapacity"]
+            assert "GlobalSecondaryIndexes" not in update_cc
+            assert update_cc["CapacityUnits"] == update_cc["Table"]["CapacityUnits"]
 
     def test_lsi_write_reports_local_secondary_index_breakdown(self, dynamodb_client):
         """An LSI is reported under LocalSecondaryIndexes and added to the total.

--- a/tests/test_item_operations.py
+++ b/tests/test_item_operations.py
@@ -1392,6 +1392,103 @@ class TestUpdateItemWCU:
         assert "WriteCapacityUnits" not in cap
 
 
+def _gsi(name, key_attr):
+    return {
+        "IndexName": name,
+        "KeySchema": [{"AttributeName": key_attr, "KeyType": "HASH"}],
+        "Projection": {"ProjectionType": "ALL"},
+    }
+
+
+class TestConsumedCapacityIndexes:
+    """Per-index consumed capacity (INDEXES/TOTAL) for single-item writes.
+
+    Complements TestUpdateItemWCU (which uses a non-GSI table and only checks
+    the Table sub-field) by exercising the actual GlobalSecondaryIndexes
+    breakdown and the base + Σ(GSI) aggregate on a table with two GSIs.
+    """
+
+    @pytest.fixture(scope="class")
+    def two_gsi_table(self, dynamodb_client):
+        with scoped_table(
+            dynamodb_client,
+            attribute_definitions=[
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "g1", "AttributeType": "S"},
+                {"AttributeName": "g2", "AttributeType": "S"},
+            ],
+            key_schema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            GlobalSecondaryIndexes=[_gsi("gsi1", "g1"), _gsi("gsi2", "g2")],
+        ) as name:
+            yield name
+
+    def test_put_item_indexes_per_index_breakdown(self, dynamodb_client, two_gsi_table):
+        """PutItem projecting into both GSIs: total = 1 base + 2 GSIs = 3."""
+        resp = dynamodb_client.put_item(
+            TableName=two_gsi_table,
+            Item={"pk": {"S": "a"}, "g1": {"S": "x"}, "g2": {"S": "y"}},
+            ReturnConsumedCapacity="INDEXES",
+        )
+        cc = resp["ConsumedCapacity"]
+        assert cc["CapacityUnits"] == 3.0
+        assert cc["Table"]["CapacityUnits"] == 1.0
+        gsis = cc["GlobalSecondaryIndexes"]
+        assert set(gsis) == {"gsi1", "gsi2"}
+        assert gsis["gsi1"]["CapacityUnits"] == 1.0
+        assert gsis["gsi2"]["CapacityUnits"] == 1.0
+
+    def test_put_item_indexes_sparse(self, dynamodb_client, two_gsi_table):
+        """Item missing g2 projects only into gsi1: total = 1 base + 1 GSI = 2."""
+        resp = dynamodb_client.put_item(
+            TableName=two_gsi_table,
+            Item={"pk": {"S": "b"}, "g1": {"S": "x"}},
+            ReturnConsumedCapacity="INDEXES",
+        )
+        cc = resp["ConsumedCapacity"]
+        assert cc["CapacityUnits"] == 2.0
+        assert set(cc["GlobalSecondaryIndexes"]) == {"gsi1"}
+
+    def test_put_item_total_aggregate_includes_gsis(self, dynamodb_client, two_gsi_table):
+        """TOTAL: aggregate counts base + affected GSIs, but no breakdown maps."""
+        resp = dynamodb_client.put_item(
+            TableName=two_gsi_table,
+            Item={"pk": {"S": "c"}, "g1": {"S": "x"}, "g2": {"S": "y"}},
+            ReturnConsumedCapacity="TOTAL",
+        )
+        cc = resp["ConsumedCapacity"]
+        assert "GlobalSecondaryIndexes" not in cc
+        assert "Table" not in cc
+        assert cc["CapacityUnits"] == 3.0
+
+    def test_delete_item_indexes_per_index_breakdown(self, dynamodb_client, two_gsi_table):
+        """DeleteItem propagates to both GSIs: total = 1 base + 2 GSIs = 3."""
+        dynamodb_client.put_item(
+            TableName=two_gsi_table,
+            Item={"pk": {"S": "d"}, "g1": {"S": "x"}, "g2": {"S": "y"}},
+        )
+        resp = dynamodb_client.delete_item(
+            TableName=two_gsi_table,
+            Key={"pk": {"S": "d"}},
+            ReturnConsumedCapacity="INDEXES",
+        )
+        cc = resp["ConsumedCapacity"]
+        assert cc["CapacityUnits"] == 3.0
+        assert set(cc["GlobalSecondaryIndexes"]) == {"gsi1", "gsi2"}
+
+    def test_update_item_indexes_per_index_breakdown(self, dynamodb_client, two_gsi_table):
+        """UpdateItem resulting in projection into both GSIs: total = 3."""
+        resp = dynamodb_client.update_item(
+            TableName=two_gsi_table,
+            Key={"pk": {"S": "e"}},
+            UpdateExpression="SET g1 = :a, g2 = :b",
+            ExpressionAttributeValues={":a": {"S": "x"}, ":b": {"S": "y"}},
+            ReturnConsumedCapacity="INDEXES",
+        )
+        cc = resp["ConsumedCapacity"]
+        assert cc["CapacityUnits"] == 3.0
+        assert set(cc["GlobalSecondaryIndexes"]) == {"gsi1", "gsi2"}
+
+
 # ---------------------------------------------------------------------------
 # Number sizing uses DynamoDB formula (a787349)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Implementing index consumed capacity accounting for the single item write operations: PutItem, UpdateItem, DeleteItem

### Deferred Changes
  
 Support for per index breakdowns for TransactWriteItems and BatchWriteItem not included, as it requires some material further changes in the storage layer with DataEngine traits, will be addressed in a followup. Also, exact byte sizing would still be a broader issue, and will resolved its own item size formula gap fix

## Why

Requests with the `ReturnConsumedCapacity` parameter set to 'INDEXES' on a table with secondary indexes was returning only the base table number, with no per-index breakdown. `TOTAL` mode also under counted, reporting only the base-table units.

ConsumedCapacity was previously hardcoded as none for GSIs/LSIs, so the breakdown was never populated and the aggregate never included index writes.

## Testing done

- New consumed capacity index python tests added and verified against local ExtendDDB Postgres server and server side DDB
- Rust tests padding
- Existing consumed capacity tests all passing as expected
- Previously failing index consumed capacity server side DDB functional tests now passing

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
