### PR TITLE
fix: return ResourceNotFoundException for data-plane ops

### DIFF
--- a/crates/storage-postgres/src/data/ddl.rs
+++ b/crates/storage-postgres/src/data/ddl.rs
@@ -277,8 +277,15 @@ impl PostgresEngine {
         let (ks_json, ad_json, status, table_id, stream_spec_json, has_lsi) =
             row.ok_or_else(|| StorageError::TableNotFound(table_name.to_owned()))?;
 
-        if status != "ACTIVE" {
-            return Err(StorageError::TableNotActive(table_name.to_owned()));
+        match status.as_str() {
+            "ACTIVE" => {}
+            // A table that is still being created, or is being deleted, is not
+            // usable for data-plane operations; DynamoDB reports it as not found
+            // (not as in-use). UPDATING keeps the not-active classification.
+            "CREATING" | "DELETING" => {
+                return Err(StorageError::TableNotFound(table_name.to_owned()));
+            }
+            _ => return Err(StorageError::TableNotActive(table_name.to_owned())),
         }
 
         let key_schema: Vec<KeySchemaElement> =
@@ -327,8 +334,15 @@ impl PostgresEngine {
         let (table_id, status) =
             row.ok_or_else(|| StorageError::TableNotFound(table_name.to_owned()))?;
 
-        if status != "ACTIVE" {
-            return Err(StorageError::TableNotActive(table_name.to_owned()));
+        match status.as_str() {
+            "ACTIVE" => {}
+            // A table that is still being created, or is being deleted, is not
+            // usable for data-plane operations; DynamoDB reports it as not found
+            // (not as in-use). UPDATING keeps the not-active classification.
+            "CREATING" | "DELETING" => {
+                return Err(StorageError::TableNotFound(table_name.to_owned()));
+            }
+            _ => return Err(StorageError::TableNotActive(table_name.to_owned())),
         }
 
         self.fetch_index_info_by_table_id(&table_id, index_name)

--- a/tests/rust/src/put_item.rs
+++ b/tests/rust/src/put_item.rs
@@ -447,3 +447,58 @@ async fn put_item_without_gsi_key_attributes() {
         .unwrap();
     check_item(c, &t.simple_key_string_gsi, &item).await;
 }
+
+/// A data-plane operation against a table still in `CREATING` returns
+/// `ResourceNotFoundException` (not `ResourceInUseException`), matching
+/// DynamoDB — a table being created is not yet usable and reports as not found.
+///
+/// Gated to the local server: it relies on the control-plane delay that holds a
+/// freshly-created table in `CREATING`; real DynamoDB creation timing differs.
+#[tokio::test]
+async fn put_item_on_creating_table_returns_not_found() {
+    if is_real_dynamodb() {
+        return;
+    }
+    use aws_sdk_dynamodb::types::{
+        AttributeDefinition, BillingMode, KeySchemaElement, KeyType, ScalarAttributeType,
+    };
+    let c = client();
+    let table = format!("CreatingInflux_{}", ts());
+    c.create_table()
+        .table_name(&table)
+        .billing_mode(BillingMode::PayPerRequest)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name(HASH_KEY_S)
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name(HASH_KEY_S)
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Do NOT wait for ACTIVE — the table is still CREATING here.
+    let err = c
+        .put_item()
+        .table_name(&table)
+        .item(HASH_KEY_S, s("k1"))
+        .send()
+        .await
+        .expect_err("PutItem against a CREATING table must fail");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("ResourceNotFoundException") || msg.contains("Requested resource not found"),
+        "expected ResourceNotFoundException for a CREATING table, got: {msg}"
+    );
+
+    wait_for_active(c, &table).await;
+    c.delete_table().table_name(&table).send().await.ok();
+}


### PR DESCRIPTION
## What

Return `ResourceNotFoundException` for data-plane operations against a table that is still being created (or is being deleted).

Data-plane operations (`GetItem`, `PutItem`, `UpdateItem`, `DeleteItem`, and the `BatchGetItem` / `BatchWriteItem` variants) against a table in the `CREATING` state returned `ResourceInUseException`. This classifies a table in `CREATING`
or `DELETING` as not found on the data-plane key/index lookups, so those operations return `ResourceNotFoundException` ("Requested resource not found"). `UPDATING` keeps the existing not-active classification, and control-plane operations are unchanged.

## Why

DynamoDB reports a table that is still being created as not found for data-plane operations, the table is not yet usable, rather than in-use. The engine collapsed every non-`ACTIVE` status to a single in-use error, so the error class diverged for the created-but-not-yet-active window. The correct behavior was confirmed against the real DynamoDB service.

Closes #

## Testing done

- Verified against the real DynamoDB service (us-east-1): a `PutItem` / `UpdateItem` / `GetItem` issued while a table is `CREATING` returns `ResourceNotFoundException: Requested resource not found`.
- Verified against the local server (control-plane delay holding the table in `CREATING`): `GetItem`, `PutItem`, `UpdateItem`, `BatchWriteItem`, and `BatchGetItem` all return `ResourceNotFoundException`, matching real DynamoDB.
- Integration test: a `PutItem` against a `CREATING` table asserts `ResourceNotFoundException`.
- `cargo test -p extenddb-storage-postgres` unit pass; integration test passes; `cargo clippy --workspace --all-targets` and `cargo fmt --all -- --check` clean.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a -- no change to wire protocol, `Storage` trait, auth model,
on-disk format, or public CLI surface. Error-class correctness only.

## Breaking changes

None. A request that previously returned the wrong error class (`ResourceInUseException`) for a table being created now returns the DynamoDB-correct `ResourceNotFoundException`; behavior for `ACTIVE` (and `UPDATING`) tables is unchanged.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.