### PR TITLE
fix: TWI API idempotency account scope

### DIFF
--- a/crates/engine/src/transact_write_items.rs
+++ b/crates/engine/src/transact_write_items.rs
@@ -127,12 +127,17 @@ pub async fn handle_transact_write_items(
         validate_client_request_token(token)?;
     }
 
-    let token_pair = input
-        .client_request_token
-        .as_deref()
-        .map(|t| (t, fingerprint.as_str()));
+    let idempotency =
+        input
+            .client_request_token
+            .as_deref()
+            .map(|t| extenddb_storage::IdempotencyKey {
+                account_id: ctx.account_id.as_ref(),
+                token: t,
+                fingerprint: fingerprint.as_str(),
+            });
 
-    match ctx.storage.transact_write_items(&ops, token_pair).await {
+    match ctx.storage.transact_write_items(&ops, idempotency).await {
         Ok(()) => {}
         Err(extenddb_storage::error::StorageError::IdempotentReplay) => {
             let output = TransactWriteItemsOutput {

--- a/crates/storage-postgres/data_migrations/003_idempotency_account_scope.sql
+++ b/crates/storage-postgres/data_migrations/003_idempotency_account_scope.sql
@@ -1,0 +1,33 @@
+-- Copyright 2026 ExtendDB contributors
+-- SPDX-License-Identifier: Apache-2.0
+-- Scope idempotency tokens per account.
+--
+-- A ClientRequestToken is unique per account in Amazon DynamoDB, not globally.
+-- The original table keyed on `token` alone, so tokens from different accounts
+-- shared one keyspace: an identical token could be treated as a replay of, or a
+-- mismatch against, an unrelated account's transaction. Re-key on
+-- (account_id, token) to match every other account-scoped table.
+--
+-- Tokens are an ephemeral dedup cache with a ~10 minute TTL, so the table is
+-- recreated rather than back-filled: any in-flight token simply re-registers
+-- under its account on the next request. A client retry that straddles this
+-- migration loses dedup and may re-apply a non-idempotent transaction, which is
+-- acceptable for a short-lived cache. Apply data migrations during the
+-- stop / migrate / restart upgrade sequence to bound that window.
+
+BEGIN;
+
+DROP TABLE IF EXISTS idempotency_tokens;
+
+CREATE TABLE idempotency_tokens (
+    account_id  TEXT NOT NULL,
+    token       TEXT NOT NULL,
+    fingerprint TEXT NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (account_id, token)
+);
+
+CREATE INDEX idx_idempotency_tokens_created
+    ON idempotency_tokens (created_at);
+
+COMMIT;

--- a/crates/storage-postgres/migrations/001_schema.sql
+++ b/crates/storage-postgres/migrations/001_schema.sql
@@ -220,6 +220,9 @@ CREATE TABLE IF NOT EXISTS iam_permissions_boundaries (
 );
 
 -- Idempotency tokens for TransactWriteItems.
+-- Vestigial in the catalog database: at runtime tokens are read and written via
+-- the data database (see data_migrations 001 + 003, keyed on
+-- (account_id, token)). This catalog copy is unused; do not wire it up.
 CREATE TABLE IF NOT EXISTS idempotency_tokens (
     token       TEXT PRIMARY KEY,
     fingerprint TEXT NOT NULL,

--- a/crates/storage-postgres/src/data/data_engine.rs
+++ b/crates/storage-postgres/src/data/data_engine.rs
@@ -7,7 +7,7 @@
 use extenddb_core::expression::{Expr, ExpressionMaps, KeyCondition, UpdateAction};
 use extenddb_core::types::{Item, TableKeyInfo};
 use extenddb_storage::error::StorageError;
-use extenddb_storage::{DataEngine, StreamCapture, TransactGetOp, TransactWriteOp};
+use extenddb_storage::{DataEngine, IdempotencyKey, StreamCapture, TransactGetOp, TransactWriteOp};
 use futures::future::BoxFuture;
 
 use crate::PostgresEngine;
@@ -184,7 +184,7 @@ impl DataEngine for PostgresEngine {
     fn transact_write_items(
         &self,
         ops: &[TransactWriteOp<'_>],
-        token: Option<(&str, &str)>,
+        idempotency: Option<IdempotencyKey<'_>>,
     ) -> BoxFuture<'_, Result<(), StorageError>> {
         // Clone ops to owned data - unavoidable due to lifetime constraints
         let owned_ops: Vec<_> = ops
@@ -264,7 +264,13 @@ impl DataEngine for PostgresEngine {
                 ),
             })
             .collect();
-        let token = token.map(|(a, b)| (a.to_string(), b.to_string()));
+        let idempotency = idempotency.map(|k| {
+            (
+                k.account_id.to_string(),
+                k.token.to_string(),
+                k.fingerprint.to_string(),
+            )
+        });
 
         Box::pin(async move {
             // Reconstruct borrowed ops from owned data
@@ -322,7 +328,13 @@ impl DataEngine for PostgresEngine {
                 .collect();
             self.transact_write_items_impl(
                 &borrowed_ops,
-                token.as_ref().map(|(a, b)| (a.as_str(), b.as_str())),
+                idempotency
+                    .as_ref()
+                    .map(|(account_id, token, fingerprint)| IdempotencyKey {
+                        account_id,
+                        token,
+                        fingerprint,
+                    }),
             )
             .await
         })

--- a/crates/storage-postgres/src/data/transactions.rs
+++ b/crates/storage-postgres/src/data/transactions.rs
@@ -11,7 +11,7 @@ use extenddb_core::types::{
 };
 use extenddb_core::validation;
 use extenddb_storage::error::StorageError;
-use extenddb_storage::{TransactGetOp, TransactWriteOp};
+use extenddb_storage::{IdempotencyKey, TransactGetOp, TransactWriteOp};
 
 use super::index::{IndexMeta, enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
 use super::tx_helpers::{
@@ -70,7 +70,7 @@ impl PostgresEngine {
     pub(crate) async fn transact_write_items_impl(
         &self,
         ops: &[TransactWriteOp<'_>],
-        token: Option<(&str, &str)>,
+        idempotency: Option<IdempotencyKey<'_>>,
     ) -> Result<(), StorageError> {
         // Pre-fetch indexes for each unique table involved in the transaction.
         let mut table_indexes: HashMap<String, Vec<IndexMeta>> = HashMap::new();
@@ -94,9 +94,11 @@ impl PostgresEngine {
             .await
             .map_err(|e| StorageError::Internal(e.to_string()))?;
 
-        // Check idempotency token within the transaction (BLOCKER #2 fix).
-        if let Some((tok, fp)) = token {
-            check_idempotency_token_in_tx(&mut tx, tok, fp).await?;
+        // Check the idempotency token within the transaction so token storage
+        // and data writes commit together. The token is scoped to its account.
+        if let Some(key) = idempotency {
+            check_idempotency_token_in_tx(&mut tx, key.account_id, key.token, key.fingerprint)
+                .await?;
         }
 
         let mut reasons: Vec<CancellationReason> = Vec::with_capacity(ops.len());

--- a/crates/storage-postgres/src/data/tx_helpers.rs
+++ b/crates/storage-postgres/src/data/tx_helpers.rs
@@ -333,19 +333,22 @@ pub(super) async fn write_stream_record_in_tx(
 
 /// Check an idempotency token within an existing transaction.
 ///
-/// Returns `Ok(())` for new tokens (inserted), `Err(IdempotentReplay)` for
-/// matching replays, `Err(IdempotentMismatch)` for fingerprint conflicts.
+/// The token is scoped to `account_id`: the same token value from different
+/// accounts is stored and matched independently. Returns `Ok(())` for new
+/// tokens (inserted), `Err(IdempotentReplay)` for matching replays,
+/// `Err(IdempotentMismatch)` for fingerprint conflicts.
 pub(super) async fn check_idempotency_token_in_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    account_id: &str,
     token: &str,
     fingerprint: &str,
 ) -> Result<(), StorageError> {
     let row: Option<(String, bool)> = sqlx::query_as(
         r"WITH ins AS (
-            INSERT INTO idempotency_tokens (token, fingerprint)
-            VALUES ($1, $2)
-            ON CONFLICT (token) DO UPDATE
-                SET fingerprint = $2, created_at = NOW()
+            INSERT INTO idempotency_tokens (account_id, token, fingerprint)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (account_id, token) DO UPDATE
+                SET fingerprint = $3, created_at = NOW()
                 WHERE idempotency_tokens.created_at <= NOW() - INTERVAL '10 minutes'
             RETURNING fingerprint, TRUE AS inserted
           )
@@ -353,11 +356,13 @@ pub(super) async fn check_idempotency_token_in_tx(
           UNION ALL
           SELECT fingerprint, FALSE AS inserted
           FROM idempotency_tokens
-          WHERE token = $1
+          WHERE account_id = $1
+            AND token = $2
             AND created_at > NOW() - INTERVAL '10 minutes'
             AND NOT EXISTS (SELECT 1 FROM ins)
           LIMIT 1",
     )
+    .bind(account_id)
     .bind(token)
     .bind(fingerprint)
     .fetch_optional(&mut **tx)

--- a/crates/storage-postgres/src/migrations.rs
+++ b/crates/storage-postgres/src/migrations.rs
@@ -43,6 +43,10 @@ pub(crate) const DATA_MIGRATIONS: &[(&str, &str)] = &[
         "002_gsi_pending.sql",
         include_str!("../../storage-postgres/data_migrations/002_gsi_pending.sql"),
     ),
+    (
+        "003_idempotency_account_scope.sql",
+        include_str!("../../storage-postgres/data_migrations/003_idempotency_account_scope.sql"),
+    ),
 ];
 
 /// Run data database migrations, skipping already-applied ones.

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -20,7 +20,7 @@ pub mod server_components;
 pub mod settings_store;
 pub mod transact;
 
-pub use transact::{TransactGetOp, TransactWriteOp};
+pub use transact::{IdempotencyKey, TransactGetOp, TransactWriteOp};
 
 pub use server_components::{
     BackendError, ServerComponents, ServerComponentsFactory, ServerComponentsRegistration,
@@ -313,8 +313,10 @@ pub trait DataEngine: Send + Sync {
     /// When `stream` is `Some`, stream records for each write operation are
     /// inserted in the same transaction as the data writes.
     ///
-    /// When `token` is `Some`, the idempotency token is checked and stored
-    /// in the same transaction as the writes, guaranteeing atomicity.
+    /// When `idempotency` is `Some`, the token is checked and stored in the
+    /// same transaction as the writes, guaranteeing atomicity. The token is
+    /// scoped to its account, so the same token value from different accounts
+    /// never collides.
     ///
     /// # Errors
     ///
@@ -322,11 +324,10 @@ pub trait DataEngine: Send + Sync {
     /// Returns [`StorageError::Internal`] on transaction or query failure.
     /// Returns [`StorageError::IdempotentReplay`] if the token matches a previous request.
     /// Returns [`StorageError::IdempotentMismatch`] if the token exists with different ops.
-    #[allow(clippy::too_many_arguments)]
     fn transact_write_items(
         &self,
         ops: &[TransactWriteOp<'_>],
-        token: Option<(&str, &str)>,
+        idempotency: Option<IdempotencyKey<'_>>,
     ) -> BoxFuture<'_, Result<(), StorageError>>;
 
     /// Delete idempotency tokens older than the given age in seconds.

--- a/crates/storage/src/transact.rs
+++ b/crates/storage/src/transact.rs
@@ -9,6 +9,21 @@ use extenddb_core::types::{Item, ReturnValuesOnConditionCheckFailure, TableKeyIn
 
 use crate::StreamCapture;
 
+/// Idempotency scope for a `TransactWriteItems` request.
+///
+/// A `ClientRequestToken` is unique per account in Amazon DynamoDB, not
+/// globally, so the token is stored and looked up under `(account_id, token)`.
+/// `fingerprint` distinguishes a genuine replay from a reused token carrying a
+/// different request, within that same account scope.
+pub struct IdempotencyKey<'a> {
+    /// Account that owns the token. Scopes the dedup keyspace.
+    pub account_id: &'a str,
+    /// The client-supplied `ClientRequestToken`.
+    pub token: &'a str,
+    /// Collision-resistant fingerprint of the request payload.
+    pub fingerprint: &'a str,
+}
+
 /// A single get operation within a transactional read.
 pub struct TransactGetOp<'a> {
     /// Table metadata.

--- a/docs/design/04-component-storage.md
+++ b/docs/design/04-component-storage.md
@@ -739,27 +739,32 @@ arithmetic assigns each partition key to exactly one segment, ensuring:
 
 ## 9. Idempotency Token Storage
 
-`TransactWriteItems` supports `ClientRequestToken` for idempotency. Tokens are stored in a dedicated table:
+`TransactWriteItems` supports `ClientRequestToken` for idempotency. Tokens are stored in a dedicated table, scoped per account:
 
 ```sql
-CREATE TABLE _dynamodb_idempotency_tokens (
-    client_request_token TEXT PRIMARY KEY,
-    response JSONB NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE idempotency_tokens (
+    account_id  TEXT NOT NULL,
+    token       TEXT NOT NULL,
+    fingerprint TEXT NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (account_id, token)
 );
-CREATE INDEX ON _dynamodb_idempotency_tokens(created_at);
+CREATE INDEX ON idempotency_tokens(created_at);
 ```
 
 **Flow:**
-1. Before executing a transaction, check if the token exists
-2. If found: return the stored response (idempotent replay)
-3. If not found: execute the transaction, store the token + response
-   atomically in the same PostgreSQL transaction
+1. Before executing a transaction, look up `(account_id, token)`
+2. If found with a matching fingerprint: treat as an idempotent replay and
+   return success without re-applying the writes
+3. If not found: execute the transaction and store `(account_id, token,
+   fingerprint)` atomically in the same PostgreSQL transaction
 4. Background cleanup: delete tokens older than 10 minutes (matching
    DynamoDB's idempotency window)
 
-If a request arrives with the same token but different parameters, return
-`IdempotentParameterMismatchException`.
+The token is scoped to `account_id`: a `ClientRequestToken` is unique per
+account in DynamoDB, so the same token value from two accounts never collides.
+If a request arrives with the same `(account_id, token)` but a different
+fingerprint, return `IdempotentParameterMismatchException`.
 
 ## 10. Backend Plugin Architecture
 

--- a/docs/manuals/12-extending-extenddb-storage.md
+++ b/docs/manuals/12-extending-extenddb-storage.md
@@ -92,7 +92,7 @@ Item CRUD, query, scan, and transaction operations:
 Key design decisions:
 - **Condition expressions** are evaluated inside the storage transaction. The engine parses and compiles expressions; the storage layer receives an AST (`Expr`) and evaluates it against the existing item within the same transaction that performs the write. This is critical for correctness — condition checks and writes must be atomic.
 - **Stream capture** is passed as `Option<&StreamCapture>`. When present, the stream record must be written in the same transaction as the data write.
-- **Idempotency tokens** for `TransactWriteItems` must be checked and stored atomically with the writes.
+- **Idempotency tokens** for `TransactWriteItems` must be checked and stored atomically with the writes, and must be scoped per account: a `ClientRequestToken` is unique per account in DynamoDB, not globally, so the store must key on `(account_id, token)`. Keying on the token alone lets the same token value from two accounts collide (one account's transaction wrongly replayed or rejected against another's).
 - **Items** are `BTreeMap<String, AttributeValue>`. A new backend must handle the full `AttributeValue` type (S, N, B, SS, NS, BS, L, M, BOOL, NULL).
 - **Query** must support forward/reverse sort order, exclusive start key pagination, and routing to secondary index storage.
 - **Parallel scan** uses `segment` and `total_segments` to partition the keyspace.

--- a/tests/test_idempotency_account_scope.py
+++ b/tests/test_idempotency_account_scope.py
@@ -1,0 +1,277 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Idempotency token (ClientRequestToken) scoping for TransactWriteItems.
+
+Amazon DynamoDB scopes a ClientRequestToken's uniqueness per account (and
+region), not globally. Two behaviors follow:
+
+  * Single account: replaying the same token with an identical request is
+    idempotent (applied at most once), and reusing the same token with a
+    different request is rejected with IdempotentParameterMismatchException.
+  * Two accounts: the same token value used by different accounts must not
+    collide. One account's token can neither suppress (idempotent replay)
+    nor reject (parameter mismatch) another account's transaction.
+
+The single-account cases run against both Amazon DynamoDB and ExtendDB. The
+cross-account isolation case needs two accounts provisioned through the
+management API, so it runs against ExtendDB only (a single AWS profile is one
+account and cannot exercise a cross-account collision).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+import boto3
+import pytest
+from botocore.config import Config as BotoConfig
+from botocore.exceptions import ClientError
+
+from conftest import wait_for_active, wait_for_deleted
+from management_helpers import ManagementClient
+
+
+# ---------------------------------------------------------------------------
+# Single-account behavior (dual-target: Amazon DynamoDB + ExtendDB)
+# ---------------------------------------------------------------------------
+
+
+def _simple_table(client, table_name: str) -> None:
+    client.create_table(
+        TableName=table_name,
+        AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    wait_for_active(client, table_name)
+
+
+def _add_one(client, table_name: str, token: str, key: str = "k", amount: int = 1):
+    """TransactWriteItems that increments a counter by ``amount`` (non-idempotent
+    op, so a wrongly-replayed transaction is observable as a double count)."""
+    return client.transact_write_items(
+        ClientRequestToken=token,
+        TransactItems=[
+            {
+                "Update": {
+                    "TableName": table_name,
+                    "Key": {"pk": {"S": key}},
+                    "UpdateExpression": "ADD #c :n",
+                    "ExpressionAttributeNames": {"#c": "count"},
+                    "ExpressionAttributeValues": {":n": {"N": str(amount)}},
+                }
+            }
+        ],
+    )
+
+
+def _count(client, table_name: str, key: str = "k") -> int:
+    item = client.get_item(
+        TableName=table_name, Key={"pk": {"S": key}}, ConsistentRead=True
+    ).get("Item")
+    return int(item["count"]["N"]) if item and "count" in item else 0
+
+
+def test_replay_same_token_same_payload_is_idempotent(dynamodb_client, unique_table_name):
+    """Same token + identical request applies exactly once (no double count)."""
+    _simple_table(dynamodb_client, unique_table_name)
+    try:
+        token = f"tok-{uuid.uuid4().hex[:12]}"
+        _add_one(dynamodb_client, unique_table_name, token)
+        assert _count(dynamodb_client, unique_table_name) == 1
+        # Replaying the exact same request is a no-op that returns success.
+        _add_one(dynamodb_client, unique_table_name, token)
+        assert _count(dynamodb_client, unique_table_name) == 1
+    finally:
+        dynamodb_client.delete_table(TableName=unique_table_name)
+        wait_for_deleted(dynamodb_client, unique_table_name)
+
+
+def test_same_token_different_payload_is_rejected(dynamodb_client, unique_table_name):
+    """Reusing a token with a different request is rejected as a mismatch."""
+    _simple_table(dynamodb_client, unique_table_name)
+    try:
+        token = f"tok-{uuid.uuid4().hex[:12]}"
+        _add_one(dynamodb_client, unique_table_name, token, amount=1)
+        with pytest.raises(ClientError) as exc:
+            _add_one(dynamodb_client, unique_table_name, token, amount=5)
+        assert (
+            exc.value.response["Error"]["Code"]
+            == "IdempotentParameterMismatchException"
+        )
+        # The rejected transaction must not have applied.
+        assert _count(dynamodb_client, unique_table_name) == 1
+    finally:
+        dynamodb_client.delete_table(TableName=unique_table_name)
+        wait_for_deleted(dynamodb_client, unique_table_name)
+
+
+def test_different_token_writes_independently(dynamodb_client, unique_table_name):
+    """A distinct token applies its own transaction (token-scoped dedup)."""
+    _simple_table(dynamodb_client, unique_table_name)
+    try:
+        _add_one(dynamodb_client, unique_table_name, f"tok-{uuid.uuid4().hex[:12]}")
+        _add_one(dynamodb_client, unique_table_name, f"tok-{uuid.uuid4().hex[:12]}")
+        assert _count(dynamodb_client, unique_table_name) == 2
+    finally:
+        dynamodb_client.delete_table(TableName=unique_table_name)
+        wait_for_deleted(dynamodb_client, unique_table_name)
+
+
+# ---------------------------------------------------------------------------
+# Cross-account isolation (ExtendDB only: needs two accounts via management API)
+# ---------------------------------------------------------------------------
+
+
+def _require_auth_env() -> tuple[str, str, str]:
+    endpoint = os.environ.get("EXTENDDB_TEST_ENDPOINT", "").strip()
+    admin_user = os.environ.get("EXTENDDB_ADMIN_USER", "").strip()
+    admin_pass = os.environ.get("EXTENDDB_ADMIN_PASSWORD", "").strip()
+    if not endpoint:
+        pytest.skip("cross-account isolation runs against ExtendDB only")
+    if not admin_user or not admin_pass:
+        pytest.fail(
+            "MISCONFIGURED: cross-account tests require EXTENDDB_ADMIN_USER and "
+            "EXTENDDB_ADMIN_PASSWORD (set by devtools/run-tests)."
+        )
+    return endpoint, admin_user, admin_pass
+
+
+def _make_client(endpoint_url: str, access_key: str, secret_key: str, region: str) -> Any:
+    kwargs: dict = dict(
+        service_name="dynamodb",
+        endpoint_url=endpoint_url,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name=region,
+        config=BotoConfig(retries={"max_attempts": 0}),
+    )
+    if endpoint_url.startswith("https://"):
+        kwargs["verify"] = False
+    return boto3.client(**kwargs)
+
+
+def _full_access_policy() -> dict:
+    return {
+        "Version": "2012-10-17",
+        "Statement": [{"Effect": "Allow", "Action": "dynamodb:*", "Resource": "*"}],
+    }
+
+
+@pytest.fixture()
+def two_account_clients():
+    """Provision two independent accounts, each with a full-access user.
+
+    Yields ``(client_a, client_b)`` bound to distinct accounts. Both accounts
+    create an identically-named table so that a shared ClientRequestToken with
+    an identical payload produces an identical server-side fingerprint, which
+    is exactly the condition that made a global token keyspace collide.
+    """
+    endpoint, admin_user, admin_pass = _require_auth_env()
+    region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+    mgmt = ManagementClient(endpoint, admin_user, admin_pass)
+
+    made: list[tuple[str, str]] = []
+
+    def provision(user: str, password: str):
+        acct_id = f"{uuid.uuid4().int % 10**12:012d}"
+        assert mgmt.create_account(acct_id, f"{user}-{acct_id}").status_code == 201
+        assert mgmt.create_user(acct_id, user, password).status_code == 201
+        made.append((acct_id, user))
+        resp = mgmt.create_access_key(acct_id, user)
+        assert resp.status_code == 201, resp.text
+        creds = resp.json()
+        assert mgmt.put_user_policy(acct_id, user, "full", _full_access_policy()).status_code == 204
+        return _make_client(endpoint, creds["access_key_id"], creds["secret_access_key"], region)
+
+    client_a = provision("acct-a", "AcctAPass123!")
+    client_b = provision("acct-b", "AcctBPass456!")
+    try:
+        yield client_a, client_b
+    finally:
+        for acct_id, user in made:
+            try:
+                mgmt.delete_user(acct_id, user)
+                mgmt.delete_account(acct_id)
+            except Exception:
+                pass
+
+
+def _put(client, table_name: str, token: str, value: str):
+    return client.transact_write_items(
+        ClientRequestToken=token,
+        TransactItems=[
+            {"Put": {"TableName": table_name, "Item": {"pk": {"S": "k"}, "v": {"S": value}}}}
+        ],
+    )
+
+
+def test_cross_account_same_token_same_payload_not_deduped(two_account_clients):
+    """A token used by account A must not suppress account B's identical write.
+
+    Both accounts use the same table name and the same payload, so the token
+    and the request fingerprint match exactly. That is the mode-1 collision: a
+    global token keyspace treats B's request as an idempotent replay of A's and
+    returns success without applying it, silently dropping B's write. Account
+    scoping must let B's write land in B's own table.
+    """
+    client_a, client_b = two_account_clients
+    table = f"idem-{uuid.uuid4().hex[:8]}"
+    token = f"tok-{uuid.uuid4().hex[:12]}"
+    _simple_table(client_a, table)
+    _simple_table(client_b, table)
+    try:
+        # Identical value under both accounts -> identical fingerprint.
+        _put(client_a, table, token, "shared")
+        _put(client_b, table, token, "shared")
+        # B's write must have landed in B's own table (not dropped as a replay).
+        b_item = client_b.get_item(
+            TableName=table, Key={"pk": {"S": "k"}}, ConsistentRead=True
+        ).get("Item")
+        assert b_item is not None, (
+            "account B's identical-payload write was dropped as a cross-account replay"
+        )
+        assert b_item["v"]["S"] == "shared"
+        # A's data is present and unchanged.
+        a_item = client_a.get_item(
+            TableName=table, Key={"pk": {"S": "k"}}, ConsistentRead=True
+        )["Item"]
+        assert a_item["v"]["S"] == "shared"
+    finally:
+        for c in (client_a, client_b):
+            try:
+                c.delete_table(TableName=table)
+                wait_for_deleted(c, table)
+            except Exception:
+                pass
+
+
+def test_cross_account_same_token_different_payload_not_rejected(two_account_clients):
+    """A token used by account A must not reject account B's different write.
+
+    A global token keyspace would raise IdempotentParameterMismatchException
+    for B because A already stored the token with a different fingerprint.
+    """
+    client_a, client_b = two_account_clients
+    table = f"idem-{uuid.uuid4().hex[:8]}"
+    token = f"tok-{uuid.uuid4().hex[:12]}"
+    _simple_table(client_a, table)
+    _simple_table(client_b, table)
+    try:
+        _put(client_a, table, token, "payload-a")
+        # Different payload under the same token, but a different account.
+        _put(client_b, table, token, "payload-b")
+        b_item = client_b.get_item(
+            TableName=table, Key={"pk": {"S": "k"}}, ConsistentRead=True
+        ).get("Item")
+        assert b_item is not None and b_item["v"]["S"] == "payload-b"
+    finally:
+        for c in (client_a, client_b):
+            try:
+                c.delete_table(TableName=table)
+                wait_for_deleted(c, table)
+            except Exception:
+                pass


### PR DESCRIPTION
## What

`TransactWriteItems` idempotency tokens were stored keyed on the token alone (`PRIMARY KEY (token)`). A `ClientRequestToken` is unique per account in Amazon DynamoDB, but the Postgres data database is shared, so tokens from different accounts collided.

Re-key `idempotency_tokens` on `(account_id, token)` (new data migration `003`) and thread the caller's account from the `TransactWriteItems` handler into the token check.

## Why

Two accounts sharing one token keyspace violates account isolation:

| Two accounts, same token | Before | After (matches DynamoDB) |
|---|---|---|
| identical request | account B's write silently dropped as a replay | each account applies independently |
| different request | account B rejected with `IdempotentParameterMismatchException` | each account applies independently |

Single-account behavior (replay-idempotent, mismatch, independence) is unchanged.

Closes # n/a.

## Testing done

- New `tests/test_idempotency_account_scope.py`: 3 single-account cases pass against Amazon DynamoDB and ExtendDB; 2 cross-account isolation cases (ExtendDB-only, two accounts) red before, green after.
- `cargo test --workspace`, `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`: clean. No regressions.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a. Refines the internal `DataEngine::transact_write_items` signature (see below).

## Breaking changes

- `DataEngine::transact_write_items` now takes `Option<IdempotencyKey<'_>>` instead of `Option<(&str, &str)>`. Backends must scope their idempotency store on `(account_id, token)`. The SQLite backend (#182) has the same defect and is handled in that PR.
- Migration `003` recreates `idempotency_tokens`. Apply during stop / migrate / restart; a client retry straddling the migration loses dedup for that short-lived cache.
