### PR TITLE
fix: minor parity updates

### DIFF
--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -613,10 +613,50 @@ pub fn validate_update_item(
     validate_key_only(&input.key, key_schema, attr_defs)?;
     validate_key_sizes(&input.key, key_schema, limits)?;
 
-    if let Some(updates) = &input.attribute_updates {
-        validate_attribute_values_nesting_depth(updates.values().filter_map(|u| u.value.as_ref()))?;
+    // Validate number values supplied via ExpressionAttributeValues. Unlike a
+    // PutItem item (validated by validate_item_numbers), these are checked here
+    // because the AttributeValue deserializer intentionally stores malformed
+    // numbers raw and defers rejection to the validation layer. Real DynamoDB
+    // wraps the error as:
+    //   "ExpressionAttributeValues contains invalid value: <inner> for key <k>"
+    if let Some(values) = &input.expression_attribute_values {
+        validate_expression_attribute_value_numbers(values)?;
     }
 
+    if let Some(updates) = &input.attribute_updates {
+        validate_attribute_values_nesting_depth(updates.values().filter_map(|u| u.value.as_ref()))?;
+        // Legacy AttributeUpdates values carry the bare numeric-value message,
+        // matching real DynamoDB (no ExpressionAttributeValues wrapper).
+        for update in updates.values() {
+            if let Some(v) = &update.value {
+                validate_attribute_number(v)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate number values provided via `ExpressionAttributeValues`, matching the
+/// service's wrapped message: `ExpressionAttributeValues contains invalid value:
+/// <inner> for key <placeholder>`. Keys are visited in sorted order so the
+/// reported placeholder is deterministic when several values are invalid.
+fn validate_expression_attribute_value_numbers(
+    values: &std::collections::HashMap<String, AttributeValue>,
+) -> Result<(), DynamoDbError> {
+    let mut keys: Vec<&String> = values.keys().collect();
+    keys.sort();
+    for key in keys {
+        match validate_attribute_number(&values[key]) {
+            Ok(()) => {}
+            Err(DynamoDbError::ValidationException(inner)) => {
+                return Err(DynamoDbError::ValidationException(format!(
+                    "ExpressionAttributeValues contains invalid value: {inner} for key {key}"
+                )));
+            }
+            Err(other) => return Err(other),
+        }
+    }
     Ok(())
 }
 
@@ -1658,6 +1698,96 @@ mod tests {
         let mut input = update_input_no_directives();
         input.update_expression = Some(String::new());
         assert!(validate_update_item(&input, &limits, &key_schema, &attr_defs).is_ok());
+    }
+
+    fn eav_update_input(key: &str, value: AttributeValue) -> UpdateItemInput {
+        let mut input = update_input_no_directives();
+        input.update_expression = Some(format!("SET bad = {key}"));
+        let mut m = std::collections::HashMap::new();
+        m.insert(key.to_owned(), value);
+        input.expression_attribute_values = Some(m);
+        input
+    }
+
+    #[test]
+    fn update_item_rejects_malformed_number_in_eav() {
+        // The AttributeValue deserializer stores malformed numbers raw and
+        // defers rejection here. Matches real DynamoDB's wrapped message.
+        let limits = LimitsConfig::default();
+        let key_schema = vec![make_ks("pk", KeyType::Hash)];
+        let attr_defs = vec![make_ad("pk", ScalarAttributeType::S)];
+        let input = eav_update_input(":v", AttributeValue::N("12e".to_owned()));
+        let err = validate_update_item(&input, &limits, &key_schema, &attr_defs).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "ExpressionAttributeValues contains invalid value: \
+             The parameter cannot be converted to a numeric value: 12e for key :v"
+        );
+    }
+
+    #[test]
+    fn update_item_rejects_number_overflow_in_eav() {
+        let limits = LimitsConfig::default();
+        let key_schema = vec![make_ks("pk", KeyType::Hash)];
+        let attr_defs = vec![make_ad("pk", ScalarAttributeType::S)];
+        let big = format!("1{}", "0".repeat(200));
+        let input = eav_update_input(":v", AttributeValue::N(big));
+        let err = validate_update_item(&input, &limits, &key_schema, &attr_defs).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "ExpressionAttributeValues contains invalid value: \
+             Number overflow. Attempting to store a number with magnitude larger than \
+             supported range for key :v"
+        );
+    }
+
+    #[test]
+    fn update_item_rejects_invalid_number_set_member_in_eav() {
+        let limits = LimitsConfig::default();
+        let key_schema = vec![make_ks("pk", KeyType::Hash)];
+        let attr_defs = vec![make_ad("pk", ScalarAttributeType::S)];
+        let ns: std::collections::BTreeSet<String> =
+            ["1".to_owned(), "abc".to_owned()].into_iter().collect();
+        let input = eav_update_input(":v", AttributeValue::NS(ns));
+        let err = validate_update_item(&input, &limits, &key_schema, &attr_defs).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "ExpressionAttributeValues contains invalid value: \
+             The parameter cannot be converted to a numeric value: abc for key :v"
+        );
+    }
+
+    #[test]
+    fn update_item_accepts_valid_number_in_eav() {
+        let limits = LimitsConfig::default();
+        let key_schema = vec![make_ks("pk", KeyType::Hash)];
+        let attr_defs = vec![make_ad("pk", ScalarAttributeType::S)];
+        let input = eav_update_input(":v", AttributeValue::N("42".to_owned()));
+        assert!(validate_update_item(&input, &limits, &key_schema, &attr_defs).is_ok());
+    }
+
+    #[test]
+    fn update_item_rejects_bad_number_in_attribute_updates() {
+        // Legacy AttributeUpdates path: bare numeric-value message, no
+        // ExpressionAttributeValues wrapper (matches real DynamoDB).
+        let limits = LimitsConfig::default();
+        let key_schema = vec![make_ks("pk", KeyType::Hash)];
+        let attr_defs = vec![make_ad("pk", ScalarAttributeType::S)];
+        let mut input = update_input_no_directives();
+        let mut updates = std::collections::HashMap::new();
+        updates.insert(
+            "bad".to_owned(),
+            crate::types::AttributeValueUpdate {
+                value: Some(AttributeValue::N("not_a_num".to_owned())),
+                action: "PUT".to_owned(),
+            },
+        );
+        input.attribute_updates = Some(updates);
+        let err = validate_update_item(&input, &limits, &key_schema, &attr_defs).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "The parameter cannot be converted to a numeric value: not_a_num"
+        );
     }
 
     fn nested_map(depth: usize) -> AttributeValue {

--- a/crates/core/src/validation/number.rs
+++ b/crates/core/src/validation/number.rs
@@ -14,7 +14,7 @@ pub fn validate_and_normalize_number(s: &str) -> Result<String, DynamoDbError> {
     // genuinely empty string is reported with a distinct message from a
     // malformed-but-non-empty one.
     if s.is_empty() {
-        return Err(number_err());
+        return Err(empty_numeric_err());
     }
 
     let (negative, rest) = match s.strip_prefix('-') {
@@ -75,7 +75,7 @@ pub fn validate_and_normalize_number(s: &str) -> Result<String, DynamoDbError> {
     }
 
     if sig_trimmed.len() > MAX_SIGNIFICANT_DIGITS {
-        return Err(number_err());
+        return Err(too_many_digits_err());
     }
 
     // The exponent for the normalized form:
@@ -90,10 +90,10 @@ pub fn validate_and_normalize_number(s: &str) -> Result<String, DynamoDbError> {
     let magnitude_exp = sig_trimmed.len() as i32 - 1 + point_offset + trailing_zeros as i32;
 
     if magnitude_exp > MAX_EXPONENT {
-        return Err(number_err());
+        return Err(overflow_err());
     }
     if magnitude_exp < MIN_EXPONENT {
-        return Err(number_err());
+        return Err(underflow_err());
     }
 
     // Format the normalized number
@@ -143,9 +143,39 @@ fn format_plain(negative: bool, digits: &str, exp: i32) -> String {
     result
 }
 
-fn number_err() -> DynamoDbError {
+/// Empty number string, e.g. `{"N":""}`. Real `DynamoDB` reports the generic
+/// numeric-conversion failure with no offending value appended (distinct from
+/// the malformed-but-non-empty message, which appends the input).
+fn empty_numeric_err() -> DynamoDbError {
     DynamoDbError::ValidationException(
-        "Supplied AttributeValue is empty, must contain exactly one of the supported datatypes"
+        "The parameter cannot be converted to a numeric value".to_owned(),
+    )
+}
+
+/// More than 38 significant digits. Real `DynamoDB`:
+/// "Attempting to store more than 38 significant digits in a Number".
+fn too_many_digits_err() -> DynamoDbError {
+    DynamoDbError::ValidationException(
+        "Attempting to store more than 38 significant digits in a Number".to_owned(),
+    )
+}
+
+/// Magnitude above the supported exponent ceiling. Real `DynamoDB`:
+/// "Number overflow. Attempting to store a number with magnitude larger than
+/// supported range".
+fn overflow_err() -> DynamoDbError {
+    DynamoDbError::ValidationException(
+        "Number overflow. Attempting to store a number with magnitude larger than supported range"
+            .to_owned(),
+    )
+}
+
+/// Magnitude below the supported exponent floor. Real `DynamoDB`:
+/// "Number underflow. Attempting to store a number with magnitude smaller than
+/// supported range".
+fn underflow_err() -> DynamoDbError {
+    DynamoDbError::ValidationException(
+        "Number underflow. Attempting to store a number with magnitude smaller than supported range"
             .to_owned(),
     )
 }
@@ -190,7 +220,11 @@ mod tests {
     #[test]
     fn rejects_39_significant_digits() {
         let n = "1".repeat(39);
-        assert!(validate_and_normalize_number(&n).is_err());
+        let err = validate_and_normalize_number(&n).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Attempting to store more than 38 significant digits in a Number"
+        );
     }
 
     #[test]
@@ -201,7 +235,11 @@ mod tests {
 
     #[test]
     fn rejects_over_max_positive() {
-        assert!(validate_and_normalize_number("1E126").is_err());
+        let err = validate_and_normalize_number("1E126").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Number overflow. Attempting to store a number with magnitude larger than supported range"
+        );
     }
 
     #[test]
@@ -211,7 +249,11 @@ mod tests {
 
     #[test]
     fn rejects_below_min_positive() {
-        assert!(validate_and_normalize_number("1E-131").is_err());
+        let err = validate_and_normalize_number("1E-131").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Number underflow. Attempting to store a number with magnitude smaller than supported range"
+        );
     }
 
     #[test]
@@ -279,8 +321,14 @@ mod tests {
     }
 
     #[test]
-    fn empty_uses_empty_value_message() {
+    fn empty_uses_numeric_value_message() {
+        // Real DynamoDB reports an empty number string ({"N":""}) as a
+        // numeric-conversion failure with no value appended, distinct from the
+        // empty-AttributeValue message.
         let err = validate_and_normalize_number("").unwrap_err();
-        assert!(err.to_string().contains("Supplied AttributeValue is empty"));
+        assert_eq!(
+            err.to_string(),
+            "The parameter cannot be converted to a numeric value"
+        );
     }
 }

--- a/crates/engine/src/update_table.rs
+++ b/crates/engine/src/update_table.rs
@@ -172,6 +172,9 @@ pub async fn handle_update_table(
             extenddb_storage::error::StorageError::NoOpUpdate(msg) => {
                 DynamoDbError::ValidationException(msg)
             }
+            extenddb_storage::error::StorageError::Validation(msg) => {
+                DynamoDbError::ValidationException(msg)
+            }
             other => {
                 tracing::error!(internal_error = %other, "storage internal error");
                 DynamoDbError::InternalServerError("Internal server error".to_owned())

--- a/crates/storage-postgres/src/update_table.rs
+++ b/crates/storage-postgres/src/update_table.rs
@@ -40,6 +40,40 @@ impl PostgresEngine {
             return Err(StorageError::TableNotActive(input.table_name.clone()));
         }
 
+        // Reject ProvisionedThroughput when the effective billing mode is
+        // PAY_PER_REQUEST. The effective mode is the requested billing_mode when
+        // the request changes it, otherwise the table's current mode. Real
+        // DynamoDB returns "Neither ReadCapacityUnits nor WriteCapacityUnits can
+        // be specified when BillingMode is PAY_PER_REQUEST". This is checked
+        // here, under the FOR UPDATE row lock, because it depends on the table's
+        // current billing mode (a stateless engine-layer check would race with a
+        // concurrent billing-mode change). The engine layer already rejects the
+        // explicit `BillingMode=PAY_PER_REQUEST + ProvisionedThroughput` combo;
+        // this additionally covers the omitted-BillingMode case on a table that
+        // is already PAY_PER_REQUEST.
+        if input.provisioned_throughput.is_some() {
+            let effective_ppr = match input.billing_mode {
+                Some(BillingMode::PayPerRequest) => true,
+                Some(BillingMode::Provisioned) => false,
+                None => {
+                    let current_bm: Option<Option<String>> = sqlx::query_scalar(
+                        "SELECT billing_mode FROM tables WHERE account_id = $1 AND table_name = $2",
+                    )
+                    .bind(account_id)
+                    .bind(&input.table_name)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    current_bm.flatten().as_deref() == Some("PAY_PER_REQUEST")
+                }
+            };
+            if effective_ppr {
+                return Err(StorageError::Validation(
+                    "One or more parameter values were invalid: Neither ReadCapacityUnits nor WriteCapacityUnits can be specified when BillingMode is PAY_PER_REQUEST".to_owned(),
+                ));
+            }
+        }
+
         // No-op rejection: setting same billing mode to PROVISIONED with same
         // throughput values is rejected by DynamoDB. This check runs under the
         // FOR UPDATE lock to eliminate the TOCTOU race that existed when the

--- a/tests/rust/src/main.rs
+++ b/tests/rust/src/main.rs
@@ -95,6 +95,10 @@ mod update_item;
 mod update_item_edge;
 #[cfg(test)]
 mod update_item_more;
+#[cfg(test)]
+mod update_item_number_validation;
+#[cfg(test)]
+mod update_table_billing_validation;
 
 fn main() {
     eprintln!("Run with `cargo test` to execute integration tests.");

--- a/tests/rust/src/update_item_number_validation.rs
+++ b/tests/rust/src/update_item_number_validation.rs
@@ -1,0 +1,139 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! UpdateItem number-value validation. Malformed, out-of-range, and invalid
+//! number-set values supplied via UpdateExpression (ExpressionAttributeValues)
+//! or the legacy AttributeUpdates map must be rejected with a
+//! ValidationException, matching real DynamoDB. Values referenced only in an
+//! UpdateExpression were previously stored without number validation.
+
+use crate::test_base::*;
+use aws_sdk_dynamodb::types::{AttributeAction, AttributeValue, AttributeValueUpdate};
+use std::collections::HashMap;
+
+async fn seed(table: &str) -> HashMap<String, AttributeValue> {
+    let c = client();
+    let item = create_item(table);
+    c.put_item()
+        .table_name(table)
+        .set_item(Some(item.clone()))
+        .send()
+        .await
+        .unwrap();
+    get_key(table, &item)
+}
+
+#[tokio::test]
+async fn update_item_rejects_malformed_number_in_expression() {
+    let c = client();
+    let t = tables().await;
+    let table = &t.simple_key_string;
+    let key = seed(table).await;
+    let e = c
+        .update_item()
+        .table_name(table)
+        .set_key(Some(key))
+        .update_expression("SET bad = :v")
+        .expression_attribute_values(":v", AttributeValue::N("12e".into()))
+        .send()
+        .await
+        .expect_err("malformed number must be rejected");
+    assert_eq!(err_code(&e), Some("ValidationException"), "{}", err_msg(&e));
+    assert!(
+        err_msg(&e).contains("ExpressionAttributeValues contains invalid value")
+            && err_msg(&e).contains("cannot be converted to a numeric value: 12e"),
+        "got: {}",
+        err_msg(&e)
+    );
+}
+
+#[tokio::test]
+async fn update_item_rejects_number_overflow_in_expression() {
+    let c = client();
+    let t = tables().await;
+    let table = &t.simple_key_string;
+    let key = seed(table).await;
+    let big = format!("1{}", "0".repeat(200));
+    let e = c
+        .update_item()
+        .table_name(table)
+        .set_key(Some(key))
+        .update_expression("SET bad = :v")
+        .expression_attribute_values(":v", AttributeValue::N(big))
+        .send()
+        .await
+        .expect_err("out-of-range number must be rejected");
+    assert_eq!(err_code(&e), Some("ValidationException"), "{}", err_msg(&e));
+    assert!(
+        err_msg(&e).contains("Number overflow"),
+        "got: {}",
+        err_msg(&e)
+    );
+}
+
+#[tokio::test]
+async fn update_item_rejects_invalid_number_set_member_in_expression() {
+    let c = client();
+    let t = tables().await;
+    let table = &t.simple_key_string;
+    let key = seed(table).await;
+    let e = c
+        .update_item()
+        .table_name(table)
+        .set_key(Some(key))
+        .update_expression("SET bad = :v")
+        .expression_attribute_values(":v", AttributeValue::Ns(vec!["1".into(), "abc".into()]))
+        .send()
+        .await
+        .expect_err("invalid number-set member must be rejected");
+    assert_eq!(err_code(&e), Some("ValidationException"), "{}", err_msg(&e));
+    assert!(
+        err_msg(&e).contains("cannot be converted to a numeric value: abc"),
+        "got: {}",
+        err_msg(&e)
+    );
+}
+
+#[tokio::test]
+async fn update_item_rejects_bad_number_in_attribute_updates() {
+    let c = client();
+    let t = tables().await;
+    let table = &t.simple_key_string;
+    let key = seed(table).await;
+    let e = c
+        .update_item()
+        .table_name(table)
+        .set_key(Some(key))
+        .attribute_updates(
+            "bad",
+            AttributeValueUpdate::builder()
+                .value(AttributeValue::N("not_a_num".into()))
+                .action(AttributeAction::Put)
+                .build(),
+        )
+        .send()
+        .await
+        .expect_err("bad AttributeUpdates number must be rejected");
+    assert_eq!(err_code(&e), Some("ValidationException"), "{}", err_msg(&e));
+    assert!(
+        err_msg(&e).contains("cannot be converted to a numeric value: not_a_num"),
+        "got: {}",
+        err_msg(&e)
+    );
+}
+
+#[tokio::test]
+async fn update_item_accepts_valid_number_in_expression() {
+    let c = client();
+    let t = tables().await;
+    let table = &t.simple_key_string;
+    let key = seed(table).await;
+    c.update_item()
+        .table_name(table)
+        .set_key(Some(key))
+        .update_expression("SET good = :v")
+        .expression_attribute_values(":v", AttributeValue::N("42".into()))
+        .send()
+        .await
+        .expect("valid number must be accepted");
+}

--- a/tests/rust/src/update_table_billing_validation.rs
+++ b/tests/rust/src/update_table_billing_validation.rs
@@ -1,0 +1,56 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! UpdateTable billing-mode validation. Supplying ProvisionedThroughput for a
+//! table whose effective billing mode is PAY_PER_REQUEST must be rejected with
+//! a ValidationException, even when BillingMode is omitted from the request
+//! (i.e. the table is already PAY_PER_REQUEST). The rejected request must not
+//! mutate the table.
+
+use crate::test_base::*;
+use aws_sdk_dynamodb::types::ProvisionedThroughput;
+
+#[tokio::test]
+async fn update_table_rejects_throughput_on_pay_per_request_table() {
+    let c = client();
+    let t = tables().await;
+    // The shared fixtures are created PAY_PER_REQUEST. Setting throughput
+    // without BillingMode must be rejected (and leave the table unchanged).
+    let table = &t.simple_key_string;
+    let e = c
+        .update_table()
+        .table_name(table)
+        .provisioned_throughput(
+            ProvisionedThroughput::builder()
+                .read_capacity_units(5)
+                .write_capacity_units(5)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect_err("throughput on a PAY_PER_REQUEST table must be rejected");
+    assert_eq!(err_code(&e), Some("ValidationException"), "{}", err_msg(&e));
+    assert!(
+        err_msg(&e).contains(
+            "Neither ReadCapacityUnits nor WriteCapacityUnits can be specified \
+             when BillingMode is PAY_PER_REQUEST"
+        ),
+        "got: {}",
+        err_msg(&e)
+    );
+
+    // The rejected update must not have changed the billing mode: a PutItem
+    // (only valid on an on-demand or provisioned-with-capacity table) still
+    // succeeds, and DescribeTable still reports PAY_PER_REQUEST.
+    let desc = c.describe_table().table_name(table).send().await.unwrap();
+    let summary = desc
+        .table()
+        .and_then(|td| td.billing_mode_summary())
+        .and_then(|b| b.billing_mode());
+    assert_eq!(
+        summary,
+        Some(&aws_sdk_dynamodb::types::BillingMode::PayPerRequest),
+        "table billing mode must remain PAY_PER_REQUEST after a rejected update"
+    );
+}

--- a/tests/test_update_item_number_validation.py
+++ b/tests/test_update_item_number_validation.py
@@ -1,0 +1,101 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""UpdateItem number-value validation.
+
+Malformed, out-of-range, and invalid number-set values supplied via an
+UpdateExpression (ExpressionAttributeValues) or the legacy AttributeUpdates
+map must be rejected with a ValidationException, matching real DynamoDB.
+Values referenced only from an UpdateExpression were previously stored
+without number validation.
+"""
+
+from __future__ import annotations
+
+import pytest
+from botocore.exceptions import ClientError
+
+
+@pytest.fixture()
+def table_with_item(dynamodb_client, create_and_cleanup_table):
+    result = create_and_cleanup_table()
+    name = result["TableDescription"]["TableName"]
+    dynamodb_client.put_item(
+        TableName=name, Item={"pk": {"S": "row1"}, "n": {"N": "5"}}
+    )
+    return name
+
+
+def _update_set(dynamodb_client, table, value):
+    dynamodb_client.update_item(
+        TableName=table,
+        Key={"pk": {"S": "row1"}},
+        UpdateExpression="SET bad = :v",
+        ExpressionAttributeValues={":v": value},
+    )
+
+
+def test_update_item_rejects_malformed_number_in_expression(
+    dynamodb_client, table_with_item
+):
+    with pytest.raises(ClientError) as ei:
+        _update_set(dynamodb_client, table_with_item, {"N": "12e"})
+    err = ei.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert "ExpressionAttributeValues contains invalid value" in err["Message"]
+    assert "cannot be converted to a numeric value: 12e" in err["Message"]
+
+
+def test_update_item_rejects_number_overflow_in_expression(
+    dynamodb_client, table_with_item
+):
+    with pytest.raises(ClientError) as ei:
+        _update_set(dynamodb_client, table_with_item, {"N": "1" + "0" * 200})
+    err = ei.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert "Number overflow" in err["Message"]
+
+
+def test_update_item_rejects_invalid_number_set_member_in_expression(
+    dynamodb_client, table_with_item
+):
+    with pytest.raises(ClientError) as ei:
+        _update_set(dynamodb_client, table_with_item, {"NS": ["1", "abc"]})
+    err = ei.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert "cannot be converted to a numeric value: abc" in err["Message"]
+
+
+def test_update_item_rejects_bad_number_in_attribute_updates(
+    dynamodb_client, table_with_item
+):
+    with pytest.raises(ClientError) as ei:
+        dynamodb_client.update_item(
+            TableName=table_with_item,
+            Key={"pk": {"S": "row1"}},
+            AttributeUpdates={
+                "bad": {"Value": {"N": "not_a_num"}, "Action": "PUT"}
+            },
+        )
+    err = ei.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    # Legacy AttributeUpdates path: bare numeric-value message, no
+    # ExpressionAttributeValues wrapper.
+    assert "cannot be converted to a numeric value: not_a_num" in err["Message"]
+
+
+def test_update_item_accepts_valid_number_in_expression(
+    dynamodb_client, table_with_item
+):
+    dynamodb_client.update_item(
+        TableName=table_with_item,
+        Key={"pk": {"S": "row1"}},
+        UpdateExpression="SET good = :v",
+        ExpressionAttributeValues={":v": {"N": "42"}},
+    )
+    resp = dynamodb_client.get_item(
+        TableName=table_with_item,
+        Key={"pk": {"S": "row1"}},
+        ConsistentRead=True,
+    )
+    assert resp["Item"]["good"] == {"N": "42"}

--- a/tests/test_update_table_billing_validation.py
+++ b/tests/test_update_table_billing_validation.py
@@ -1,0 +1,44 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""UpdateTable billing-mode validation.
+
+Supplying ProvisionedThroughput for a table whose effective billing mode is
+PAY_PER_REQUEST must be rejected with a ValidationException, even when
+BillingMode is omitted from the request (i.e. the table is already
+PAY_PER_REQUEST). A rejected request must not mutate the table.
+"""
+
+from __future__ import annotations
+
+import pytest
+from botocore.exceptions import ClientError
+
+
+def test_update_table_rejects_throughput_on_pay_per_request_table(
+    dynamodb_client, create_and_cleanup_table
+):
+    # create_and_cleanup_table defaults to PAY_PER_REQUEST.
+    name = create_and_cleanup_table()["TableDescription"]["TableName"]
+
+    with pytest.raises(ClientError) as ei:
+        dynamodb_client.update_table(
+            TableName=name,
+            ProvisionedThroughput={
+                "ReadCapacityUnits": 5,
+                "WriteCapacityUnits": 5,
+            },
+        )
+    err = ei.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert (
+        "Neither ReadCapacityUnits nor WriteCapacityUnits can be specified "
+        "when BillingMode is PAY_PER_REQUEST" in err["Message"]
+    )
+
+    # The rejected update must not have changed the billing mode.
+    desc = dynamodb_client.describe_table(TableName=name)["Table"]
+    assert (
+        desc.get("BillingModeSummary", {}).get("BillingMode")
+        == "PAY_PER_REQUEST"
+    )


### PR DESCRIPTION
## What

Two DynamoDB API-parity fixes plus a related error-message correction:

1. **UpdateItem number validation.** `UpdateItem` now rejects invalid number
   values that were previously accepted silently:
   - via `UpdateExpression` (`ExpressionAttributeValues`) — errors are wrapped
     as `ExpressionAttributeValues contains invalid value: <inner> for key <k>`.
   - via the legacy `AttributeUpdates` map — errors use the bare numeric-value
     message.
   Covers malformed numbers (e.g. `12e`), magnitude overflow/underflow,
   > 38 significant digits, and invalid number-set members.

2. **Number error messages.** Number validation now returns the distinct
   DynamoDB messages instead of collapsing every failure to the
   empty-`AttributeValue` message. This also corrects `PutItem` item
   validation:
   - empty          → `The parameter cannot be converted to a numeric value`
   - > 38 digits    → `Attempting to store more than 38 significant digits in a Number`
   - magnitude high → `Number overflow. Attempting to store a number with magnitude larger than supported range`
   - magnitude low  → `Number underflow. Attempting to store a number with magnitude smaller than supported range`

3. **UpdateTable billing validation.** `UpdateTable` now rejects
   `ProvisionedThroughput` when the effective billing mode is
   `PAY_PER_REQUEST` — including the case where `BillingMode` is omitted and
   the table is already `PAY_PER_REQUEST`. The check runs under the table row
   lock (it depends on current billing mode; a stateless check would race a
   concurrent billing-mode change).

Note: this makes validation stricter — inputs real DynamoDB rejects are now
rejected by ExtendDB. It does not change response shapes for valid requests.

## Why

ExtendDB accepted several inputs that the AWS DynamoDB service rejects, and
returned an incorrect error message for out-of-range/oversized numbers. These
divergences surfaced through API-parity checks against the live service; each
fix's expected behavior and exact message was verified against AWS DynamoDB
(us-east-1) before implementing.

Closes # <!-- no tracking issue; delete this line or add one if applicable -->

## Testing done

Every behavior was captured from the live AWS DynamoDB service first, then
implemented to match verbatim, then verified end-to-end against a local server.

- **Unit** (`cargo test -p extenddb-core --lib`): 347 passed — new UpdateItem
  number-validation cases + corrected number-message assertions.
- **Rust integration** (`tests/rust/src/update_item_number_validation.rs`,
  `tests/rust/src/update_table_billing_validation.rs`): 6 passed against a live
  server.
- **Python integration** (`tests/test_update_item_number_validation.py`,
  `tests/test_update_table_billing_validation.py`): 6 passed against a live
  server.
- **Live parity spot-check** against a running server (values verified equal to
  AWS DynamoDB):
  - `SET bad = :v` with `{"N":"12e"}` →
    `ExpressionAttributeValues contains invalid value: The parameter cannot be converted to a numeric value: 12e for key :v`
  - overflow → `...Number overflow. Attempting to store a number with magnitude larger than supported range for key :v`
  - `AttributeUpdates` bad number → `The parameter cannot be converted to a numeric value: not_a_num`
  - `UpdateTable` with throughput on a `PAY_PER_REQUEST` table →
    `Neither ReadCapacityUnits nor WriteCapacityUnits can be specified when BillingMode is PAY_PER_REQUEST` (table unchanged)
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed — n/a (error-message
      parity with DynamoDB; no user-facing docs affected)
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below). — none of
      these change; validation-only.

ADR / RFC: n/a — validation/error-parity fixes; no wire protocol, `Storage`
trait, auth, on-disk format, or CLI change.

## Breaking changes

None to the wire protocol or response shapes. Validation is stricter: requests
carrying invalid numbers (UpdateItem) or `ProvisionedThroughput` on a
`PAY_PER_REQUEST` table (UpdateTable) are now rejected with a
`ValidationException`, matching AWS DynamoDB. A client that previously relied on
ExtendDB accepting these invalid inputs will now receive an error — the same
error the AWS service returns.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.