### PR TITLE
fix: consumed capacity parity

### DIFF
--- a/crates/core/src/types/capacity.rs
+++ b/crates/core/src/types/capacity.rs
@@ -156,12 +156,12 @@ impl ConsumedCapacity {
         Self {
             table_name: table_name.to_owned(),
             capacity_units: cu,
-            read_capacity_units: Some(cu),
+            read_capacity_units: None,
             write_capacity_units: None,
             table: if indexes {
                 Some(Capacity {
                     capacity_units: cu,
-                    read_capacity_units: Some(cu),
+                    read_capacity_units: None,
                     write_capacity_units: None,
                 })
             } else {
@@ -179,12 +179,12 @@ impl ConsumedCapacity {
             table_name: table_name.to_owned(),
             capacity_units: cu,
             read_capacity_units: None,
-            write_capacity_units: Some(cu),
+            write_capacity_units: None,
             table: if indexes {
                 Some(Capacity {
                     capacity_units: cu,
                     read_capacity_units: None,
-                    write_capacity_units: Some(cu),
+                    write_capacity_units: None,
                 })
             } else {
                 None

--- a/crates/core/src/types/capacity.rs
+++ b/crates/core/src/types/capacity.rs
@@ -193,6 +193,58 @@ impl ConsumedCapacity {
             local_secondary_indexes: None,
         }
     }
+
+    /// Build a `ConsumedCapacity` for a transaction read (`TransactGetItems`).
+    ///
+    /// Unlike single-item and batch reads, real DynamoDB includes the granular
+    /// `ReadCapacityUnits` sub-field for transactions — both at the top level
+    /// and inside the nested `Table` breakdown at INDEXES granularity.
+    #[must_use]
+    pub fn transact_read(table_name: &str, cu: f64, indexes: bool) -> Self {
+        Self {
+            table_name: table_name.to_owned(),
+            capacity_units: cu,
+            read_capacity_units: Some(cu),
+            write_capacity_units: None,
+            table: if indexes {
+                Some(Capacity {
+                    capacity_units: cu,
+                    read_capacity_units: Some(cu),
+                    write_capacity_units: None,
+                })
+            } else {
+                None
+            },
+            global_secondary_indexes: None,
+            local_secondary_indexes: None,
+        }
+    }
+
+    /// Build a `ConsumedCapacity` for a transaction write (`TransactWriteItems`).
+    ///
+    /// Unlike single-item and batch writes, real DynamoDB includes the granular
+    /// `WriteCapacityUnits` sub-field for transactions — both at the top level
+    /// and inside the nested `Table` breakdown at INDEXES granularity.
+    #[must_use]
+    pub fn transact_write(table_name: &str, cu: f64, indexes: bool) -> Self {
+        Self {
+            table_name: table_name.to_owned(),
+            capacity_units: cu,
+            read_capacity_units: None,
+            write_capacity_units: Some(cu),
+            table: if indexes {
+                Some(Capacity {
+                    capacity_units: cu,
+                    read_capacity_units: None,
+                    write_capacity_units: Some(cu),
+                })
+            } else {
+                None
+            },
+            global_secondary_indexes: None,
+            local_secondary_indexes: None,
+        }
+    }
 }
 
 impl ItemCollectionMetrics {

--- a/crates/engine/src/capacity_helpers.rs
+++ b/crates/engine/src/capacity_helpers.rs
@@ -94,6 +94,52 @@ pub fn batch_write_capacity<'a>(
     }
 }
 
+/// Build a `Vec<ConsumedCapacity>` for `TransactGetItems`, or `None` if not requested.
+///
+/// Transactions differ from single-item/batch reads: real DynamoDB emits the
+/// granular `ReadCapacityUnits` sub-field, so this uses `ConsumedCapacity::transact_read`.
+#[must_use]
+pub fn transact_read_capacity<'a>(
+    rcc: ReturnConsumedCapacity,
+    table_cus: impl Iterator<Item = (&'a str, f64)>,
+) -> Option<Vec<ConsumedCapacity>> {
+    match rcc {
+        ReturnConsumedCapacity::None => None,
+        rcc => {
+            CAPACITY_REQUEST_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let indexes = rcc == ReturnConsumedCapacity::Indexes;
+            Some(
+                table_cus
+                    .map(|(t, cu)| ConsumedCapacity::transact_read(t, cu, indexes))
+                    .collect(),
+            )
+        }
+    }
+}
+
+/// Build a `Vec<ConsumedCapacity>` for `TransactWriteItems`, or `None` if not requested.
+///
+/// Transactions differ from single-item/batch writes: real DynamoDB emits the
+/// granular `WriteCapacityUnits` sub-field, so this uses `ConsumedCapacity::transact_write`.
+#[must_use]
+pub fn transact_write_capacity<'a>(
+    rcc: ReturnConsumedCapacity,
+    table_cus: impl Iterator<Item = (&'a str, f64)>,
+) -> Option<Vec<ConsumedCapacity>> {
+    match rcc {
+        ReturnConsumedCapacity::None => None,
+        rcc => {
+            CAPACITY_REQUEST_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let indexes = rcc == ReturnConsumedCapacity::Indexes;
+            Some(
+                table_cus
+                    .map(|(t, cu)| ConsumedCapacity::transact_write(t, cu, indexes))
+                    .collect(),
+            )
+        }
+    }
+}
+
 /// Compute read capacity units for a single item: `ceil(item_size / 4096)`.
 ///
 /// `strongly_consistent`: if `true`, returns full RCU; if `false` (eventually

--- a/crates/engine/src/transact_get_items.rs
+++ b/crates/engine/src/transact_get_items.rs
@@ -172,7 +172,7 @@ pub async fn handle_transact_get_items(
         })
         .collect();
 
-    let consumed_capacity = capacity_helpers::batch_read_capacity(
+    let consumed_capacity = capacity_helpers::transact_read_capacity(
         input.return_consumed_capacity,
         per_table_rcu.iter().map(|(t, cu)| (t.as_str(), *cu)),
     );

--- a/crates/engine/src/transact_write_items.rs
+++ b/crates/engine/src/transact_write_items.rs
@@ -164,7 +164,7 @@ pub async fn handle_transact_write_items(
         })
         .sum();
 
-    let consumed_capacity = capacity_helpers::batch_write_capacity(
+    let consumed_capacity = capacity_helpers::transact_write_capacity(
         input.return_consumed_capacity,
         per_table_wcu.iter().map(|(t, cu)| (t.as_str(), *cu)),
     );

--- a/tests/rust/src/consumed_capacity_shape.rs
+++ b/tests/rust/src/consumed_capacity_shape.rs
@@ -78,6 +78,49 @@ async fn put_item_consumed_capacity_has_no_granular_fields() {
 }
 
 #[tokio::test]
+async fn delete_item_consumed_capacity_has_no_granular_fields() {
+    let c = client();
+    let t = tables().await;
+    let resp = c
+        .delete_item()
+        .table_name(&t.simple_key_string)
+        .set_key(Some(key(&format!("ccd_{}", ts()))))
+        .return_consumed_capacity(ReturnConsumedCapacity::Total)
+        .send()
+        .await
+        .unwrap();
+    let cc = resp.consumed_capacity().expect("ConsumedCapacity");
+    assert!(cc.capacity_units().is_some());
+    assert!(
+        cc.write_capacity_units().is_none() && cc.read_capacity_units().is_none(),
+        "DeleteItem TOTAL must emit only CapacityUnits"
+    );
+}
+
+#[tokio::test]
+async fn update_item_consumed_capacity_has_no_granular_fields() {
+    let c = client();
+    let t = tables().await;
+    let resp = c
+        .update_item()
+        .table_name(&t.simple_key_string)
+        .set_key(Some(key(&format!("ccu_{}", ts()))))
+        .update_expression("SET #d = :v")
+        .expression_attribute_names("#d", "data")
+        .expression_attribute_values(":v", s("x"))
+        .return_consumed_capacity(ReturnConsumedCapacity::Total)
+        .send()
+        .await
+        .unwrap();
+    let cc = resp.consumed_capacity().expect("ConsumedCapacity");
+    assert!(cc.capacity_units().is_some());
+    assert!(
+        cc.write_capacity_units().is_none() && cc.read_capacity_units().is_none(),
+        "UpdateItem TOTAL must emit only CapacityUnits"
+    );
+}
+
+#[tokio::test]
 async fn batch_get_consumed_capacity_has_no_granular_fields() {
     let c = client();
     let t = tables().await;

--- a/tests/rust/src/consumed_capacity_shape.rs
+++ b/tests/rust/src/consumed_capacity_shape.rs
@@ -1,0 +1,140 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! ConsumedCapacity response shape. Real DynamoDB returns only `CapacityUnits`
+//! (top-level and in the nested `Table` breakdown) for these single-item and
+//! batch operations at both TOTAL and INDEXES granularity — it does NOT emit
+//! the granular `ReadCapacityUnits` / `WriteCapacityUnits` sub-fields.
+//! Verified against real DynamoDB (us-east-1).
+
+use crate::test_base::*;
+use aws_sdk_dynamodb::types::{KeysAndAttributes, ReturnConsumedCapacity, WriteRequest};
+use std::collections::HashMap;
+
+fn key(v: &str) -> HashMap<String, aws_sdk_dynamodb::types::AttributeValue> {
+    let mut k = HashMap::new();
+    k.insert(HASH_KEY_S.into(), s(v));
+    k
+}
+
+#[tokio::test]
+async fn get_item_consumed_capacity_has_no_granular_fields() {
+    let c = client();
+    let t = tables().await;
+    let table = &t.simple_key_string;
+    let id = format!("cc_{}", ts());
+    c.put_item()
+        .table_name(table)
+        .set_item(Some(key(&id)))
+        .send()
+        .await
+        .unwrap();
+
+    for gran in [
+        ReturnConsumedCapacity::Total,
+        ReturnConsumedCapacity::Indexes,
+    ] {
+        let resp = c
+            .get_item()
+            .table_name(table)
+            .set_key(Some(key(&id)))
+            .return_consumed_capacity(gran.clone())
+            .send()
+            .await
+            .unwrap();
+        let cc = resp.consumed_capacity().expect("ConsumedCapacity");
+        assert!(cc.capacity_units().is_some(), "CapacityUnits present");
+        assert!(
+            cc.read_capacity_units().is_none() && cc.write_capacity_units().is_none(),
+            "top-level RCU/WCU must be absent ({gran:?})"
+        );
+        if let Some(tbl) = cc.table() {
+            assert!(
+                tbl.read_capacity_units().is_none() && tbl.write_capacity_units().is_none(),
+                "nested Table RCU/WCU must be absent ({gran:?})"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn put_item_consumed_capacity_has_no_granular_fields() {
+    let c = client();
+    let t = tables().await;
+    let resp = c
+        .put_item()
+        .table_name(&t.simple_key_string)
+        .set_item(Some(key(&format!("cc_{}", ts()))))
+        .return_consumed_capacity(ReturnConsumedCapacity::Total)
+        .send()
+        .await
+        .unwrap();
+    let cc = resp.consumed_capacity().expect("ConsumedCapacity");
+    assert!(cc.capacity_units().is_some());
+    assert!(
+        cc.write_capacity_units().is_none() && cc.read_capacity_units().is_none(),
+        "PutItem TOTAL must emit only CapacityUnits"
+    );
+}
+
+#[tokio::test]
+async fn batch_get_consumed_capacity_has_no_granular_fields() {
+    let c = client();
+    let t = tables().await;
+    let table = &t.simple_key_string;
+    let id = format!("ccb_{}", ts());
+    c.put_item()
+        .table_name(table)
+        .set_item(Some(key(&id)))
+        .send()
+        .await
+        .unwrap();
+    let resp = c
+        .batch_get_item()
+        .request_items(
+            table,
+            KeysAndAttributes::builder().keys(key(&id)).build().unwrap(),
+        )
+        .return_consumed_capacity(ReturnConsumedCapacity::Total)
+        .send()
+        .await
+        .unwrap();
+    let cc = resp.consumed_capacity().first().expect("ConsumedCapacity");
+    assert!(cc.capacity_units().is_some());
+    assert!(
+        cc.read_capacity_units().is_none() && cc.write_capacity_units().is_none(),
+        "BatchGetItem per-table CC must emit only CapacityUnits"
+    );
+}
+
+#[tokio::test]
+async fn batch_write_consumed_capacity_has_no_granular_fields() {
+    let c = client();
+    let t = tables().await;
+    let table = &t.simple_key_string;
+    let mut item = key(&format!("ccw_{}", ts()));
+    item.insert("v".into(), s("x"));
+    let resp = c
+        .batch_write_item()
+        .request_items(
+            table,
+            vec![WriteRequest::builder()
+                .put_request(
+                    aws_sdk_dynamodb::types::PutRequest::builder()
+                        .set_item(Some(item))
+                        .build()
+                        .unwrap(),
+                )
+                .build()],
+        )
+        .return_consumed_capacity(ReturnConsumedCapacity::Total)
+        .send()
+        .await
+        .unwrap();
+    let cc = resp.consumed_capacity().first().expect("ConsumedCapacity");
+    assert!(cc.capacity_units().is_some());
+    assert!(
+        cc.write_capacity_units().is_none() && cc.read_capacity_units().is_none(),
+        "BatchWriteItem per-table CC must emit only CapacityUnits"
+    );
+}

--- a/tests/rust/src/main.rs
+++ b/tests/rust/src/main.rs
@@ -26,6 +26,8 @@ mod condition_expressions;
 #[cfg(test)]
 mod condition_expressions_more;
 #[cfg(test)]
+mod consumed_capacity_shape;
+#[cfg(test)]
 mod create_table_validation;
 #[cfg(test)]
 mod data_types;

--- a/tests/test_consumed_capacity_shape.py
+++ b/tests/test_consumed_capacity_shape.py
@@ -47,6 +47,27 @@ def test_put_item_consumed_capacity_shape(dynamodb_client, table, granularity):
     _assert_only_capacity_units(resp["ConsumedCapacity"])
 
 
+@pytest.mark.parametrize("granularity", ["TOTAL", "INDEXES"])
+def test_delete_item_consumed_capacity_shape(dynamodb_client, table, granularity):
+    resp = dynamodb_client.delete_item(
+        TableName=table, Key={"pk": {"S": "kd"}}, ReturnConsumedCapacity=granularity
+    )
+    _assert_only_capacity_units(resp["ConsumedCapacity"])
+
+
+@pytest.mark.parametrize("granularity", ["TOTAL", "INDEXES"])
+def test_update_item_consumed_capacity_shape(dynamodb_client, table, granularity):
+    resp = dynamodb_client.update_item(
+        TableName=table,
+        Key={"pk": {"S": "ku"}},
+        UpdateExpression="SET #d = :v",
+        ExpressionAttributeNames={"#d": "data"},
+        ExpressionAttributeValues={":v": {"S": "x"}},
+        ReturnConsumedCapacity=granularity,
+    )
+    _assert_only_capacity_units(resp["ConsumedCapacity"])
+
+
 def test_batch_get_consumed_capacity_shape(dynamodb_client, table):
     dynamodb_client.put_item(TableName=table, Item={"pk": {"S": "b1"}})
     resp = dynamodb_client.batch_get_item(

--- a/tests/test_consumed_capacity_shape.py
+++ b/tests/test_consumed_capacity_shape.py
@@ -1,0 +1,64 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""ConsumedCapacity response shape.
+
+Real DynamoDB returns only ``CapacityUnits`` (top-level and in the nested
+``Table`` breakdown) for these single-item and batch operations at both TOTAL
+and INDEXES granularity — it does NOT emit granular ``ReadCapacityUnits`` /
+``WriteCapacityUnits`` sub-fields. Verified against real DynamoDB (us-east-1).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def table(create_and_cleanup_table):
+    return create_and_cleanup_table()["TableDescription"]["TableName"]
+
+
+def _assert_only_capacity_units(cc: dict):
+    assert "CapacityUnits" in cc, cc
+    assert "ReadCapacityUnits" not in cc, cc
+    assert "WriteCapacityUnits" not in cc, cc
+    if "Table" in cc:
+        tbl = cc["Table"]
+        assert "CapacityUnits" in tbl, tbl
+        assert "ReadCapacityUnits" not in tbl, tbl
+        assert "WriteCapacityUnits" not in tbl, tbl
+
+
+@pytest.mark.parametrize("granularity", ["TOTAL", "INDEXES"])
+def test_get_item_consumed_capacity_shape(dynamodb_client, table, granularity):
+    dynamodb_client.put_item(TableName=table, Item={"pk": {"S": "k1"}})
+    resp = dynamodb_client.get_item(
+        TableName=table, Key={"pk": {"S": "k1"}}, ReturnConsumedCapacity=granularity
+    )
+    _assert_only_capacity_units(resp["ConsumedCapacity"])
+
+
+@pytest.mark.parametrize("granularity", ["TOTAL", "INDEXES"])
+def test_put_item_consumed_capacity_shape(dynamodb_client, table, granularity):
+    resp = dynamodb_client.put_item(
+        TableName=table, Item={"pk": {"S": "k2"}}, ReturnConsumedCapacity=granularity
+    )
+    _assert_only_capacity_units(resp["ConsumedCapacity"])
+
+
+def test_batch_get_consumed_capacity_shape(dynamodb_client, table):
+    dynamodb_client.put_item(TableName=table, Item={"pk": {"S": "b1"}})
+    resp = dynamodb_client.batch_get_item(
+        RequestItems={table: {"Keys": [{"pk": {"S": "b1"}}]}},
+        ReturnConsumedCapacity="TOTAL",
+    )
+    _assert_only_capacity_units(resp["ConsumedCapacity"][0])
+
+
+def test_batch_write_consumed_capacity_shape(dynamodb_client, table):
+    resp = dynamodb_client.batch_write_item(
+        RequestItems={table: [{"PutRequest": {"Item": {"pk": {"S": "bw1"}}}}]},
+        ReturnConsumedCapacity="TOTAL",
+    )
+    _assert_only_capacity_units(resp["ConsumedCapacity"][0])

--- a/tests/test_item_operations.py
+++ b/tests/test_item_operations.py
@@ -1345,10 +1345,11 @@ class TestUpdateItemWCU:
         )
         cap = resp["ConsumedCapacity"]
         assert cap["CapacityUnits"] >= 1.0
-        assert cap["WriteCapacityUnits"] >= 1.0
+        # Real DynamoDB reports write cost via CapacityUnits only — no granular sub-field.
+        assert "WriteCapacityUnits" not in cap
 
-    def test_update_item_indexes_capacity_has_wcu_in_table(self, dynamodb_client, wcu_table):
-        """INDEXES-level capacity includes WriteCapacityUnits in Table breakdown."""
+    def test_update_item_indexes_capacity_only_capacity_units(self, dynamodb_client, wcu_table):
+        """INDEXES-level capacity reports only CapacityUnits in the Table breakdown (matches real DynamoDB — no granular RCU/WCU)."""
         dynamodb_client.put_item(
             TableName=wcu_table,
             Item={"pk": {"S": "wcu-idx"}, "v": {"N": "1"}},
@@ -1361,11 +1362,14 @@ class TestUpdateItemWCU:
             ReturnConsumedCapacity="INDEXES",
         )
         cap = resp["ConsumedCapacity"]
-        assert cap["WriteCapacityUnits"] >= 1.0
+        assert cap["CapacityUnits"] >= 1.0
+        # Real DynamoDB emits only CapacityUnits for UpdateItem — no granular RCU/WCU.
+        assert "WriteCapacityUnits" not in cap
+        assert "ReadCapacityUnits" not in cap
         table_cap = cap.get("Table", {})
-        assert table_cap.get("WriteCapacityUnits") >= 1.0
-        # ReadCapacityUnits should not be present for writes
-        assert table_cap.get("ReadCapacityUnits") is None
+        assert table_cap.get("CapacityUnits") >= 1.0
+        assert "WriteCapacityUnits" not in table_cap
+        assert "ReadCapacityUnits" not in table_cap
 
     def test_update_item_wcu_reflects_new_item_size(self, dynamodb_client, wcu_table):
         """UpdateItem WCU is based on the larger of old/new item (new item here)."""
@@ -1383,8 +1387,9 @@ class TestUpdateItemWCU:
             ReturnConsumedCapacity="TOTAL",
         )
         cap = resp["ConsumedCapacity"]
-        # New item is ~1.5KB → rounds up to 2 WCU
-        assert cap["WriteCapacityUnits"] >= 2.0
+        # New item is ~1.5KB → rounds up to 2 WCU, reported via CapacityUnits (no granular field).
+        assert cap["CapacityUnits"] >= 2.0
+        assert "WriteCapacityUnits" not in cap
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Aligns the `ConsumedCapacity` response shape with DynamoDB, which is **not uniform across operations**:

- **Single-item, `Scan`, `Query`, and batch** operations (`GetItem`, `PutItem`, `DeleteItem`, `UpdateItem`, `Scan`, `Query`, `BatchGetItem`, `BatchWriteItem`) return **only `CapacityUnits`** (plus `TableName`, and the nested `Table` breakdown at `INDEXES` granularity). ExtendDB was wrongly emitting extra granular `ReadCapacityUnits` / `WriteCapacityUnits` sub-fields here — now removed.
- **Transaction** operations (`TransactGetItems`, `TransactWriteItems`) **do** include the granular `ReadCapacityUnits` (reads) / `WriteCapacityUnits` (writes) sub-field, both top-level and in the nested `Table` breakdown. These are retained.

Implementation: the shared `ConsumedCapacity::read` / `::write` constructors emit `CapacityUnits` only (used by single-item/batch). Dedicated `ConsumedCapacity::transact_read` / `::transact_write` constructors (and matching
`transact_read_capacity` / `transact_write_capacity` helpers) retain the granular field for the transaction handlers. Capacity **values** are unchanged (they already matched DynamoDB).

## Why

Consumers that assert on the `ConsumedCapacity` response shape saw extra fields for single-item/batch operations that the AWS DynamoDB service does not return. The per-operation shape (including the transaction carve-out) was captured from the live AWS DynamoDB service (us-east-1) at both `TOTAL` and `INDEXES` granularity and verified to match after the fix.

## Testing done

Response shapes were captured from the live AWS DynamoDB service first, then verified to match after the change.

- **Unit** (`cargo test -p extenddb-core --lib`): core 342 passed; full workspace unit suite green.
- **Rust integration** (against a live server): full suite green (377), including the `ConsumedCapacity` shape assertions for single-item and batch, and the transaction capacity assertions.
- **Python integration** (against a live server): 790 passed, covering `ConsumedCapacity` shape for `GetItem`/`PutItem`/`DeleteItem`/`UpdateItem` and `BatchGetItem`/`BatchWriteItem` (only `CapacityUnits`), plus `TransactGetItems` (`ReadCapacityUnits`) and `TransactWriteItems` (`WriteCapacityUnits`) at both `TOTAL` and `INDEXES`.
- Live spot-check vs AWS DynamoDB (us-east-1):
  - `GetItem … TOTAL` -> `{"TableName": …, "CapacityUnits": 0.5}` (no granular field)
  - `UpdateItem … INDEXES` -> `{… "CapacityUnits": 1.0, "Table": {"CapacityUnits": 1.0}}`
  - `TransactGetItems … TOTAL` -> `{… "CapacityUnits": 2.0, "ReadCapacityUnits": 2.0}`
  - `TransactWriteItems … TOTAL` -> `{… "CapacityUnits": 2.0, "WriteCapacityUnits": 2.0}`
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed — n/a (response-shape
      parity with DynamoDB; no user-facing docs affected)
- [x] Breaking changes are noted below
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below). — none of
      these change; response-serialization only.

ADR / RFC: n/a — response-shape parity fix. No change to the wire protocol,
`Storage` trait, auth model, on-disk format, or CLI surface.

## Breaking changes

For **single-item and batch** operations, the `ConsumedCapacity` object no longer
includes the `ReadCapacityUnits` / `WriteCapacityUnits` sub-fields, matching AWS
DynamoDB. `CapacityUnits` (the aggregate) and all capacity values are unchanged.
**Transaction** responses are unchanged (they correctly continue to include the
granular field). A consumer that specifically read the granular sub-fields from
single-item/batch ExtendDB responses (which AWS DynamoDB does not return there) would
no longer find them — this brings the response into line with the real service.
