### PR TITLE
fix: validate ConditionalOperator usage and expression-parameter mixing

### DIFF
--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -2192,4 +2192,81 @@ mod tests {
         });
         assert!(validate_create_table(&input, &LimitsConfig::default()).is_ok());
     }
+
+    #[test]
+    fn test_expression_param_mixing_lists_present_params_in_order() {
+        let err = validate_no_expression_param_mixing(
+            &[
+                ("AttributesToGet", true),
+                ("ScanFilter", true),
+                ("ConditionalOperator", true),
+            ],
+            &[("ProjectionExpression", true), ("FilterExpression", true)],
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Can not use both expression and non-expression parameters in the same request: \
+             Non-expression parameters: {AttributesToGet, ScanFilter, ConditionalOperator} \
+             Expression parameters: {ProjectionExpression, FilterExpression}"
+        );
+    }
+
+    #[test]
+    fn test_expression_param_mixing_skips_absent_params() {
+        let err = validate_no_expression_param_mixing(
+            &[("ScanFilter", false), ("ConditionalOperator", true)],
+            &[("ProjectionExpression", false), ("FilterExpression", true)],
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Can not use both expression and non-expression parameters in the same request: \
+             Non-expression parameters: {ConditionalOperator} \
+             Expression parameters: {FilterExpression}"
+        );
+    }
+
+    #[test]
+    fn test_expression_param_mixing_allows_one_side_only() {
+        assert!(
+            validate_no_expression_param_mixing(
+                &[("ScanFilter", true), ("ConditionalOperator", true)],
+                &[("FilterExpression", false)],
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_no_expression_param_mixing(
+                &[("ScanFilter", false)],
+                &[("FilterExpression", true), ("ProjectionExpression", true)],
+            )
+            .is_ok()
+        );
+        assert!(validate_no_expression_param_mixing(&[], &[]).is_ok());
+    }
+
+    #[test]
+    fn test_conditional_operator_requires_conditions() {
+        let err = validate_conditional_operator_usage(true, 0).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "ConditionalOperator cannot be used without Filter or Expected"
+        );
+
+        let err = validate_conditional_operator_usage(true, 1).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "ConditionalOperator can only be used when Filter or Expected has two or more elements"
+        );
+
+        assert!(validate_conditional_operator_usage(true, 2).is_ok());
+        assert!(validate_conditional_operator_usage(true, 5).is_ok());
+    }
+
+    #[test]
+    fn test_conditional_operator_absent_is_ok() {
+        assert!(validate_conditional_operator_usage(false, 0).is_ok());
+        assert!(validate_conditional_operator_usage(false, 1).is_ok());
+    }
 }

--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -1016,6 +1016,69 @@ pub fn validate_select_projection(
     Ok(())
 }
 
+/// Reject requests that mix legacy (non-expression) and expression parameters.
+///
+/// Each slice lists the API's parameters as `(name, present)` pairs in the
+/// canonical order Amazon DynamoDB reports them. If at least one parameter is
+/// present on each side, the error message lists every present parameter.
+///
+/// # Errors
+///
+/// Returns `DynamoDbError::ValidationException` when both sides are non-empty.
+pub fn validate_no_expression_param_mixing(
+    non_expression: &[(&str, bool)],
+    expression: &[(&str, bool)],
+) -> Result<(), DynamoDbError> {
+    // Happy path allocates nothing; the name lists are built only on error.
+    let any_present = |params: &[(&str, bool)]| params.iter().any(|(_, p)| *p);
+    if !any_present(non_expression) || !any_present(expression) {
+        return Ok(());
+    }
+    fn present_names(params: &[(&str, bool)]) -> String {
+        params
+            .iter()
+            .filter(|(_, p)| *p)
+            .map(|(n, _)| *n)
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+    Err(DynamoDbError::ValidationException(format!(
+        "Can not use both expression and non-expression parameters in the same request: \
+         Non-expression parameters: {{{}}} Expression parameters: {{{}}}",
+        present_names(non_expression),
+        present_names(expression)
+    )))
+}
+
+/// Validate `ConditionalOperator` accompanies a legacy Filter/Expected with
+/// two or more conditions, matching Amazon DynamoDB.
+///
+/// `condition_count` is the number of entries in the request's legacy
+/// `ScanFilter`/`QueryFilter`/`Expected` map (0 when absent or empty).
+///
+/// # Errors
+///
+/// Returns `DynamoDbError::ValidationException` when `ConditionalOperator` is
+/// present with fewer than two legacy conditions.
+pub fn validate_conditional_operator_usage(
+    conditional_operator_present: bool,
+    condition_count: usize,
+) -> Result<(), DynamoDbError> {
+    if !conditional_operator_present {
+        return Ok(());
+    }
+    match condition_count {
+        0 => Err(DynamoDbError::ValidationException(
+            "ConditionalOperator cannot be used without Filter or Expected".to_owned(),
+        )),
+        1 => Err(DynamoDbError::ValidationException(
+            "ConditionalOperator can only be used when Filter or Expected has two or more elements"
+                .to_owned(),
+        )),
+        _ => Ok(()),
+    }
+}
+
 /// Validate partition key and sort key sizes against limits.
 ///
 /// # Errors

--- a/crates/engine/src/delete_item.rs
+++ b/crates/engine/src/delete_item.rs
@@ -49,12 +49,30 @@ pub async fn handle_delete_item(
         .condition_expression
         .as_ref()
         .is_some_and(|s| !s.is_empty());
+    let has_expected = input.expected.as_ref().is_some_and(|m| !m.is_empty());
+    let has_cond_op = input.conditional_operator.is_some();
+    extenddb_core::validation::validate_no_expression_param_mixing(
+        &[
+            ("Expected", has_expected),
+            ("ConditionalOperator", has_cond_op),
+        ],
+        &[("ConditionExpression", has_condition)],
+    )?;
     extenddb_core::expression::validate_expression_param_usage(
         input.expression_attribute_names.as_ref(),
         has_condition,
         input.expression_attribute_values.as_ref(),
         has_condition,
         &[extenddb_core::expression::ExpressionKind::Condition],
+    )?;
+
+    // ConditionalOperator requires an Expected with two or more conditions.
+    extenddb_core::validation::validate_conditional_operator_usage(
+        has_cond_op,
+        input
+            .expected
+            .as_ref()
+            .map_or(0, std::collections::HashMap::len),
     )?;
 
     let (condition, maps) = resolve_condition(

--- a/crates/engine/src/expression_helpers.rs
+++ b/crates/engine/src/expression_helpers.rs
@@ -172,13 +172,10 @@ pub fn resolve_condition(
     let has_condition = condition_expression.is_some_and(|s| !s.is_empty());
     let has_expected = expected.is_some_and(|m| !m.is_empty());
 
-    if has_condition && has_expected {
-        return Err(DynamoDbError::ValidationException(
-            "Can not use both expression and non-expression parameters in the same request: \
-             Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}"
-                .to_owned(),
-        ));
-    }
+    extenddb_core::validation::validate_no_expression_param_mixing(
+        &[("Expected", has_expected)],
+        &[("ConditionExpression", has_condition)],
+    )?;
 
     if let Some(exp) = expected.filter(|m| !m.is_empty()) {
         let (expr, mut maps) = desugar_expected(exp, conditional_operator.unwrap_or_default())?;

--- a/crates/engine/src/put_item.rs
+++ b/crates/engine/src/put_item.rs
@@ -85,17 +85,36 @@ pub async fn handle_put_item(
         }
     })?;
 
-    // Reject EAN/EAV supplied without a referencing expression.
+    // Reject mixing legacy and expression parameters, then EAN/EAV supplied
+    // without a referencing expression.
     let has_expression = input
         .condition_expression
         .as_ref()
         .is_some_and(|s| !s.is_empty());
+    let has_expected = input.expected.as_ref().is_some_and(|m| !m.is_empty());
+    let has_cond_op = input.conditional_operator.is_some();
+    extenddb_core::validation::validate_no_expression_param_mixing(
+        &[
+            ("Expected", has_expected),
+            ("ConditionalOperator", has_cond_op),
+        ],
+        &[("ConditionExpression", has_expression)],
+    )?;
     extenddb_core::expression::validate_expression_param_usage(
         input.expression_attribute_names.as_ref(),
         has_expression,
         input.expression_attribute_values.as_ref(),
         has_expression,
         &[extenddb_core::expression::ExpressionKind::Condition],
+    )?;
+
+    // ConditionalOperator requires an Expected with two or more conditions.
+    extenddb_core::validation::validate_conditional_operator_usage(
+        has_cond_op,
+        input
+            .expected
+            .as_ref()
+            .map_or(0, std::collections::HashMap::len),
     )?;
 
     extenddb_core::validation::validate_table_name(&input.table_name, &ctx.limits)?;

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -96,41 +96,33 @@ pub async fn handle_query(
     };
 
     // --- Legacy vs expression mutual exclusivity checks ---
-    let has_kce = input.key_condition_expression.is_some();
+    let kce_present = input.key_condition_expression.is_some();
     let has_kc = input.key_conditions.as_ref().is_some_and(|m| !m.is_empty());
-
-    if has_kce && has_kc {
-        return Err(DynamoDbError::ValidationException(
-            "Can not use both expression and non-expression parameters in the same request: \
-             Non-expression parameters: {KeyConditions} Expression parameters: {KeyConditionExpression}"
-                .to_owned(),
-        ));
-    }
-
     let has_fe = input.filter_expression.is_some();
     let has_qf = input.query_filter.as_ref().is_some_and(|m| !m.is_empty());
-
-    if has_fe && has_qf {
-        return Err(DynamoDbError::ValidationException(
-            "Can not use both expression and non-expression parameters in the same request: \
-             Non-expression parameters: {QueryFilter} Expression parameters: {FilterExpression}"
-                .to_owned(),
-        ));
-    }
-
     let has_pe = input.projection_expression.is_some();
     let has_atg = input
         .attributes_to_get
         .as_ref()
         .is_some_and(|a| !a.is_empty());
+    let has_cond_op = input.conditional_operator.is_some();
 
-    if has_pe && has_atg {
-        return Err(DynamoDbError::ValidationException(
-            "Can not use both expression and non-expression parameters in the same request: \
-             Non-expression parameters: {AttributesToGet} Expression parameters: {ProjectionExpression}"
-                .to_owned(),
-        ));
-    }
+    // KeyConditions legitimately combines with FilterExpression and
+    // ProjectionExpression, so it joins the mixing check only when
+    // KeyConditionExpression is also present.
+    extenddb_core::validation::validate_no_expression_param_mixing(
+        &[
+            ("AttributesToGet", has_atg),
+            ("QueryFilter", has_qf),
+            ("ConditionalOperator", has_cond_op),
+            ("KeyConditions", has_kc && kce_present),
+        ],
+        &[
+            ("ProjectionExpression", has_pe),
+            ("FilterExpression", has_fe),
+            ("KeyConditionExpression", kce_present),
+        ],
+    )?;
 
     // An explicitly empty KeyConditionExpression is rejected up front, before
     // the expression-parameter-usage checks (matching real DynamoDB).
@@ -162,6 +154,12 @@ pub async fn handle_query(
         input.expression_attribute_values.as_ref(),
         has_kce || has_filter_expr,
         &[],
+    )?;
+
+    // ConditionalOperator requires a QueryFilter with two or more conditions.
+    extenddb_core::validation::validate_conditional_operator_usage(
+        has_cond_op,
+        input.query_filter.as_ref().map_or(0, HashMap::len),
     )?;
 
     // Parse KeyConditionExpression or desugar legacy KeyConditions

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -44,28 +44,24 @@ pub async fn handle_scan(
     // --- Legacy vs expression mutual exclusivity checks ---
     let has_fe = input.filter_expression.is_some();
     let has_sf = input.scan_filter.as_ref().is_some_and(|m| !m.is_empty());
-
-    if has_fe && has_sf {
-        return Err(DynamoDbError::ValidationException(
-            "Can not use both expression and non-expression parameters in the same request: \
-             Non-expression parameters: {ScanFilter} Expression parameters: {FilterExpression}"
-                .to_owned(),
-        ));
-    }
-
     let has_pe = input.projection_expression.is_some();
     let has_atg = input
         .attributes_to_get
         .as_ref()
         .is_some_and(|a| !a.is_empty());
+    let has_cond_op = input.conditional_operator.is_some();
 
-    if has_pe && has_atg {
-        return Err(DynamoDbError::ValidationException(
-            "Can not use both expression and non-expression parameters in the same request: \
-             Non-expression parameters: {AttributesToGet} Expression parameters: {ProjectionExpression}"
-                .to_owned(),
-        ));
-    }
+    extenddb_core::validation::validate_no_expression_param_mixing(
+        &[
+            ("AttributesToGet", has_atg),
+            ("ScanFilter", has_sf),
+            ("ConditionalOperator", has_cond_op),
+        ],
+        &[
+            ("ProjectionExpression", has_pe),
+            ("FilterExpression", has_fe),
+        ],
+    )?;
 
     let maps = build_expression_maps(
         input.expression_attribute_names.as_ref(),
@@ -86,6 +82,12 @@ pub async fn handle_scan(
         input.expression_attribute_values.as_ref(),
         has_filter_expr,
         &[ExpressionKind::Filter],
+    )?;
+
+    // ConditionalOperator requires a ScanFilter with two or more conditions.
+    extenddb_core::validation::validate_conditional_operator_usage(
+        has_cond_op,
+        input.scan_filter.as_ref().map_or(0, HashMap::len),
     )?;
 
     // Parse FilterExpression or desugar legacy ScanFilter

--- a/crates/engine/src/update_item.rs
+++ b/crates/engine/src/update_item.rs
@@ -60,25 +60,40 @@ pub async fn handle_update_item(
     // desugaring) before the existence check; key, item-content nesting, and
     // the no-key-update checks stay after (post-existence on Amazon DynamoDB).
 
+    let has_update_expr = input
+        .update_expression
+        .as_ref()
+        .is_some_and(|s| !s.is_empty());
+    let has_condition = input
+        .condition_expression
+        .as_ref()
+        .is_some_and(|s| !s.is_empty());
+    let has_expected = input.expected.as_ref().is_some_and(|m| !m.is_empty());
+    let has_cond_op = input.conditional_operator.is_some();
+
+    extenddb_core::validation::validate_no_expression_param_mixing(
+        &[
+            ("AttributeUpdates", input.attribute_updates.is_some()),
+            ("Expected", has_expected),
+            ("ConditionalOperator", has_cond_op),
+        ],
+        &[
+            ("UpdateExpression", input.update_expression.is_some()),
+            ("ConditionExpression", has_condition),
+        ],
+    )?;
+
     // Desugar legacy AttributeUpdates into UpdateExpression if present.
-    // N.B. The literal `{AttributeUpdates}` / `{UpdateExpression}` in the error message
-    // matches real DynamoDB's format — they are not Rust format placeholders.
-    let (effective_update_expr, extra_expr_values, extra_expr_names) = if let Some(attr_updates) =
-        &input.attribute_updates
-    {
-        if input.update_expression.is_some() {
-            return Err(DynamoDbError::ValidationException(
-                "Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {AttributeUpdates} Expression parameters: {UpdateExpression}".to_owned(),
-            ));
-        }
-        desugar_attribute_updates(attr_updates)?
-    } else {
-        (
-            input.update_expression.clone(),
-            HashMap::new(),
-            HashMap::new(),
-        )
-    };
+    let (effective_update_expr, extra_expr_values, extra_expr_names) =
+        if let Some(attr_updates) = &input.attribute_updates {
+            desugar_attribute_updates(attr_updates)?
+        } else {
+            (
+                input.update_expression.clone(),
+                HashMap::new(),
+                HashMap::new(),
+            )
+        };
 
     // Merge extra expression values from desugaring with any existing ones.
     let effective_expr_values = if extra_expr_values.is_empty() {
@@ -101,14 +116,6 @@ pub async fn handle_update_item(
         Some(merged)
     };
 
-    let has_update_expr = input
-        .update_expression
-        .as_ref()
-        .is_some_and(|s| !s.is_empty());
-    let has_condition = input
-        .condition_expression
-        .as_ref()
-        .is_some_and(|s| !s.is_empty());
     let has_expr = has_update_expr || has_condition;
     extenddb_core::expression::validate_expression_param_usage(
         input.expression_attribute_names.as_ref(),
@@ -116,6 +123,12 @@ pub async fn handle_update_item(
         input.expression_attribute_values.as_ref(),
         has_expr,
         &[ExpressionKind::Update, ExpressionKind::Condition],
+    )?;
+
+    // ConditionalOperator requires an Expected with two or more conditions.
+    extenddb_core::validation::validate_conditional_operator_usage(
+        has_cond_op,
+        input.expected.as_ref().map_or(0, HashMap::len),
     )?;
 
     let (condition, maps) = resolve_condition(

--- a/tests/test_conditional_operator.py
+++ b/tests/test_conditional_operator.py
@@ -1,0 +1,579 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Legacy ConditionalOperator validation and expression-parameter mixing.
+
+Amazon DynamoDB rejects ConditionalOperator unless it accompanies a legacy
+Filter (ScanFilter/QueryFilter) or Expected with two or more conditions.
+ConditionalOperator also counts as a non-expression parameter, so combining
+it with any expression parameter raises the mixing error, whose message
+lists every present parameter on each side in a fixed per-API order.
+
+KeyConditions is exempt from the mixing check unless KeyConditionExpression
+is also present: legacy KeyConditions combined with FilterExpression or
+ProjectionExpression is accepted.
+
+Dual-target against Amazon DynamoDB and extenddb.
+"""
+
+from __future__ import annotations
+
+import pytest
+from botocore.exceptions import ClientError
+
+from conftest import scoped_table
+
+WITHOUT_FILTER_MSG = "ConditionalOperator cannot be used without Filter or Expected"
+TWO_OR_MORE_MSG = (
+    "ConditionalOperator can only be used when Filter or Expected has two or more elements"
+)
+MIXING_PREFIX = (
+    "Can not use both expression and non-expression parameters in the same request: "
+)
+
+
+def _mixing_msg(non_expression: str, expression: str) -> str:
+    return (
+        f"{MIXING_PREFIX}Non-expression parameters: {{{non_expression}}} "
+        f"Expression parameters: {{{expression}}}"
+    )
+
+
+def _cond(value: str = "x") -> dict:
+    return {"ComparisonOperator": "EQ", "AttributeValueList": [{"S": value}]}
+
+
+@pytest.fixture(scope="class")
+def hash_table(dynamodb_client):
+    """Hash-only table for the class, with one item, deleted on teardown."""
+    with scoped_table(dynamodb_client) as name:
+        dynamodb_client.put_item(
+            TableName=name,
+            Item={"pk": {"S": "k1"}, "a": {"S": "x"}, "b": {"S": "y"}},
+        )
+        yield name
+
+
+def _expect_validation(func, expected_message: str):
+    with pytest.raises(ClientError) as exc_info:
+        func()
+    err = exc_info.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert err["Message"] == expected_message
+
+
+class TestConditionalOperatorRequiresConditions:
+    """ConditionalOperator without a 2+ element Filter/Expected is rejected."""
+
+    def test_scan_condop_without_filter(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.scan(
+                TableName=hash_table, ConditionalOperator="AND"
+            ),
+            WITHOUT_FILTER_MSG,
+        )
+
+    def test_scan_condop_or_without_filter(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.scan(
+                TableName=hash_table, ConditionalOperator="OR"
+            ),
+            WITHOUT_FILTER_MSG,
+        )
+
+    def test_scan_condop_empty_scan_filter(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.scan(
+                TableName=hash_table, ConditionalOperator="AND", ScanFilter={}
+            ),
+            WITHOUT_FILTER_MSG,
+        )
+
+    def test_scan_condop_single_condition_filter(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.scan(
+                TableName=hash_table,
+                ConditionalOperator="AND",
+                ScanFilter={"a": _cond()},
+            ),
+            TWO_OR_MORE_MSG,
+        )
+
+    def test_scan_condop_with_attributes_to_get_only(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.scan(
+                TableName=hash_table,
+                ConditionalOperator="AND",
+                AttributesToGet=["a", "b"],
+            ),
+            WITHOUT_FILTER_MSG,
+        )
+
+    def test_query_condop_without_filter(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.query(
+                TableName=hash_table,
+                ConditionalOperator="AND",
+                KeyConditions={"pk": _cond("k1")},
+            ),
+            WITHOUT_FILTER_MSG,
+        )
+
+    def test_query_condop_without_any_key_condition(self, dynamodb_client, hash_table):
+        # The ConditionalOperator rule fires before the missing
+        # KeyConditions/KeyConditionExpression error.
+        _expect_validation(
+            lambda: dynamodb_client.query(
+                TableName=hash_table,
+                ConditionalOperator="AND",
+            ),
+            WITHOUT_FILTER_MSG,
+        )
+
+    def test_query_condop_single_condition_filter(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.query(
+                TableName=hash_table,
+                ConditionalOperator="AND",
+                KeyConditions={"pk": _cond("k1")},
+                QueryFilter={"a": _cond()},
+            ),
+            TWO_OR_MORE_MSG,
+        )
+
+    def test_put_item_condop_without_expected(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.put_item(
+                TableName=hash_table,
+                Item={"pk": {"S": "k2"}},
+                ConditionalOperator="AND",
+            ),
+            WITHOUT_FILTER_MSG,
+        )
+
+    def test_put_item_condop_single_condition_expected(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.put_item(
+                TableName=hash_table,
+                Item={"pk": {"S": "k2"}},
+                ConditionalOperator="AND",
+                Expected={"a": _cond()},
+            ),
+            TWO_OR_MORE_MSG,
+        )
+
+    def test_delete_item_condop_without_expected(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.delete_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ConditionalOperator="AND",
+            ),
+            WITHOUT_FILTER_MSG,
+        )
+
+    def test_delete_item_condop_single_condition_expected(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.delete_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ConditionalOperator="AND",
+                Expected={"a": _cond()},
+            ),
+            TWO_OR_MORE_MSG,
+        )
+
+    def test_update_item_condop_without_expected(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.update_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ConditionalOperator="AND",
+                AttributeUpdates={"a": {"Value": {"S": "v"}, "Action": "PUT"}},
+            ),
+            WITHOUT_FILTER_MSG,
+        )
+
+    def test_update_item_condop_no_updates_at_all(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.update_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ConditionalOperator="AND",
+            ),
+            WITHOUT_FILTER_MSG,
+        )
+
+
+class TestConditionalOperatorMixing:
+    """ConditionalOperator with any expression parameter raises the mixing error."""
+
+    def test_scan_condop_with_filter_expression(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.scan(
+                TableName=hash_table,
+                ConditionalOperator="AND",
+                FilterExpression="a = :v",
+                ExpressionAttributeValues={":v": {"S": "x"}},
+            ),
+            _mixing_msg("ConditionalOperator", "FilterExpression"),
+        )
+
+    def test_scan_condop_with_projection_expression(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.scan(
+                TableName=hash_table,
+                ConditionalOperator="AND",
+                ProjectionExpression="a",
+            ),
+            _mixing_msg("ConditionalOperator", "ProjectionExpression"),
+        )
+
+    def test_scan_full_sets_ordering(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.scan(
+                TableName=hash_table,
+                AttributesToGet=["a"],
+                ScanFilter={"a": _cond()},
+                ConditionalOperator="AND",
+                FilterExpression="a = :v",
+                ProjectionExpression="b",
+                ExpressionAttributeValues={":v": {"S": "x"}},
+            ),
+            _mixing_msg(
+                "AttributesToGet, ScanFilter, ConditionalOperator",
+                "ProjectionExpression, FilterExpression",
+            ),
+        )
+
+    def test_query_condop_with_key_condition_expression(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.query(
+                TableName=hash_table,
+                ConditionalOperator="AND",
+                KeyConditionExpression="pk = :p",
+                ExpressionAttributeValues={":p": {"S": "k1"}},
+            ),
+            _mixing_msg("ConditionalOperator", "KeyConditionExpression"),
+        )
+
+    def test_query_full_sets_ordering(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.query(
+                TableName=hash_table,
+                KeyConditions={"pk": _cond("k1")},
+                QueryFilter={"a": _cond()},
+                ConditionalOperator="AND",
+                KeyConditionExpression="pk = :p",
+                FilterExpression="a = :v",
+                ProjectionExpression="b",
+                ExpressionAttributeValues={":p": {"S": "k1"}, ":v": {"S": "x"}},
+            ),
+            _mixing_msg(
+                "QueryFilter, ConditionalOperator, KeyConditions",
+                "ProjectionExpression, FilterExpression, KeyConditionExpression",
+            ),
+        )
+
+    def test_put_item_condop_with_condition_expression(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.put_item(
+                TableName=hash_table,
+                Item={"pk": {"S": "k2"}},
+                ConditionalOperator="AND",
+                ConditionExpression="attribute_exists(pk)",
+            ),
+            _mixing_msg("ConditionalOperator", "ConditionExpression"),
+        )
+
+    def test_put_item_expected_condop_with_condition_expression(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.put_item(
+                TableName=hash_table,
+                Item={"pk": {"S": "k2"}},
+                Expected={"a": _cond()},
+                ConditionalOperator="AND",
+                ConditionExpression="attribute_exists(pk)",
+            ),
+            _mixing_msg("Expected, ConditionalOperator", "ConditionExpression"),
+        )
+
+    def test_delete_item_condop_with_condition_expression(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.delete_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ConditionalOperator="AND",
+                ConditionExpression="attribute_exists(pk)",
+            ),
+            _mixing_msg("ConditionalOperator", "ConditionExpression"),
+        )
+
+    def test_update_item_condop_with_update_expression(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.update_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                ConditionalOperator="AND",
+                UpdateExpression="SET a = :v",
+                ExpressionAttributeValues={":v": {"S": "x"}},
+            ),
+            _mixing_msg("ConditionalOperator", "UpdateExpression"),
+        )
+
+    def test_update_item_full_sets_ordering(self, dynamodb_client, hash_table):
+        _expect_validation(
+            lambda: dynamodb_client.update_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                AttributeUpdates={"a": {"Value": {"S": "v"}, "Action": "PUT"}},
+                Expected={"a": _cond()},
+                ConditionalOperator="AND",
+                UpdateExpression="SET a = :v",
+                ConditionExpression="attribute_exists(pk)",
+                ExpressionAttributeValues={":v": {"S": "x"}},
+            ),
+            _mixing_msg(
+                "AttributeUpdates, Expected, ConditionalOperator",
+                "UpdateExpression, ConditionExpression",
+            ),
+        )
+
+    def test_scan_condop_mixing_beats_unused_values(self, dynamodb_client, hash_table):
+        # The mixing error fires before the unused-ExpressionAttributeValues check.
+        _expect_validation(
+            lambda: dynamodb_client.scan(
+                TableName=hash_table,
+                ConditionalOperator="AND",
+                FilterExpression="a = :v",
+                ExpressionAttributeValues={":v": {"S": "x"}, ":unused": {"S": "y"}},
+            ),
+            _mixing_msg("ConditionalOperator", "FilterExpression"),
+        )
+
+
+class TestTableNameValidationPrecedence:
+    """An invalid TableName wins over the ConditionalOperator and mixing errors."""
+
+    @staticmethod
+    def _expect_table_name_error(func):
+        with pytest.raises(ClientError) as exc_info:
+            func()
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert "at 'tableName' failed to satisfy constraint" in err["Message"]
+
+    def test_put_item_short_table_name_with_condop_mixing(
+        self, dynamodb_client_no_validation
+    ):
+        self._expect_table_name_error(
+            lambda: dynamodb_client_no_validation.put_item(
+                TableName="aa",
+                Item={"pk": {"S": "x"}},
+                ConditionalOperator="AND",
+                ConditionExpression="attribute_exists(pk)",
+            )
+        )
+
+    def test_update_item_short_table_name_with_condop_mixing(
+        self, dynamodb_client_no_validation
+    ):
+        self._expect_table_name_error(
+            lambda: dynamodb_client_no_validation.update_item(
+                TableName="aa",
+                Key={"pk": {"S": "x"}},
+                ConditionalOperator="AND",
+                UpdateExpression="SET a = :v",
+                ExpressionAttributeValues={":v": {"S": "x"}},
+            )
+        )
+
+    def test_delete_item_short_table_name_with_condop(
+        self, dynamodb_client_no_validation
+    ):
+        self._expect_table_name_error(
+            lambda: dynamodb_client_no_validation.delete_item(
+                TableName="aa",
+                Key={"pk": {"S": "x"}},
+                ConditionalOperator="AND",
+            )
+        )
+
+
+class TestCrossAspectMixing:
+    """Legacy params mix with expression params of a different aspect too."""
+
+    def test_scan_scan_filter_with_projection_expression(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.scan(
+                TableName=hash_table,
+                ScanFilter={"a": _cond()},
+                ProjectionExpression="b",
+            ),
+            _mixing_msg("ScanFilter", "ProjectionExpression"),
+        )
+
+    def test_scan_attributes_to_get_with_filter_expression(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.scan(
+                TableName=hash_table,
+                AttributesToGet=["a"],
+                FilterExpression="a = :v",
+                ExpressionAttributeValues={":v": {"S": "x"}},
+            ),
+            _mixing_msg("AttributesToGet", "FilterExpression"),
+        )
+
+    def test_query_attributes_to_get_with_key_condition_expression(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.query(
+                TableName=hash_table,
+                AttributesToGet=["a"],
+                KeyConditionExpression="pk = :p",
+                ExpressionAttributeValues={":p": {"S": "k1"}},
+            ),
+            _mixing_msg("AttributesToGet", "KeyConditionExpression"),
+        )
+
+    def test_query_query_filter_with_key_condition_expression(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.query(
+                TableName=hash_table,
+                QueryFilter={"a": _cond()},
+                KeyConditionExpression="pk = :p",
+                ExpressionAttributeValues={":p": {"S": "k1"}},
+            ),
+            _mixing_msg("QueryFilter", "KeyConditionExpression"),
+        )
+
+    def test_update_item_attribute_updates_with_condition_expression(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.update_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                AttributeUpdates={"a": {"Value": {"S": "v"}, "Action": "PUT"}},
+                ConditionExpression="attribute_exists(pk)",
+            ),
+            _mixing_msg("AttributeUpdates", "ConditionExpression"),
+        )
+
+    def test_update_item_expected_with_update_expression(
+        self, dynamodb_client, hash_table
+    ):
+        _expect_validation(
+            lambda: dynamodb_client.update_item(
+                TableName=hash_table,
+                Key={"pk": {"S": "k1"}},
+                Expected={"a": _cond(), "b": _cond("y")},
+                UpdateExpression="SET c = :v",
+                ExpressionAttributeValues={":v": {"S": "x"}},
+            ),
+            _mixing_msg("Expected", "UpdateExpression"),
+        )
+
+
+class TestAcceptedCombinations:
+    """Valid combinations must not be over-rejected by the fix."""
+
+    def test_scan_condop_two_condition_filter(self, dynamodb_client, hash_table):
+        resp = dynamodb_client.scan(
+            TableName=hash_table,
+            ConditionalOperator="AND",
+            ScanFilter={"a": _cond("x"), "b": _cond("y")},
+        )
+        assert resp["Count"] == 1
+
+    def test_scan_single_condition_filter_no_condop(self, dynamodb_client, hash_table):
+        resp = dynamodb_client.scan(TableName=hash_table, ScanFilter={"a": _cond("x")})
+        assert resp["Count"] == 1
+
+    def test_query_condop_two_condition_filter(self, dynamodb_client, hash_table):
+        resp = dynamodb_client.query(
+            TableName=hash_table,
+            KeyConditions={"pk": _cond("k1")},
+            ConditionalOperator="OR",
+            QueryFilter={"a": _cond("x"), "b": _cond("nope")},
+        )
+        assert resp["Count"] == 1
+
+    def test_query_key_conditions_with_filter_expression(
+        self, dynamodb_client, hash_table
+    ):
+        # KeyConditions is exempt from the mixing check when
+        # KeyConditionExpression is absent.
+        resp = dynamodb_client.query(
+            TableName=hash_table,
+            KeyConditions={"pk": _cond("k1")},
+            FilterExpression="a = :v",
+            ExpressionAttributeValues={":v": {"S": "x"}},
+        )
+        assert resp["Count"] == 1
+
+    def test_query_key_conditions_with_projection_expression(
+        self, dynamodb_client, hash_table
+    ):
+        resp = dynamodb_client.query(
+            TableName=hash_table,
+            KeyConditions={"pk": _cond("k1")},
+            ProjectionExpression="a",
+        )
+        assert resp["Count"] == 1
+        assert resp["Items"][0] == {"a": {"S": "x"}}
+
+    def test_query_key_conditions_with_attributes_to_get(
+        self, dynamodb_client, hash_table
+    ):
+        resp = dynamodb_client.query(
+            TableName=hash_table,
+            KeyConditions={"pk": _cond("k1")},
+            AttributesToGet=["a"],
+        )
+        assert resp["Count"] == 1
+
+    def test_put_item_condop_two_condition_expected(self, dynamodb_client, hash_table):
+        resp = dynamodb_client.put_item(
+            TableName=hash_table,
+            Item={"pk": {"S": "k1"}, "a": {"S": "x"}, "b": {"S": "y"}},
+            ConditionalOperator="AND",
+            Expected={"a": _cond("x"), "b": _cond("y")},
+        )
+        assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    def test_delete_item_condop_two_condition_expected(
+        self, dynamodb_client, hash_table
+    ):
+        dynamodb_client.put_item(
+            TableName=hash_table,
+            Item={"pk": {"S": "k3"}, "a": {"S": "x"}, "b": {"S": "y"}},
+        )
+        resp = dynamodb_client.delete_item(
+            TableName=hash_table,
+            Key={"pk": {"S": "k3"}},
+            ConditionalOperator="OR",
+            Expected={"a": _cond("x"), "b": _cond("zzz")},
+        )
+        assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200


### PR DESCRIPTION
## What

ExtendDB silently accepted the legacy `ConditionalOperator` parameter when it was supplied without a legacy filter (`ScanFilter` / `QueryFilter` / `Expected`), and its expression/non-expression mixing checks were same-aspect pairs that never counted `ConditionalOperator` and missed cross-aspect mixes. Amazon DynamoDB rejects all of these.

This adds two engine-agnostic validators in `crates/core` and wires them into `scan`, `query`, `put_item`, `delete_item`, and `update_item`: `validate_conditional_operator_usage` (valid only with a 2+ condition legacy filter) and `validate_no_expression_param_mixing` (builds the full-set Amazon DynamoDB message from ordered `(name, present)` slices). `KeyConditions` stays exempt from the mixing check unless `KeyConditionExpression` is also present.

## Behavior: today vs Amazon DynamoDB

Every message below was captured directly via the AWS CLI against Amazon DynamoDB.

| Scenario | ExtendDB (before) | Amazon DynamoDB |
|---|---|---|
| `Scan` `ConditionalOperator=AND`, no `ScanFilter` | Runs, HTTP 200 | `ValidationException: ConditionalOperator cannot be used without Filter or Expected` |
| `ConditionalOperator` + single-condition `ScanFilter`/`QueryFilter`/`Expected` | Runs | `ValidationException: ConditionalOperator can only be used when Filter or Expected has two or more elements` |
| Same, applies to `Query` (legacy `KeyConditions`), `PutItem`, `DeleteItem`, `UpdateItem` | Runs | same two messages |
| `Scan` `ScanFilter` + `ConditionalOperator` + `FilterExpression` | `{ScanFilter}` only | `... Non-expression parameters: {ScanFilter, ConditionalOperator} Expression parameters: {FilterExpression}` |
| `Scan` `ScanFilter` + `ProjectionExpression` (cross-aspect) | Runs, no error | `... Non-expression parameters: {ScanFilter} Expression parameters: {ProjectionExpression}` |
| `UpdateItem` `AttributeUpdates` + `ConditionExpression` (cross-aspect) | Runs, no error | `... Non-expression parameters: {AttributeUpdates} Expression parameters: {ConditionExpression}` |
| `Query` `KeyConditions` + `FilterExpression` / `ProjectionExpression` (control) | Runs | Runs (legal) |
| `PutItem` `ConditionalOperator` + 2-condition `Expected` (control) | Runs | Runs (legal) |

The mixing message lists every present parameter per side in Amazon DynamoDB's per-API order: `Scan` non-expression `{AttributesToGet, ScanFilter, ConditionalOperator}`; `Query` non-expression `{AttributesToGet, QueryFilter, ConditionalOperator, KeyConditions}`; `UpdateItem` non-expression `{AttributeUpdates, Expected, ConditionalOperator}`; `PutItem`/`DeleteItem` `{Expected, ConditionalOperator}`.

Precedence matches Amazon DynamoDB: an invalid `TableName` is rejected first (the write handlers validate the table name at the top of the handler, before these checks); the mixing error beats the unused-`ExpressionAttributeValues` check; the `ConditionalOperator` rule runs after both. In `Query`, the `ConditionalOperator` error precedes the missing-key-condition error.

## Why

Conformance gap found by comparing ExtendDB against Amazon DynamoDB with the AWS CLI. The fix is engine-agnostic (validation in `crates/core`, no storage coupling). Continues the expression-parameter mixing line of work from #178.

Closes # n/a

## Testing done

Captured every expected message from Amazon DynamoDB, then verified dual-target (ExtendDB and Amazon DynamoDB).

- New pytest `tests/test_conditional_operator.py`: 42 cases, all 42 pass against ExtendDB and the same 42 against Amazon DynamoDB. Covers both `ConditionalOperator` messages per API (absent / empty / single-condition), the mixing message and per-API ordering (including full-set cases), the previously accepted cross-aspect mixes, the `KeyConditions` exemption, the `TableName`-beats-mixing and mixing-beats-unused-values precedence, and valid combinations that must not be over-rejected.
- New Rust unit tests in `crates/core/src/validation`: 5, covering the full-set message, ordering, absent-parameter skipping, one-side-only, and both `ConditionalOperator` messages.
- `cargo test -p extenddb-core -p extenddb-engine`: pass. `cargo test --workspace` (with a PostgreSQL backend): all suites pass, 0 failures. `cargo fmt --check`: clean. `cargo clippy --all-targets -- -D warnings`: clean.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface, an RFC has been accepted or is linked below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a
