### PR TITLE
fix(storage-postgres): paginate hash-only GSI on a composite base table

### DIFF
--- a/crates/storage-postgres/src/data/query_scan.rs
+++ b/crates/storage-postgres/src/data/query_scan.rs
@@ -277,8 +277,14 @@ impl PostgresEngine {
         // The enum variant determines exactly which values are bound and in what order,
         // preventing bind-order divergence between SQL generation and execution.
         let pagination_binds = if let Some(start_key) = exclusive_start_key {
-            if let Some((ref base_sk_name, base_sk_type)) = base_sk_info {
-                // Index with base SK tie-breaker (SQL has $N for base_sk)
+            if sk_info_val.is_some()
+                && let Some((ref base_sk_name, base_sk_type)) = base_sk_info
+            {
+                // Index that has its own SK, with a base-table SK tie-breaker.
+                // The index SK is bound separately (see execute_query_sql); here
+                // we bind only the base SK. (SQL has $N for base_sk.)
+                // A hash-only index falls through to the BasePkAndSk arm below,
+                // because its SQL binds base_pk AND base_sk, not base_sk alone.
                 if let Some(base_sk_val) = start_key.get(base_sk_name.as_str()) {
                     let sk = parse_sk(base_sk_val, base_sk_type)?;
                     PaginationBinds::BaseSkOnly { sk }

--- a/tests/rust/src/gsi_more.rs
+++ b/tests/rust/src/gsi_more.rs
@@ -230,3 +230,141 @@ async fn query_gsi_composite_key_table() {
 
     assert_eq!(resp.count(), 3);
 }
+
+/// Regression: a hash-only GSI on a composite-key base table. Many items share
+/// the GSI hash and the base partition key, differing only by the base sort
+/// key, so a continuation must carry the base sort key to disambiguate.
+///
+/// Previously the pagination resume bound the base sort key without the base
+/// partition key, diverging from the generated SQL (which binds both), causing
+/// a parameter/bind-count mismatch and a 500 on the second page. This walks
+/// every item across pages and asserts each is returned exactly once.
+#[tokio::test]
+async fn hash_only_gsi_pagination_on_composite_base_table() {
+    use aws_sdk_dynamodb::types::{AttributeValue, BillingMode};
+    use std::collections::{BTreeSet, HashMap};
+    use std::time::Duration;
+
+    let c = client();
+    let table = format!("HashOnlyGsiPage_{}", ts());
+    let gh = format!("gho_{}", ts());
+
+    let gsi = GlobalSecondaryIndex::builder()
+        .index_name("gho")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("gh")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .projection(
+            Projection::builder()
+                .projection_type(ProjectionType::All)
+                .build(),
+        )
+        .build()
+        .unwrap();
+
+    c.create_table()
+        .table_name(&table)
+        .billing_mode(BillingMode::PayPerRequest)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("sk")
+                .key_type(KeyType::Range)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("sk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("gh")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .global_secondary_indexes(gsi)
+        .send()
+        .await
+        .unwrap();
+    wait_for_active(c, &table).await;
+
+    let count = 5;
+    for i in 0..count {
+        let mut item = HashMap::new();
+        item.insert("pk".to_string(), s("p"));
+        item.insert("sk".to_string(), s(&format!("s{i}")));
+        item.insert("gh".to_string(), s(&gh));
+        c.put_item()
+            .table_name(&table)
+            .set_item(Some(item))
+            .send()
+            .await
+            .unwrap();
+    }
+    // GSI is eventually consistent — allow projection to settle.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    let mut total = 0usize;
+    let mut pages = 0usize;
+    let mut esk: Option<HashMap<String, AttributeValue>> = None;
+
+    loop {
+        let mut req = c
+            .query()
+            .table_name(&table)
+            .index_name("gho")
+            .key_condition_expression("#gh = :gh")
+            .expression_attribute_names("#gh", "gh")
+            .expression_attribute_values(":gh", s(&gh))
+            .limit(2);
+        if let Some(ref lek) = esk {
+            req = req.set_exclusive_start_key(Some(lek.clone()));
+        }
+
+        let resp = req.send().await.unwrap();
+        for it in resp.items() {
+            if let Some(AttributeValue::S(sk)) = it.get("sk") {
+                seen.insert(sk.clone());
+                total += 1;
+            }
+        }
+        pages += 1;
+        match resp.last_evaluated_key() {
+            Some(lek) => esk = Some(lek.to_owned()),
+            None => break,
+        }
+        assert!(pages < 10, "pagination did not terminate");
+    }
+
+    assert_eq!(seen.len(), count, "every item must be seen exactly once");
+    assert_eq!(
+        total, count,
+        "no item may be returned twice across a page boundary"
+    );
+    assert!(pages > 1, "Limit 2 over 5 items must force real pagination");
+
+    let _ = c.delete_table().table_name(&table).send().await;
+}


### PR DESCRIPTION
## What

Fixes an `InternalServerError` (500) returned when paginating a **hash-only GSI whose base table has a composite primary key**. The continuation request (page 2, carrying `ExclusiveStartKey`) failed with the Postgres error `bind message supplies 2 parameters, but prepared statement requires 3`, surfaced to the client as a silent `Internal` 500.

Root cause: for a hash-only index on a composite base table, the SQL builder emits a base-sort-key tie-breaker predicate (`base_pk > $2 OR (base_pk = $2 AND base_sk > $3)`), so it needs **base_pk + base_sk**. The value-binding logic's first arm was gated only on `base_sk_info.is_some()`, so it bound `base_sk` alone (1 pagination value) before the correct `base_pk + base_sk` arm could run — 2 bound values vs 3 SQL placeholders.

The fix guards that arm with `sk_info_val.is_some()` so it applies only to an index that has *its own* sort key; a hash-only index now falls through to the arm that binds both `base_pk` and `base_sk`, matching the emitted SQL.

## Why

Pagination over a hash-only GSI on a composite-key base table is a valid, common access pattern, and it currently crashes with a 500 on the second page instead of returning the next page. This is the Query-side counterpart to the Scan-side fix
already merged as `fa0dfc4` ("include base sort key in hash-only GSI scan pagination on a composite base").

Closes # n/a — no tracking issue

## Testing done

- Added a Rust integration test, `tests/rust/src/gsi_more.rs::hash_only_gsi_pagination_on_composite_base_table`, which creates a composite-key base table with a hash-only GSI, writes items across multiple GSI partitions, and pages through the GSI with an enforced page size — asserting every item is returned exactly once across pages and that the paginated resume (`ExclusiveStartKey`/`LastEvaluatedKey`) does not error. This test fails (500 on page 2) before the fix and passes after.
- `cargo fmt --all -- --check` → clean (exit 0).
- `cargo clippy` on `storage-postgres` → clean (no new warnings from this change).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed (n/a — bug fix, no documented behavior contract changed)
- [x] Breaking changes are noted below (none)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a — internal query/pagination bug fix; no change to wire protocol, `Storage` trait, auth model, on-disk format, or CLI surface.

## Breaking changes

None. This corrects a crash into the already-specified pagination behavior; requests that previously succeeded are unaffected.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.