### PR TITLE
fix: expr operand type and size

### DIFF
--- a/crates/core/src/expression/evaluator.rs
+++ b/crates/core/src/expression/evaluator.rs
@@ -14,7 +14,7 @@ use crate::error::DynamoDbError;
 use crate::types::AttributeValue;
 
 use super::ast::{CompareOp, Expr, PathElement};
-use super::resolver::{ExpressionMaps, resolve_path};
+use super::resolver::{ExpressionMaps, attribute_type_code, resolve_path};
 
 /// Evaluate a condition expression against an item.
 ///
@@ -363,34 +363,18 @@ fn evaluate_size<'a>(
     let sz = match v.as_ref() {
         AttributeValue::S(s) => s.encode_utf16().count(),
         AttributeValue::B(b) => b.len(),
-        AttributeValue::N(n) => n.len(), // ASCII digits are 1 byte each, so len() == UTF-8 byte count
         AttributeValue::L(l) => l.len(),
         AttributeValue::M(m) => m.len(),
         AttributeValue::SS(s) | AttributeValue::NS(s) => s.len(),
         AttributeValue::BS(s) => s.len(),
-        AttributeValue::Bool(_) | AttributeValue::Null => {
-            return Err(DynamoDbError::ValidationException(
-                "Invalid ConditionExpression: size is not supported for this type".to_owned(),
-            ));
+        // size() is unsupported for Number, Bool and Null. Amazon DynamoDB
+        // yields no value for these, so the enclosing comparison evaluates to
+        // false rather than raising a ValidationException.
+        AttributeValue::N(_) | AttributeValue::Bool(_) | AttributeValue::Null => {
+            return Ok(None);
         }
     };
     Ok(Some(Cow::Owned(AttributeValue::N(sz.to_string()))))
-}
-
-/// Return the `DynamoDB` type code for an `AttributeValue`.
-fn attribute_type_code(val: &AttributeValue) -> &'static str {
-    match val {
-        AttributeValue::S(_) => "S",
-        AttributeValue::N(_) => "N",
-        AttributeValue::B(_) => "B",
-        AttributeValue::Bool(_) => "BOOL",
-        AttributeValue::Null => "NULL",
-        AttributeValue::L(_) => "L",
-        AttributeValue::M(_) => "M",
-        AttributeValue::SS(_) => "SS",
-        AttributeValue::NS(_) => "NS",
-        AttributeValue::BS(_) => "BS",
-    }
 }
 
 /// Format an `AttributeValue` for error messages (e.g. `N:5`, `S:hello`).

--- a/crates/core/src/expression/evaluator_tests.rs
+++ b/crates/core/src/expression/evaluator_tests.rs
@@ -409,3 +409,32 @@ fn size_of_missing_attribute_lt_returns_false() {
     // size(missing) < :one should be false
     assert!(!eval("size(missing) < :one", &item, HashMap::new(), values).unwrap());
 }
+
+#[test]
+fn size_of_number_attribute_yields_no_value() {
+    // size() is unsupported for Number: DynamoDB yields no value, so the
+    // comparison is false (never a ValidationException).
+    let item = simple_item(); // age is N:30
+    let mut values = HashMap::new();
+    values.insert("zero".into(), AttributeValue::N("0".into()));
+    assert!(!eval("size(age) > :zero", &item, HashMap::new(), values).unwrap());
+}
+
+#[test]
+fn size_of_bool_attribute_yields_no_value() {
+    // size() is unsupported for Bool: yields no value, comparison false.
+    let item = simple_item(); // active is BOOL:true
+    let mut values = HashMap::new();
+    values.insert("zero".into(), AttributeValue::N("0".into()));
+    assert!(!eval("size(active) > :zero", &item, HashMap::new(), values).unwrap());
+}
+
+#[test]
+fn size_of_null_attribute_yields_no_value() {
+    // size() is unsupported for Null: yields no value, comparison false.
+    let mut item = BTreeMap::new();
+    item.insert("nu".into(), AttributeValue::Null);
+    let mut values = HashMap::new();
+    values.insert("zero".into(), AttributeValue::N("0".into()));
+    assert!(!eval("size(nu) > :zero", &item, HashMap::new(), values).unwrap());
+}

--- a/crates/core/src/expression/mod.rs
+++ b/crates/core/src/expression/mod.rs
@@ -31,7 +31,7 @@ pub use reserved_words::validate_no_reserved_words;
 pub use resolver::{
     ExpressionMaps, collect_key_condition_refs, collect_value_placeholders, resolve_element_name,
     resolve_name_ref, resolve_path, validate_begins_with_operands, validate_expression_param_usage,
-    validate_unused_attributes,
+    validate_ordering_operand_types, validate_unused_attributes,
 };
 pub use tokenizer::{Token, tokenize, tokenize_for, tokenize_with_limit};
 pub use update_evaluator::apply_update;

--- a/crates/core/src/expression/resolver.rs
+++ b/crates/core/src/expression/resolver.rs
@@ -706,6 +706,81 @@ mod tests {
         assert!(err.to_string().contains("operand type: N"));
     }
 
+    #[test]
+    fn ordering_rejects_non_orderable_literal_with_operator_symbol() {
+        for (op, sym) in [("<", "<"), ("<=", "<="), (">", ">"), (">=", ">=")] {
+            let expr = parse(&format!("n {op} :v"));
+            let maps = maps_with("v", AttributeValue::Bool(true));
+            let err = validate_ordering_operand_types(&expr, &maps).unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains(&format!("operator or function: {sym}")),
+                "{msg}"
+            );
+            assert!(msg.contains("operand type: BOOL"), "{msg}");
+        }
+    }
+
+    #[test]
+    fn ordering_reports_each_non_orderable_type_code() {
+        for (val, code) in [
+            (AttributeValue::Null, "NULL"),
+            (AttributeValue::L(vec![]), "L"),
+            (AttributeValue::M(BTreeMap::new()), "M"),
+            (AttributeValue::SS(BTreeSet::from(["a".to_owned()])), "SS"),
+        ] {
+            let expr = parse("n > :v");
+            let maps = maps_with("v", val);
+            let err = validate_ordering_operand_types(&expr, &maps).unwrap_err();
+            assert!(err.to_string().contains(&format!("operand type: {code}")));
+        }
+    }
+
+    #[test]
+    fn equality_ops_accept_non_orderable_literal() {
+        for op in ["=", "<>"] {
+            let expr = parse(&format!("n {op} :v"));
+            let maps = maps_with("v", AttributeValue::Bool(true));
+            assert!(validate_ordering_operand_types(&expr, &maps).is_ok());
+        }
+    }
+
+    #[test]
+    fn between_rejects_non_orderable_literal_bounds() {
+        let expr = parse("n BETWEEN :a AND :b");
+        let mut values = HashMap::new();
+        values.insert("a".to_owned(), AttributeValue::Bool(true));
+        values.insert("b".to_owned(), AttributeValue::Bool(false));
+        let maps = ExpressionMaps::new(HashMap::new(), values);
+        let err = validate_ordering_operand_types(&expr, &maps).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("operator or function: BETWEEN"), "{msg}");
+        assert!(msg.contains("operand type: BOOL"), "{msg}");
+    }
+
+    #[test]
+    fn ordering_ignores_non_orderable_document_path() {
+        // Both operands are document paths: not validated (evaluates false at runtime).
+        let expr = parse("flag > other");
+        let maps = ExpressionMaps::new(HashMap::new(), HashMap::new());
+        assert!(validate_ordering_operand_types(&expr, &maps).is_ok());
+    }
+
+    #[test]
+    fn ordering_validated_across_short_circuit_branches() {
+        // The bad compare is rejected even behind a short-circuiting AND/OR or NOT.
+        for expr_str in [
+            "attribute_exists(x) AND n > :v",
+            "attribute_not_exists(x) OR n > :v",
+            "NOT (n > :v)",
+        ] {
+            let expr = parse(expr_str);
+            let maps = maps_with("v", AttributeValue::Bool(true));
+            let err = validate_ordering_operand_types(&expr, &maps).unwrap_err();
+            assert!(err.to_string().contains("Incorrect operand type"));
+        }
+    }
+
     fn placeholder(s: &str) -> Expr {
         Expr::Placeholder(s.to_owned())
     }

--- a/crates/core/src/expression/resolver.rs
+++ b/crates/core/src/expression/resolver.rs
@@ -12,8 +12,7 @@ use std::collections::{BTreeMap, HashMap};
 use crate::error::DynamoDbError;
 use crate::types::AttributeValue;
 
-use super::ast::Expr;
-use super::ast::PathElement;
+use super::ast::{CompareOp, Expr, PathElement};
 
 /// Resolved expression attribute names and values.
 ///
@@ -473,17 +472,7 @@ pub fn validate_begins_with_operands(
                 && let Some(val) = maps.values.get(placeholder)
                 && !matches!(val, AttributeValue::S(_) | AttributeValue::B(_))
             {
-                let type_code = match val {
-                    AttributeValue::N(_) => "N",
-                    AttributeValue::Bool(_) => "BOOL",
-                    AttributeValue::Null => "NULL",
-                    AttributeValue::L(_) => "L",
-                    AttributeValue::M(_) => "M",
-                    AttributeValue::SS(_) => "SS",
-                    AttributeValue::NS(_) => "NS",
-                    AttributeValue::BS(_) => "BS",
-                    _ => "UNKNOWN",
-                };
+                let type_code = attribute_type_code(val);
                 return Err(DynamoDbError::ValidationException(format!(
                     "Incorrect operand type for operator or function; operator or function: begins_with, operand type: {type_code}"
                 )));
@@ -497,6 +486,97 @@ pub fn validate_begins_with_operands(
         Expr::Not(inner) => validate_begins_with_operands(inner, maps),
         _ => Ok(()),
     }
+}
+
+/// Return the DynamoDB type code for an AttributeValue (S, N, B, BOOL, NULL,
+/// L, M, SS, NS, BS). Used in operand-type validation messages.
+pub(crate) fn attribute_type_code(val: &AttributeValue) -> &'static str {
+    match val {
+        AttributeValue::S(_) => "S",
+        AttributeValue::N(_) => "N",
+        AttributeValue::B(_) => "B",
+        AttributeValue::Bool(_) => "BOOL",
+        AttributeValue::Null => "NULL",
+        AttributeValue::L(_) => "L",
+        AttributeValue::M(_) => "M",
+        AttributeValue::SS(_) => "SS",
+        AttributeValue::NS(_) => "NS",
+        AttributeValue::BS(_) => "BS",
+    }
+}
+
+/// Reject ordering comparisons (`<`, `<=`, `>`, `>=`) and `BETWEEN` whose
+/// literal (expression-attribute-value) operand is a non-orderable type. Only
+/// S, N and B are orderable in Amazon DynamoDB. A document path is not checked
+/// here: at runtime a path that resolves to a non-orderable type makes the
+/// comparison evaluate to false. Runs over the whole tree before evaluation so
+/// short-circuited branches and empty scans still reject. Equality (`=`) and
+/// inequality (`<>`) accept every type and are left alone.
+///
+/// The message carries no expression-kind prefix; the caller adds
+/// `Invalid ConditionExpression:` / `Invalid FilterExpression:`.
+///
+/// # Errors
+///
+/// Returns `ValidationException` when an ordering operand is a non-orderable literal.
+pub fn validate_ordering_operand_types(
+    expr: &Expr,
+    maps: &ExpressionMaps,
+) -> Result<(), DynamoDbError> {
+    match expr {
+        Expr::Compare { left, op, right } => {
+            if let Some(symbol) = ordering_op_symbol(*op) {
+                reject_non_orderable_literal(left, maps, symbol)?;
+                reject_non_orderable_literal(right, maps, symbol)?;
+            }
+            Ok(())
+        }
+        Expr::Between { operand, low, high } => {
+            reject_non_orderable_literal(operand, maps, "BETWEEN")?;
+            reject_non_orderable_literal(low, maps, "BETWEEN")?;
+            reject_non_orderable_literal(high, maps, "BETWEEN")
+        }
+        Expr::And(left, right) | Expr::Or(left, right) => {
+            validate_ordering_operand_types(left, maps)?;
+            validate_ordering_operand_types(right, maps)
+        }
+        Expr::Not(inner) => validate_ordering_operand_types(inner, maps),
+        _ => Ok(()),
+    }
+}
+
+/// The DynamoDB symbol for an ordering operator, or `None` for equality and
+/// inequality (which accept every operand type).
+fn ordering_op_symbol(op: CompareOp) -> Option<&'static str> {
+    match op {
+        CompareOp::Lt => Some("<"),
+        CompareOp::Le => Some("<="),
+        CompareOp::Gt => Some(">"),
+        CompareOp::Ge => Some(">="),
+        CompareOp::Eq | CompareOp::Ne => None,
+    }
+}
+
+/// Reject a literal (`:value`) operand whose resolved type is not orderable.
+/// Non-literal operands (document paths, function results) are left to runtime.
+fn reject_non_orderable_literal(
+    operand: &Expr,
+    maps: &ExpressionMaps,
+    op_label: &str,
+) -> Result<(), DynamoDbError> {
+    if let Expr::Placeholder(placeholder) = operand
+        && let Some(val) = maps.values.get(placeholder)
+        && !matches!(
+            val,
+            AttributeValue::S(_) | AttributeValue::N(_) | AttributeValue::B(_)
+        )
+    {
+        let type_code = attribute_type_code(val);
+        return Err(DynamoDbError::ValidationException(format!(
+            "Incorrect operand type for operator or function; operator or function: {op_label}, operand type: {type_code}"
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/engine/src/expression_helpers.rs
+++ b/crates/engine/src/expression_helpers.rs
@@ -9,7 +9,7 @@ use extenddb_core::error::DynamoDbError;
 use extenddb_core::expression::{
     Expr, ExpressionKind, ExpressionMaps, KeyCondition, PathElement, Token, UpdateAction,
     parse_condition_with_depth_limit, parse_key_condition, parse_projection, parse_update_from,
-    tokenize_for, tokenize_with_limit, validate_no_reserved_words,
+    tokenize_for, tokenize_with_limit, validate_no_reserved_words, validate_ordering_operand_types,
 };
 use extenddb_core::limits::LimitsConfig;
 use extenddb_core::types::{AttributeValue, ConditionalOperator, ExpectedAttributeValue};
@@ -202,6 +202,10 @@ pub fn resolve_condition(
 
     let maps = build_expression_maps(names, values);
     let condition = parse_optional_condition(condition_expression, limits)?;
+    if let Some(ref expr) = condition {
+        validate_ordering_operand_types(expr, &maps)
+            .map_err(|e| prefix_expression_error(e, ExpressionKind::Condition))?;
+    }
     Ok((condition, maps))
 }
 

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -385,6 +385,9 @@ pub async fn handle_query(
         extenddb_core::expression::validate_begins_with_operands(f, &combined_maps).map_err(
             |e| crate::expression_helpers::prefix_expression_error(e, ExpressionKind::Filter),
         )?;
+        extenddb_core::expression::validate_ordering_operand_types(f, &combined_maps).map_err(
+            |e| crate::expression_helpers::prefix_expression_error(e, ExpressionKind::Filter),
+        )?;
     }
 
     // Validate ExclusiveStartKey matches the key schema

--- a/crates/engine/src/scan.rs
+++ b/crates/engine/src/scan.rs
@@ -344,6 +344,9 @@ pub async fn handle_scan(
         extenddb_core::expression::validate_begins_with_operands(f, &combined_maps).map_err(
             |e| crate::expression_helpers::prefix_expression_error(e, ExpressionKind::Filter),
         )?;
+        extenddb_core::expression::validate_ordering_operand_types(f, &combined_maps).map_err(
+            |e| crate::expression_helpers::prefix_expression_error(e, ExpressionKind::Filter),
+        )?;
     }
 
     // Scan storage

--- a/crates/engine/src/transact_write_items.rs
+++ b/crates/engine/src/transact_write_items.rs
@@ -224,6 +224,16 @@ async fn prepare_write_op(
             put.expression_attribute_values.as_ref(),
         );
         let condition = parse_optional_condition(put.condition_expression.as_deref(), &ctx.limits)?;
+        if let Some(ref expr) = condition {
+            extenddb_core::expression::validate_ordering_operand_types(expr, &maps).map_err(
+                |e| {
+                    crate::expression_helpers::prefix_expression_error(
+                        e,
+                        extenddb_core::expression::ExpressionKind::Condition,
+                    )
+                },
+            )?;
+        }
         // Transactions accept names/values with no expression (unlike single-item
         // APIs); only check for unused refs when a condition is present.
         if condition.is_some() {
@@ -268,6 +278,16 @@ async fn prepare_write_op(
             del.expression_attribute_values.as_ref(),
         );
         let condition = parse_optional_condition(del.condition_expression.as_deref(), &ctx.limits)?;
+        if let Some(ref expr) = condition {
+            extenddb_core::expression::validate_ordering_operand_types(expr, &maps).map_err(
+                |e| {
+                    crate::expression_helpers::prefix_expression_error(
+                        e,
+                        extenddb_core::expression::ExpressionKind::Condition,
+                    )
+                },
+            )?;
+        }
         if condition.is_some() {
             let exprs: Vec<&extenddb_core::expression::Expr> = condition.iter().collect();
             extenddb_core::expression::validate_unused_attributes(
@@ -328,6 +348,16 @@ async fn prepare_write_op(
             validate_attribute_values_nesting_depth(stored)?;
         }
         let condition = parse_optional_condition(upd.condition_expression.as_deref(), &ctx.limits)?;
+        if let Some(ref expr) = condition {
+            extenddb_core::expression::validate_ordering_operand_types(expr, &maps).map_err(
+                |e| {
+                    crate::expression_helpers::prefix_expression_error(
+                        e,
+                        extenddb_core::expression::ExpressionKind::Condition,
+                    )
+                },
+            )?;
+        }
         {
             let exprs: Vec<&extenddb_core::expression::Expr> = condition.iter().collect();
             extenddb_core::expression::validate_unused_attributes(
@@ -372,6 +402,14 @@ async fn prepare_write_op(
         );
         let condition =
             crate::expression_helpers::parse_condition_expr(&cc.condition_expression, &ctx.limits)?;
+        extenddb_core::expression::validate_ordering_operand_types(&condition, &maps).map_err(
+            |e| {
+                crate::expression_helpers::prefix_expression_error(
+                    e,
+                    extenddb_core::expression::ExpressionKind::Condition,
+                )
+            },
+        )?;
         {
             let exprs: Vec<&extenddb_core::expression::Expr> = vec![&condition];
             extenddb_core::expression::validate_unused_attributes(

--- a/tests/test_expr_operand_type_and_size.py
+++ b/tests/test_expr_operand_type_and_size.py
@@ -1,0 +1,352 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Operand-type validation for ordering comparisons, and size() on unsupported types.
+
+Two related expression-evaluator behaviours, verified against Amazon DynamoDB:
+
+Case A (missing validation): an ordering comparison (<, <=, >, >=) or BETWEEN
+whose *literal* operand (an ExpressionAttributeValue) is a non-orderable type
+(BOOL, NULL, or any set/list/map) is rejected up front with a
+ValidationException, regardless of whether the branch is evaluated. A document
+*path* that resolves to a non-orderable type is not validated: the comparison
+just evaluates to false.
+
+Case B (over-validation): size() applied to an attribute that resolves to a
+type size() does not support (Number, Bool, Null) yields no value, so the
+enclosing comparison evaluates to false. It must not raise.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from botocore.exceptions import ClientError
+
+BASE_ITEM = {
+    "pk": {"S": "p1"},
+    "n": {"N": "5"},
+    "num": {"N": "9"},
+    "flag": {"BOOL": True},
+    "s": {"S": "x"},
+    "nu": {"NULL": True},
+    "sset": {"SS": ["a", "b"]},
+    "lst": {"L": [{"S": "a"}]},
+}
+
+# Non-orderable literal operands keyed by the DynamoDB type code DynamoDB reports.
+NON_ORDERABLE = {
+    "BOOL": {"BOOL": True},
+    "NULL": {"NULL": True},
+    "SS": {"SS": ["a", "b"]},
+    "NS": {"NS": ["1", "2"]},
+    "L": {"L": [{"S": "a"}]},
+    "M": {"M": {"k": {"S": "a"}}},
+}
+
+ORDERING_OPS = ["<", "<=", ">", ">="]
+
+
+@pytest.fixture(scope="class")
+def probe_table(dynamodb_client):
+    name = f"expr_operand_{uuid.uuid4().hex[:8]}"
+    dynamodb_client.create_table(
+        TableName=name,
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    from conftest import wait_for_active
+
+    wait_for_active(dynamodb_client, name)
+    dynamodb_client.put_item(TableName=name, Item=BASE_ITEM)
+    yield name
+    dynamodb_client.delete_table(TableName=name)
+
+
+def _put_cond(client, table, condition, eav):
+    """PutItem the base item under a condition. Rewrites identical data on success."""
+    client.put_item(
+        TableName=table,
+        Item=BASE_ITEM,
+        ConditionExpression=condition,
+        ExpressionAttributeValues=eav,
+    )
+
+
+def _err(exc_info):
+    return exc_info.value.response["Error"]
+
+
+class TestOrderingOperandType:
+    """Case A: ordering comparison / BETWEEN with a non-orderable literal -> ValidationException."""
+
+    @pytest.mark.parametrize("op", ORDERING_OPS)
+    @pytest.mark.parametrize("type_code", list(NON_ORDERABLE))
+    def test_ordering_op_rejects_non_orderable_literal(
+        self, dynamodb_client, probe_table, op, type_code
+    ):
+        with pytest.raises(ClientError) as ei:
+            _put_cond(
+                dynamodb_client,
+                probe_table,
+                f"n {op} :v",
+                {":v": NON_ORDERABLE[type_code]},
+            )
+        err = _err(ei)
+        assert err["Code"] == "ValidationException"
+        assert "Incorrect operand type for operator or function" in err["Message"]
+        assert f"operator or function: {op}" in err["Message"]
+        assert f"operand type: {type_code}" in err["Message"]
+
+    def test_between_rejects_non_orderable_literal_bounds(
+        self, dynamodb_client, probe_table
+    ):
+        with pytest.raises(ClientError) as ei:
+            _put_cond(
+                dynamodb_client,
+                probe_table,
+                "n BETWEEN :a AND :b",
+                {":a": {"BOOL": True}, ":b": {"BOOL": False}},
+            )
+        err = _err(ei)
+        assert err["Code"] == "ValidationException"
+        assert "operator or function: BETWEEN" in err["Message"]
+        assert "operand type: BOOL" in err["Message"]
+
+    def test_reports_offending_operand_regardless_of_position(
+        self, dynamodb_client, probe_table
+    ):
+        # Right operand non-orderable.
+        with pytest.raises(ClientError) as ei:
+            _put_cond(
+                dynamodb_client,
+                probe_table,
+                ":x > :v",
+                {":x": {"N": "1"}, ":v": {"BOOL": True}},
+            )
+        assert "operand type: BOOL" in _err(ei)["Message"]
+        # Left operand non-orderable.
+        with pytest.raises(ClientError) as ei:
+            _put_cond(
+                dynamodb_client,
+                probe_table,
+                ":v > :x",
+                {":v": {"BOOL": True}, ":x": {"N": "1"}},
+            )
+        assert "operand type: BOOL" in _err(ei)["Message"]
+
+    def test_validated_upfront_across_short_circuit_and_not(
+        self, dynamodb_client, probe_table
+    ):
+        # Whole-expression validation: the bad compare is rejected even when the
+        # boolean structure would short-circuit past it, or NOT-wraps it.
+        for cond in [
+            "attribute_not_exists(zzz) OR n > :bool",
+            "attribute_exists(zzz) AND n > :bool",
+            "NOT (n > :bool)",
+        ]:
+            with pytest.raises(ClientError) as ei:
+                _put_cond(dynamodb_client, probe_table, cond, {":bool": {"BOOL": True}})
+            assert _err(ei)["Code"] == "ValidationException"
+            assert "Incorrect operand type" in _err(ei)["Message"]
+
+    def test_absent_path_with_non_orderable_literal_still_rejects(
+        self, dynamodb_client, probe_table
+    ):
+        with pytest.raises(ClientError) as ei:
+            _put_cond(
+                dynamodb_client, probe_table, "nope > :bool", {":bool": {"BOOL": True}}
+            )
+        assert _err(ei)["Code"] == "ValidationException"
+
+    def test_size_result_compared_to_non_orderable_literal_rejects(
+        self, dynamodb_client, probe_table
+    ):
+        with pytest.raises(ClientError) as ei:
+            _put_cond(
+                dynamodb_client, probe_table, "size(s) > :bool", {":bool": {"BOOL": True}}
+            )
+        assert "operand type: BOOL" in _err(ei)["Message"]
+
+    def test_filter_expression_carries_filter_prefix(self, dynamodb_client, probe_table):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.scan(
+                TableName=probe_table,
+                FilterExpression="n > :v",
+                ExpressionAttributeValues={":v": {"BOOL": True}},
+            )
+        err = _err(ei)
+        assert err["Code"] == "ValidationException"
+        assert "Invalid FilterExpression: Incorrect operand type" in err["Message"]
+
+
+class TestOrderingOperandControls:
+    """Case A controls: must NOT raise ValidationException."""
+
+    @pytest.mark.parametrize("op", ["=", "<>"])
+    def test_equality_ops_accept_non_orderable_literal(
+        self, dynamodb_client, probe_table, op
+    ):
+        # Equality/inequality are defined for all types: no ValidationException.
+        try:
+            _put_cond(dynamodb_client, probe_table, f"n {op} :v", {":v": {"BOOL": True}})
+        except ClientError as e:
+            assert e.response["Error"]["Code"] == "ConditionalCheckFailedException"
+
+    @pytest.mark.parametrize(
+        "cond,eav",
+        [
+            ("flag > :zero", {":zero": {"N": "0"}}),  # stored BOOL path
+            ("nu > :zero", {":zero": {"N": "0"}}),  # stored NULL path
+            ("nope > :zero", {":zero": {"N": "0"}}),  # absent path
+            ("flag > n", None),  # both document paths
+            ("sset > n", None),  # stored SS path
+        ],
+    )
+    def test_non_orderable_document_path_does_not_reject(
+        self, dynamodb_client, probe_table, cond, eav
+    ):
+        # A path that resolves to a non-orderable type evaluates false (CCFE),
+        # never a ValidationException.
+        kwargs = {"ConditionExpression": cond}
+        if eav is not None:
+            kwargs["ExpressionAttributeValues"] = eav
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.put_item(TableName=probe_table, Item=BASE_ITEM, **kwargs)
+        assert _err(ei)["Code"] == "ConditionalCheckFailedException"
+
+    def test_orderable_literal_accepted(self, dynamodb_client, probe_table):
+        # 5 > 0 is true: the conditional put succeeds, no exception.
+        _put_cond(dynamodb_client, probe_table, "n > :zero", {":zero": {"N": "0"}})
+
+
+class TestSizeUnsupportedTypes:
+    """Case B: size() on Number/Bool/Null yields no value -> comparison false (CCFE), never a ValidationException."""
+
+    @pytest.mark.parametrize("attr", ["flag", "nu", "num"])
+    def test_size_on_unsupported_type_evaluates_false(
+        self, dynamodb_client, probe_table, attr
+    ):
+        with pytest.raises(ClientError) as ei:
+            _put_cond(
+                dynamodb_client, probe_table, f"size({attr}) > :z", {":z": {"N": "0"}}
+            )
+        assert _err(ei)["Code"] == "ConditionalCheckFailedException"
+
+    def test_size_on_supported_type_still_works(self, dynamodb_client, probe_table):
+        # size(s) == 1 > 0 is true: the conditional put succeeds.
+        _put_cond(dynamodb_client, probe_table, "size(s) > :z", {":z": {"N": "0"}})
+
+    def test_size_on_set_still_works(self, dynamodb_client, probe_table):
+        # size(sset) == 2 > 0 is true.
+        _put_cond(dynamodb_client, probe_table, "size(sset) > :z", {":z": {"N": "0"}})
+
+    def test_size_on_number_inequality_evaluates_true(self, dynamodb_client, probe_table):
+        # size(num) yields no value; `<>` against a value is TRUE, so the
+        # conditional put succeeds (locks in the None/Ne semantics the fix relies on).
+        _put_cond(dynamodb_client, probe_table, "size(num) <> :z", {":z": {"N": "0"}})
+
+
+class TestTransactionConditions:
+    """Case A applies to TransactWriteItems condition expressions: a malformed
+    operand type is a top-level ValidationException, not a cancellation reason."""
+
+    BAD = {":v": {"BOOL": True}}
+
+    def test_twi_put_rejects_non_orderable_literal(self, dynamodb_client, probe_table):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.transact_write_items(TransactItems=[{"Put": {
+                "TableName": probe_table,
+                "Item": {"pk": {"S": "p1"}, "n": {"N": "5"}},
+                "ConditionExpression": "n > :v",
+                "ExpressionAttributeValues": self.BAD}}])
+        err = _err(ei)
+        assert err["Code"] == "ValidationException"
+        assert "Incorrect operand type" in err["Message"]
+        assert "operand type: BOOL" in err["Message"]
+
+    def test_twi_delete_rejects_non_orderable_literal(self, dynamodb_client, probe_table):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.transact_write_items(TransactItems=[{"Delete": {
+                "TableName": probe_table,
+                "Key": {"pk": {"S": "p1"}},
+                "ConditionExpression": "n > :v",
+                "ExpressionAttributeValues": self.BAD}}])
+        assert _err(ei)["Code"] == "ValidationException"
+        assert "operand type: BOOL" in _err(ei)["Message"]
+
+    def test_twi_update_rejects_non_orderable_literal(self, dynamodb_client, probe_table):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.transact_write_items(TransactItems=[{"Update": {
+                "TableName": probe_table,
+                "Key": {"pk": {"S": "p1"}},
+                "UpdateExpression": "SET z = :one",
+                "ConditionExpression": "n > :v",
+                "ExpressionAttributeValues": {":v": {"BOOL": True}, ":one": {"N": "1"}}}}])
+        assert _err(ei)["Code"] == "ValidationException"
+        assert "operand type: BOOL" in _err(ei)["Message"]
+
+    def test_twi_condition_check_rejects_non_orderable_literal(self, dynamodb_client, probe_table):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.transact_write_items(TransactItems=[{"ConditionCheck": {
+                "TableName": probe_table,
+                "Key": {"pk": {"S": "p1"}},
+                "ConditionExpression": "n > :v",
+                "ExpressionAttributeValues": self.BAD}}])
+        assert _err(ei)["Code"] == "ValidationException"
+        assert "operand type: BOOL" in _err(ei)["Message"]
+
+    def test_twi_genuine_condition_failure_is_transaction_cancelled(
+        self, dynamodb_client, probe_table
+    ):
+        # A well-formed but failing condition is a cancellation, not a
+        # ValidationException: the two must not be conflated.
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.transact_write_items(TransactItems=[{"Put": {
+                "TableName": probe_table,
+                "Item": {"pk": {"S": "p1"}, "n": {"N": "5"}},
+                "ConditionExpression": "attribute_exists(zzz)"}}])
+        assert _err(ei)["Code"] == "TransactionCanceledException"
+
+
+class TestConditionApiSurface:
+    """Operand-type validation reaches every condition/filter-bearing API, not just PutItem/Scan."""
+
+    def test_update_item_condition_rejects_non_orderable_literal(
+        self, dynamodb_client, probe_table
+    ):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.update_item(
+                TableName=probe_table,
+                Key={"pk": {"S": "p1"}},
+                UpdateExpression="SET s = :one",
+                ConditionExpression="n > :v",
+                ExpressionAttributeValues={":one": {"S": "y"}, ":v": {"BOOL": True}},
+            )
+        assert "operand type: BOOL" in _err(ei)["Message"]
+
+    def test_delete_item_condition_rejects_non_orderable_literal(
+        self, dynamodb_client, probe_table
+    ):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.delete_item(
+                TableName=probe_table,
+                Key={"pk": {"S": "p1"}},
+                ConditionExpression="n > :v",
+                ExpressionAttributeValues={":v": {"BOOL": True}},
+            )
+        assert "operand type: BOOL" in _err(ei)["Message"]
+
+    def test_query_filter_carries_filter_prefix(self, dynamodb_client, probe_table):
+        with pytest.raises(ClientError) as ei:
+            dynamodb_client.query(
+                TableName=probe_table,
+                KeyConditionExpression="pk = :p",
+                FilterExpression="n > :v",
+                ExpressionAttributeValues={":p": {"S": "p1"}, ":v": {"BOOL": True}},
+            )
+        err = _err(ei)
+        assert err["Code"] == "ValidationException"
+        assert "Invalid FilterExpression: Incorrect operand type" in err["Message"]


### PR DESCRIPTION
## What

Two related condition/filter expression divergences from Amazon DynamoDB, in opposite directions.

- **Ordering comparisons (`<`, `<=`, `>`, `>=`) and `BETWEEN` now reject a non-orderable literal operand.** Only String, Number, and Binary are orderable in Amazon DynamoDB. A comparison whose literal (ExpressionAttributeValue) operand is a BOOL, NULL, or any set/list/map now returns a `ValidationException`. The check is a single whole-expression pass that runs before evaluation, so it fires regardless of short-circuiting, `NOT`, or whether the referenced item exists, matching Amazon DynamoDB. A document *path* that resolves to a non-orderable type is not rejected: the comparison evaluates to false (also matching Amazon DynamoDB).
- **`size()` on a Number, Bool, or Null attribute now yields no value** (so the enclosing comparison evaluates to false) instead of raising. `size()` is defined only for String, Binary, List, Map, and the set types.

The operand-type pass is wired into every condition: `PutItem`, `DeleteItem`, `UpdateItem`, the `Query`/`Scan` filter, and the `TransactWriteItems` sub-op conditions (`Put`/`Delete`/`Update`/`ConditionCheck`). In transactions it runs in the prepare phase, so a malformed operand surfaces as a top-level `ValidationException`, while a genuinely failing condition remains a `TransactionCanceledException`.

The fix is engine-agnostic: the operand-type walker and the `size()` change live in `crates/core`. A shared `attribute_type_code` helper is reused by the existing `begins_with` operand check.

## Behavior: today vs Amazon DynamoDB

Captured from Amazon DynamoDB via the AWS CLI:

| Scenario | ExtendDB (before) | Amazon DynamoDB |
|---|---|---|
| `n > :v`, `:v` a BOOL / NULL / set / list / map literal | accepted, evaluates false | `ValidationException: Invalid ConditionExpression: Incorrect operand type for operator or function; operator or function: >, operand type: BOOL` |
| `n BETWEEN :a AND :b`, bool bounds | accepted | `ValidationException: ... operator or function: BETWEEN, operand type: BOOL` |
| `Scan` `FilterExpression="n > :v"`, `:v` a bool | accepted | `ValidationException: Invalid FilterExpression: Incorrect operand type ...` |
| `TransactWriteItems` `Put`/`Delete`/`Update`/`ConditionCheck` with `n > :bool` | `TransactionCanceledException` | top-level `ValidationException` |
| `size(flag) > :z` (flag is BOOL) | `ValidationException: size is not supported for this type` | condition evaluates false (`ConditionalCheckFailedException`) |
| `size(num) > :z` (num is Number) | evaluated as the digit count | condition evaluates false |
| stored non-orderable *path* `flag > :n` (n Number) | false | false (unchanged) |
| `n = :v` / `n <> :v`, `:v` a bool | accepted | accepted (unchanged) |

## Why

An ordering comparison against a bool/null/collection literal is a client bug that Amazon DynamoDB surfaces as a `ValidationException`; ExtendDB silently evaluated it as false. Conversely, `size()` on an unsupported type should make the condition false, not raise. Both bring ExtendDB's expression semantics to parity with Amazon DynamoDB. Only literal operands are validated (their type is known up front); a document path's runtime type is not, matching Amazon DynamoDB exactly.

## Testing done

- **Dual-target pytest** `tests/test_expr_operand_type_and_size.py`: 52 cases pass against both ExtendDB and Amazon DynamoDB.
- **Rust unit tests**: the operand-type walker (7 cases) and `size()` on Number/Bool/Null (3 cases).
- `cargo test -p extenddb-core -p extenddb-engine` pass; `cargo fmt --all --check` clean; `cargo clippy --all-targets` clean.


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a

## Breaking changes

n/a
---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
