### PR TITLE
fix: count per-element overhead in list and map item sizing

### DIFF
--- a/crates/core/src/types/item.rs
+++ b/crates/core/src/types/item.rs
@@ -356,8 +356,8 @@ pub fn item_size_bytes(item: &Item) -> usize {
 /// - B: raw byte length
 /// - BOOL: 1 byte
 /// - NULL: 1 byte
-/// - L: 3 bytes overhead + sum of element sizes
-/// - M: 3 bytes overhead + sum of (name length + value size) per entry
+/// - L: 3 bytes overhead + sum of (element size + 1) per element
+/// - M: 3 bytes overhead + sum of (name length + value size + 1) per entry
 /// - SS/NS/BS: sum of element sizes
 #[must_use]
 pub fn attribute_value_size(value: &AttributeValue) -> usize {
@@ -366,11 +366,18 @@ pub fn attribute_value_size(value: &AttributeValue) -> usize {
         AttributeValue::N(n) => dynamodb_number_size(n),
         AttributeValue::B(b) => b.len(),
         AttributeValue::Bool(_) | AttributeValue::Null => 1,
-        AttributeValue::L(list) => 3 + list.iter().map(attribute_value_size).sum::<usize>(),
+        // Every list element and map entry adds 1 byte of overhead beyond the
+        // 3-byte container overhead, matching Amazon DynamoDB's item sizing.
+        AttributeValue::L(list) => {
+            3 + list
+                .iter()
+                .map(|v| attribute_value_size(v) + 1)
+                .sum::<usize>()
+        }
         AttributeValue::M(map) => {
             3 + map
                 .iter()
-                .map(|(k, v)| k.len() + attribute_value_size(v))
+                .map(|(k, v)| k.len() + attribute_value_size(v) + 1)
                 .sum::<usize>()
         }
         AttributeValue::SS(set) => set.iter().map(String::len).sum(),
@@ -411,4 +418,61 @@ fn dynamodb_number_size(n: &str) -> usize {
         size += 1;
     }
     size.min(21)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(v: &str) -> AttributeValue {
+        AttributeValue::S(v.to_owned())
+    }
+
+    #[test]
+    fn scalar_sizes_unchanged() {
+        assert_eq!(attribute_value_size(&s("hello")), 5);
+        assert_eq!(attribute_value_size(&AttributeValue::Bool(true)), 1);
+        assert_eq!(attribute_value_size(&AttributeValue::Null), 1);
+    }
+
+    #[test]
+    fn empty_list_and_map_are_container_overhead_only() {
+        assert_eq!(attribute_value_size(&AttributeValue::L(vec![])), 3);
+        assert_eq!(attribute_value_size(&AttributeValue::M(BTreeMap::new())), 3);
+    }
+
+    #[test]
+    fn list_adds_one_byte_per_element() {
+        // Each {"S": "aa"} element is 2 value bytes + 1 byte overhead = 3.
+        let list = AttributeValue::L(vec![s("aa"); 500]);
+        assert_eq!(attribute_value_size(&list), 3 + 500 * 3);
+    }
+
+    #[test]
+    fn map_adds_one_byte_per_entry() {
+        // Entry sizes: name length + value size + 1 byte per entry.
+        let mut m = BTreeMap::new();
+        m.insert("a".to_owned(), s("xy"));
+        m.insert("bb".to_owned(), s("z"));
+        assert_eq!(
+            attribute_value_size(&AttributeValue::M(m)),
+            3 + (1 + 2 + 1) + (2 + 1 + 1)
+        );
+    }
+
+    #[test]
+    fn nested_container_overhead_compounds() {
+        // Outer list holding one empty list: 3 + (3 + 1) = 7.
+        let nested = AttributeValue::L(vec![AttributeValue::L(vec![])]);
+        assert_eq!(attribute_value_size(&nested), 7);
+    }
+
+    #[test]
+    fn item_size_counts_names_and_per_element_overhead() {
+        // pk(2) + "b"(1) + data(4) + [3 + 500*3] = 1510.
+        let mut item = Item::new();
+        item.insert("pk".to_owned(), s("b"));
+        item.insert("data".to_owned(), AttributeValue::L(vec![s("aa"); 500]));
+        assert_eq!(item_size_bytes(&item), 2 + 1 + 4 + (3 + 500 * 3));
+    }
 }

--- a/docs/design/03-component-core.md
+++ b/docs/design/03-component-core.md
@@ -363,7 +363,7 @@ Item size is calculated as the sum of all attribute (name size + value size) pai
 | `BOOL` | 1 byte |
 | `NULL` | 1 byte |
 | `L` | Sum of (element value size + 1 byte overhead per element) for all elements. Empty list = 3 bytes overhead. |
-| `M` | Sum of (key name UTF-8 byte length + value size + 3 bytes overhead per entry) for all entries. Empty map = 3 bytes overhead. |
+| `M` | Sum of (key name UTF-8 byte length + value size + 1 byte overhead per entry) for all entries. Empty map = 3 bytes overhead. |
 
 **Total item size** = sum of (attribute name byte length + attribute value size) for all top-level attributes.
 
@@ -388,7 +388,7 @@ fn calculate_attribute_size(value: &AttributeValue) -> usize {
             3 + list.iter().map(|v| calculate_attribute_size(v) + 1).sum::<usize>()
         }
         AttributeValue::M(map) => {
-            3 + map.iter().map(|(k, v)| k.len() + calculate_attribute_size(v) + 3).sum::<usize>()
+            3 + map.iter().map(|(k, v)| k.len() + calculate_attribute_size(v) + 1).sum::<usize>()
         }
     }
 }

--- a/tests/test_list_map_item_size.py
+++ b/tests/test_list_map_item_size.py
@@ -1,0 +1,136 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""List/Map write sizing: ConsumedCapacity and the 400 KB item-size limit.
+
+DynamoDB charges a per-element overhead for every List element and a per-entry
+overhead for every Map entry, on top of the 3-byte container overhead. Because
+that per-element overhead feeds both write ConsumedCapacity and the 400 KB
+item-size limit, an undercount makes dense list/map items report too little
+capacity and lets some oversized nested items slip past the size limit.
+
+All expected values verified against real DynamoDB (us-east-1) with
+ReturnConsumedCapacity=TOTAL.
+"""
+
+from __future__ import annotations
+
+import botocore.exceptions
+import pytest
+
+
+@pytest.fixture()
+def table(create_and_cleanup_table):
+    return create_and_cleanup_table()["TableDescription"]["TableName"]
+
+
+def _capacity_units(resp: dict) -> float:
+    return resp["ConsumedCapacity"]["CapacityUnits"]
+
+
+# --- Write ConsumedCapacity for dense lists ------------------------------------
+# Each element of {"S": "aa"} is 2 value bytes + 1 byte per-element overhead.
+
+
+@pytest.mark.parametrize(
+    ("count", "expected_cu"),
+    [(500, 2.0), (1500, 5.0), (3000, 9.0)],
+)
+def test_put_item_dense_list_capacity(dynamodb_client, table, count, expected_cu):
+    resp = dynamodb_client.put_item(
+        TableName=table,
+        Item={"pk": {"S": f"l{count}"}, "data": {"L": [{"S": "aa"}] * count}},
+        ReturnConsumedCapacity="TOTAL",
+    )
+    assert _capacity_units(resp) == expected_cu
+
+
+def test_put_item_dense_map_capacity(dynamodb_client, table):
+    # 800 entries "k0".."k799", each value {"S": "v"} (1 value byte),
+    # plus 1 byte per-entry overhead. Real DynamoDB reports 5.0.
+    item = {
+        "pk": {"S": "m800"},
+        "data": {"M": {f"k{i}": {"S": "v"} for i in range(800)}},
+    }
+    resp = dynamodb_client.put_item(
+        TableName=table, Item=item, ReturnConsumedCapacity="TOTAL"
+    )
+    assert _capacity_units(resp) == 5.0
+
+
+def test_put_item_nested_list_of_maps_capacity(dynamodb_client, table):
+    # Overhead compounds recursively: inner map {"a":{"S":"b"}} = 3 + (1+1+1) = 6,
+    # each list element = 6 + 1 = 7, list = 3 + 500*7. Real DynamoDB reports 4.0.
+    item = {
+        "pk": {"S": "nest"},
+        "data": {"L": [{"M": {"a": {"S": "b"}}} for _ in range(500)]},
+    }
+    resp = dynamodb_client.put_item(
+        TableName=table, Item=item, ReturnConsumedCapacity="TOTAL"
+    )
+    assert _capacity_units(resp) == 4.0
+
+
+def test_put_item_nested_map_of_lists_capacity(dynamodb_client, table):
+    # Map entries each hold a one-element list; per-entry and per-element
+    # overhead both apply. Real DynamoDB reports 5.0.
+    item = {
+        "pk": {"S": "mapl"},
+        "data": {"M": {f"k{i}": {"L": [{"S": "b"}]} for i in range(500)}},
+    }
+    resp = dynamodb_client.put_item(
+        TableName=table, Item=item, ReturnConsumedCapacity="TOTAL"
+    )
+    assert _capacity_units(resp) == 5.0
+
+
+def test_update_item_set_list_capacity(dynamodb_client, table):
+    # The write-path plumbing (UpdateItem) derives capacity from the same
+    # sizing as PutItem: SET of a 1500-element list is 5.0 on both.
+    resp = dynamodb_client.update_item(
+        TableName=table,
+        Key={"pk": {"S": "upd"}},
+        UpdateExpression="SET #d = :v",
+        ExpressionAttributeNames={"#d": "data"},
+        ExpressionAttributeValues={":v": {"L": [{"S": "aa"}] * 1500}},
+        ReturnConsumedCapacity="TOTAL",
+    )
+    assert _capacity_units(resp) == 5.0
+
+
+def test_put_item_scalar_capacity_unchanged(dynamodb_client, table):
+    # Control: an item with no list/map is one WCU and must stay one WCU.
+    resp = dynamodb_client.put_item(
+        TableName=table,
+        Item={"pk": {"S": "scalar"}, "n": {"N": "1"}, "s": {"S": "hello"}},
+        ReturnConsumedCapacity="TOTAL",
+    )
+    assert _capacity_units(resp) == 1.0
+
+
+# --- 400 KB item-size limit driven by the same per-element sizing --------------
+
+
+def test_large_nested_list_under_limit_accepted(dynamodb_client, table):
+    # ~390 KB with per-element overhead counted: just under 400 KB, accepted,
+    # and 381 WCU. Guards against the fix over-rejecting at the boundary.
+    resp = dynamodb_client.put_item(
+        TableName=table,
+        Item={"pk": {"S": "under"}, "data": {"L": [{"S": "aa"}] * 130_000}},
+        ReturnConsumedCapacity="TOTAL",
+    )
+    assert _capacity_units(resp) == 381.0
+
+
+def test_oversized_nested_list_rejected(dynamodb_client, table):
+    # ~450 KB once per-element overhead is counted. Real DynamoDB rejects this
+    # with an item-size ValidationException; ExtendDB must too. Without the
+    # per-element overhead the summed size is only ~300 KB and slips past.
+    with pytest.raises(botocore.exceptions.ClientError) as exc:
+        dynamodb_client.put_item(
+            TableName=table,
+            Item={"pk": {"S": "over"}, "data": {"L": [{"S": "aa"}] * 150_000}},
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert "Item size has exceeded the maximum allowed size" in err["Message"]


### PR DESCRIPTION
## What

`attribute_value_size` in `crates/core` charged only a fixed 3-byte container overhead for lists (`L`) and maps (`M`) and no per-element / per-entry overhead. Amazon DynamoDB charges 1 byte for every list element and every map entry on top of the 3-byte container. This corrects the sizing:

- `L`: `3 + sum(element_size + 1)` per element.
- `M`: `3 + sum(name_len + value_size + 1)` per entry.
- Empty list / map stay at 3 bytes; the overhead compounds through nested containers.

Both write `ConsumedCapacity` (`ceil(size / 1024)`) and the 400 KB item-size limit derive from this one function, so a single fix clears two symptoms: dense list/map items under-reported write capacity, and some oversized nested items slipped past the item-size limit.

Scalars (`S`, `N`, `B`, `BOOL`, `NULL`) and sets (`SS`, `NS`, `BS`) are unchanged; sets were checked against Amazon DynamoDB and are already conformant (sum of element sizes, no per-element overhead). The core design doc's map-entry overhead is corrected from 3 bytes to 1 to match the code and Amazon DynamoDB.

## Behavior: today vs Amazon DynamoDB

Every value below was captured directly via the AWS CLI / SDK (`ReturnConsumedCapacity=TOTAL`).

| Scenario | ExtendDB (before this PR) | Amazon DynamoDB |
|---|---|---|
| `PutItem` list of 500 x `{"S":"aa"}` | `CapacityUnits` 1.0 | 2.0 |
| `PutItem` list of 1500 x `{"S":"aa"}` | 3.0 | 5.0 |
| `PutItem` list of 3000 x `{"S":"aa"}` | 6.0 | 9.0 |
| `PutItem` map of 800 entries | 4.0 | 5.0 |
| `PutItem` list of 500 single-entry maps (nested) | 3.0 | 4.0 |
| `UpdateItem` `SET` a 1500-element list | 3.0 | 5.0 |
| `PutItem` oversized nested list (~450 KB counted) | Accepted (summed to ~300 KB) | `ValidationException: Item size has exceeded the maximum allowed size` |


## Why

Conformance gap found by comparing ExtendDB against Amazon DynamoDB: wrong write `ConsumedCapacity` for list/map items, and missing 400 KB item-size enforcement for oversized nested items (same root cause).

Closes # n/a

## Testing done

Captured every expected value from Amazon DynamoDB, then validated dual-target (ExtendDB and Amazon DynamoDB).

- New pytest `tests/test_list_map_item_size.py` (10 cases)
- New Rust unit tests (6)
- `cargo test --workspace`, `cargo fmt --check`, and `cargo clippy --all-targets -- -D warnings` all pass.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface, an RFC has been accepted or is linked below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a

## Breaking changes

n/a

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.