### PR TITLE
fix: session token constant time

### DIFF
--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -164,24 +164,19 @@ impl<C: CredentialStore + 'static> AuthProvider for BuiltinAuthProvider<C> {
         // ExpiredTokenException on the cache-miss path, and CachedCredentialStore
         // re-validates `expires_at` on every cache hit before returning so cached
         // entries cannot survive past their issued lifetime.
-        if credential.is_session {
+        // S-5: Compare the session token in constant time and defer the
+        // rejection until after signature verification, so neither the token's
+        // byte contents nor its presence changes the failure-path timing.
+        let session_token_ok = if credential.is_session {
             let token = headers
                 .get("x-amz-security-token")
                 .and_then(|v| v.to_str().ok())
-                .ok_or_else(|| {
-                    DynamoDbError::UnrecognizedClientException(
-                        "The security token included in the request is invalid.".to_owned(),
-                    )
-                })?;
-
-            // Validate the token value against the stored session token.
+                .unwrap_or("");
             let expected = credential.session_token.as_deref().unwrap_or("");
-            if token != expected {
-                return Err(DynamoDbError::UnrecognizedClientException(
-                    "The security token included in the request is invalid.".to_owned(),
-                ));
-            }
-        }
+            sigv4::verify::constant_time_eq(token.as_bytes(), expected.as_bytes())
+        } else {
+            true
+        };
 
         // Verify SigV4 signature — always, even for inactive keys (S-5).
         sigv4::verify::verify_signature(
@@ -194,9 +189,9 @@ impl<C: CredentialStore + 'static> AuthProvider for BuiltinAuthProvider<C> {
             body,
         )?;
 
-        // S-5: Reject inactive keys only after full signature verification
-        // to prevent timing side-channels.
-        if is_inactive {
+        // S-5: Reject inactive keys or a mismatched session token only after
+        // full signature verification, to prevent timing side-channels.
+        if is_inactive || !session_token_ok {
             return Err(DynamoDbError::UnrecognizedClientException(
                 "The security token included in the request is invalid.".to_owned(),
             ));

--- a/crates/auth/src/sigv4/verify.rs
+++ b/crates/auth/src/sigv4/verify.rs
@@ -178,7 +178,7 @@ fn parse_iso8601_basic(s: &str) -> Option<i64> {
 /// The early return on length mismatch leaks timing information about whether
 /// lengths match. Callers must ensure both inputs have equal length (e.g.,
 /// hex-encoded signatures are always 64 bytes).
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+pub(crate) fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     if a.len() != b.len() {
         return false;
     }

--- a/tests/test_auth_integration.py
+++ b/tests/test_auth_integration.py
@@ -498,6 +498,71 @@ class TestRBAC:
             self.mgmt.delete_user(self.account_id, user)
             self.mgmt.delete_user(self.account_id, admin_user)
             self.mgmt.delete_role(self.account_id, role)
+
+    def test_assume_role_wrong_session_token_rejected(self):
+        """A mismatched X-Amz-Security-Token is rejected even with a valid
+        signature; the correct token authenticates. Regression: the session
+        token is compared in constant time and enforced after signature
+        verification."""
+        role = f"tokrole-{uuid.uuid4().hex[:8]}"
+        user = f"caller-{uuid.uuid4().hex[:8]}"
+
+        resp = self.mgmt.create_user(self.account_id, user, "TestPass123!")
+        assert resp.status_code == 201
+        caller_arn = f"arn:aws:iam::{self.account_id}:user/{user}"
+
+        trust_policy = {
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": {"AWS": caller_arn},
+                "Action": "sts:AssumeRole",
+            }],
+        }
+        resp = self.mgmt.create_role(self.account_id, role, trust_policy)
+        assert resp.status_code == 201, resp.text
+        resp = self.mgmt.put_role_policy(
+            self.account_id, role, "full-access", _full_access_policy()
+        )
+        assert resp.status_code == 204, resp.text
+
+        resp = self.mgmt.assume_role(
+            self.account_id, role, caller_arn, "tok-session"
+        )
+        assert resp.status_code == 201, resp.text
+        creds = resp.json()
+
+        try:
+            # Positive control: the correct session token authenticates.
+            good = _make_dynamodb_client(
+                self.endpoint,
+                creds["access_key_id"],
+                creds["secret_access_key"],
+                self.region,
+                session_token=creds["session_token"],
+            )
+            good.list_tables()
+
+            # Same access key + secret (so the SigV4 signature is valid), but a
+            # different value in X-Amz-Security-Token. The server must reject it
+            # with UnrecognizedClientException, not accept it or 500.
+            bad = _make_dynamodb_client(
+                self.endpoint,
+                creds["access_key_id"],
+                creds["secret_access_key"],
+                self.region,
+                session_token="FwoGZXIvYXdzEBmismatchedSessionToken0123456789ABCDEF",
+            )
+            with pytest.raises(ClientError) as exc_info:
+                bad.list_tables()
+            err = exc_info.value.response["Error"]
+            msg = err.get("Message", "")
+            assert (
+                "security token" in msg.lower() or "invalid" in msg.lower()
+            ), f"expected security-token rejection, got: {err}"
+        finally:
+            self.mgmt.delete_user(self.account_id, user)
+            self.mgmt.delete_role(self.account_id, role)
 # ---------------------------------------------------------------------------
 # Error Path Tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Compare the session security token (`X-Amz-Security-Token`) in **constant time** instead of a short-circuiting `!=`, and defer the rejection until **after** SigV4 signature verification — folding it into the existing S-5 constant-time failure path alongside the inactive-key check. `constant_time_eq` is promoted to `pub(crate)` and reused (it already backed signature verification and the console). A missing token header now also defers to the same constant-time rejection rather than returning early. Adds an integration test covering the behavior.

Files: `crates/auth/src/lib.rs`, `crates/auth/src/sigv4/verify.rs`, `tests/test_auth_integration.py`.

## Why

The session-credential path compared the client-supplied token against the stored token with a plain `!=`, which short-circuits on the first differing byte and returns early. That leaks timing information about how many leading bytes of the session token match (a timing side-channel) and breaks the surrounding S-5 design, which otherwise runs every failure path at constant time and defers rejections until after full signature verification. This is shared auth code, so the hardening applies to every backend. Observable behavior is unchanged — a wrong or missing token still returns `UnrecognizedClientException`.

Closes # _(no linked issue — internal security-review finding)_

## Testing done

- `cargo test --workspace`: all crates green.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p extenddb-auth --all-targets -- -D warnings` (the CI gate): clean.
- New integration test `tests/test_auth_integration.py::TestRBAC::test_assume_role_wrong_session_token_rejected`: assumes a role for temporary credentials, then issues a validly-signed request whose `X-Amz-Security-Token` does not match the stored session token. Verified **end-to-end against a server built from this branch**: 3/3 `TestRBAC` tests pass, and the server log shows a clean 4xx `UnrecognizedClientException` (no `InternalServerError`). The correct token still authenticates (positive control).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean — CI gate `cargo clippy --all-targets -- -D warnings` passes (`-W clippy::pedantic` surfaces only pre-existing, repo-wide style warnings unrelated to this change)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed — n/a, observable behavior is unchanged (same error responses); no user-facing docs affected
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface, an RFC has been accepted or is linked below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a — the auth model/contract is unchanged (identical inputs, outputs, and accept/reject semantics). This alters only the comparison's timing characteristics and internal ordering, so it is a security hardening rather than an auth-model change.

## Breaking changes

None. A wrong or missing `X-Amz-Security-Token` still returns `UnrecognizedClientException`; the only differences are that the comparison is now constant-time and the rejection is enforced after signature verification.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.