### PR TITLE
test: cover binary sort-key unsigned byte ordering and BETWEEN

### DIFF
--- a/tests/rust/src/binary_sort_key.rs
+++ b/tests/rust/src/binary_sort_key.rs
@@ -1,0 +1,168 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Binary (B) sort-key ordering and range-condition tests.
+//!
+//! DynamoDB orders Binary values by **unsigned lexicographic byte order**
+//! (each byte treated as an unsigned value, compared left to right; a shorter
+//! run of equal leading bytes sorts first). This is distinct from orderings
+//! that compare length first. These tests pin the byte-order contract for
+//! Query result order and for `BETWEEN` range conditions on a binary sort key,
+//! a path not otherwise covered by the suite.
+
+use crate::test_base::*;
+
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition, AttributeValue, BillingMode, KeySchemaElement, KeyType,
+    ScalarAttributeType,
+};
+use aws_smithy_types::Blob;
+
+/// Build a Binary `AttributeValue` from raw bytes.
+fn bb(bytes: &[u8]) -> AttributeValue {
+    AttributeValue::B(Blob::new(bytes.to_vec()))
+}
+
+/// Create a `pk` (S, HASH) + `sk` (B, RANGE) table for binary sort-key tests.
+async fn create_binary_sk_table(c: &aws_sdk_dynamodb::Client, table: &str) {
+    c.create_table()
+        .table_name(table)
+        .billing_mode(BillingMode::PayPerRequest)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("sk")
+                .key_type(KeyType::Range)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("sk")
+                .attribute_type(ScalarAttributeType::B)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    wait_for_active(c, table).await;
+}
+
+async fn seed(c: &aws_sdk_dynamodb::Client, table: &str, pk: &str, sks: &[&[u8]]) {
+    for sk in sks {
+        let mut item = std::collections::HashMap::new();
+        item.insert("pk".to_string(), s(pk));
+        item.insert("sk".to_string(), bb(sk));
+        c.put_item()
+            .table_name(table)
+            .set_item(Some(item))
+            .send()
+            .await
+            .unwrap();
+    }
+}
+
+/// Extract the `sk` binary values from a Query response, in returned order.
+fn sk_bytes(items: &[std::collections::HashMap<String, AttributeValue>]) -> Vec<Vec<u8>> {
+    items
+        .iter()
+        .map(|i| i.get("sk").unwrap().as_b().unwrap().as_ref().to_vec())
+        .collect()
+}
+
+#[tokio::test]
+async fn query_binary_sort_key_orders_by_unsigned_bytes() {
+    let c = client();
+    let table = format!("BinSkOrder_{}", ts());
+    create_binary_sk_table(c, &table).await;
+
+    let pk = "p";
+    // Insert scrambled. Unsigned byte order is:
+    //   [0x01,0x00] < [0x01,0xFF] < [0x02]
+    // A length-first ordering (e.g. BSON BinData) would instead yield
+    //   [0x02] < [0x01,0x00] < [0x01,0xFF].
+    seed(c, &table, pk, &[&[0x02], &[0x01, 0xFF], &[0x01, 0x00]]).await;
+
+    // Ascending (ScanIndexForward = true, the default).
+    let resp = c
+        .query()
+        .table_name(&table)
+        .key_condition_expression("#h = :hv")
+        .expression_attribute_names("#h", "pk")
+        .expression_attribute_values(":hv", s(pk))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        sk_bytes(resp.items()),
+        vec![vec![0x01, 0x00], vec![0x01, 0xFF], vec![0x02]],
+        "binary sort keys must be returned in unsigned lexicographic byte order"
+    );
+
+    // Descending must be the exact reverse.
+    let resp_desc = c
+        .query()
+        .table_name(&table)
+        .key_condition_expression("#h = :hv")
+        .expression_attribute_names("#h", "pk")
+        .expression_attribute_values(":hv", s(pk))
+        .scan_index_forward(false)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        sk_bytes(resp_desc.items()),
+        vec![vec![0x02], vec![0x01, 0xFF], vec![0x01, 0x00]],
+        "descending scan must reverse the unsigned byte order"
+    );
+
+    let _ = c.delete_table().table_name(&table).send().await;
+}
+
+#[tokio::test]
+async fn query_binary_sort_key_between_uses_byte_order() {
+    let c = client();
+    let table = format!("BinSkBetween_{}", ts());
+    create_binary_sk_table(c, &table).await;
+
+    let pk = "p";
+    seed(c, &table, pk, &[&[0x01, 0x00], &[0x01, 0xFF], &[0x02]]).await;
+
+    // BETWEEN [0x01,0x00] AND [0x01,0xFF] (inclusive) must select the two
+    // 0x01-prefixed keys and exclude [0x02] (0x02 > 0x01 in the first byte).
+    // A length-first ordering would include [0x02] (length 1) and mis-scope
+    // the range.
+    let resp = c
+        .query()
+        .table_name(&table)
+        .key_condition_expression("#h = :hv AND #r BETWEEN :lo AND :hi")
+        .expression_attribute_names("#h", "pk")
+        .expression_attribute_names("#r", "sk")
+        .expression_attribute_values(":hv", s(pk))
+        .expression_attribute_values(":lo", bb(&[0x01, 0x00]))
+        .expression_attribute_values(":hi", bb(&[0x01, 0xFF]))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        sk_bytes(resp.items()),
+        vec![vec![0x01, 0x00], vec![0x01, 0xFF]],
+        "BETWEEN on a binary sort key must use unsigned byte order and exclude [0x02]"
+    );
+
+    let _ = c.delete_table().table_name(&table).send().await;
+}

--- a/tests/rust/src/main.rs
+++ b/tests/rust/src/main.rs
@@ -18,6 +18,8 @@ mod batch_get_item;
 #[cfg(test)]
 mod batch_write_item;
 #[cfg(test)]
+mod binary_sort_key;
+#[cfg(test)]
 mod capacity_throttling;
 #[cfg(test)]
 mod composite_keys;


### PR DESCRIPTION
## What

Adds `tests/rust/src/binary_sort_key.rs` — a Rust integration test covering Query ordering and range conditions on a **Binary sort (RANGE) key**. DynamoDB orders Binary values by unsigned lexicographic byte order; the suite previously had no coverage for this (only binary *partition* keys, which are hashed so ordering never applies, and a binary `contains` scan-filter). The new module asserts:

- `query_binary_sort_key_orders_by_unsigned_bytes` — Query returns `[0x01,0x00] < [0x01,0xFF] < [0x02]` ascending, and the exact reverse descending.
- `query_binary_sort_key_between_uses_byte_order` — `BETWEEN [0x01,0x00]..[0x01,0xFF]` selects the two `0x01`-prefixed keys and excludes `[0x02]`.

Both cases discriminate unsigned byte order from a length-first ordering (`[0x02]` sorts *after* `[0x01,0xFF]` under unsigned bytes, but *before* it under length-first). Test-only change; no production code is touched.

## Why

Binary sort-key ordering is a DynamoDB conformance requirement (unsigned lexicographic byte order) that had zero test coverage. A backend could silently order Binary ranges wrong — e.g. a store that sorts BSON BinData length-first would return the wrong result set for `BETWEEN`/`<`/`>` and the wrong Query order — and nothing in the suite would catch it. This adds the missing conformance bar so any current or future storage backend is held to DynamoDB's byte-ordering semantics.

Closes # _(no linked issue — conformance-coverage gap found during code review)_

## Testing done

- New tests verified **green against the Postgres backend** (stores the key as `bytea`, compared in unsigned byte order, which matches DynamoDB): `query_binary_sort_key_orders_by_unsigned_bytes ... ok` and `query_binary_sort_key_between_uses_byte_order ... ok` (2 passed).
- Test crate compiles clean; `cargo fmt --all -- --check` clean on the new file; `main.rs` module registration is correctly `#[cfg(test)]`-gated.
- Assertions are grounded on AWS's documented unsigned-byte ordering. Live real-DynamoDB confirmation is pending a credential refresh; the Postgres reference backend (byte-unsigned `bytea`) served as the live oracle in the meantime.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass — the new binary-sort-key integration tests pass against the Postgres backend (`cargo test --workspace` covers unit/doc tests; these are integration tests run via the Rust integ harness)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean — CI gate `cargo clippy --all-targets -- -D warnings` passes (`-W clippy::pedantic` surfaces only pre-existing, repo-wide style warnings unrelated to this change)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed — n/a, test-only change, no behavior change
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface, an RFC has been accepted or is linked below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a — test-only change; adds coverage for existing documented behavior, changes no interface.

## Breaking changes

None. Test-only addition.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.