### PR TITLE
fix(streams,metrics): scope GetRecords to the shard's owning account;

### DIFF
--- a/crates/engine/src/streams.rs
+++ b/crates/engine/src/streams.rs
@@ -173,19 +173,18 @@ pub async fn handle_get_records(
     let input: GetRecordsInput = serde_json::from_value(body)
         .map_err(|e| DynamoDbError::SerializationException(e.to_string()))?;
 
-    let decoded = base64::Engine::decode(
+    let token = base64::Engine::decode(
         &base64::engine::general_purpose::STANDARD,
         &input.shard_iterator,
     )
-    .map_err(|_| DynamoDbError::ValidationException("Invalid shard iterator".to_owned()))?;
-    let token = String::from_utf8(decoded).map_err(|_| {
-        DynamoDbError::ValidationException("Invalid shard iterator encoding".to_owned())
-    })?;
+    .ok()
+    .and_then(|d| String::from_utf8(d).ok())
+    .ok_or_else(|| DynamoDbError::ValidationException("Invalid ShardIterator".to_owned()))?;
 
     let parts: Vec<&str> = token.splitn(4, '|').collect();
     if parts.len() < 2 {
         return Err(DynamoDbError::ValidationException(
-            "Invalid shard iterator format".to_owned(),
+            "Invalid ShardIterator".to_owned(),
         ));
     }
 
@@ -227,7 +226,7 @@ pub async fn handle_get_records(
 
     let (records, last_seq) = ctx
         .storage
-        .get_stream_records(shard_id, after_sequence.as_deref(), limit)
+        .get_stream_records(&ctx.account_id, shard_id, after_sequence.as_deref(), limit)
         .await
         .map_err(storage_to_dynamo)?;
 

--- a/crates/server/src/console/mod.rs
+++ b/crates/server/src/console/mod.rs
@@ -51,6 +51,10 @@ pub struct ConsoleState {
     /// console-driven mutations leave stale entries in the cache for up
     /// to `auth.cache.ttl_seconds`.
     pub auth_cache: extenddb_auth::AuthCacheRegistry,
+    /// In-memory metrics collector, used to enrich the session-authed
+    /// `/console/metrics-data` response with latency segments (same data the
+    /// top-level `/metrics` handler adds).
+    pub metrics: Arc<extenddb_core::metrics::MetricsCollector>,
 }
 
 /// Build the console router.
@@ -68,6 +72,10 @@ pub fn router() -> Router<Arc<ConsoleState>> {
         .route("/", get(pages::dashboard))
         // Metrics
         .route("/metrics", get(pages::metrics_page))
+        // Metrics data (JSON) — session-authed backend for the dashboard's
+        // client-side charts. Replaces the browser fetch of the top-level
+        // `/metrics` (now Basic-auth only, for Prometheus).
+        .route("/metrics-data", get(pages::metrics_data))
         // Settings (read-only, admin-only)
         .route("/settings", get(pages::settings_page))
         // Cache (admin-only break-glass invalidation).

--- a/crates/server/src/console/pages/metrics_content.rs
+++ b/crates/server/src/console/pages/metrics_content.rs
@@ -131,7 +131,7 @@ function drawLine(id,labels,series,yLabel){
   for(let i=0;i<labels.length;i+=st){const x=P.l+(i/Math.max(labels.length-1,1))*pw;ctx.fillText(labels[i],x,h-4);}
   for(const s of series){ctx.strokeStyle=s.color;ctx.lineWidth=s.width||2;ctx.beginPath();for(let i=0;i<s.values.length;i++){const x=P.l+(i/Math.max(s.values.length-1,1))*pw,y=P.t+ph*(1-(s.values[i]-mn)/rng);if(i===0)ctx.moveTo(x,y);else ctx.lineTo(x,y);}ctx.stroke();}
 }
-function buildUrl(){if(customStart&&customEnd)return'/metrics?start='+encodeURIComponent(customStart)+'&end='+encodeURIComponent(customEnd);return'/metrics?window='+currentWindow;}
+function buildUrl(){if(customStart&&customEnd)return'/console/metrics-data?start='+encodeURIComponent(customStart)+'&end='+encodeURIComponent(customEnd);return'/console/metrics-data?window='+currentWindow;}
 function updateWindowLinks(){document.querySelectorAll('.window-link').forEach(a=>{if(a.dataset.window===currentWindow&&!customStart){a.style.background='#2563eb';a.style.color='#fff';}else{a.style.background='';a.style.color='';}});}
 function tsLabel(t){const d=new Date(t);return d.getHours().toString().padStart(2,'0')+':'+d.getMinutes().toString().padStart(2,'0');}
 function aggBuckets(bkts,metric,opF){

--- a/crates/server/src/console/pages/metrics_pages.rs
+++ b/crates/server/src/console/pages/metrics_pages.rs
@@ -14,7 +14,7 @@
 use std::sync::Arc;
 
 use axum::extract::State;
-use axum::http::HeaderMap;
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::{Html, IntoResponse, Response};
 
 use crate::console::ConsoleState;
@@ -78,4 +78,47 @@ pub async fn metrics_page(State(state): State<Arc<ConsoleState>>, headers: Heade
         &session.csrf_token,
     ))
     .into_response()
+}
+
+/// GET /console/metrics-data — session-authed JSON metrics for the dashboard.
+///
+/// Returns the same payload as the top-level `/metrics` (per-table
+/// CloudWatch-style dimensions), but is gated by a console **session** instead
+/// of admin Basic auth, so the browser dashboard can fetch it with its session
+/// cookie. Both routes require authentication while preserving the per-table
+/// dashboard.
+pub async fn metrics_data(
+    State(state): State<Arc<ConsoleState>>,
+    headers: HeaderMap,
+    axum::extract::Query(params): axum::extract::Query<extenddb_core::metrics::MetricsQuery>,
+) -> Response {
+    // Require a valid console session (same gate as the dashboard page).
+    if let Err(redirect) = require_session(&headers, &state).await {
+        return redirect;
+    }
+
+    match crate::metrics_endpoint::query_metrics_from_store(state.catalog_store.as_ref(), &params)
+        .await
+    {
+        Ok(mut response) => {
+            // Enrich with in-memory latency segments (not persisted to DB) —
+            // mirrors the top-level `/metrics` handler.
+            let window = params
+                .window
+                .unwrap_or(extenddb_core::metrics::TimeWindow::Last5Minutes);
+            let seg_metrics = state.metrics.clone();
+            response.segments =
+                tokio::task::spawn_blocking(move || seg_metrics.query_segments(window))
+                    .await
+                    .unwrap_or_default();
+            axum::Json(serde_json::to_value(response).unwrap_or_default()).into_response()
+        }
+        Err(msg) => {
+            let body = serde_json::json!({
+                "__type": "ValidationException",
+                "message": msg,
+            });
+            (StatusCode::BAD_REQUEST, axum::Json(body)).into_response()
+        }
+    }
 }

--- a/crates/server/src/console/pages/mod.rs
+++ b/crates/server/src/console/pages/mod.rs
@@ -30,7 +30,7 @@ pub use docs_page::{docs_page, docs_pdf, docs_view};
 pub use group_pages::{
     add_group_member, create_group, delete_group, group_detail, new_group_form, remove_group_member,
 };
-pub use metrics_pages::metrics_page;
+pub use metrics_pages::{metrics_data, metrics_page};
 pub use policy_pages::{
     delete_group_policy, delete_role_policy, delete_user_policy, new_group_policy_form,
     new_role_policy_form, new_user_policy_form, put_group_policy, put_role_policy, put_user_policy,

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -113,6 +113,7 @@ pub async fn start_server(
     let catalog_store = state.catalog_store.clone();
     let auth_cache_for_mgmt = state.auth_cache.clone();
     let auth_cache_for_console = state.auth_cache.clone();
+    let metrics_for_console = state.metrics.clone();
     let authz_cache_for_mgmt = state.authz_cache.clone();
     let table_key_info_cache_for_mgmt = state.table_key_info_cache.clone();
     let version_info = state.version_info.clone();
@@ -144,11 +145,12 @@ pub async fn start_server(
         .route("/", post(handler::handle_request))
         .layer(DefaultBodyLimit::max(DYNAMODB_BODY_LIMIT))
         .route("/health", get(health_check))
-        // REQ-OBS-005: Prometheus-compatible metrics endpoint. Public by
-        // design (Prometheus scrapers expect no auth on the scrape URL);
-        // operators who need stricter access should expose this on a
-        // separate bind via firewall/proxy. Returns aggregate metrics
-        // only; per-request data is in the management API.
+        // REQ-OBS-005: Prometheus-compatible metrics endpoint. Requires admin
+        // HTTP Basic auth (enforced in the handler) because the payload carries
+        // per-table CloudWatch-style dimensions, so it is served only to an
+        // authorized caller. Prometheus scrapers configure
+        // `basic_auth`. The web console dashboard uses the session-authed
+        // `/console/metrics-data` route instead.
         .route("/metrics", get(metrics_endpoint::metrics_endpoint))
         // S-6: Explicit small body limit for non-DynamoDB endpoints.
         .layer(DefaultBodyLimit::max(1024))
@@ -173,6 +175,7 @@ pub async fn start_server(
             catalog_store,
             docs_store: docs_store.clone(),
             auth_cache: auth_cache_for_console,
+            metrics: metrics_for_console,
         });
         let console_router = console::router().with_state(console_state);
         app = app

--- a/crates/server/src/management/mod.rs
+++ b/crates/server/src/management/mod.rs
@@ -12,7 +12,7 @@ mod account;
 pub(crate) use account::generate_account_id;
 mod admin;
 mod assume_role;
-mod auth;
+pub(crate) mod auth;
 pub mod cache_invalidate;
 mod cache_metrics;
 pub(crate) mod crypto;

--- a/crates/server/src/metrics_endpoint.rs
+++ b/crates/server/src/metrics_endpoint.rs
@@ -22,7 +22,50 @@ use crate::AppState;
 /// full map, so we run it on a blocking thread to avoid stalling the async runtime.
 pub(crate) async fn metrics_endpoint(
     State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
     axum::extract::Query(params): axum::extract::Query<extenddb_core::metrics::MetricsQuery>,
+) -> axum::response::Response {
+    // `/metrics` returns per-table CloudWatch-style dimensions (TableName /
+    // index), so it requires admin authentication. It uses admin HTTP Basic
+    // auth, reusing the management API's mechanism; Prometheus scrapers configure
+    // `basic_auth`. The web console dashboard does not call this route — it uses
+    // the session-authed `/console/metrics-data` route instead.
+    let Some(ref catalog_store) = state.catalog_store else {
+        // No catalog store => no admin store to authenticate against. `/metrics`
+        // requires admin auth, so an unauthenticatable request returns 401 — the
+        // same response an unauthenticated request gets when a catalog IS
+        // configured, giving a consistent response regardless of server config.
+        // (Not 503: this is not a transient condition a retry would resolve.)
+        return (
+            StatusCode::UNAUTHORIZED,
+            [(
+                axum::http::header::WWW_AUTHENTICATE,
+                "Basic realm=\"extenddb\"",
+            )],
+            "metrics requires admin authentication",
+        )
+            .into_response();
+    };
+    if let Err(resp) = crate::management::auth::authenticate_admin(
+        &headers,
+        catalog_store.as_ref(),
+        catalog_store.as_ref(),
+        None,
+    )
+    .await
+    {
+        return resp;
+    }
+
+    render_metrics(&state, params).await.into_response()
+}
+
+/// Build the metrics response. Callers MUST authenticate before invoking this
+/// (top-level `/metrics` uses admin Basic auth; `/console/metrics-data` uses a
+/// console session).
+pub(crate) async fn render_metrics(
+    state: &Arc<AppState>,
+    params: extenddb_core::metrics::MetricsQuery,
 ) -> impl IntoResponse {
     use extenddb_core::metrics::MetricsResponse;
 
@@ -88,7 +131,7 @@ pub(crate) async fn metrics_endpoint(
 ///
 /// Aggregates rows into time-series buckets at the requested granularity
 /// and also produces aggregate `MetricSnapshot`s for backward compatibility.
-async fn query_metrics_from_store(
+pub(crate) async fn query_metrics_from_store(
     store: &dyn extenddb_storage::management_store::MetricsStore,
     params: &extenddb_core::metrics::MetricsQuery,
 ) -> Result<extenddb_core::metrics::MetricsResponse, String> {
@@ -180,6 +223,9 @@ fn aggregate_rows(
     let mut bucket_map: HashMap<(DimKey, i64), (f64, u64, f64, f64)> = HashMap::new();
 
     for row in rows {
+        // CloudWatch-style dimensions: metrics are keyed per table and per
+        // index. The endpoint is authenticated (admin Basic auth), so per-table
+        // dimensions are only returned to an authorized caller.
         let key = (
             row.metric.clone(),
             row.table_name.clone().unwrap_or_default(),
@@ -275,4 +321,46 @@ fn aggregate_rows(
     buckets.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
 
     (snapshots, buckets)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use extenddb_core::metrics::{Dimension, TimeWindow};
+    use extenddb_storage::management_store::MetricsRow;
+
+    /// The aggregation MUST retain per-table and per-index dimensions
+    /// (CloudWatch parity) so authorized callers get full per-table
+    /// observability; this test pins that they are not stripped.
+    #[test]
+    fn aggregate_rows_retains_table_and_index_dimensions() {
+        let rows = vec![MetricsRow {
+            bucket: time::OffsetDateTime::UNIX_EPOCH,
+            metric: "SystemErrors".to_owned(),
+            table_name: Some("MyTable".to_owned()),
+            index_name: Some("MyIndex".to_owned()),
+            operation: Some("GetItem".to_owned()),
+            sum: 1.0,
+            count: 1,
+            min: 1.0,
+            max: 1.0,
+        }];
+
+        let (snapshots, _buckets) = aggregate_rows(&rows, 60, TimeWindow::Last5Minutes);
+
+        assert_eq!(snapshots.len(), 1, "expected one dimension group");
+        let dims = &snapshots[0].dimensions;
+        assert!(
+            dims.iter()
+                .any(|d| matches!(d, Dimension::TableName(t) if t.as_str() == "MyTable")),
+            "TableName dimension must be retained, got {dims:?}"
+        );
+        assert!(
+            dims.iter().any(|d| matches!(
+                d,
+                Dimension::GlobalSecondaryIndexName(i) if i.as_str() == "MyIndex"
+            )),
+            "GSI-name dimension must be retained, got {dims:?}"
+        );
+    }
 }

--- a/crates/storage-postgres/src/stream_engine.rs
+++ b/crates/storage-postgres/src/stream_engine.rs
@@ -121,13 +121,52 @@ impl StreamEngine for PostgresEngine {
 
     fn get_stream_records(
         &self,
+        account_id: &str,
         shard_id: &str,
         after_sequence: Option<&str>,
         limit: i64,
     ) -> BoxFuture<'_, Result<(Vec<StreamRecord>, Option<String>), StorageError>> {
+        let account_id = account_id.to_string();
         let shard_id = shard_id.to_string();
         let after_sequence = after_sequence.map(std::string::ToString::to_string);
         Box::pin(async move {
+            // Ownership guard: only return records if the shard's backing table
+            // belongs to the calling account. `stream_shards`/`stream_records`
+            // rows live in the data database while the `tables` catalog (which
+            // carries `account_id`) lives in the catalog database, so ownership
+            // is resolved in two steps across the two pools: shard -> table_id
+            // (data pool), then table_id + account_id (catalog pool). A shard
+            // iterator for a table the caller does not own is rejected as an
+            // invalid shard iterator (below).
+            let shard_table_id: Option<(String,)> =
+                sqlx::query_as("SELECT table_id FROM stream_shards WHERE shard_id = $1")
+                    .bind(&shard_id)
+                    .fetch_optional(&self.data_pool)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let owned = match &shard_table_id {
+                Some((table_id,)) => sqlx::query_as::<_, (i32,)>(
+                    "SELECT 1 FROM tables WHERE table_id = $1 AND account_id = $2",
+                )
+                .bind(table_id)
+                .bind(account_id)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?
+                .is_some(),
+                None => false,
+            };
+            // A shard iterator resolves to a shard the caller does not own (step
+            // 2 fails) or one that does not exist (step 1 fails). Real DynamoDB
+            // returns `ValidationException: Invalid ShardIterator` for a
+            // GetRecords iterator it did not issue, and does NOT distinguish
+            // "exists but not yours" from "does not exist" — so neither do we
+            // (both collapse here). Verified against DynamoDB
+            // Streams (us-east-1).
+            if !owned {
+                return Err(StorageError::Validation("Invalid ShardIterator".to_owned()));
+            }
+
             let rows: Vec<(serde_json::Value,)> = if let Some(after) = after_sequence {
                 sqlx::query_as(
                     "SELECT record_data FROM stream_records \

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -440,8 +440,14 @@ pub trait StreamEngine: Send + Sync {
     ) -> BoxFuture<'_, Result<(), StorageError>>;
 
     /// Read stream records from a shard starting after a sequence number.
+    ///
+    /// `account_id` is the authenticated caller's account. Implementations MUST
+    /// return records only for shards whose backing table belongs to that
+    /// account; a shard whose table belongs to a different account must yield no
+    /// records, so a shard iterator only reads its owning account's stream data.
     fn get_stream_records(
         &self,
+        account_id: &str,
         shard_id: &str,
         after_sequence: Option<&str>,
         limit: i64,

--- a/tests/rust/src/raw_http.rs
+++ b/tests/rust/src/raw_http.rs
@@ -169,7 +169,8 @@ async fn health_endpoint() {
 
 #[tokio::test]
 async fn metrics_endpoint() {
-    // /metrics is a extenddb-specific extension, not present on real DynamoDB.
+    // /metrics is an extenddb-specific extension, not present on real DynamoDB.
+    // It requires admin authentication; an unauthenticated request returns 401.
     if is_real_dynamodb() {
         return;
     }
@@ -179,7 +180,7 @@ async fn metrics_endpoint() {
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status().as_u16(), 200);
+    assert_eq!(resp.status().as_u16(), 401);
 }
 
 #[tokio::test]

--- a/tests/test_cross_account_isolation.py
+++ b/tests/test_cross_account_isolation.py
@@ -353,3 +353,220 @@ class TestConsoleIsolation:
         assert resp.status_code == 200
         assert self.bob_acct in resp.text
         assert self.alice_acct not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Stream record account scoping
+# ---------------------------------------------------------------------------
+import base64
+import time
+
+
+def _make_streams_client(endpoint_url: str, access_key: str, secret_key: str,
+                         region: str) -> Any:
+    kwargs: dict = dict(
+        service_name="dynamodbstreams",
+        endpoint_url=endpoint_url,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name=region,
+        config=BotoConfig(retries={"max_attempts": 0}),
+    )
+    if endpoint_url.startswith("https://"):
+        kwargs["verify"] = False
+    return boto3.client(**kwargs)
+
+
+def _stream_arn(ddb: Any, table: str) -> str:
+    return ddb.describe_table(TableName=table)["Table"]["LatestStreamArn"]
+
+
+@pytest.fixture(scope="module")
+def stream_accounts(auth_env, mgmt, region):
+    """Two accounts, each with a DynamoDB and a DynamoDB Streams client."""
+    endpoint = auth_env[0]
+    accts: dict[str, dict] = {}
+    for name, passwd in (("accta", "AcctaPass123!"), ("acctb", "AcctbPass456!")):
+        acct_id = f"{uuid.uuid4().int % 10**12:012d}"
+        assert mgmt.create_account(acct_id, f"{name}-acct-{acct_id}").status_code == 201
+        assert mgmt.create_user(acct_id, name, passwd).status_code == 201
+        creds = mgmt.create_access_key(acct_id, name).json()
+        assert mgmt.put_user_policy(acct_id, name, "full",
+                                    _full_access_policy()).status_code == 204
+        ak, sk = creds["access_key_id"], creds["secret_access_key"]
+        accts[name] = {
+            "acct": acct_id,
+            "ddb": _make_dynamodb_client(endpoint, ak, sk, region),
+            "streams": _make_streams_client(endpoint, ak, sk, region),
+        }
+    yield accts
+    for name in ("accta", "acctb"):
+        mgmt.delete_user(accts[name]["acct"], name)
+        mgmt.delete_account(accts[name]["acct"])
+
+
+class TestStreamAccountScoping:
+    """GetRecords returns only the records of the shard's owning account."""
+
+    def test_shard_iterator_only_returns_owning_account_records(self, stream_accounts):
+        owner = stream_accounts["accta"]
+        other = stream_accounts["acctb"]
+        table = f"accta-stream-{uuid.uuid4().hex[:8]}"
+
+        owner["ddb"].create_table(
+            TableName=table,
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            BillingMode="PAY_PER_REQUEST",
+            StreamSpecification={"StreamEnabled": True,
+                                 "StreamViewType": "NEW_AND_OLD_IMAGES"},
+        )
+        wait_for_active(owner["ddb"], table)
+        owner["ddb"].put_item(
+            TableName=table,
+            Item={"pk": {"S": "item1"}, "data": {"S": "owner-value"}},
+        )
+
+        arn = _stream_arn(owner["ddb"], table)
+        shards = owner["streams"].describe_stream(StreamArn=arn)[
+            "StreamDescription"]["Shards"]
+
+        def drain(client: Any, shard_id: str) -> list:
+            it = client.get_shard_iterator(
+                StreamArn=arn, ShardId=shard_id, ShardIteratorType="TRIM_HORIZON",
+            )["ShardIterator"]
+            recs: list = []
+            for _ in range(10):
+                resp = client.get_records(ShardIterator=it, Limit=100)
+                recs.extend(resp["Records"])
+                it = resp.get("NextShardIterator")
+                if recs or not it:
+                    break
+                time.sleep(0.5)
+            return recs
+
+        # Positive control: the owner finds its record in whichever shard holds
+        # it (the item's key hashes to one of the stream's shards).
+        drained = {sh["ShardId"]: drain(owner["streams"], sh["ShardId"]) for sh in shards}
+        target_shard = next(
+            (
+                sid
+                for sid, recs in drained.items()
+                if any(
+                    r["dynamodb"].get("NewImage", {}).get("data", {}).get("S")
+                    == "owner-value"
+                    for r in recs
+                )
+            ),
+            None,
+        )
+        assert target_shard is not None, (
+            "owner should be able to read its own stream records; drained counts="
+            + str({sid: len(recs) for sid, recs in drained.items()})
+            + " sample="
+            + str(drained)[:600]
+        )
+
+        # Construct a shard-iterator token for the shard holding account A's
+        # record and call GetRecords with account B's own credentials. The
+        # token is "<shard_id>|AFTER_SEQUENCE_NUMBER|<seq>|<ts>" in plain base64.
+        other_iterator = base64.b64encode(
+            f"{target_shard}|AFTER_SEQUENCE_NUMBER||{int(time.time())}".encode()
+        ).decode()
+        # Real DynamoDB rejects a GetRecords iterator it did not issue with
+        # ValidationException("Invalid ShardIterator") -- and does not
+        # distinguish "exists but not yours" from "does not exist", so the
+        # response cannot be used to probe another account's shard existence.
+        with pytest.raises(ClientError) as exc:
+            other["streams"].get_records(ShardIterator=other_iterator, Limit=100)
+        err = exc.value.response["Error"]
+        assert err["Code"] == "ValidationException", (
+            "a shard iterator for another account's shard must be rejected as "
+            f"ValidationException, got {err}"
+        )
+        assert err["Message"] == "Invalid ShardIterator", (
+            "expected DynamoDB-verbatim 'Invalid ShardIterator', got "
+            f"{err['Message']!r}"
+        )
+
+    def test_metrics_endpoint_requires_admin_auth(self, auth_env):
+        endpoint, admin_user, admin_pass = auth_env
+
+        # An unauthenticated request is rejected outright. Deterministic --
+        # no dependency on the async metrics flush.
+        r = requests.get(f"{endpoint}/metrics", verify=False, timeout=10)
+        assert r.status_code == 401, (
+            f"unauthenticated /metrics returned {r.status_code}, "
+            "expected 401 (must require admin auth)"
+        )
+
+        # With admin Basic auth the endpoint is reachable and returns a metrics
+        # document. (Per-table dimension *retention* is covered deterministically
+        # by the aggregate_rows Rust unit test, not by polling the 60s flush.)
+        r = requests.get(
+            f"{endpoint}/metrics",
+            auth=(admin_user, admin_pass),
+            verify=False,
+            timeout=10,
+        )
+        assert r.status_code == 200, (
+            f"admin /metrics returned {r.status_code}, expected 200"
+        )
+        body = r.json()
+        assert isinstance(body, dict) and ("metrics" in body or "buckets" in body), (
+            "admin /metrics should return a MetricsResponse JSON body"
+        )
+
+
+    def test_console_metrics_data_requires_session(self, auth_env):
+        endpoint, admin_user, admin_pass = auth_env
+
+        # 1. Without a console session, the data route must not serve
+        #    metrics -- it redirects to the console login.
+        r = requests.get(
+            f"{endpoint}/console/metrics-data?window=Last5Minutes",
+            verify=False,
+            timeout=10,
+            allow_redirects=False,
+        )
+        assert r.status_code in (302, 303), (
+            f"unauthenticated /console/metrics-data returned {r.status_code}, "
+            "expected a redirect to login"
+        )
+        assert "/console/login" in r.headers.get("Location", ""), (
+            "unauthenticated /console/metrics-data should redirect to console login"
+        )
+
+        # 2. With a valid console session, the route returns metrics JSON
+        #    (per-table dimensions), gated by the session cookie rather than
+        #    admin Basic auth.
+        s = requests.Session()
+        # The harness sets REQUESTS_CA_BUNDLE/SSL_CERT_FILE, which overrides
+        # session.verify; disable env trust and pass verify=False per request so
+        # the self-signed dev cert is accepted (same as the direct calls above).
+        s.trust_env = False
+        s.verify = False
+        login = s.post(
+            f"{endpoint}/console/login",
+            data={"username": admin_user, "password": admin_pass},
+            timeout=10,
+            allow_redirects=False,
+            verify=False,
+        )
+        assert login.status_code in (302, 303), (
+            f"console login failed: {login.status_code}"
+        )
+        r = s.get(
+            f"{endpoint}/console/metrics-data?window=Last5Minutes",
+            timeout=10,
+            verify=False,
+        )
+        assert r.status_code == 200, (
+            f"authenticated /console/metrics-data returned {r.status_code}, "
+            "expected 200"
+        )
+        body = r.json()
+        assert isinstance(body, dict) and ("metrics" in body or "buckets" in body), (
+            "authenticated /console/metrics-data should return a MetricsResponse "
+            "JSON body"
+        )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -28,6 +28,13 @@ import requests
 
 from conftest import wait_for_active
 
+# /metrics requires admin HTTP Basic auth. The harness (devtools/run-tests)
+# exports EXTENDDB_ADMIN_USER / EXTENDDB_ADMIN_PASSWORD from `extenddb init`.
+_ADMIN_AUTH = (
+    os.environ.get("EXTENDDB_ADMIN_USER", "admin"),
+    os.environ.get("EXTENDDB_ADMIN_PASSWORD", ""),
+)
+
 
 def _endpoint() -> str:
     """Return the extenddb endpoint or fail."""
@@ -111,7 +118,7 @@ class TestMetricsEndpoint:
 
     def test_metrics_returns_200(self, endpoint_url: str) -> None:
         """GET /metrics returns 200 with JSON body."""
-        resp = requests.get(f"{endpoint_url}/metrics", timeout=10, verify=False)
+        resp = requests.get(f"{endpoint_url}/metrics", timeout=10, verify=False, auth=_ADMIN_AUTH)
         assert resp.status_code == 200
         data = resp.json()
         assert "metrics" in data
@@ -119,14 +126,14 @@ class TestMetricsEndpoint:
 
     def test_metrics_source(self, endpoint_url: str) -> None:
         """Default query reports its data source."""
-        resp = requests.get(f"{endpoint_url}/metrics", timeout=10, verify=False)
+        resp = requests.get(f"{endpoint_url}/metrics", timeout=10, verify=False, auth=_ADMIN_AUTH)
         data = resp.json()
         assert data["source"] in ("memory", "database")
 
     def test_metrics_with_window(self, endpoint_url: str) -> None:
         """Window parameter selects time range."""
         resp = requests.get(
-            f"{endpoint_url}/metrics?window=Last5Minutes", timeout=10, verify=False
+            f"{endpoint_url}/metrics?window=Last5Minutes", timeout=10, verify=False, auth=_ADMIN_AUTH
         )
         assert resp.status_code == 200
         data = resp.json()
@@ -142,7 +149,7 @@ class TestMetricsEndpoint:
         but tolerate empty results from the database source.
         """
         resp = requests.get(
-            _metrics_url(endpoint_url, table_name=metrics_table), timeout=10, verify=False
+            _metrics_url(endpoint_url, table_name=metrics_table), timeout=10, verify=False, auth=_ADMIN_AUTH
         )
         assert resp.status_code == 200
         data = resp.json()
@@ -168,7 +175,7 @@ class TestMetricsEndpoint:
                 table_name=metrics_table,
                 metric="ConsumedWriteCapacityUnits",
             ),
-            timeout=10, verify=False,
+            timeout=10, verify=False, auth=_ADMIN_AUTH,
         )
         assert resp.status_code == 200
         data = resp.json()
@@ -188,7 +195,7 @@ class TestMetricsEndpoint:
                 table_name=metrics_table,
                 metric="ConsumedWriteCapacityUnits",
             ),
-            timeout=10, verify=False,
+            timeout=10, verify=False, auth=_ADMIN_AUTH,
         )
         data = resp.json()
         total_sum = sum(m["sum"] for m in data["metrics"])
@@ -209,7 +216,7 @@ class TestMetricsEndpoint:
                 table_name=metrics_table,
                 metric="ConsumedReadCapacityUnits",
             ),
-            timeout=10, verify=False,
+            timeout=10, verify=False, auth=_ADMIN_AUTH,
         )
         data = resp.json()
         total_sum = sum(m["sum"] for m in data["metrics"])
@@ -230,7 +237,7 @@ class TestMetricsEndpoint:
                 table_name=metrics_table,
                 metric="SuccessfulRequestLatency",
             ),
-            timeout=10, verify=False,
+            timeout=10, verify=False, auth=_ADMIN_AUTH,
         )
         data = resp.json()
         latency_metrics = [
@@ -251,7 +258,7 @@ class TestMetricsEndpoint:
     ) -> None:
         """Metrics include table name and operation dimensions."""
         resp = requests.get(
-            _metrics_url(endpoint_url, table_name=metrics_table), timeout=10, verify=False
+            _metrics_url(endpoint_url, table_name=metrics_table), timeout=10, verify=False, auth=_ADMIN_AUTH
         )
         data = resp.json()
         for m in data["metrics"]:
@@ -269,7 +276,7 @@ class TestMetricsEndpoint:
         only incidental latency metrics (e.g. from the query itself)."""
         resp = requests.get(
             _metrics_url(endpoint_url, table_name="nonexistent-table-xyz"),
-            timeout=10, verify=False,
+            timeout=10, verify=False, auth=_ADMIN_AUTH,
         )
         assert resp.status_code == 200
         data = resp.json()
@@ -286,7 +293,7 @@ class TestMetricsEndpoint:
     def test_metrics_last_hour_window(self, endpoint_url: str) -> None:
         """LastHour window queries the database source (if available)."""
         resp = requests.get(
-            f"{endpoint_url}/metrics?window=LastHour", timeout=10, verify=False
+            f"{endpoint_url}/metrics?window=LastHour", timeout=10, verify=False, auth=_ADMIN_AUTH
         )
         assert resp.status_code == 200
         data = resp.json()
@@ -297,7 +304,7 @@ class TestMetricsEndpoint:
     def test_metrics_invalid_start_time(self, endpoint_url: str) -> None:
         """Invalid ISO 8601 start time returns 400."""
         resp = requests.get(
-            f"{endpoint_url}/metrics?start=not-a-date", timeout=10, verify=False
+            f"{endpoint_url}/metrics?start=not-a-date", timeout=10, verify=False, auth=_ADMIN_AUTH
         )
         assert resp.status_code == 400
         data = resp.json()


### PR DESCRIPTION
## What

Two changes to the DynamoDB Streams read path and the `/metrics` endpoint:

- **Streams — account scoping on `GetRecords`.** `get_stream_records` on the `Storage` trait now takes the caller's `account_id`, and `handle_get_records` passes `ctx.account_id`. Implementations must return records only for shards whose backing table belongs to that account. The Postgres backend resolves this in two steps across its pools — `shard_id → table_id` (data pool), then `table_id + account_id` (catalog pool) — and returns `ValidationException("Invalid ShardIterator")` for an iterator whose shard the caller does not own, which is exactly what real DynamoDB returns for a `GetRecords` iterator it did not issue (it does not distinguish "exists but not yours" from "does not exist"). Enforced at the trait level so every backend inherits it.
- **Metrics — authentication on `/metrics`.** The top-level `/metrics` endpoint now requires admin HTTP Basic auth (reusing the management API's `authenticate_admin`; Prometheus scrapers configure `basic_auth`). Per-table CloudWatch-style dimensions (`TableName` / index) are retained for authorized callers rather than stripped. The web console dashboard now reads metrics from a new session-authed `/console/metrics-data` route instead of the Basic-auth `/metrics`.

## Why

`GetRecords` read stream records by shard id without checking that the shard's backing table belonged to the caller's account, so on a single instance shared across multiple accounts the read path was not account-scoped the way `GetShardIterator` already was. This aligns `GetRecords` with the account scoping applied elsewhere and with real DynamoDB's iterator semantics. Separately, `/metrics` was unauthenticated while exposing per-table dimensions; gating it behind admin auth (and giving the console its own session-authed route) keeps full per-table observability for authorized callers without leaving the endpoint open.

Closes # _(n/a — no public issue)_

## Testing done

- `cargo fmt --all -- --check` — clean (exit 0).
- `cargo build --release` for `extenddb-server` + `extenddb-storage-postgres` — clean.
- Integration tests (in `tests/test_cross_account_isolation.py`), verified against a running server + Postgres:
  - `test_shard_iterator_only_returns_owning_account_records` — the owning account reads its own stream record; a shard iterator constructed for another account's shard, called with that account's own credentials, returns `ValidationException: Invalid ShardIterator`.
  - `test_metrics_endpoint_requires_admin_auth` — unauthenticated `/metrics` → `401`; admin Basic auth → `200` with a metrics document.
  - `test_console_metrics_data_requires_session` — unauthenticated `/console/metrics-data` → redirect to console login; valid console session → `200` metrics JSON.
- `aggregate_rows` unit test (`crates/server/src/metrics_endpoint.rs`) pins that per-table/GSI dimensions are retained (no dependency on the 60s metrics flush).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean — CI gate `cargo clippy --all-targets -- -D warnings` passes (`-W clippy::pedantic` surfaces only pre-existing, repo-wide style warnings unrelated to this change)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed — endpoint doc comments updated; no user-facing docs affected (`/metrics` now requires admin auth — see Breaking changes)
- [x] Breaking changes are noted below
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface, an RFC has been accepted or is linked below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a — the `get_stream_records` trait signature gains an `account_id` parameter and `/metrics` gains an auth requirement; both are maintainer-approved correctness/operational changes. No wire-protocol, on-disk format, or public CLI change.

## Breaking changes

- **`Storage` trait:** `get_stream_records` gains an `account_id: &str` parameter. Out-of-tree backends implementing `Storage` must update their signature; in-tree backends are updated in this PR. No change to client-visible API responses.
- **`/metrics`:** now requires admin HTTP Basic auth. Existing Prometheus scrapers must be configured with `basic_auth`; unauthenticated scrapes now receive `401`. The browser console dashboard is unaffected (it uses the new session-authed `/console/metrics-data` route).

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
