### PR TITLE
chore: bump workspace version to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-auth"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-cache"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "futures",
  "moka",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-core"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-engine"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
  "crc32fast",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-server"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-postgres"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"


### PR DESCRIPTION
## What

<!-- Describe what this PR changes. -->

## Why

<!-- Link the issue this addresses. Explain the motivation. -->

Closes #

## Testing done

<!-- How did you verify this change works? Include test commands or output. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] All tests pass (`cargo test --workspace`)
- [ ] Code is formatted (`cargo fmt --check`)
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [ ] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: <!-- link or "n/a" -->

## Breaking changes

<!-- If this PR introduces breaking changes, describe them here. Otherwise delete this section. -->

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
