### PR TITLE
fix: scope backup ARN operations to the caller's account

### DIFF
--- a/crates/engine/src/backup.rs
+++ b/crates/engine/src/backup.rs
@@ -8,6 +8,41 @@ use serde_json::{Value, json};
 
 use crate::{OperationContext, serialize_output};
 
+/// Resolve the `BackupArn` field, rejecting ARNs that name a different account.
+///
+/// A backup ARN embeds the owning account:
+/// `arn:aws:dynamodb:<region>:<account>:table/<table>/backup/<id>`. Backups are
+/// account-scoped resources, so an ARN belonging to another account is treated
+/// as absent rather than as a permission error — the same response a caller gets
+/// for an ARN that was never issued, and consistent with `ListBackups`, which
+/// only ever returns the caller's own backups.
+///
+/// Backends also filter on `account_id`; this check keeps the rule in the engine
+/// so it holds for every backend rather than depending on each one to repeat it.
+fn backup_arn_field(body: &Value, account_id: &str) -> Result<String, DynamoDbError> {
+    let backup_arn = body
+        .get("BackupArn")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            DynamoDbError::ValidationException(
+                "1 validation error detected: Value null at 'backupArn' \
+                 failed to satisfy constraint: Member must not be null"
+                    .to_owned(),
+            )
+        })?;
+
+    // Field 4 of a colon-delimited ARN is the account id. A malformed ARN has no
+    // account to match, so it falls through as not found too.
+    let arn_account = backup_arn.split(':').nth(4);
+    if arn_account != Some(account_id) {
+        return Err(DynamoDbError::ResourceNotFoundException(format!(
+            "Backup not found: {backup_arn}"
+        )));
+    }
+
+    Ok(backup_arn.to_owned())
+}
+
 /// Handle `CreateBackup`.
 pub(crate) async fn handle_create_backup(
     body: Value,
@@ -48,20 +83,11 @@ pub(crate) async fn handle_describe_backup(
     body: Value,
     ctx: &OperationContext,
 ) -> Result<Value, DynamoDbError> {
-    let backup_arn = body
-        .get("BackupArn")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| {
-            DynamoDbError::ValidationException(
-                "1 validation error detected: Value null at 'backupArn' \
-                 failed to satisfy constraint: Member must not be null"
-                    .to_owned(),
-            )
-        })?;
+    let backup_arn = backup_arn_field(&body, &ctx.account_id)?;
 
     let desc = ctx
         .storage
-        .describe_backup(backup_arn)
+        .describe_backup(&ctx.account_id, &backup_arn)
         .await
         .map_err(storage_err_to_dynamo)?;
 
@@ -89,20 +115,11 @@ pub(crate) async fn handle_delete_backup(
     body: Value,
     ctx: &OperationContext,
 ) -> Result<Value, DynamoDbError> {
-    let backup_arn = body
-        .get("BackupArn")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| {
-            DynamoDbError::ValidationException(
-                "1 validation error detected: Value null at 'backupArn' \
-                 failed to satisfy constraint: Member must not be null"
-                    .to_owned(),
-            )
-        })?;
+    let backup_arn = backup_arn_field(&body, &ctx.account_id)?;
 
     let desc = ctx
         .storage
-        .delete_backup(backup_arn)
+        .delete_backup(&ctx.account_id, &backup_arn)
         .await
         .map_err(storage_err_to_dynamo)?;
 
@@ -124,20 +141,11 @@ pub(crate) async fn handle_restore_table_from_backup(
                     .to_owned(),
             )
         })?;
-    let backup_arn = body
-        .get("BackupArn")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| {
-            DynamoDbError::ValidationException(
-                "1 validation error detected: Value null at 'backupArn' \
-                 failed to satisfy constraint: Member must not be null"
-                    .to_owned(),
-            )
-        })?;
+    let backup_arn = backup_arn_field(&body, &ctx.account_id)?;
 
     let desc = ctx
         .storage
-        .restore_table_from_backup(&ctx.account_id, target_table_name, backup_arn)
+        .restore_table_from_backup(&ctx.account_id, target_table_name, &backup_arn)
         .await
         .map_err(storage_err_to_dynamo)?;
 
@@ -248,5 +256,72 @@ fn storage_err_to_dynamo(e: extenddb_storage::error::StorageError) -> DynamoDbEr
             tracing::error!(internal_error = %other, "backup storage error");
             DynamoDbError::InternalServerError("Internal server error".to_owned())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::backup_arn_field;
+    use extenddb_core::error::DynamoDbError;
+    use serde_json::json;
+
+    const ACCOUNT: &str = "123456789012";
+
+    fn arn(account: &str) -> String {
+        format!("arn:aws:dynamodb:us-east-1:{account}:table/Music/backup/01489602797149-73d8d5bc")
+    }
+
+    #[test]
+    fn own_account_arn_is_accepted() {
+        let body = json!({ "BackupArn": arn(ACCOUNT) });
+        assert_eq!(backup_arn_field(&body, ACCOUNT).unwrap(), arn(ACCOUNT));
+    }
+
+    #[test]
+    fn other_account_arn_is_reported_missing() {
+        let body = json!({ "BackupArn": arn("999999999999") });
+        let err = backup_arn_field(&body, ACCOUNT).unwrap_err();
+        assert!(
+            matches!(err, DynamoDbError::ResourceNotFoundException(_)),
+            "expected ResourceNotFoundException, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn malformed_arn_is_reported_missing() {
+        for candidate in [
+            "not-an-arn",
+            "arn:aws:dynamodb",
+            "arn:aws:dynamodb:us-east-1",
+            "",
+            // Account field present but empty.
+            "arn:aws:dynamodb:us-east-1::table/Music/backup/1",
+            // Account appears later in the string but not in field 4.
+            "arn:aws:dynamodb:us-east-1:table/Music/backup/123456789012",
+        ] {
+            let body = json!({ "BackupArn": candidate });
+            let err = backup_arn_field(&body, ACCOUNT).unwrap_err();
+            assert!(
+                matches!(err, DynamoDbError::ResourceNotFoundException(_)),
+                "expected ResourceNotFoundException for {candidate:?}, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn missing_arn_field_is_a_validation_error() {
+        let body = json!({});
+        let err = backup_arn_field(&body, ACCOUNT).unwrap_err();
+        assert!(
+            matches!(err, DynamoDbError::ValidationException(_)),
+            "expected ValidationException, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn account_prefix_does_not_match() {
+        // A shorter account id that is a prefix of the caller's must not pass.
+        let body = json!({ "BackupArn": arn("12345678901") });
+        assert!(backup_arn_field(&body, ACCOUNT).is_err());
     }
 }

--- a/crates/storage-postgres/src/backup_engine.rs
+++ b/crates/storage-postgres/src/backup_engine.rs
@@ -15,12 +15,25 @@ use futures::future::BoxFuture;
 use crate::PostgresEngine;
 use crate::data::data_table_name;
 
-/// Current epoch milliseconds for unique ARN generation.
+/// Current epoch milliseconds, used as the leading component of a backup id.
 fn epoch_millis() -> u128 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis()
+}
+
+/// Build the trailing `backup/<id>` component of a backup ARN.
+///
+/// `DynamoDB` formats this as `<epoch_millis>-<8 hex chars>` (for example
+/// `01489602797149-73d8d5bc`). The random component is part of the identifier,
+/// not decoration: a timestamp alone makes a backup id derivable by anyone who
+/// knows roughly when the backup ran, so the id is only a usable handle for a
+/// caller that was given it.
+fn backup_id() -> String {
+    use rand::Rng;
+    let suffix: u32 = rand::rng().random();
+    format!("{ts}-{suffix:08x}", ts = epoch_millis())
 }
 
 /// Convert a `PostgreSQL` `TIMESTAMPTZ` to epoch seconds as `f64`.
@@ -75,9 +88,9 @@ impl BackupEngine for PostgresEngine {
             ) = row;
 
             let backup_arn = format!(
-                "arn:aws:dynamodb:{region}:{account_id}:table/{table_name}/backup/{ts}",
+                "arn:aws:dynamodb:{region}:{account_id}:table/{table_name}/backup/{id}",
                 region = self.region,
-                ts = epoch_millis()
+                id = backup_id()
             );
 
             // Snapshot items from the data table.
@@ -179,8 +192,10 @@ impl BackupEngine for PostgresEngine {
 
     fn describe_backup(
         &self,
+        account_id: &str,
         backup_arn: &str,
     ) -> BoxFuture<'_, Result<BackupDescription, StorageError>> {
+        let account_id = account_id.to_string();
         let backup_arn = backup_arn.to_string();
         Box::pin(async move {
             let row: (
@@ -205,10 +220,11 @@ impl BackupEngine for PostgresEngine {
                  COALESCE(t.creation_date_time, b.created_at) \
                  FROM backups b \
                  LEFT JOIN tables t ON t.table_id = b.table_id \
-                 WHERE b.backup_arn = $1",
+                 WHERE b.backup_arn = $1 AND b.account_id = $3",
             )
             .bind(&backup_arn)
             .bind(&self.region)
+            .bind(&account_id)
             .fetch_optional(&self.pool)
             .await
             .map_err(|e| StorageError::Internal(format!("Database error: {e}")))?
@@ -329,23 +345,38 @@ impl BackupEngine for PostgresEngine {
 
     fn delete_backup(
         &self,
+        account_id: &str,
         backup_arn: &str,
     ) -> BoxFuture<'_, Result<BackupDescription, StorageError>> {
+        let account_id = account_id.to_string();
         let backup_arn = backup_arn.to_string();
         Box::pin(async move {
-            let desc = self.describe_backup(&backup_arn).await?;
+            // Resolves account-scoped, so a backup owned by another account is
+            // reported missing here and the writes below never run.
+            let desc = self.describe_backup(&account_id, &backup_arn).await?;
 
-            sqlx::query("DELETE FROM backup_items WHERE backup_arn = $1")
-                .bind(&backup_arn)
-                .execute(&self.pool)
-                .await
-                .map_err(|e| StorageError::Internal(format!("Database error: {e}")))?;
+            // The account predicate is repeated on both writes rather than
+            // relying on the lookup above, so the statements are correct on
+            // their own terms.
+            sqlx::query(
+                "DELETE FROM backup_items WHERE backup_arn = $1 AND EXISTS (\
+                 SELECT 1 FROM backups b WHERE b.backup_arn = $1 AND b.account_id = $2)",
+            )
+            .bind(&backup_arn)
+            .bind(&account_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(format!("Database error: {e}")))?;
 
-            sqlx::query("UPDATE backups SET backup_status = 'DELETED' WHERE backup_arn = $1")
-                .bind(&backup_arn)
-                .execute(&self.pool)
-                .await
-                .map_err(|e| StorageError::Internal(format!("Database error: {e}")))?;
+            sqlx::query(
+                "UPDATE backups SET backup_status = 'DELETED' \
+                 WHERE backup_arn = $1 AND account_id = $2",
+            )
+            .bind(&backup_arn)
+            .bind(&account_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(format!("Database error: {e}")))?;
 
             Ok(BackupDescription {
                 backup_details: BackupDetails {
@@ -376,9 +407,11 @@ impl BackupEngine for PostgresEngine {
             ) = sqlx::query_as(
                 "SELECT table_name, key_schema, attribute_definitions, billing_mode, \
                  provisioned_throughput \
-                 FROM backups WHERE backup_arn = $1 AND backup_status = 'AVAILABLE'",
+                 FROM backups \
+                 WHERE backup_arn = $1 AND account_id = $2 AND backup_status = 'AVAILABLE'",
             )
             .bind(&backup_arn)
+            .bind(&account_id)
             .fetch_optional(&self.pool)
             .await
             .map_err(|e| StorageError::Internal(format!("Database error: {e}")))?
@@ -620,7 +653,7 @@ impl BackupEngine for PostgresEngine {
             let desc = self
                 .restore_table_from_backup(&account_id, &target_table_name, &backup.backup_arn)
                 .await?;
-            let _ = self.delete_backup(&backup.backup_arn).await;
+            let _ = self.delete_backup(&account_id, &backup.backup_arn).await;
             Ok(desc)
         })
     }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -530,9 +530,15 @@ pub trait BackupEngine: Send + Sync {
         backup_name: &str,
     ) -> BoxFuture<'_, Result<extenddb_core::types::BackupDetails, StorageError>>;
 
-    /// Describe a backup by ARN.
+    /// Describe a backup by ARN, scoped to the owning account.
+    ///
+    /// Backups belong to an account, so implementations must match on both
+    /// `account_id` and `backup_arn` and report a missing backup when the ARN
+    /// belongs to another account — consistent with `list_backups`, which is
+    /// already account-scoped.
     fn describe_backup(
         &self,
+        account_id: &str,
         backup_arn: &str,
     ) -> BoxFuture<'_, Result<extenddb_core::types::BackupDescription, StorageError>>;
 
@@ -543,13 +549,21 @@ pub trait BackupEngine: Send + Sync {
         table_name: Option<&str>,
     ) -> BoxFuture<'_, Result<Vec<extenddb_core::types::BackupSummary>, StorageError>>;
 
-    /// Delete a backup by ARN.
+    /// Delete a backup by ARN, scoped to the owning account.
+    ///
+    /// Same scoping requirement as `describe_backup`: an ARN owned by another
+    /// account must be reported as missing rather than deleted.
     fn delete_backup(
         &self,
+        account_id: &str,
         backup_arn: &str,
     ) -> BoxFuture<'_, Result<extenddb_core::types::BackupDescription, StorageError>>;
 
     /// Restore a table from a backup.
+    ///
+    /// `account_id` is the caller's account: it owns the new table *and* scopes
+    /// the source backup lookup, since a backup can only be restored by the
+    /// account that owns it.
     fn restore_table_from_backup(
         &self,
         account_id: &str,

--- a/tests/rust/src/backup_arn_scoping.rs
+++ b/tests/rust/src/backup_arn_scoping.rs
@@ -1,0 +1,199 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Backup operations addressed by ARN resolve only within the caller's account.
+//!
+//! A backup ARN embeds the owning account
+//! (`arn:aws:dynamodb:<region>:<account>:table/<table>/backup/<id>`). Backups
+//! are account-scoped resources, so `DescribeBackup`, `DeleteBackup`, and
+//! `RestoreTableFromBackup` treat an ARN naming a different account as absent —
+//! the same answer as an ARN that was never issued, and consistent with
+//! `ListBackups`, which only returns the caller's own backups.
+//!
+//! These tests drive the ARN directly rather than provisioning a second account,
+//! so they exercise the resolution rule without needing a second set of
+//! credentials.
+
+use crate::test_base::*;
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition, BillingMode, KeySchemaElement, KeyType, ScalarAttributeType,
+};
+
+/// An account id that no test ever provisions.
+const FOREIGN_ACCOUNT: &str = "999999999999";
+
+/// A well-formed backup ARN owned by `FOREIGN_ACCOUNT`.
+fn foreign_backup_arn(table: &str) -> String {
+    let region = std::env::var("AWS_DEFAULT_REGION").unwrap_or_else(|_| "us-east-1".into());
+    format!(
+        "arn:aws:dynamodb:{region}:{FOREIGN_ACCOUNT}:table/{table}/backup/01489602797149-73d8d5bc"
+    )
+}
+
+async fn make_table(name: &str) {
+    let c = client();
+    c.create_table()
+        .table_name(name)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+    wait_for_active(c, name).await;
+}
+
+#[tokio::test]
+async fn describe_backup_with_another_accounts_arn_reports_not_found() {
+    let c = client();
+    let err = c
+        .describe_backup()
+        .backup_arn(foreign_backup_arn("SomeTable"))
+        .send()
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err_code(&err),
+        Some("ResourceNotFoundException"),
+        "expected the ARN to resolve as absent, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn delete_backup_with_another_accounts_arn_reports_not_found() {
+    let c = client();
+    let err = c
+        .delete_backup()
+        .backup_arn(foreign_backup_arn("SomeTable"))
+        .send()
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err_code(&err),
+        Some("ResourceNotFoundException"),
+        "expected the ARN to resolve as absent, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn restore_from_another_accounts_backup_arn_reports_not_found() {
+    let c = client();
+    let target = format!("BackupScopeRestore_{}", ts());
+
+    let err = c
+        .restore_table_from_backup()
+        .target_table_name(&target)
+        .backup_arn(foreign_backup_arn("SomeTable"))
+        .send()
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err_code(&err),
+        Some("ResourceNotFoundException"),
+        "expected the ARN to resolve as absent, got: {err:?}"
+    );
+
+    // The target table must not have been created as a side effect.
+    let describe = c.describe_table().table_name(&target).send().await;
+    assert!(
+        describe.is_err(),
+        "restore from an unresolvable backup ARN created table {target}"
+    );
+}
+
+/// Positive control: the scoping rule must not reject a caller's own ARN.
+///
+/// Without this, all three tests above would also pass if backup resolution
+/// were broken outright.
+#[tokio::test]
+async fn describe_backup_with_own_arn_still_resolves() {
+    let c = client();
+    let table = format!("BackupScopeOwn_{}", ts());
+    make_table(&table).await;
+
+    let create = c
+        .create_backup()
+        .table_name(&table)
+        .backup_name("scope-own")
+        .send()
+        .await
+        .unwrap();
+    let arn = create.backup_details().unwrap().backup_arn().to_string();
+
+    let resp = c.describe_backup().backup_arn(&arn).send().await.unwrap();
+    assert_eq!(
+        resp.backup_description()
+            .unwrap()
+            .backup_details()
+            .unwrap()
+            .backup_arn(),
+        arn.as_str()
+    );
+
+    c.delete_backup().backup_arn(&arn).send().await.ok();
+    c.delete_table().table_name(&table).send().await.ok();
+}
+
+/// The backup id carries a random component after the timestamp, so two backups
+/// taken in the same millisecond still get distinct ARNs.
+#[tokio::test]
+async fn backup_ids_are_not_derived_from_the_timestamp_alone() {
+    let c = client();
+    let table = format!("BackupScopeIds_{}", ts());
+    make_table(&table).await;
+
+    let mut arns = Vec::new();
+    for i in 0..3 {
+        let create = c
+            .create_backup()
+            .table_name(&table)
+            .backup_name(format!("scope-id-{i}"))
+            .send()
+            .await
+            .unwrap();
+        arns.push(create.backup_details().unwrap().backup_arn().to_string());
+    }
+
+    for arn in &arns {
+        let id = arn.rsplit('/').next().unwrap();
+        let (ts_part, suffix) = id.split_once('-').unwrap_or((id, ""));
+        assert!(
+            ts_part.chars().all(char::is_numeric) && !ts_part.is_empty(),
+            "backup id {id} does not start with a numeric timestamp"
+        );
+        assert_eq!(
+            suffix.len(),
+            8,
+            "backup id {id} is missing the 8-character suffix"
+        );
+        assert!(
+            suffix.chars().all(|ch| ch.is_ascii_hexdigit()),
+            "backup id {id} suffix is not hex"
+        );
+    }
+
+    let mut unique = arns.clone();
+    unique.sort();
+    unique.dedup();
+    assert_eq!(unique.len(), arns.len(), "duplicate backup ARNs: {arns:?}");
+
+    for arn in &arns {
+        c.delete_backup().backup_arn(arn).send().await.ok();
+    }
+    c.delete_table().table_name(&table).send().await.ok();
+}

--- a/tests/rust/src/main.rs
+++ b/tests/rust/src/main.rs
@@ -12,6 +12,8 @@ mod test_base;
 #[cfg(test)]
 mod authorization;
 #[cfg(test)]
+mod backup_arn_scoping;
+#[cfg(test)]
 mod backup_restore;
 #[cfg(test)]
 mod batch_get_item;


### PR DESCRIPTION
## What

Scope the ARN-addressed backup operations to the caller's account. `DescribeBackup`,
`DeleteBackup` and `RestoreTableFromBackup` previously resolved a caller-supplied
`BackupArn` without reference to the caller's account, so an ARN issued for one
account resolved for any caller. `ListBackups` was already account-scoped; this
brings the ARN-addressed operations in line with it.

- `BackupEngine::describe_backup` and `delete_backup` now take `account_id`, and the
  restore source lookup reuses the caller's `account_id`, so the scoping rule lives in
  the trait rather than in each backend.
- The engine resolves the `BackupArn` field and treats an ARN naming another account
  as absent (`ResourceNotFoundException`) — the same response as an ARN that was never
  issued.
- The Postgres backend filters on `account_id` in the describe, delete and restore
  queries.
- Backup ids now carry the `<epoch_millis>-<8 hex>` suffix DynamoDB uses, instead of a
  bare timestamp — matching the documented ARN format and making ids unique within a
  millisecond.

## Why

The ARN-addressed backup operations were the only backup path not scoped to the
caller's account, which is inconsistent with `ListBackups` and with DynamoDB's
resource model. Bringing them in line closes that inconsistency.

Closes #

## Testing done

Verified live against a Postgres-backed server built from this branch:

- `cargo build --workspace` — clean
- `cargo clippy --workspace --all-targets` — 0 warnings
- `cargo fmt --all -- --check` — exit 0
- `cargo test -p extenddb-engine backup` — 5/5 ARN-resolution unit tests pass
- Rust integration suite — **391 passed, 0 failed** (386 baseline + 5 new)
- Backup tests specifically — 16/16 (5 new `backup_arn_scoping` + 11 existing
  `backup_restore`, unchanged)

The 5 new integration tests drive the ARN directly (no second account provisioned):
another account's ARN returns `ResourceNotFoundException` on Describe, Delete and
Restore; Restore additionally asserts the target table is not created as a side
effect; a positive control confirms the caller's own ARN still resolves; and one test
pins the `<epoch_millis>-<8 hex>` id format.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: needed — this changes the `BackupEngine` trait signature (adds
`account_id` to `describe_backup`/`delete_backup`). An ADR should capture the
decision before merge.

## Breaking changes

The `BackupEngine` trait signatures for `describe_backup` and `delete_backup` gain an
`account_id` parameter. Any out-of-tree backend implementing `BackupEngine` must update
these signatures and filter on `account_id`.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.