### PR TITLE
fix: align tag-resource ARN validation with DynamoDB error classes

### DIFF
--- a/crates/engine/src/tagging.rs
+++ b/crates/engine/src/tagging.rs
@@ -13,40 +13,85 @@ use crate::OperationContext;
 use crate::sanitize_storage_error;
 use crate::serialize_output;
 
+/// Split a `DynamoDB` resource ARN into `(region, account, resource)`.
+///
+/// Expected format: `arn:aws:dynamodb:{region}:{account}:table/{name}[/...]`
+fn split_dynamodb_arn(arn: &str) -> Option<(&str, &str, &str)> {
+    let rest = arn.strip_prefix("arn:aws:dynamodb:")?;
+    let mut parts = rest.splitn(3, ':');
+    let region = parts.next()?;
+    let account = parts.next()?;
+    let resource = parts.next()?;
+    Some((region, account, resource))
+}
+
 /// Extract the table name from a `DynamoDB` table ARN.
 ///
 /// Expected format: `arn:aws:dynamodb:{region}:{account}:table/{name}[/...]`
 fn extract_table_name_from_arn(arn: &str) -> Option<&str> {
-    let resource = arn.strip_prefix("arn:aws:dynamodb:")?.split(':').nth(2)?;
+    let (_, _, resource) = split_dynamodb_arn(arn)?;
     let table_name = resource.strip_prefix("table/")?;
     // Strip any sub-resource (e.g. /index/foo, /stream/label)
     Some(table_name.split('/').next().unwrap_or(table_name))
 }
 
-/// Extract the account ID from a `DynamoDB` table ARN.
-fn extract_account_from_arn(arn: &str) -> Option<&str> {
-    arn.strip_prefix("arn:aws:dynamodb:")?.split(':').nth(1)
-}
-
-/// Validate that the ARN refers to an existing table.
+/// Validate that the ARN refers to an existing table owned by the caller.
 ///
-/// Returns `ResourceNotFoundException` if the table does not exist.
+/// The error classes and messages below match `DynamoDB`, verified against the
+/// service:
+///
+/// | Input | Result |
+/// |---|---|
+/// | Does not start with `arn:` | `ValidationException` (ARNs must start with `arn:`) |
+/// | Valid ARN for another service | `AccessDeniedException` |
+/// | `DynamoDB` ARN naming a non-table resource | `ValidationException` (not a `DynamoDB` resource arn) |
+/// | Account differs from the caller's | `AccessDeniedException` |
+/// | Region differs from this deployment's | `ValidationException` (invalid `TableArn`) |
+/// | Table does not exist | `ResourceNotFoundException` |
+///
+/// Account is checked before region, matching the service: a cross-account ARN
+/// is denied without revealing whether its region is valid.
 async fn validate_resource_arn(arn: &str, ctx: &OperationContext) -> Result<(), DynamoDbError> {
-    let table_name = extract_table_name_from_arn(arn).ok_or_else(|| {
-        DynamoDbError::ValidationException(format!(
-            "1 validation error detected: Value '{arn}' at 'resourceArn' failed to satisfy constraint: \
-             Member must satisfy regular expression pattern: arn:aws:dynamodb:.+"
-        ))
-    })?;
+    if !arn.starts_with("arn:") {
+        return Err(DynamoDbError::ValidationException(format!(
+            "One or more parameter values were invalid: ARNs must start with 'arn:': {arn}"
+        )));
+    }
 
-    // Check the ARN's account matches the caller's account.
-    if let Some(arn_account) = extract_account_from_arn(arn)
-        && arn_account != ctx.account_id.as_ref()
-    {
+    // An ARN for another service is denied rather than reported as malformed:
+    // authorization is evaluated against the resource before its shape is
+    // inspected further.
+    let Some((arn_region, arn_account, resource)) = split_dynamodb_arn(arn) else {
+        return Err(DynamoDbError::AccessDeniedException(
+            "Access is denied".to_owned(),
+        ));
+    };
+
+    if !resource.starts_with("table/") {
+        return Err(DynamoDbError::ValidationException(format!(
+            "One or more parameter values were invalid: \
+             Provided Arn is not a DynamoDB resource arn: {arn}"
+        )));
+    }
+
+    if arn_account != ctx.account_id.as_ref() {
         return Err(DynamoDbError::AccessDeniedException(
             "Access is denied".to_owned(),
         ));
     }
+
+    if arn_region != ctx.region.as_ref() {
+        return Err(DynamoDbError::ValidationException(format!(
+            "Invalid TableArn: Invalid ResourceArn provided as input {arn}"
+        )));
+    }
+
+    let table_name = extract_table_name_from_arn(arn).ok_or_else(|| {
+        DynamoDbError::ValidationException(format!(
+            "One or more parameter values were invalid: \
+             Provided Arn is not a DynamoDB resource arn: {arn}"
+        ))
+    })?;
 
     // Verify the table exists via table_key_info (lightweight check).
     ctx.storage
@@ -55,7 +100,7 @@ async fn validate_resource_arn(arn: &str, ctx: &OperationContext) -> Result<(), 
         .map_err(|e| match e {
             extenddb_storage::error::StorageError::TableNotFound(_) => {
                 DynamoDbError::ResourceNotFoundException(format!(
-                    "Requested resource not found: {arn}"
+                    "Requested resource not found: ResourceArn: {arn} not found"
                 ))
             }
             other => sanitize_storage_error(other),

--- a/tests/rust/src/tagging.rs
+++ b/tests/rust/src/tagging.rs
@@ -158,7 +158,7 @@ async fn list_tags_empty() {
 }
 
 #[tokio::test]
-async fn tag_nonexistent_resource() {
+async fn tag_cross_account_resource_is_denied() {
     let c = client();
     let fake_arn = "arn:aws:dynamodb:us-east-1:000000000000:table/nonexistent-xyz";
     let err = c
@@ -166,35 +166,29 @@ async fn tag_nonexistent_resource() {
         .resource_arn(fake_arn)
         .tags(Tag::builder().key("k").value("v").build().unwrap())
         .send()
-        .await;
-    assert!(err.is_err());
-    // extenddb returns ResourceNotFoundException; real DynamoDB returns
-    // AccessDeniedException for cross-account ARNs.
-    let err = err.unwrap_err();
-    let code = err_code(&err);
-    assert!(
-        code == Some("ResourceNotFoundException") || code == Some("AccessDeniedException"),
-        "unexpected error code: {code:?}"
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err_code(&err),
+        Some("AccessDeniedException"),
+        "cross-account ARN must be denied without disclosing existence"
     );
 }
 
 #[tokio::test]
-async fn list_tags_nonexistent_resource() {
+async fn list_tags_cross_account_resource_is_denied() {
     let c = client();
     let fake_arn = "arn:aws:dynamodb:us-east-1:000000000000:table/nonexistent-xyz";
     let err = c
         .list_tags_of_resource()
         .resource_arn(fake_arn)
         .send()
-        .await;
-    assert!(err.is_err());
-    // extenddb returns ResourceNotFoundException; real DynamoDB returns
-    // AccessDeniedException for cross-account ARNs.
-    let err = err.unwrap_err();
-    let code = err_code(&err);
-    assert!(
-        code == Some("ResourceNotFoundException") || code == Some("AccessDeniedException"),
-        "unexpected error code: {code:?}"
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err_code(&err),
+        Some("AccessDeniedException"),
+        "cross-account ARN must be denied without disclosing existence"
     );
 }
 
@@ -230,7 +224,7 @@ async fn tag_multiple_then_untag_all() {
 }
 
 #[tokio::test]
-async fn untag_nonexistent_resource() {
+async fn untag_cross_account_resource_is_denied() {
     let c = client();
     let fake_arn = "arn:aws:dynamodb:us-east-1:000000000000:table/nonexistent-xyz";
     let err = c
@@ -238,15 +232,12 @@ async fn untag_nonexistent_resource() {
         .resource_arn(fake_arn)
         .tag_keys("k")
         .send()
-        .await;
-    assert!(err.is_err());
-    // extenddb returns ResourceNotFoundException; real DynamoDB returns
-    // AccessDeniedException for cross-account ARNs.
-    let err = err.unwrap_err();
-    let code = err_code(&err);
-    assert!(
-        code == Some("ResourceNotFoundException") || code == Some("AccessDeniedException"),
-        "unexpected error code: {code:?}"
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err_code(&err),
+        Some("AccessDeniedException"),
+        "cross-account ARN must be denied without disclosing existence"
     );
 }
 
@@ -306,4 +297,114 @@ async fn tag_empty_value() {
         .map(|t| (t.key().to_string(), t.value().to_string()))
         .collect();
     assert_eq!(tags.get("k").unwrap(), "");
+}
+
+// ---------------------------------------------------------------------------
+// Resource ARN validation.
+//
+// Error classes below match DynamoDB, verified against the service. The ARNs
+// are derived from a real table's ARN so the account and region match the
+// caller's without hardcoding either.
+// ---------------------------------------------------------------------------
+
+/// Replace the table name in a table ARN.
+fn with_table_name(arn: &str, table_name: &str) -> String {
+    format!("{}/{table_name}", arn.rsplit_once('/').unwrap().0)
+}
+
+#[tokio::test]
+async fn tag_nonexistent_table_in_own_account_reports_not_found() {
+    let c = client();
+    let (_name, arn) = create_tagged_table(c).await;
+    let missing = with_table_name(&arn, "nonexistent-xyz-99");
+
+    let err = c
+        .tag_resource()
+        .resource_arn(&missing)
+        .tags(Tag::builder().key("k").value("v").build().unwrap())
+        .send()
+        .await
+        .unwrap_err();
+    assert_eq!(err_code(&err), Some("ResourceNotFoundException"));
+}
+
+#[tokio::test]
+async fn tag_resource_arn_in_another_region_is_a_validation_error() {
+    let c = client();
+    let (_name, arn) = create_tagged_table(c).await;
+    // Rewrite only the region component, keeping the caller's own account.
+    let parts: Vec<&str> = arn.splitn(6, ':').collect();
+    let other_region = if parts[3] == "us-west-2" {
+        "us-east-1"
+    } else {
+        "us-west-2"
+    };
+    let wrong_region = format!(
+        "{}:{}:{}:{}:{}:{}",
+        parts[0], parts[1], parts[2], other_region, parts[4], parts[5]
+    );
+
+    let err = c
+        .tag_resource()
+        .resource_arn(&wrong_region)
+        .tags(Tag::builder().key("k").value("v").build().unwrap())
+        .send()
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err_code(&err),
+        Some("ValidationException"),
+        "an ARN for a different region must be rejected as invalid"
+    );
+}
+
+#[tokio::test]
+async fn tag_resource_arn_without_arn_prefix_is_a_validation_error() {
+    let c = client();
+    let err = c
+        .tag_resource()
+        .resource_arn("not-an-arn")
+        .tags(Tag::builder().key("k").value("v").build().unwrap())
+        .send()
+        .await
+        .unwrap_err();
+    assert_eq!(err_code(&err), Some("ValidationException"));
+}
+
+#[tokio::test]
+async fn tag_non_table_dynamodb_arn_is_a_validation_error() {
+    let c = client();
+    let (_name, arn) = create_tagged_table(c).await;
+    // Same account and region, but an index resource rather than a table.
+    let parts: Vec<&str> = arn.splitn(6, ':').collect();
+    let index_arn = format!(
+        "{}:{}:{}:{}:{}:index/foo",
+        parts[0], parts[1], parts[2], parts[3], parts[4]
+    );
+
+    let err = c
+        .tag_resource()
+        .resource_arn(&index_arn)
+        .tags(Tag::builder().key("k").value("v").build().unwrap())
+        .send()
+        .await
+        .unwrap_err();
+    assert_eq!(err_code(&err), Some("ValidationException"));
+}
+
+#[tokio::test]
+async fn tag_arn_for_another_service_is_denied() {
+    let c = client();
+    let err = c
+        .tag_resource()
+        .resource_arn("arn:aws:s3:::mybucket")
+        .tags(Tag::builder().key("k").value("v").build().unwrap())
+        .send()
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err_code(&err),
+        Some("AccessDeniedException"),
+        "an ARN for another service is denied, not reported as malformed"
+    );
 }


### PR DESCRIPTION
## What

Align the tagging operations' resource-ARN validation with DynamoDB's error classes.
`TagResource`, `UntagResource` and `ListTagsOfResource` previously returned a single
`ValidationException` for any ARN that failed to parse and only checked the account.
Verified against DynamoDB, the error class depends on which part of the ARN is wrong:

- no `arn:` prefix → `ValidationException` (ARNs must start with `arn:`)
- valid ARN for another service → `AccessDeniedException`
- DynamoDB ARN for a non-table resource → `ValidationException` (not a DynamoDB
  resource arn)
- account differs from the caller → `AccessDeniedException`
- region differs from this deployment → `ValidationException` (invalid `TableArn`)
- table does not exist → `ResourceNotFoundException`

Account is checked before region, matching the service: a cross-account ARN is denied
without revealing whether its region is valid. The not-found message now matches
DynamoDB's `ResourceArn: <arn> not found` form.

## Why

The tagging operations diverged from DynamoDB's error classes for malformed, cross-region, non-table and other-service ARNs, and the not-found message did not match. This closes those divergences so client error handling behaves the same against extenddb as against DynamoDB.

Closes #

## Testing done

Verified live against a Postgres-backed server built from this branch, each error class confirmed against real DynamoDB (us-east-1) before implementing:

- `cargo build --workspace` — clean
- `cargo clippy --workspace --all-targets` — 0 warnings
- `cargo fmt --all -- --check` — exit 0
- Tagging tests — 16/16 pass
- Rust integration suite — **391 passed, 0 failed**

Five new integration tests cover the region, missing-table (same account), no-prefix, non-table-resource and other-service paths. Three existing cross-account tests were renamed and tightened from a loose "either code" assert to the exact `AccessDeniedException` they now verify.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a — error-response parity fix, no trait, wire-format or CLI change.

## Breaking changes

None to any interface. Error responses change for malformed / cross-region / non-table /
other-service ARNs (now matching DynamoDB); clients relying on the previous
`ValidationException`-for-everything behavior would observe different error codes.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.