### PR TITLE
feat(cli): add healthcheck, foreground supervision, and configurable cert SANs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,7 +47,9 @@ jobs:
 
       - name: Start ExtendDB
         run: |
-          ./target/release/extenddb serve --config extenddb.toml --foreground &
+          # --write-pid-file so devtools/run-tests can restart the server with
+          # 'extenddb stop' when it needs to apply a config change.
+          ./target/release/extenddb serve --config extenddb.toml --foreground --write-pid-file &
           for i in $(seq 1 30); do
             if curl -sk https://127.0.0.1:18443/health | grep -q healthy; then
               echo "Server ready"
@@ -114,7 +116,9 @@ jobs:
 
       - name: Start ExtendDB
         run: |
-          ./target/release/extenddb serve --config extenddb.toml --foreground &
+          # --write-pid-file so devtools/run-tests can restart the server with
+          # 'extenddb stop' when it needs to apply a config change.
+          ./target/release/extenddb serve --config extenddb.toml --foreground --write-pid-file &
           for i in $(seq 1 30); do
             if curl -sk https://127.0.0.1:18443/health | grep -q healthy; then
               echo "Server ready"

--- a/README.md
+++ b/README.md
@@ -112,7 +112,32 @@ By default `extenddb serve` daemonizes itself, which doesn't play well with cont
 extenddb serve --config extenddb.toml --foreground
 ```
 
-Use this with Docker, Kubernetes, `systemd Type=simple`, runit, s6, or any other supervisor that captures stdout/stderr. `extenddb status` and `extenddb stop` continue to work as in daemon mode, since the PID file is still written.
+Use this with Docker, Kubernetes, `systemd Type=simple`, runit, s6, or any other supervisor that captures stdout/stderr.
+
+In `--foreground` mode extenddb writes no PID file and never creates `run_dir`, so the container can run with a read-only root filesystem. Two consequences:
+
+- `extenddb status` still works (it probes the port) but reports the PID as unknown.
+- `extenddb stop` cannot signal the process — there is no PID file to read. Stop it through your supervisor, which delivers `SIGTERM` and triggers the same graceful shutdown.
+
+Pass `--write-pid-file` to opt back in when you do want `stop` and `status` to work against a foreground server, for example when running it from a shell rather than under a supervisor. The file goes to the usual `run_dir` path, so neither command needs extra arguments, and `run_dir` has to be writable.
+
+For a container `HEALTHCHECK`, use the `healthcheck` subcommand rather than `curl`; it needs no shell or extra binaries, so it works on a `distroless`/`scratch` image and accepts the self-signed certificate:
+
+```bash
+extenddb healthcheck --config extenddb.toml            # exit 0 healthy, 1 not
+extenddb healthcheck --endpoint https://127.0.0.1:18443 # explicit target
+```
+
+This is a liveness check, which is what a container `HEALTHCHECK` wants: `/health` does not query the storage backend, so it reports healthy even if PostgreSQL becomes unreachable after startup. That is deliberate, since a liveness probe that failed on a database outage would restart every replica at once. A backend that is unreachable at startup does stop the server from listening, so that case is caught. There is no separate readiness endpoint yet.
+
+To make the generated self-signed certificate valid for the name clients use — an in-cluster service DNS name, for example — pass `--tls-san` to `init` (repeatable):
+
+```bash
+extenddb init --catalog-db extenddb_catalog \
+  --tls-san extenddb.default.svc.cluster.local --tls-san extenddb.example.com
+```
+
+`init` never regenerates an existing certificate, so if one is already present it verifies that it already covers every requested `--tls-san` and fails with an explicit error if it does not, rather than silently dropping the name.
 
 ## Monitoring
 
@@ -142,6 +167,7 @@ extenddb serve --config extenddb.toml --foreground  # Start in foreground
 extenddb init --catalog-db NAME            # Initialize deployment
 extenddb stop --config extenddb.toml           # Graceful shutdown
 extenddb status --config extenddb.toml         # Check if running
+extenddb healthcheck --config extenddb.toml    # Probe /health (exit 0 healthy, 1 not)
 extenddb verify --config extenddb.toml         # Validate deployment
 extenddb migrate --config extenddb.toml        # Apply schema migrations
 extenddb destroy --config extenddb.toml        # Tear down deployment

--- a/crates/app/src/cmd_healthcheck.rs
+++ b/crates/app/src/cmd_healthcheck.rs
@@ -1,0 +1,492 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `extenddb healthcheck` — probe the local `/health` endpoint over HTTPS.
+//!
+//! Intended for a container `HEALTHCHECK`: it sends an HTTPS `GET /health` over
+//! loopback and exits 0 or 1. It needs no shell or `curl`, so it also works on
+//! a minimal `distroless`/`scratch` image.
+//!
+//! This checks liveness: exit 0 means the process is listening, completing TLS,
+//! and serving HTTP. That is the signal a container `HEALTHCHECK` or a Kubernetes
+//! liveness probe wants, since its job is to restart a wedged process. A liveness
+//! probe should deliberately not fail on a backend outage. If it did, a shared
+//! database briefly going away would restart every replica at once and make the
+//! outage worse.
+//!
+//! What this does not give you is readiness. `/health` is a static handler that
+//! never queries the storage backend, so a replica whose backend has gone away
+//! still reports healthy and keeps receiving traffic. A backend that is
+//! unreachable at startup does stop the server from listening at all, so that
+//! case is caught. Closing the gap properly means adding a separate readiness
+//! endpoint backed by a cheap cached round-trip to the storage layer and
+//! pointing readiness probes at that, rather than making `/health` query the
+//! backend and losing its value as a liveness signal.
+
+use std::io::{self, Read, Write};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::sync::{Arc, mpsc};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use clap::Args;
+
+use extenddb_config as config;
+
+/// Port used when neither `--endpoint` nor the config file supplies one.
+const DEFAULT_PORT: u16 = 18443;
+
+/// End-to-end deadline for the network probe, including address resolution,
+/// connect, TLS handshake, request write, and response read. The remaining
+/// budget is applied before every blocking operation so a peer cannot keep the
+/// probe alive indefinitely by making partial progress.
+const TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Maximum response bytes read. Only the HTTP status line is used, so accepting
+/// an unbounded body would waste memory without improving the health verdict.
+const MAX_RESPONSE_BYTES: u64 = 8 * 1024;
+
+#[derive(Args)]
+pub struct HealthcheckArgs {
+    /// Path to the config file, used to find the port when --endpoint is not given
+    #[arg(short, long, default_value = "extenddb.toml")]
+    config: String,
+
+    /// Override the port to probe (defaults to the port in the config file)
+    #[arg(short, long)]
+    port: Option<u16>,
+
+    /// Endpoint to probe, e.g. https://127.0.0.1:18443. Overrides --port and
+    /// the config.
+    #[arg(long)]
+    endpoint: Option<String>,
+}
+
+/// Host and port to probe.
+#[derive(Debug, PartialEq, Eq)]
+struct Target {
+    host: String,
+    port: u16,
+}
+
+impl Target {
+    /// `host:port`, bracketing a bare IPv6 literal so the result parses as an
+    /// address.
+    fn authority(&self) -> String {
+        if self.host.contains(':') {
+            format!("[{}]:{}", self.host, self.port)
+        } else {
+            format!("{}:{}", self.host, self.port)
+        }
+    }
+}
+
+/// Run the health check. Returns `Ok(())` when healthy, `Err` otherwise.
+pub fn run(args: &HealthcheckArgs) -> anyhow::Result<()> {
+    let target = resolve_target(args)?;
+    let status = probe(&target)?;
+    if (200..300).contains(&status) {
+        Ok(())
+    } else {
+        anyhow::bail!("/health returned HTTP {status}")
+    }
+}
+
+/// Decide what to probe: `--endpoint` if given, otherwise the address the
+/// configured `bind_addr` implies, on `--port` or the configured port.
+fn resolve_target(args: &HealthcheckArgs) -> anyhow::Result<Target> {
+    if let Some(ep) = &args.endpoint {
+        return parse_endpoint(ep);
+    }
+    // A config file that exists but cannot be parsed is worth reporting rather
+    // than papering over by falling back to defaults.
+    let (host, config_port) = if std::path::Path::new(&args.config).exists() {
+        let cfg = config::load(&args.config)
+            .map_err(|e| anyhow::anyhow!("Failed to load config '{}': {e}", args.config))?;
+        (probe_host(&cfg.server.bind_addr), cfg.server.port)
+    } else {
+        ("127.0.0.1".to_owned(), DEFAULT_PORT)
+    };
+    Ok(Target {
+        host,
+        port: args.port.unwrap_or(config_port),
+    })
+}
+
+/// The address to probe for a server bound to `bind_addr`.
+///
+/// A wildcard bind is not itself connectable, so it maps to the loopback address
+/// of the same family. Any other bind address is probed as configured, which
+/// matters for an IPv6-only deployment: assuming `127.0.0.1` reports a healthy
+/// server bound to `::1` as unhealthy.
+fn probe_host(bind_addr: &str) -> String {
+    match bind_addr.trim() {
+        "" | "0.0.0.0" => "127.0.0.1".to_owned(),
+        "::" | "[::]" | "::0" => "::1".to_owned(),
+        other => other
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .to_owned(),
+    }
+}
+
+/// Parse `[scheme://]host[:port][/path]` into a [`Target`].
+///
+/// The scheme and path are accepted and then ignored. The probe always speaks
+/// TLS, because the server has no plaintext mode, and always requests
+/// `/health`.
+fn parse_endpoint(endpoint: &str) -> anyhow::Result<Target> {
+    let ep = endpoint.trim();
+    let rest = ep
+        .strip_prefix("https://")
+        .or_else(|| ep.strip_prefix("http://"))
+        .unwrap_or(ep);
+    // Keep only the authority, dropping any path or query.
+    let authority = rest
+        .split(['/', '?'])
+        .next()
+        .unwrap_or("")
+        .trim_end_matches('.');
+    if authority.is_empty() {
+        anyhow::bail!("--endpoint '{endpoint}' has no host");
+    }
+
+    // Bracketed IPv6 literal: [::1] or [::1]:18443.
+    if let Some(after_bracket) = authority.strip_prefix('[') {
+        let (host, tail) = after_bracket
+            .split_once(']')
+            .ok_or_else(|| anyhow::anyhow!("--endpoint '{endpoint}' has an unclosed '['"))?;
+        return Ok(Target {
+            host: host.to_owned(),
+            port: parse_port(tail, endpoint)?,
+        });
+    }
+
+    // An unbracketed IPv6 literal has more than one colon and cannot carry a
+    // port, so treat the whole thing as the host.
+    if authority.matches(':').count() > 1 {
+        return Ok(Target {
+            host: authority.to_owned(),
+            port: DEFAULT_PORT,
+        });
+    }
+
+    match authority.split_once(':') {
+        Some((host, port)) => Ok(Target {
+            host: host.to_owned(),
+            port: parse_port(&format!(":{port}"), endpoint)?,
+        }),
+        None => Ok(Target {
+            host: authority.to_owned(),
+            port: DEFAULT_PORT,
+        }),
+    }
+}
+
+/// Parse a `":<port>"` suffix, falling back to the default port when there is
+/// no suffix at all.
+fn parse_port(suffix: &str, endpoint: &str) -> anyhow::Result<u16> {
+    match suffix.strip_prefix(':') {
+        None if suffix.is_empty() => Ok(DEFAULT_PORT),
+        None => anyhow::bail!("--endpoint '{endpoint}' has trailing garbage after the host"),
+        Some(p) => p
+            .parse()
+            .map_err(|e| anyhow::anyhow!("--endpoint '{endpoint}' has an invalid port '{p}': {e}")),
+    }
+}
+
+/// Return the time left before `deadline`, or a timeout error when exhausted.
+fn remaining_budget(deadline: Instant) -> io::Result<Duration> {
+    deadline
+        .checked_duration_since(Instant::now())
+        .filter(|remaining| !remaining.is_zero())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::TimedOut, "healthcheck deadline exceeded"))
+}
+
+/// A TCP stream that applies the probe's remaining budget before every socket
+/// read and write, including the calls rustls makes internally during the TLS
+/// handshake. A fixed per-syscall timeout is insufficient because a peer can
+/// make partial progress just before each timeout and keep the probe alive.
+struct DeadlineStream {
+    inner: TcpStream,
+    deadline: Instant,
+}
+
+impl DeadlineStream {
+    fn new(inner: TcpStream, deadline: Instant) -> Self {
+        Self { inner, deadline }
+    }
+}
+
+impl Read for DeadlineStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner
+            .set_read_timeout(Some(remaining_budget(self.deadline)?))?;
+        self.inner.read(buf)
+    }
+}
+
+impl Write for DeadlineStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner
+            .set_write_timeout(Some(remaining_budget(self.deadline)?))?;
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner
+            .set_write_timeout(Some(remaining_budget(self.deadline)?))?;
+        self.inner.flush()
+    }
+}
+
+/// Make an HTTPS `GET /health` request. Returns the HTTP status code.
+fn probe(target: &Target) -> anyhow::Result<u16> {
+    let deadline = Instant::now() + TIMEOUT;
+
+    // rustls 0.23 requires an explicit CryptoProvider. Installing it is
+    // idempotent, so ignore the error if one is already installed.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    let tls_config = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(AcceptAnyServerCert))
+        .with_no_client_auth();
+
+    let server_name = rustls::pki_types::ServerName::try_from(target.host.clone())
+        .map_err(|e| anyhow::anyhow!("Invalid server name '{}': {e}", target.host))?;
+
+    let mut conn = rustls::ClientConnection::new(Arc::new(tls_config), server_name)
+        .map_err(|e| anyhow::anyhow!("TLS setup failed: {e}"))?;
+
+    let tcp = connect(target, deadline)?;
+    let mut tcp = DeadlineStream::new(tcp, deadline);
+
+    let authority = target.authority();
+    let request = format!("GET /health HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\r\n");
+
+    let mut tls = rustls::Stream::new(&mut conn, &mut tcp);
+    tls.write_all(request.as_bytes())
+        .map_err(|e| anyhow::anyhow!("Failed to send request: {e}"))?;
+
+    let mut response = Vec::new();
+    match (&mut tls)
+        .take(MAX_RESPONSE_BYTES)
+        .read_to_end(&mut response)
+    {
+        Ok(_) => {}
+        // We asked for `Connection: close`, so the server closing the
+        // connection after the response is expected.
+        Err(ref e) if e.kind() == io::ErrorKind::UnexpectedEof => {}
+        Err(e) => return Err(anyhow::anyhow!("Read error: {e}")),
+    }
+
+    let status_line = response
+        .split(|byte| *byte == b'\n')
+        .next()
+        .and_then(|line| std::str::from_utf8(line).ok())
+        .unwrap_or("");
+    status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| anyhow::anyhow!("No HTTP status in response"))
+}
+
+/// Resolve the target without allowing a wedged system resolver to outlive the
+/// probe deadline. A timed-out resolver thread is detached; the short-lived CLI
+/// process exits immediately and the operating system tears it down.
+fn resolve(target: &Target, deadline: Instant) -> anyhow::Result<Vec<SocketAddr>> {
+    let authority = target.authority();
+    let resolve_authority = authority.clone();
+    let (sender, receiver) = mpsc::sync_channel(1);
+    let worker = thread::Builder::new()
+        .name("healthcheck-resolver".to_owned())
+        .spawn(move || {
+            let result = resolve_authority
+                .to_socket_addrs()
+                .map(|addrs| addrs.collect());
+            let _ = sender.send(result);
+        })
+        .map_err(|e| anyhow::anyhow!("Cannot start resolver for {authority}: {e}"))?;
+
+    let remaining = remaining_budget(deadline)
+        .map_err(|e| anyhow::anyhow!("Cannot resolve {authority}: {e}"))?;
+    match receiver.recv_timeout(remaining) {
+        Ok(result) => {
+            worker
+                .join()
+                .map_err(|_| anyhow::anyhow!("Resolver for {authority} panicked"))?;
+            result.map_err(|e| anyhow::anyhow!("Cannot resolve {authority}: {e}"))
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            anyhow::bail!("Cannot resolve {authority}: healthcheck deadline exceeded")
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            let _ = worker.join();
+            anyhow::bail!("Cannot resolve {authority}: resolver stopped without a result")
+        }
+    }
+}
+
+/// Connect within the shared probe deadline, trying every resolved address.
+///
+/// Trying all of them matters for a name like `localhost` that resolves to both
+/// `::1` and `127.0.0.1`, since the server may be bound to only one of them.
+fn connect(target: &Target, deadline: Instant) -> anyhow::Result<TcpStream> {
+    let authority = target.authority();
+    let addrs = resolve(target, deadline)?;
+    if addrs.is_empty() {
+        anyhow::bail!("Cannot resolve {authority}: no addresses");
+    }
+    let mut last_err = None;
+    for addr in addrs {
+        let remaining = remaining_budget(deadline)
+            .map_err(|e| anyhow::anyhow!("Cannot connect to {authority}: {e}"))?;
+        match TcpStream::connect_timeout(&addr, remaining) {
+            Ok(stream) => return Ok(stream),
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(anyhow::anyhow!(
+        "Cannot connect to {authority}: {}",
+        last_err.expect("non-empty address list yields an error")
+    ))
+}
+
+/// A rustls verifier that accepts any server certificate.
+///
+/// The health check makes no trust decision. All it reports is whether the
+/// server answered, and all it reads from the response is the HTTP status line.
+/// The default deployment serves a self-signed certificate, so validating it
+/// would mean distributing a trust anchor to every probe for no benefit.
+///
+/// This applies to `--endpoint` as well as to the loopback default, so a
+/// non-loopback endpoint could be answered by an impostor. The worst outcome is
+/// a wrong health verdict, but only point `--endpoint` at a server you
+/// control.
+#[derive(Debug)]
+struct AcceptAnyServerCert;
+
+impl rustls::client::danger::ServerCertVerifier for AcceptAnyServerCert {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_PORT, Target, parse_endpoint};
+
+    fn target(host: &str, port: u16) -> Target {
+        Target {
+            host: host.to_owned(),
+            port,
+        }
+    }
+
+    #[test]
+    fn parses_scheme_host_and_port() {
+        assert_eq!(
+            parse_endpoint("https://127.0.0.1:18443").unwrap(),
+            target("127.0.0.1", 18443)
+        );
+        // A plaintext scheme is accepted and ignored, since the probe always
+        // uses TLS.
+        assert_eq!(
+            parse_endpoint("http://127.0.0.1:9000").unwrap(),
+            target("127.0.0.1", 9000)
+        );
+        assert_eq!(
+            parse_endpoint("  https://extenddb.svc:8443/  ").unwrap(),
+            target("extenddb.svc", 8443)
+        );
+    }
+
+    #[test]
+    fn defaults_the_port_when_absent() {
+        assert_eq!(
+            parse_endpoint("https://localhost").unwrap(),
+            target("localhost", DEFAULT_PORT)
+        );
+        assert_eq!(
+            parse_endpoint("localhost").unwrap(),
+            target("localhost", DEFAULT_PORT)
+        );
+    }
+
+    #[test]
+    fn ignores_a_path() {
+        assert_eq!(
+            parse_endpoint("https://127.0.0.1:18443/health").unwrap(),
+            target("127.0.0.1", 18443)
+        );
+    }
+
+    #[test]
+    fn parses_ipv6_literals() {
+        assert_eq!(
+            parse_endpoint("https://[::1]:18443").unwrap(),
+            target("::1", 18443)
+        );
+        assert_eq!(
+            parse_endpoint("https://[::1]").unwrap(),
+            target("::1", DEFAULT_PORT)
+        );
+        // Unbracketed IPv6 is treated as a bare host on the default port.
+        assert_eq!(parse_endpoint("::1").unwrap(), target("::1", DEFAULT_PORT));
+    }
+
+    #[test]
+    fn maps_bind_addr_to_a_probe_host() {
+        use super::probe_host;
+        // Wildcard binds map to loopback of the same family.
+        assert_eq!(probe_host("0.0.0.0"), "127.0.0.1");
+        assert_eq!(probe_host(""), "127.0.0.1");
+        assert_eq!(probe_host("::"), "::1");
+        assert_eq!(probe_host("[::]"), "::1");
+        // Anything else is probed as configured.
+        assert_eq!(probe_host("127.0.0.1"), "127.0.0.1");
+        assert_eq!(probe_host("::1"), "::1");
+        assert_eq!(probe_host("[::1]"), "::1");
+        assert_eq!(probe_host("10.0.0.5"), "10.0.0.5");
+    }
+
+    #[test]
+    fn rejects_malformed_endpoints() {
+        assert!(parse_endpoint("https://").is_err());
+        assert!(parse_endpoint("https://127.0.0.1:notaport").is_err());
+        assert!(parse_endpoint("https://[::1:18443").is_err());
+    }
+}

--- a/crates/app/src/cmd_init.rs
+++ b/crates/app/src/cmd_init.rs
@@ -60,6 +60,12 @@ pub struct InitArgs {
     #[arg(long)]
     bind_addr: Option<String>,
 
+    /// Additional Subject Alternative Name for the self-signed certificate,
+    /// repeatable. Added to the default localhost/127.0.0.1/bind-addr list so
+    /// the cert is also valid for names like an in-cluster service DNS name.
+    #[arg(long = "tls-san")]
+    tls_san: Vec<String>,
+
     /// Overwrite existing config file (default: --no-overwrite, exit 255 if exists)
     #[arg(long, overrides_with = "no_overwrite")]
     overwrite: bool,
@@ -138,6 +144,16 @@ pub async fn run(args: InitArgs) -> anyhow::Result<u8> {
 
     // Collect CLI args for backend-specific parsing
     let cli_args: Vec<String> = std::env::args().collect();
+
+    // Extract bind_addr from CLI args
+    let bind_addr =
+        extract_arg(&cli_args, "--bind-addr").unwrap_or_else(|| "127.0.0.1".to_string());
+
+    // Generate the self-signed TLS certificate if it isn't already present,
+    // covering the bind address plus any --tls-san values so it matches the URLs
+    // clients use. This runs before any database work so that an unusable
+    // --tls-san fails before we create users or databases.
+    generate_tls_cert_if_needed(&bind_addr, &args.tls_san)?;
 
     // Create bootstrapper via registry (no hardcoded match!)
     let bootstrapper = extenddb_storage::bootstrapper::create_bootstrapper(&args.config, &cli_args)
@@ -232,14 +248,6 @@ pub async fn run(args: InitArgs) -> anyhow::Result<u8> {
             admin_result.username, password,
         );
     }
-
-    // Extract bind_addr from CLI args
-    let bind_addr =
-        extract_arg(&cli_args, "--bind-addr").unwrap_or_else(|| "127.0.0.1".to_string());
-
-    // Generate self-signed TLS certificate if not already present.
-    // Include the server bind address as a SAN so the cert matches the URL.
-    generate_tls_cert_if_needed(&bind_addr)?;
 
     // AI-1: Discover rendered docs directory for the config file.
     let docs_dir = discover_docs_dir();

--- a/crates/app/src/cmd_serve.rs
+++ b/crates/app/src/cmd_serve.rs
@@ -31,6 +31,18 @@ pub struct ServeArgs {
     /// them.
     #[arg(long, alias = "no-daemon")]
     foreground: bool,
+
+    /// Write a PID file in --foreground mode.
+    ///
+    /// Foreground mode normally writes none, because the supervisor owns the
+    /// process and a read-only root filesystem then needs no run directory.
+    /// Pass this when you want `extenddb status` and `extenddb stop` to work
+    /// against a foreground server, for example when running it from a shell.
+    /// It goes to the same `run_dir` path daemon mode uses, so `stop` and
+    /// `status` find it with no extra arguments. Ignored in daemon mode, which
+    /// always writes one.
+    #[arg(long)]
+    write_pid_file: bool,
 }
 
 /// Bind the listening socket, daemonize, then start the tokio runtime.
@@ -111,11 +123,18 @@ pub fn run(args: &ServeArgs, build: BuildInfo) -> anyhow::Result<()> {
         println!("{banner_line2}");
     }
 
-    // D-3: Write PID file so `extenddb status` can report the daemon PID.
+    // D-3: A PID file lets `extenddb status` and `extenddb stop` find the
+    // process. Daemon mode always writes one. Foreground mode writes one only on
+    // request, so by default it needs no run directory at all and the container
+    // can use a read-only root filesystem.
     let run_dir = config::expand_tilde(&app_config.server.run_dir);
-    std::fs::create_dir_all(&run_dir)
-        .map_err(|e| anyhow::anyhow!("Failed to create run directory {run_dir}: {e}"))?;
-    let pid_file = pid_file_path(&run_dir, port);
+    let pid_file = if args.foreground && !args.write_pid_file {
+        None
+    } else {
+        std::fs::create_dir_all(&run_dir)
+            .map_err(|e| anyhow::anyhow!("Failed to create run directory {run_dir}: {e}"))?;
+        Some(pid_file_path(&run_dir, port))
+    };
 
     // P57 Bug 7 fix: Use execute() instead of start() so the parent can
     // verify the daemon child is healthy before exiting. start() exits the
@@ -123,17 +142,19 @@ pub fn run(args: &ServeArgs, build: BuildInfo) -> anyhow::Result<()> {
     //
     // When --foreground is set, skip daemonization entirely so the process
     // can be supervised by Docker, Kubernetes, systemd Type=simple, etc.
-    // The PID file is still written below by `start_server`, and graceful
-    // shutdown on SIGINT/SIGTERM still works.
+    // Graceful shutdown on SIGINT/SIGTERM still works.
     if !args.foreground {
-        let daemon = Daemonize::new().pid_file(&pid_file);
+        let pid_file = pid_file
+            .as_ref()
+            .expect("daemon mode always has a PID file path");
+        let daemon = Daemonize::new().pid_file(pid_file);
         match daemon.execute() {
             daemonize::Outcome::Parent(Ok(_)) => {
                 // Parent process: wait for the PID file to appear (written by
                 // the grandchild after the double-fork), then verify the daemon
                 // is still alive. This catches crashes during early startup
                 // (bad config, missing tables, TLS cert errors).
-                return verify_daemon_started(&pid_file, &bind_addr);
+                return verify_daemon_started(pid_file, &bind_addr);
             }
             daemonize::Outcome::Parent(Err(e)) => {
                 return Err(anyhow::anyhow!("Failed to daemonize: {e}"));
@@ -160,7 +181,7 @@ pub fn run(args: &ServeArgs, build: BuildInfo) -> anyhow::Result<()> {
         .enable_all()
         .build()?
         .block_on(extenddb_server::serve(
-            ServeParams::new(app_config, std_listener, run_dir, build).with_log_target(
+            ServeParams::new(app_config, std_listener, pid_file, build).with_log_target(
                 if args.foreground {
                     LogTarget::Stderr
                 } else {

--- a/crates/app/src/cmd_stop.rs
+++ b/crates/app/src/cmd_stop.rs
@@ -48,12 +48,24 @@ pub fn run(args: &StopArgs) {
     let pid_str = match std::fs::read_to_string(&pid_file) {
         Ok(s) => s.trim().to_owned(),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            eprintln!(
-                "No extenddb server is running on port {port} (PID file {} not found).\n\
-                 Start one with: extenddb serve --config {}",
-                pid_file.display(),
-                args.config,
-            );
+            // `serve --foreground` writes no PID file, so a missing file does
+            // not mean nothing is running. Probe the port before saying so.
+            if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+                eprintln!(
+                    "A server is listening on port {port} but wrote no PID file ({}).\n\
+                     It was most likely started with `extenddb serve --foreground`, which \
+                     leaves process supervision to the container runtime, systemd, or your \
+                     shell. Stop it there (or send it SIGTERM directly).",
+                    pid_file.display(),
+                );
+            } else {
+                eprintln!(
+                    "No extenddb server is running on port {port} (PID file {} not found).\n\
+                     Start one with: extenddb serve --config {}",
+                    pid_file.display(),
+                    args.config,
+                );
+            }
             std::process::exit(1);
         }
         Err(e) => {

--- a/crates/app/src/init_helpers.rs
+++ b/crates/app/src/init_helpers.rs
@@ -4,12 +4,34 @@
 //! Helpers for `extenddb init`: TLS certificate generation and config file creation.
 
 /// Generate a self-signed TLS certificate and key if they don't already exist.
-pub fn generate_tls_cert_if_needed(bind_addr: &str) -> anyhow::Result<()> {
+///
+/// `extra_sans` are additional Subject Alternative Names, such as an in-cluster
+/// service DNS name. They are appended to the default list of `localhost`,
+/// `127.0.0.1`, and the bind address so the certificate is valid for the names
+/// clients use.
+///
+/// An existing certificate is never regenerated, because rotating the key pair
+/// under a live deployment would be a surprise. That means `--tls-san` cannot
+/// take effect on a later run, so instead of exiting successfully having dropped
+/// the requested names, we check that the existing certificate already covers
+/// them and fail with an actionable error if it does not.
+pub fn generate_tls_cert_if_needed(bind_addr: &str, extra_sans: &[String]) -> anyhow::Result<()> {
     let tls_dir = extenddb_config::expand_tilde("~/.extenddb/tls");
     let cert_path = format!("{tls_dir}/cert.pem");
     let key_path = format!("{tls_dir}/key.pem");
 
+    // Requested SANs, trimmed, with blanks and duplicates removed.
+    let requested = normalize_sans(extra_sans);
+
+    // Validate every requested name before either path uses it, so a name we
+    // could not verify later is rejected on the first run rather than only on
+    // the next one.
+    for san in &requested {
+        coverage_probe(san)?;
+    }
+
     if std::path::Path::new(&cert_path).exists() && std::path::Path::new(&key_path).exists() {
+        ensure_cert_covers_sans(&cert_path, &key_path, &requested)?;
         println!("--- TLS certificate already exists, skipping generation.");
         return Ok(());
     }
@@ -23,6 +45,12 @@ pub fn generate_tls_cert_if_needed(bind_addr: &str) -> anyhow::Result<()> {
     let mut sans: Vec<String> = vec!["localhost".to_owned(), "127.0.0.1".to_owned()];
     if bind_addr != "localhost" && bind_addr != "127.0.0.1" && bind_addr != "0.0.0.0" {
         sans.push(bind_addr.to_owned());
+    }
+    // Append the `--tls-san` values the defaults don't already cover.
+    for san in &requested {
+        if !sans.iter().any(|s| s.eq_ignore_ascii_case(san)) {
+            sans.push(san.clone());
+        }
     }
 
     let sans_display = sans.join(", ");
@@ -59,6 +87,109 @@ pub fn generate_tls_cert_if_needed(bind_addr: &str) -> anyhow::Result<()> {
     println!("    SANs: {sans_display}");
 
     Ok(())
+}
+
+/// Trim `--tls-san` values, drop blanks, and remove duplicates.
+///
+/// DNS names are case-insensitive, so `Foo.example.com` and `foo.example.com`
+/// are the same name and only the first spelling given is kept.
+fn normalize_sans(sans: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for san in sans {
+        let san = san.trim();
+        if !san.is_empty() && !out.iter().any(|s: &String| s.eq_ignore_ascii_case(san)) {
+            out.push(san.to_owned());
+        }
+    }
+    out
+}
+
+/// Label substituted for the `*` when testing whether a certificate covers a
+/// wildcard SAN. Any single label works; this one is chosen to be implausible
+/// as a real hostname.
+const WILDCARD_PROBE_LABEL: &str = "extenddb-tls-san-probe";
+
+/// The server name used to test whether a certificate covers `san`.
+///
+/// A wildcard such as `*.svc.cluster.local` is a legitimate certificate entry
+/// but not a legitimate server name, so it cannot be verified directly. Verify a
+/// synthetic single-label substitution instead: a certificate is valid for
+/// `<label>.svc.cluster.local` only if it carries the wildcard (or that exact
+/// name), which is what we want to know. Wildcards match exactly one leftmost
+/// label, so one substitution is enough.
+///
+/// Doubles as validation: callers run every requested `--tls-san` through this
+/// before generating a certificate, so a name that could never be verified is
+/// rejected up front instead of on the next run.
+fn coverage_probe(san: &str) -> anyhow::Result<rustls::pki_types::ServerName<'static>> {
+    let probe = match san.strip_prefix("*.") {
+        Some(rest) if rest.is_empty() || rest.contains('*') => {
+            anyhow::bail!(
+                "Invalid --tls-san value '{san}': a wildcard must be a single leading \
+                 label followed by a domain, as in '*.svc.cluster.local'"
+            )
+        }
+        Some(rest) => format!("{WILDCARD_PROBE_LABEL}.{rest}"),
+        None if san.contains('*') => anyhow::bail!(
+            "Invalid --tls-san value '{san}': a wildcard is only valid as the leftmost \
+             label, as in '*.svc.cluster.local'"
+        ),
+        None => san.to_owned(),
+    };
+    rustls::pki_types::ServerName::try_from(probe).map_err(|e| {
+        anyhow::anyhow!("Invalid --tls-san value '{san}' (not a DNS name or IP address): {e}")
+    })
+}
+
+/// Fail unless the certificate at `cert_path` is already valid for every
+/// requested SAN.
+///
+/// Since `init` never regenerates an existing certificate, this check is all
+/// that stands between a mistyped or newly added `--tls-san` and clients failing
+/// hostname verification at runtime against a name `init` appeared to accept.
+fn ensure_cert_covers_sans(
+    cert_path: &str,
+    key_path: &str,
+    requested: &[String],
+) -> anyhow::Result<()> {
+    if requested.is_empty() {
+        return Ok(());
+    }
+
+    let pem = std::fs::read(cert_path)
+        .map_err(|e| anyhow::anyhow!("Failed to read existing certificate {cert_path}: {e}"))?;
+    let der = rustls_pemfile::certs(&mut pem.as_slice())
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("No certificate found in {cert_path}"))?
+        .map_err(|e| anyhow::anyhow!("Failed to parse certificate {cert_path}: {e}"))?;
+    let cert = rustls::server::ParsedCertificate::try_from(&der)
+        .map_err(|e| anyhow::anyhow!("Failed to parse certificate {cert_path}: {e}"))?;
+
+    let mut missing = Vec::new();
+    for san in requested {
+        let name = coverage_probe(san)?;
+        if rustls::client::verify_server_name(&cert, &name).is_err() {
+            missing.push(san.clone());
+        }
+    }
+
+    if missing.is_empty() {
+        println!(
+            "    Existing certificate already covers --tls-san: {}",
+            requested.join(", ")
+        );
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "The existing TLS certificate {cert_path} is not valid for the requested \
+         --tls-san value(s): {}. init does not regenerate an existing certificate, \
+         so these names would be silently dropped and clients using them would fail \
+         TLS hostname verification. Either delete {cert_path} and {key_path} and \
+         re-run init to generate a certificate covering them, or mount a certificate \
+         that already covers them.",
+        missing.join(", "),
+    )
 }
 
 /// Generate a comprehensive config file with all settings.

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -4,7 +4,8 @@
 //! ExtendDB application/CLI library.
 //!
 //! Owns the command-line interface (`serve`, `init`, `destroy`, `verify`,
-//! `migrate`, `status`, `stop`, `settings`, `manage`, `catalog-check`) and the
+//! `migrate`, `status`, `stop`, `settings`, `manage`, `catalog-check`,
+//! `healthcheck`) and the
 //! subcommand dispatch. It is backend-agnostic: a backend's thin `main`
 //! installs its backend with
 //! [`set_backend`](extenddb_storage::set_backend) and then calls [`run`]:
@@ -22,6 +23,7 @@
 
 mod cmd_catalog_check;
 mod cmd_destroy;
+mod cmd_healthcheck;
 mod cmd_init;
 mod cmd_manage;
 mod cmd_migrate;
@@ -78,6 +80,8 @@ enum Command {
     Manage(cmd_manage::ManageArgs),
     /// Check catalog and data database integrity
     CatalogCheck(cmd_catalog_check::CatalogCheckArgs),
+    /// Probe the local /health endpoint over HTTPS (exit 0 healthy, 1 not)
+    Healthcheck(cmd_healthcheck::HealthcheckArgs),
     /// Print version, catalog version, git commit, and build timestamp
     Version,
 }
@@ -121,6 +125,13 @@ pub fn run(build: BuildInfo) -> anyhow::Result<()> {
         Command::Settings(args) => run_interactive(cmd_settings::run(args)),
         Command::Manage(args) => run_interactive(cmd_manage::run(args)),
         Command::CatalogCheck(args) => run_interactive(cmd_catalog_check::run(args)),
+        Command::Healthcheck(args) => match cmd_healthcheck::run(&args) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                eprintln!("healthcheck failed: {e}");
+                std::process::exit(1);
+            }
+        },
         Command::Version => {
             print_version(build);
             Ok(())

--- a/crates/server/src/serve.rs
+++ b/crates/server/src/serve.rs
@@ -15,8 +15,9 @@ use std::net::TcpListener;
 use std::sync::Arc;
 use std::time::Duration;
 
+use std::path::PathBuf;
+
 use extenddb_config as config;
-use extenddb_config::pid_file_path;
 use extenddb_storage::CancellationToken;
 use syslog_tracing::{Facility, Options, Syslog};
 use tracing_subscriber::{
@@ -86,8 +87,14 @@ pub struct ServeParams {
     /// port conflicts surface on stderr before the parent exits. The listening
     /// port is read from this socket, so it cannot disagree with it.
     pub listener: TcpListener,
-    /// Directory holding the PID file.
-    pub run_dir: String,
+    /// Where to write the PID file, or `None` to write none.
+    ///
+    /// `None` suits a supervised deployment: the supervisor owns the process,
+    /// and skipping the file means no writable run directory is needed, so the
+    /// root filesystem can be read-only. `extenddb status` and `extenddb stop`
+    /// locate the file by convention, so a caller that wants them to work should
+    /// pass the conventional path from `extenddb_config::pid_file_path`.
+    pub pid_file: Option<PathBuf>,
     /// Where log output is written.
     pub log_target: LogTarget,
     /// Build provenance of the deployed binary.
@@ -100,13 +107,13 @@ impl ServeParams {
     pub fn new(
         app_config: config::AppConfig,
         listener: TcpListener,
-        run_dir: String,
+        pid_file: Option<PathBuf>,
         build: BuildInfo,
     ) -> Self {
         Self {
             app_config,
             listener,
-            run_dir,
+            pid_file,
             log_target: LogTarget::Syslog,
             build,
         }
@@ -142,11 +149,13 @@ pub async fn serve(params: ServeParams) -> anyhow::Result<()> {
     // CB-27: Clean up PID file if serve fails before reaching the HTTP server
     // (e.g., backend connection failure). The PID file was already written by
     // the daemonize step in the caller.
-    let pid_path = pid_file_path(&params.run_dir, port);
+    let pid_path = params.pid_file.clone();
     let log_target = params.log_target;
     let result = serve_inner(params, port).await;
     if let Err(ref e) = result {
-        let _ = std::fs::remove_file(&pid_path);
+        if let Some(ref path) = pid_path {
+            let _ = std::fs::remove_file(path);
+        }
         // P57 Bug 7: Log fatal errors where the operator will see them. After
         // daemonize, stderr is /dev/null so anyhow's error display is lost. Use
         // tracing if available, fall back to the raw writer if tracing isn't
@@ -166,21 +175,23 @@ async fn serve_inner(params: ServeParams, port: u16) -> anyhow::Result<()> {
     let ServeParams {
         app_config,
         listener: std_listener,
-        run_dir,
+        pid_file,
         log_target,
         build,
     } = params;
     let catalog_version =
         extenddb_storage::operations::catalog_version().unwrap_or_else(|_| "unknown".to_string());
 
-    // Write the PID file so `extenddb status`/`stop` and `start_server`'s
-    // graceful shutdown cleanup work in every deployment. When the caller
-    // daemonized, the grandchild PID that `daemonize` wrote is the same value
-    // as `std::process::id()` post-fork, so this is a consistent rewrite rather
-    // than a conflicting one.
-    let pid_file = pid_file_path(&run_dir, port);
-    std::fs::write(&pid_file, format!("{}\n", std::process::id()))
-        .map_err(|e| anyhow::anyhow!("Failed to write PID file {}: {e}", pid_file.display()))?;
+    // Write the PID file, when the caller asked for one, so `extenddb status`,
+    // `extenddb stop`, and `start_server`'s graceful shutdown cleanup work. When
+    // the caller daemonized, the grandchild PID that `daemonize` wrote is the
+    // same value as `std::process::id()` post-fork, so this is a consistent
+    // rewrite rather than a conflicting one. A supervised deployment passes
+    // `None` and needs no writable run directory at all.
+    if let Some(ref path) = pid_file {
+        std::fs::write(path, format!("{}\n", std::process::id()))
+            .map_err(|e| anyhow::anyhow!("Failed to write PID file {}: {e}", path.display()))?;
+    }
 
     // Init logging (REQ-LOG-003, REQ-LOG-006) — the caller chose the target via
     // [`LogTarget`]; a supervised/container deployment picks stderr so the
@@ -552,13 +563,7 @@ async fn serve_inner(params: ServeParams, port: u16) -> anyhow::Result<()> {
         None
     };
 
-    let server_result = crate::start_server(
-        listener,
-        state,
-        Some(pid_file_path(&run_dir, port)),
-        tls_config,
-    )
-    .await;
+    let server_result = crate::start_server(listener, state, pid_file, tls_config).await;
 
     // The HTTP server has stopped accepting; drain the workers so in-flight
     // cycles finish and the metrics flush worker writes its final bucket.

--- a/devtools/run-tests
+++ b/devtools/run-tests
@@ -331,9 +331,22 @@ if $NEEDS_INTEGRATION && [[ "$TARGET" != "real-dynamodb" ]]; then
         fi
         if $NEED_RESTART && [[ -x "$BINARY" ]]; then
             echo "  Restarting server to pick up import/export config..."
-            "$BINARY" stop --config "$CONFIG_FOR_SETTINGS" 2>/dev/null || true
+            # Report failures instead of hiding them. A health check alone is not
+            # proof of a restart: if `stop` cannot signal the server (a
+            # --foreground server without --write-pid-file writes no PID file)
+            # the old process keeps serving and answers the health check while
+            # the new config is never picked up.
+            if ! "$BINARY" stop --config "$CONFIG_FOR_SETTINGS"; then
+                echo "  ✗ Could not stop the running server to apply the config change."
+                echo "    If it was started with 'serve --foreground', restart it with"
+                echo "    --write-pid-file so 'stop' can signal it."
+                exit 1
+            fi
             sleep 1
-            "$BINARY" serve --config "$CONFIG_FOR_SETTINGS" 2>/dev/null
+            if ! "$BINARY" serve --config "$CONFIG_FOR_SETTINGS"; then
+                echo "  ✗ Server failed to start after config change"
+                exit 1
+            fi
             sleep 2
             if health_check "$EXTENDDB_TEST_ENDPOINT"; then
                 echo "  ✓ Server restarted with import/export enabled"
@@ -428,7 +441,7 @@ if $RUN_PYTEST; then
     fi
     echo "  AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}"
     # CLI lifecycle tests manage their own server; exclude from main suite
-    PYTEST_ARGS=(python3 -m pytest tests/ -v --ignore=tests/python --ignore=tests/test_cli_lifecycle.py --ignore=tests/test_gsi_async_queue.py)
+    PYTEST_ARGS=(python3 -m pytest tests/ -v --ignore=tests/python --ignore=tests/test_cli_lifecycle.py --ignore=tests/test_cli_container_readiness.py --ignore=tests/test_gsi_async_queue.py)
     # Parallel execution (--parallel): distribute by file so module/class-scoped
     # fixtures stay within a single worker.
     if [[ -n "$PARALLEL" ]] && python3 -c "import xdist" 2>/dev/null; then
@@ -517,7 +530,7 @@ fi
 if $RUN_PYTEST && [[ "$TARGET" != "real-dynamodb" && -n "${EXTENDDB_TEST_PG_CONNECTION_STRING:-}" ]]; then
     CLI_OUTFILE="discussions/test-cli-${HASH}.txt"
     echo "=== CLI lifecycle tests → ${CLI_OUTFILE} ==="
-    CLI_ARGS=(python3 -m pytest tests/test_cli_lifecycle.py -v)
+    CLI_ARGS=(python3 -m pytest tests/test_cli_lifecycle.py tests/test_cli_container_readiness.py -v)
     if [[ -n "$FILTER" ]]; then
         CLI_ARGS+=(-k "$FILTER")
     fi

--- a/docs/manuals/01-architecture-guide.md
+++ b/docs/manuals/01-architecture-guide.md
@@ -139,17 +139,27 @@ Thin binary that wires everything together:
 8. Response formatted with correct DynamoDB JSON structure
 9. HTTP response includes `x-amzn-RequestId`, `x-amz-crc32`, and `Content-Type` headers
 
-## Daemon Lifecycle
+## Process Lifecycle
 
-extenddb always runs as a daemon. There is no foreground mode.
+extenddb daemonizes by default. Pass `serve --foreground` (alias `--no-daemon`)
+to stay attached, which is what container runtimes and process supervisors
+expect.
 
 1. Parse CLI arguments and load configuration
 2. Bind TCP socket (port conflicts reported before forking)
-3. Fork to background via `daemonize`
-4. Initialize syslog logging
+3. Fork to background via `daemonize`, writing a PID file to `run_dir`
+   (skipped entirely in `--foreground` mode, so no run directory is needed and
+   the root filesystem can be read-only)
+4. Initialize logging — syslog when daemonized, stderr in `--foreground`
 5. Connect to PostgreSQL (catalog + data databases)
 6. Verify catalog version matches binary expectation
 7. Start axum server on the pre-bound socket
+
+Because `--foreground` writes no PID file, `extenddb stop` cannot signal a
+foreground server; stop it through whatever supervises it. `extenddb status`
+still reports it as running, with the PID shown as unknown. Pass
+`serve --foreground --write-pid-file` to write one anyway, which restores both
+commands at the cost of needing a writable `run_dir`.
 8. Spawn background tasks (log level polling, throttling polling, GSI delay polling, stream cleanup, TTL expiry, metrics persistence)
 9. On SIGTERM/SIGINT: drain connections (5s timeout), exit
 

--- a/docs/manuals/05-admin-guide.md
+++ b/docs/manuals/05-admin-guide.md
@@ -42,12 +42,41 @@ kill <pid>
 
 extenddb handles SIGTERM and SIGINT gracefully — it drains active connections for up to 5 seconds before exiting.
 
+Note that `extenddb stop` reads the PID file, which a server started with
+`serve --foreground` does not write by default. Stop a foreground server through
+whatever supervises it (container runtime, systemd, your shell) or send it
+SIGTERM directly. Alternatively start it with
+`serve --foreground --write-pid-file`, which writes the PID file to the usual
+`run_dir` path so `stop` and `status` work as they do in daemon mode.
+
 ### Health Check
 
 ```bash
 curl --cacert ~/.extenddb/tls/cert.pem https://127.0.0.1:18443/health
 # {"status":"healthy"}
 ```
+
+Or without `curl` — useful inside a minimal container image, and what a Docker
+`HEALTHCHECK` should call:
+
+```bash
+./target/release/extenddb healthcheck --config extenddb.toml
+echo $?   # 0 = healthy, 1 = not
+```
+
+`healthcheck` reads the port from the config file, or takes an explicit
+`--endpoint https://host:port`. It accepts the server's self-signed certificate.
+
+This checks liveness, not readiness. `/health` is a static handler that does not
+query PostgreSQL, so it reports healthy even when the database has become
+unreachable since startup. That is intentional for a liveness probe: one that
+failed on a database outage would restart every replica at once and prolong the
+outage. A database that is unreachable at startup stops the server from listening
+at all, so that case is still caught.
+
+There is no readiness endpoint yet, so nothing will currently drain traffic from
+a replica whose backend is gone. Until one exists, gate on `/health` for restarts
+only, and rely on client retries for backend failures.
 
 ## Configuration Reference
 

--- a/docs/manuals/11-deployment-guide.md
+++ b/docs/manuals/11-deployment-guide.md
@@ -96,26 +96,46 @@ COPY extenddb.toml /etc/extenddb/extenddb.toml
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 EXPOSE 18443
+# `extenddb healthcheck` needs no shell or curl, so it also works on a
+# distroless/scratch base. It probes GET /health over loopback.
+HEALTHCHECK --interval=10s --timeout=5s --start-period=15s --retries=3 \
+  CMD ["/usr/local/bin/extenddb", "healthcheck", "--config", "/etc/extenddb/extenddb.toml"]
 ENTRYPOINT ["tini", "--"]
 CMD ["/usr/local/bin/entrypoint.sh"]
 ```
 
-extenddb always daemonizes (there is no foreground mode). In a container, the parent process exits after forking, which causes the container runtime to stop the container. Use `tini` as PID 1 and a wrapper script that starts extenddb and waits on the daemon process:
+Run the server with `serve --foreground` (alias `--no-daemon`) so it stays PID 1's
+child and receives `SIGTERM` directly. In foreground mode extenddb writes no PID
+file and never creates `run_dir`, so the root filesystem can be read-only. Use
+`tini` as PID 1 to reap any stray children and forward signals:
 
 ```bash
 #!/bin/sh
 # entrypoint.sh
-extenddb serve --config /etc/extenddb/extenddb.toml
-# Wait on the daemon PID — the PID file location depends on run_dir in extenddb.toml
-# Default: ~/.extenddb/run/extenddb-<port>.pid
-PID_FILE="${HOME}/.extenddb/run/extenddb-18443.pid"
-if [ -f "$PID_FILE" ]; then
-  tail --pid="$(cat "$PID_FILE")" -f /dev/null
-else
-  echo "extenddb failed to start — PID file not found at $PID_FILE" >&2
-  exit 1
-fi
+set -e
+# Safe to run on every start: already-applied migrations are skipped.
+extenddb migrate --yes --config /etc/extenddb/extenddb.toml
+exec extenddb serve --foreground --config /etc/extenddb/extenddb.toml
 ```
+
+`extenddb stop` cannot stop a foreground server, because there is no PID file to
+read; stop the container instead, which delivers `SIGTERM` and triggers the same
+graceful shutdown. Outside a container, where you may want `stop` to work, add
+`--write-pid-file` — it writes the PID file to the usual `run_dir` path, which
+then has to be writable.
+
+What the health check covers: `extenddb healthcheck` exits 0 when the server is
+listening, completing TLS, and serving HTTP. Use it as a liveness probe, which is
+what a Docker `HEALTHCHECK` and a Kubernetes `livenessProbe` are for. `/health`
+does not query PostgreSQL, and for a liveness probe that is the behaviour you
+want: one that failed on a database outage would restart every replica at once.
+A backend that is unreachable at startup does stop the server from listening, so
+container start-up failures are still caught.
+
+There is no readiness endpoint yet, so do not expect a Kubernetes
+`readinessProbe` on `/health` to remove a replica from service when its database
+becomes unreachable. Until a readiness endpoint that probes the storage layer
+exists, treat backend failures as something clients retry through.
 
 For Kubernetes, run `extenddb init` as an init container or a one-time Job, then deploy extenddb as a Deployment with the generated `extenddb.toml` mounted as a ConfigMap or Secret.
 

--- a/tests/test_cli_container_readiness.py
+++ b/tests/test_cli_container_readiness.py
@@ -1,0 +1,570 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Container-readiness CLI tests (Phase 1 / gaps G1, G3, G4).
+
+Cover the container-oriented binary changes:
+
+  G1  `extenddb init --tls-san <name>` adds extra Subject Alternative Names to
+      the generated self-signed certificate, and refuses to drop them silently
+      when a certificate already exists.
+  G3  `extenddb healthcheck` exits 0 when the server is healthy and non-zero
+      when it is not (used by the container HEALTHCHECK).
+  G4  `extenddb serve --foreground` writes no PID file (so a read-only root
+      filesystem needs no run directory), and still shuts down on SIGTERM.
+
+Like the other CLI lifecycle tests these require a PostgreSQL instance
+(EXTENDDB_TEST_PG_CONNECTION_STRING) and a built binary, and are excluded from
+the backend-agnostic pytest suite.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import socket
+import ssl
+import subprocess
+import threading
+import time
+
+import pytest
+
+from lifecycle_helpers import (
+    EXTENDDB_BINARY,
+    _init_args,
+    _patch_config_port,
+    _run_extenddb,
+    _wait_for_server,
+)
+
+
+def _cert_sans(cert_path: str) -> list[str]:
+    """Return the Subject Alternative Names in a PEM certificate.
+
+    Shells out to ``openssl`` rather than using a private CPython API
+    (``ssl._ssl._test_decode_cert``) or adding a ``cryptography`` dependency.
+    Uses ``-text`` rather than ``-ext subjectAltName``, which needs OpenSSL
+    1.1.1 or later. The SAN values sit on the line after the extension header,
+    formatted as ``DNS:localhost, IP Address:127.0.0.1``.
+    """
+    if shutil.which("openssl") is None:
+        pytest.fail("MISCONFIGURED: openssl is required to decode certificate SANs")
+    out = subprocess.run(
+        ["openssl", "x509", "-in", cert_path, "-noout", "-text"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    lines = out.splitlines()
+    for i, line in enumerate(lines):
+        if "Subject Alternative Name" not in line or i + 1 >= len(lines):
+            continue
+        sans = []
+        for entry in lines[i + 1].split(","):
+            _typ, _, value = entry.strip().partition(":")
+            if value:
+                sans.append(value.strip())
+        return sans
+    return []
+
+
+class _IsolatedHome:
+    """A throwaway ``$HOME`` so tests never touch the real ~/.extenddb.
+
+    ``init`` writes the TLS certificate, key, and run directory under ``$HOME``,
+    since ``expand_tilde`` resolves ``~`` from the environment. Pointing HOME at
+    a per-test directory stops the tests overwriting the developer's or CI
+    user's real certificate, and makes them order-independent and safe to run in
+    parallel.
+    """
+
+    def __init__(self, tmp_path):
+        self.home = str(tmp_path / "home")
+        os.makedirs(self.home, exist_ok=True)
+
+    @property
+    def env(self) -> dict[str, str]:
+        return {"HOME": self.home}
+
+    @property
+    def cert(self) -> str:
+        return os.path.join(self.home, ".extenddb", "tls", "cert.pem")
+
+    @property
+    def key(self) -> str:
+        return os.path.join(self.home, ".extenddb", "tls", "key.pem")
+
+
+def _init_with_home(cli_env, home: _IsolatedHome, *extra_args, check=True):
+    """Run `extenddb init` against an isolated HOME."""
+    env = {"EXTENDDB_ADMIN_PASSWORD": "TestPass1!"}
+    env.update(home.env)
+    return _run_extenddb(
+        "init", *_init_args(cli_env), *extra_args,
+        config=cli_env["config_path"],
+        env_override=env,
+        check=check,
+    )
+
+
+def _start_tls_server(cert_path: str, key_path: str, handler):
+    """Start a one-connection TLS server and return endpoint, cleanup, and state."""
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    listener.settimeout(0.2)
+    port = listener.getsockname()[1]
+    stop = threading.Event()
+    request_received = threading.Event()
+    errors = []
+
+    def serve():
+        try:
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
+            context.load_cert_chain(cert_path, key_path)
+            raw = None
+            while not stop.is_set():
+                try:
+                    raw, _addr = listener.accept()
+                    break
+                except socket.timeout:
+                    continue
+            if raw is None:
+                return
+            with raw:
+                # Bound a client that connects but never starts or completes TLS.
+                raw.settimeout(2)
+                with context.wrap_socket(raw, server_side=True) as tls:
+                    request = tls.recv(4096)
+                    if not request.startswith(b"GET /health "):
+                        raise AssertionError(f"unexpected healthcheck request: {request!r}")
+                    request_received.set()
+                    handler(tls, stop)
+        except (BrokenPipeError, ConnectionResetError, ssl.SSLEOFError):
+            # Expected when a deadline expires and the healthcheck disconnects.
+            pass
+        except Exception as exc:
+            errors.append(exc)
+        finally:
+            listener.close()
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+
+    def cleanup():
+        stop.set()
+        thread.join(timeout=5)
+        assert not thread.is_alive(), "TLS test server did not stop"
+        if errors:
+            raise AssertionError(f"TLS test server failed: {errors[0]}") from errors[0]
+
+    return f"https://127.0.0.1:{port}", cleanup, request_received
+
+
+class TestInitTlsSan:
+    """G1: init --tls-san appends extra SANs to the self-signed cert."""
+
+    def test_tls_san_added_to_cert(self, cli_env, tmp_path):
+        home = _IsolatedHome(tmp_path)
+        san = "extenddb.svc.cluster.local"
+        result = _init_with_home(cli_env, home, "--tls-san", san)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        sans = _cert_sans(home.cert)
+        # Defaults remain, plus the extra SAN we asked for.
+        assert "localhost" in sans, sans
+        assert "127.0.0.1" in sans, sans
+        assert san in sans, sans
+
+    def test_multiple_tls_sans(self, cli_env, tmp_path):
+        home = _IsolatedHome(tmp_path)
+        first, second = "one.example.com", "two.example.com"
+        result = _init_with_home(
+            cli_env, home, "--tls-san", first, "--tls-san", second
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        sans = _cert_sans(home.cert)
+        assert sans.count(first) == 1, sans
+        assert sans.count(second) == 1, sans
+
+    def test_blank_and_duplicate_sans_are_dropped(self, cli_env, tmp_path):
+        """Blanks are skipped, and a duplicate in any case appears once."""
+        home = _IsolatedHome(tmp_path)
+        result = _init_with_home(
+            cli_env, home,
+            "--tls-san", "   ",
+            "--tls-san", "dup.example.com",
+            "--tls-san", "DUP.example.com",
+            "--tls-san", "localhost",
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        sans = _cert_sans(home.cert)
+        assert [s for s in sans if s.lower() == "dup.example.com"] == ["dup.example.com"], sans
+        assert sans.count("localhost") == 1, sans
+        assert "" not in sans, sans
+
+    def test_wildcard_tls_san_is_accepted_and_rechecked(self, cli_env, tmp_path):
+        """A wildcard SAN survives a re-run of init.
+
+        `*.svc.cluster.local` is a valid certificate entry but not a valid
+        server name, so it cannot be verified directly. The coverage check
+        substitutes a single label; without that, init succeeded on the first
+        run and then failed on every later one, which is a crash loop for the
+        idempotent container entrypoint.
+        """
+        home = _IsolatedHome(tmp_path)
+        wildcard = "*.svc.cluster.local"
+        assert _init_with_home(cli_env, home, "--tls-san", wildcard).returncode == 0
+        assert wildcard in _cert_sans(home.cert), _cert_sans(home.cert)
+
+        # Re-running with the same wildcard is accepted, not rejected.
+        again = _init_with_home(
+            cli_env, home, "--overwrite", "--tls-san", wildcard, check=False
+        )
+        combined = again.stdout + again.stderr
+        assert "already covers" in combined, combined
+        assert "not valid for the requested" not in combined, combined
+
+        # A wildcard the certificate does not carry is still caught.
+        other = _init_with_home(
+            cli_env, home, "--overwrite", "--tls-san", "*.other.example.com", check=False
+        )
+        assert other.returncode != 0
+        assert "*.other.example.com" in other.stdout + other.stderr
+
+    def test_wildcard_must_be_leftmost_label(self, cli_env, tmp_path):
+        """A misplaced wildcard fails on the first run, not a later one."""
+        home = _IsolatedHome(tmp_path)
+        result = _init_with_home(
+            cli_env, home, "--tls-san", "foo.*.example.com", check=False
+        )
+        assert result.returncode != 0
+        assert "leftmost label" in result.stdout + result.stderr
+        assert not os.path.exists(home.cert), "no certificate should have been written"
+
+    def test_tls_san_not_silently_dropped_when_cert_exists(self, cli_env, tmp_path):
+        """init must not succeed having ignored --tls-san for an existing cert.
+
+        init never regenerates an existing certificate, so a newly added
+        --tls-san cannot take effect. It has to fail loudly rather than leave
+        clients to discover the missing name as a TLS hostname-verification
+        error.
+        """
+        home = _IsolatedHome(tmp_path)
+        late = "late.example.com"
+        assert _init_with_home(cli_env, home).returncode == 0
+        assert os.path.isfile(home.cert), "first init should have generated a cert"
+        before = _cert_sans(home.cert)
+        assert before.count(late) == 0, before
+
+        # Re-init with a SAN the existing certificate does not cover.
+        result = _init_with_home(
+            cli_env, home, "--overwrite", "--tls-san", late, check=False
+        )
+        assert result.returncode != 0, (
+            "init should fail rather than silently ignore --tls-san\n"
+            + result.stdout + result.stderr
+        )
+        combined = result.stdout + result.stderr
+        assert late in combined, combined
+        # And it must not have quietly rotated the certificate either.
+        assert _cert_sans(home.cert) == before
+
+    def test_tls_san_already_covered_is_idempotent(self, cli_env, tmp_path):
+        """Re-running init with an already-covered --tls-san must not fail on TLS.
+
+        The idempotent container entrypoint re-runs init on every start, so a SAN
+        the existing certificate already covers has to be accepted. The rest of
+        that second init still stops at "database already exists", so this
+        asserts only that the TLS step accepted the SAN and left the certificate
+        alone.
+        """
+        home = _IsolatedHome(tmp_path)
+        san = "extenddb.svc.cluster.local"
+        assert _init_with_home(cli_env, home, "--tls-san", san).returncode == 0
+        first = _cert_sans(home.cert)
+        assert san in first, first
+
+        again = _init_with_home(cli_env, home, "--overwrite", "--tls-san", san, check=False)
+        combined = again.stdout + again.stderr
+        assert "already covers" in combined, combined
+        assert "not valid for the requested" not in combined, combined
+        # Same certificate, not a rotated one.
+        assert _cert_sans(home.cert) == first
+
+
+class TestHealthcheck:
+    """G3: `extenddb healthcheck` reflects server health via its exit code."""
+
+    def test_healthcheck_up_and_down(self, cli_env):
+        result = _run_extenddb(
+            "init", *_init_args(cli_env),
+            config=cli_env["config_path"],
+            env_override={"EXTENDDB_ADMIN_PASSWORD": "TestPass1!"},
+        )
+        assert result.returncode == 0
+        _patch_config_port(cli_env["config_path"], cli_env["port"])
+
+        # Server not started yet → healthcheck must fail.
+        down = _run_extenddb("healthcheck", config=cli_env["config_path"], check=False)
+        assert down.returncode != 0, "healthcheck should fail when server is down"
+
+        # Start (daemon mode) and wait for health.
+        assert _run_extenddb("serve", config=cli_env["config_path"]).returncode == 0
+        assert _wait_for_server(cli_env["port"]), "server did not become healthy"
+
+        # Server up → healthcheck must succeed.
+        up = _run_extenddb("healthcheck", config=cli_env["config_path"], check=False)
+        assert up.returncode == 0, up.stdout + up.stderr
+
+        # Stop → healthcheck must fail again. Poll rather than sleeping a fixed
+        # interval, so a slow drain cannot make this flaky.
+        _run_extenddb("stop", config=cli_env["config_path"])
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            down2 = _run_extenddb("healthcheck", config=cli_env["config_path"], check=False)
+            if down2.returncode != 0:
+                break
+            time.sleep(0.25)
+        assert down2.returncode != 0, "healthcheck should fail after stop"
+
+    def test_healthcheck_endpoint_override(self, cli_env):
+        """--endpoint targets an explicit address regardless of config port."""
+        result = _run_extenddb(
+            "init", *_init_args(cli_env),
+            config=cli_env["config_path"],
+            env_override={"EXTENDDB_ADMIN_PASSWORD": "TestPass1!"},
+        )
+        assert result.returncode == 0
+        _patch_config_port(cli_env["config_path"], cli_env["port"])
+        assert _run_extenddb("serve", config=cli_env["config_path"]).returncode == 0
+        assert _wait_for_server(cli_env["port"])
+
+        endpoint = f"https://127.0.0.1:{cli_env['port']}"
+        up = _run_extenddb(
+            "healthcheck", "--endpoint", endpoint,
+            config=cli_env["config_path"], check=False,
+        )
+        assert up.returncode == 0, up.stdout + up.stderr
+
+        # A trailing path is accepted and ignored.
+        with_path = _run_extenddb(
+            "healthcheck", "--endpoint", endpoint + "/health",
+            config=cli_env["config_path"], check=False,
+        )
+        assert with_path.returncode == 0, with_path.stdout + with_path.stderr
+
+        _run_extenddb("stop", config=cli_env["config_path"])
+
+    def test_healthcheck_unreachable_endpoint_fails_promptly(self, cli_env):
+        """An unreachable endpoint must fail fast, not hang past the probe interval.
+
+        TcpStream::connect has no timeout of its own, so without an explicit
+        connect timeout this blocks for the OS default of roughly two minutes.
+        """
+        started = time.monotonic()
+        result = _run_extenddb(
+            "healthcheck", "--endpoint", "https://192.0.2.1:18443",
+            check=False, timeout=30,
+        )
+        elapsed = time.monotonic() - started
+        assert result.returncode != 0
+        assert elapsed < 15, f"healthcheck took {elapsed:.1f}s against an unreachable host"
+
+    def test_healthcheck_slow_drip_respects_one_deadline(self, cli_env, tmp_path):
+        """Partial reads cannot reset the timeout and keep the probe alive."""
+        home = _IsolatedHome(tmp_path)
+        assert _init_with_home(cli_env, home).returncode == 0
+        status_sent = threading.Event()
+        drip_sent = threading.Event()
+
+        def slow_drip(tls, stop):
+            tls.sendall(b"HTTP/1.1 200 OK\r\n")
+            status_sent.set()
+            # Every byte arrives before the old 3s per-read timeout, so the old
+            # read_to_string loop stayed alive forever despite being unhealthy.
+            while not stop.wait(1):
+                tls.sendall(b"x")
+                drip_sent.set()
+
+        endpoint, cleanup, request_received = _start_tls_server(
+            home.cert, home.key, slow_drip
+        )
+        started = time.monotonic()
+        try:
+            result = _run_extenddb(
+                "healthcheck", "--endpoint", endpoint,
+                check=False, timeout=10, env_override=home.env,
+            )
+        finally:
+            cleanup()
+        elapsed = time.monotonic() - started
+        combined = result.stdout + result.stderr
+
+        assert request_received.is_set(), "TLS server never received GET /health"
+        assert status_sent.is_set(), "TLS server never sent the HTTP status line"
+        assert drip_sent.is_set(), "TLS server never made partial read progress"
+        assert result.returncode != 0, combined
+        assert "Read error:" in combined, combined
+        assert elapsed < 6, f"slow-drip healthcheck exceeded its deadline: {elapsed:.1f}s"
+
+    def test_healthcheck_caps_response_without_waiting_for_close(
+        self, cli_env, tmp_path
+    ):
+        """Only a bounded response prefix is read before parsing the status."""
+        home = _IsolatedHome(tmp_path)
+        assert _init_with_home(cli_env, home).returncode == 0
+
+        def oversized_response(tls, stop):
+            tls.sendall(b"HTTP/1.1 200 OK\r\nX-Fill: " + b"x" * (16 * 1024))
+            # Keep the connection open: a bounded reader returns after its cap,
+            # while read_to_string waits for EOF and eventually times out.
+            stop.wait(10)
+
+        endpoint, cleanup, request_received = _start_tls_server(
+            home.cert, home.key, oversized_response
+        )
+        started = time.monotonic()
+        try:
+            result = _run_extenddb(
+                "healthcheck", "--endpoint", endpoint,
+                check=False, timeout=10, env_override=home.env,
+            )
+        finally:
+            cleanup()
+        elapsed = time.monotonic() - started
+
+        assert request_received.is_set(), "TLS server never received GET /health"
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert elapsed < 5, f"bounded response read took {elapsed:.1f}s"
+
+
+class TestForegroundNoPidFile:
+    """G4: `serve --foreground` writes no PID file and stops on SIGTERM."""
+
+    def test_foreground_writes_no_pid_file(self, cli_env, tmp_path):
+        home = _IsolatedHome(tmp_path)
+        result = _init_with_home(cli_env, home)
+        assert result.returncode == 0
+        _patch_config_port(cli_env["config_path"], cli_env["port"])
+
+        # The PID file would live at <run_dir>/extenddb-<port>.pid, and the
+        # default run_dir is ~/.extenddb/run, inside our isolated HOME.
+        pid_file = os.path.join(home.home, ".extenddb", "run", f"extenddb-{cli_env['port']}.pid")
+        assert not os.path.exists(pid_file)
+
+        env = os.environ.copy()
+        env.update(home.env)
+        # Logs go to stderr in foreground mode. Send them to a file rather than
+        # a pipe nobody drains, which would block the server once the pipe
+        # buffer filled up.
+        log_path = tmp_path / "foreground.log"
+        with open(log_path, "wb") as log:
+            proc = subprocess.Popen(
+                [EXTENDDB_BINARY, "serve", "--foreground", "--config", cli_env["config_path"]],
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                env=env,
+            )
+            try:
+                assert _wait_for_server(cli_env["port"]), (
+                    "foreground server did not become healthy: "
+                    + log_path.read_text(errors="replace")
+                )
+                # G4: no PID file, and no run directory at all.
+                assert not os.path.exists(pid_file), f"unexpected PID file {pid_file}"
+                assert not os.path.isdir(os.path.join(home.home, ".extenddb", "run")), (
+                    "foreground mode should not create the run directory"
+                )
+
+                # healthcheck should also pass against the foreground server.
+                hc = _run_extenddb(
+                    "healthcheck", config=cli_env["config_path"], check=False,
+                    env_override=home.env,
+                )
+                assert hc.returncode == 0, hc.stdout + hc.stderr
+
+                # `stop` has no PID file to read, but it must not claim that
+                # nothing is running while the port is live.
+                stop = _run_extenddb(
+                    "stop", config=cli_env["config_path"], check=False,
+                    env_override=home.env,
+                )
+                assert stop.returncode != 0
+                assert "listening on port" in (stop.stdout + stop.stderr), (
+                    stop.stdout + stop.stderr
+                )
+                assert proc.poll() is None, "`stop` must not have killed the server"
+            finally:
+                # SIGTERM should shut it down gracefully (already-implemented).
+                proc.terminate()
+                try:
+                    rc = proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    raise
+            assert rc in (0, -signal.SIGTERM), (
+                f"unexpected exit {rc}: " + log_path.read_text(errors="replace")
+            )
+
+    def test_write_pid_file_opt_in(self, cli_env, tmp_path):
+        """--write-pid-file restores the PID file, so `stop` works again.
+
+        Foreground mode writes none by default. Tooling and shell users that
+        want `extenddb stop` opt back in, and the file lands at the same path
+        daemon mode uses, so `stop` needs no extra arguments.
+        """
+        home = _IsolatedHome(tmp_path)
+        assert _init_with_home(cli_env, home).returncode == 0
+        _patch_config_port(cli_env["config_path"], cli_env["port"])
+
+        pid_file = os.path.join(
+            home.home, ".extenddb", "run", f"extenddb-{cli_env['port']}.pid"
+        )
+        env = os.environ.copy()
+        env.update(home.env)
+        log_path = tmp_path / "foreground-pid.log"
+        with open(log_path, "wb") as log:
+            proc = subprocess.Popen(
+                [
+                    EXTENDDB_BINARY, "serve", "--foreground", "--write-pid-file",
+                    "--config", cli_env["config_path"],
+                ],
+                stdout=log, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL, env=env,
+            )
+            try:
+                assert _wait_for_server(cli_env["port"]), (
+                    "server did not become healthy: "
+                    + log_path.read_text(errors="replace")
+                )
+                assert os.path.exists(pid_file), f"expected PID file {pid_file}"
+                with open(pid_file) as f:
+                    assert int(f.read().strip()) == proc.pid
+
+                # `stop` reads the PID file and signals the server. Launch it
+                # without blocking: until this test reaps the server process it
+                # lingers as a zombie, and `stop`'s liveness check (kill(pid, 0))
+                # cannot tell a zombie from a live process, so a blocking call
+                # would sit through its full timeout.
+                stop = subprocess.Popen(
+                    [EXTENDDB_BINARY, "stop", "--config", cli_env["config_path"]],
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                    stdin=subprocess.DEVNULL, text=True, env=env,
+                )
+                rc = proc.wait(timeout=15)
+                out, err = stop.communicate(timeout=15)
+                assert stop.returncode == 0, out + err
+                assert rc in (0, -signal.SIGTERM), rc
+                assert not os.path.exists(pid_file), "PID file should be cleaned up"
+            finally:
+                if proc.poll() is None:
+                    proc.kill()
+                    proc.wait(timeout=10)
+


### PR DESCRIPTION
## What
  
Makes the `extenddb` binary supervisable and probeable from a container runtime. First of two container-readiness PRs; the migration concurrency guard follows in a separate PR.
- **`extenddb healthcheck`** — new subcommand that sends an HTTPS `GET /health` and exits 0 or 1, so a Docker `HEALTHCHECK` needs no shell or `curl` and works on a `distroless`/`scratch` base. Reads the port from the config file, or takes `--endpoint https://host:port`. Connect, read, and write are bounded at 3s `TcpStream::connect` has no timeout of its own), every resolved address is tried so a name resolving to both `::1` and `127.0.0.1` works, and `--endpoint` accepts an optional scheme, port, path, and IPv6 literal.
- **`serve --foreground` writes no PID file** and skips the run directory entirely, so the container can use a read-only root filesystem. Daemon mode is unchanged. With no PID file to read, `stop` now probes the port and reports that a server is listening under foreign supervision instead of claiming nothing is running; `status` already degraded to reporting an unknown PID.
- **`serve --write-pid-file`** — opts back into the PID file in foreground mode, for shell use and for tooling that wants `stop` and `status` to work. It goes to the same `run_dir` path daemon mode uses, so neither command needs extra arguments, and `run_dir` then has to be writable. Ignored in daemon mode, which always writes one.
- **`init --tls-san <name>`** (repeatable) — appends Subject Alternative Names to the generated self-signed certificate so it is valid for the name clients actually use, such as an in-cluster service DNS name, rather than only `localhost`/`127.0.0.1`/bind-addr. Values are trimmed and de-duplicated case-insensitively.
- **Docs**: the architecture and deployment guides claimed the server always daemonizes and that foreground mode still writes a PID file. Corrected, and the container recipe that waited on that PID file is replaced with a foreground entrypoint plus a `HEALTHCHECK`.
- **CI/tooling** — the new test file is excluded from the main pytest suite and run in `devtools/run-tests`' CLI section instead, alongside `test_cli_lifecycle.py`; like those tests it starts and stops its own servers and creates its own databases, so it cannot run in parallel against the shared instance the main suite uses. The integration workflow now starts the server with `--write-pid-file`, because `run-tests` restarts it via `extenddb stop` to apply an import/export config change. That restart also no longer suppresses errors — see Notable below.
  
### Implementation Decisions
 -  **`healthcheck` is a liveness probe, deliberately.** `/health` is a static handler that does not query the storage backend, so a replica whose database has gone away still reports healthy. That is the right behaviour for a `HEALTHCHECK` and a Kubernetes `livenessProbe`: one that failed on a database outage would restart every replica at once and prolong the outage. A backend that is unreachable *at* startup does stop the server from listening, so that case is caught. There is no readiness endpoint yet, and the follow-up is to add one backed by a cached storage-layer round-trip rather than to make `/health` query the backend and lose its value as a liveness signal. This is stated in the module docs, the admin guide, and the deployment guide so nobody wires it to a `readinessProbe` expecting traffic to drain.
 -  **`init` fails rather than silently dropping a `--tls-san`.** `init` never regenerates an existing certificate, since rotating the key pair under a live deployment would be a surprise. That means a `--tls-san` added on a later run cannot take effect — and the container story generates the certificate into a persistent volume with an idempotent entrypoint that re-runs `init` on every start, so this is the common path, not an edge case. Exiting 0 having dropped the name leaves the operator to discover it as a client-side TLS hostname verification failure. Instead, when a certificate already exists we verify it covers every requested SAN and fail with an actionable error otherwise; an already-covered SAN is accepted, so the idempotent entrypoint still works. Certificate generation also moved ahead of all database work so a bad SAN fails before any users or databases are created.
  
## Why

Prerequisite binary changes from the containerization design: the server daemonizes by default (so the container runtime sees PID 1 exit), needs a health probe that works without a shell, and fixes its certificate SANs to localhost/bind-addr, which is wrong for any in-cluster service name.
  
## Testing done
  
New `tests/test_cli_container_readiness.py`, against a real PostgreSQL:
- `--tls-san` adds one and multiple SANs to the generated certificate; blanks are skipped and case-insensitive duplicates appear once.
- `init` fails, naming the SAN, when an existing certificate does not cover it, and does not rotate the certificate; an already-covered SAN is accepted.
- `healthcheck` exits 0 when the server is up, non-zero before start and after `stop`, honours `--endpoint` including a trailing path, and fails in under 15s against an unreachable host instead of hanging for the OS connect timeout.
- `serve --foreground` leaves no PID file and no run directory, answers `healthcheck`, is not killed by `extenddb stop` (which reports the port is listening), and exits on SIGTERM.

Plus 5 unit tests for `--endpoint` parsing (scheme, path, default port, IPv6, malformed input).
  
Also verified manually that the tests fail if the SAN coverage check is removed, so they are not passing by accident, and that the suite no longer touches the real `~/.extenddb/tls`
  
  ## Checklist
  
  - [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
  - [x] All tests pass (`cargo test --workspace`)
  - [x] Code is formatted (`cargo fmt --check`)
  - [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
  - [x] I have added or updated tests for new functionality
  - [x] I have updated documentation if behavior changed
  - [x] Breaking changes are noted below (if any)
  - [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
        format, or public CLI surface, an RFC has been accepted or is linked
        below. Otherwise, an ADR captures the decision (link below).
  
## Breaking changes
  
`serve --foreground` no longer writes a PID file or creates `run_dir`. On `main` it does both, and `extenddb stop` works against a foreground server. Anyone relying on that must add `--write-pid-file`, which restores the previous behaviour exactly. `extenddb status` is unaffected apart from reporting the PID as unknown, since it probes the port. Daemon mode is unchanged.
  
The repo's own tooling was such a consumer: `devtools/run-tests` restarts the server with `extenddb stop`, so the integration workflow passes the new flag.
  
One newly non-silent failure: `init --tls-san X` against an existing certificate that does not cover `X` now exits non-zero where it previously exited 0 and ignored the flag. Since `--tls-san` is new in this PR, no existing invocation can hit it.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.