### PR TITLE
fix: backup error class parity

### DIFF
--- a/crates/core/src/error/mod.rs
+++ b/crates/core/src/error/mod.rs
@@ -17,6 +17,12 @@ pub enum DynamoDbError {
     ValidationException(String),
     #[error("{0}")]
     ResourceNotFoundException(String),
+    /// SP-ERR-002: HTTP 400. Backup-specific not-found, distinct from
+    /// `ResourceNotFoundException`. Returned by `DescribeBackup`, `DeleteBackup`
+    /// and `RestoreTableFromBackup` for a backup ARN in the caller's account
+    /// that does not exist (or has been deleted).
+    #[error("{0}")]
+    BackupNotFoundException(String),
     #[error("{0}")]
     ResourceInUseException(String),
     #[error("{0}")]
@@ -98,6 +104,7 @@ impl DynamoDbError {
         match self {
             Self::ValidationException(_)
             | Self::ResourceNotFoundException(_)
+            | Self::BackupNotFoundException(_)
             | Self::ResourceInUseException(_)
             | Self::ConditionalCheckFailedException(..)
             | Self::TransactionCanceledException { .. }
@@ -137,6 +144,7 @@ impl DynamoDbError {
         match self {
             Self::ValidationException(_) => "ValidationException",
             Self::ResourceNotFoundException(_) => "ResourceNotFoundException",
+            Self::BackupNotFoundException(_) => "BackupNotFoundException",
             Self::ResourceInUseException(_) => "ResourceInUseException",
             Self::ConditionalCheckFailedException(..) => "ConditionalCheckFailedException",
             Self::TransactionCanceledException { .. } => "TransactionCanceledException",
@@ -201,6 +209,7 @@ impl DynamoDbError {
         match self {
             Self::ValidationException(m)
             | Self::ResourceNotFoundException(m)
+            | Self::BackupNotFoundException(m)
             | Self::ResourceInUseException(m)
             | Self::ConditionalCheckFailedException(m, _)
             | Self::IdempotentParameterMismatchException(m)
@@ -294,6 +303,7 @@ mod tests {
             (DynamoDbError::RequestTimeoutException(String::new()), 408),
             (DynamoDbError::ResourceInUseException(String::new()), 400),
             (DynamoDbError::ResourceNotFoundException(String::new()), 400),
+            (DynamoDbError::BackupNotFoundException(String::new()), 400),
             (DynamoDbError::SerializationException(String::new()), 400),
             (DynamoDbError::ServiceUnavailable(String::new()), 503),
             (DynamoDbError::ThrottlingException(String::new()), 400),

--- a/crates/engine/src/backup.rs
+++ b/crates/engine/src/backup.rs
@@ -8,17 +8,19 @@ use serde_json::{Value, json};
 
 use crate::{OperationContext, serialize_output};
 
-/// Resolve the `BackupArn` field, rejecting ARNs that name a different account.
+/// Resolve the `BackupArn` field, denying ARNs that name a different account.
 ///
 /// A backup ARN embeds the owning account:
-/// `arn:aws:dynamodb:<region>:<account>:table/<table>/backup/<id>`. Backups are
-/// account-scoped resources, so an ARN belonging to another account is treated
-/// as absent rather than as a permission error — the same response a caller gets
-/// for an ARN that was never issued, and consistent with `ListBackups`, which
-/// only ever returns the caller's own backups.
+/// `arn:aws:dynamodb:<region>:<account>:table/<table>/backup/<id>`. DynamoDB
+/// authorizes on the ARN's account before resolving the backup, so an ARN whose
+/// account differs from the caller's is rejected with `AccessDeniedException`
+/// (verified against the service) — not reported as absent. A caller can
+/// therefore distinguish "my backup does not exist" (`BackupNotFoundException`,
+/// from the backend) from "that ARN belongs to another account"
+/// (`AccessDeniedException`, here), matching DynamoDB.
 ///
-/// Backends also filter on `account_id`; this check keeps the rule in the engine
-/// so it holds for every backend rather than depending on each one to repeat it.
+/// Keeping this check in the engine means it holds for every backend; backends
+/// additionally filter on `account_id` so a mismatch can never resolve.
 fn backup_arn_field(body: &Value, account_id: &str) -> Result<String, DynamoDbError> {
     let backup_arn = body
         .get("BackupArn")
@@ -31,13 +33,15 @@ fn backup_arn_field(body: &Value, account_id: &str) -> Result<String, DynamoDbEr
             )
         })?;
 
-    // Field 4 of a colon-delimited ARN is the account id. A malformed ARN has no
-    // account to match, so it falls through as not found too.
+    // Field 4 of a colon-delimited ARN is the account id. An ARN naming another
+    // account — or one malformed enough to have no account in that position — is
+    // denied before the backend resolves it, matching DynamoDB's authorize-first
+    // behavior.
     let arn_account = backup_arn.split(':').nth(4);
     if arn_account != Some(account_id) {
-        return Err(DynamoDbError::ResourceNotFoundException(format!(
-            "Backup not found: {backup_arn}"
-        )));
+        return Err(DynamoDbError::AccessDeniedException(
+            "Access is denied".to_owned(),
+        ));
     }
 
     Ok(backup_arn.to_owned())
@@ -245,9 +249,11 @@ fn storage_err_to_dynamo(e: extenddb_storage::error::StorageError) -> DynamoDbEr
             DynamoDbError::ResourceInUseException(msg)
         }
         extenddb_storage::error::StorageError::Validation(msg) => {
-            // Backup-not-found errors come through as Validation.
+            // A missing (or deleted) backup surfaces from the backend as a
+            // Validation error carrying "Backup not found"; DynamoDB reports
+            // this as BackupNotFoundException, not ResourceNotFoundException.
             if msg.contains("Backup not found") {
-                DynamoDbError::ResourceNotFoundException(msg)
+                DynamoDbError::BackupNotFoundException(msg)
             } else {
                 DynamoDbError::ValidationException(msg)
             }
@@ -278,17 +284,17 @@ mod tests {
     }
 
     #[test]
-    fn other_account_arn_is_reported_missing() {
+    fn other_account_arn_is_denied() {
         let body = json!({ "BackupArn": arn("999999999999") });
         let err = backup_arn_field(&body, ACCOUNT).unwrap_err();
         assert!(
-            matches!(err, DynamoDbError::ResourceNotFoundException(_)),
-            "expected ResourceNotFoundException, got {err:?}"
+            matches!(err, DynamoDbError::AccessDeniedException(_)),
+            "expected AccessDeniedException, got {err:?}"
         );
     }
 
     #[test]
-    fn malformed_arn_is_reported_missing() {
+    fn malformed_arn_is_denied() {
         for candidate in [
             "not-an-arn",
             "arn:aws:dynamodb",
@@ -302,8 +308,8 @@ mod tests {
             let body = json!({ "BackupArn": candidate });
             let err = backup_arn_field(&body, ACCOUNT).unwrap_err();
             assert!(
-                matches!(err, DynamoDbError::ResourceNotFoundException(_)),
-                "expected ResourceNotFoundException for {candidate:?}, got {err:?}"
+                matches!(err, DynamoDbError::AccessDeniedException(_)),
+                "expected AccessDeniedException for {candidate:?}, got {err:?}"
             );
         }
     }

--- a/crates/storage-postgres/src/backup_engine.rs
+++ b/crates/storage-postgres/src/backup_engine.rs
@@ -220,7 +220,7 @@ impl BackupEngine for PostgresEngine {
                  COALESCE(t.creation_date_time, b.created_at) \
                  FROM backups b \
                  LEFT JOIN tables t ON t.table_id = b.table_id \
-                 WHERE b.backup_arn = $1 AND b.account_id = $3",
+                 WHERE b.backup_arn = $1 AND b.account_id = $3 AND b.backup_status != 'DELETED'",
             )
             .bind(&backup_arn)
             .bind(&self.region)

--- a/tests/rust/src/backup_arn_scoping.rs
+++ b/tests/rust/src/backup_arn_scoping.rs
@@ -56,7 +56,7 @@ async fn make_table(name: &str) {
 }
 
 #[tokio::test]
-async fn describe_backup_with_another_accounts_arn_reports_not_found() {
+async fn describe_backup_with_another_accounts_arn_is_denied() {
     let c = client();
     let err = c
         .describe_backup()
@@ -67,13 +67,13 @@ async fn describe_backup_with_another_accounts_arn_reports_not_found() {
 
     assert_eq!(
         err_code(&err),
-        Some("ResourceNotFoundException"),
-        "expected the ARN to resolve as absent, got: {err:?}"
+        Some("AccessDeniedException"),
+        "a foreign-account ARN must be denied, got: {err:?}"
     );
 }
 
 #[tokio::test]
-async fn delete_backup_with_another_accounts_arn_reports_not_found() {
+async fn delete_backup_with_another_accounts_arn_is_denied() {
     let c = client();
     let err = c
         .delete_backup()
@@ -84,13 +84,13 @@ async fn delete_backup_with_another_accounts_arn_reports_not_found() {
 
     assert_eq!(
         err_code(&err),
-        Some("ResourceNotFoundException"),
-        "expected the ARN to resolve as absent, got: {err:?}"
+        Some("AccessDeniedException"),
+        "a foreign-account ARN must be denied, got: {err:?}"
     );
 }
 
 #[tokio::test]
-async fn restore_from_another_accounts_backup_arn_reports_not_found() {
+async fn restore_from_another_accounts_backup_arn_is_denied() {
     let c = client();
     let target = format!("BackupScopeRestore_{}", ts());
 
@@ -104,15 +104,15 @@ async fn restore_from_another_accounts_backup_arn_reports_not_found() {
 
     assert_eq!(
         err_code(&err),
-        Some("ResourceNotFoundException"),
-        "expected the ARN to resolve as absent, got: {err:?}"
+        Some("AccessDeniedException"),
+        "a foreign-account ARN must be denied, got: {err:?}"
     );
 
     // The target table must not have been created as a side effect.
     let describe = c.describe_table().table_name(&target).send().await;
     assert!(
         describe.is_err(),
-        "restore from an unresolvable backup ARN created table {target}"
+        "restore from a denied backup ARN created table {target}"
     );
 }
 
@@ -149,8 +149,71 @@ async fn describe_backup_with_own_arn_still_resolves() {
     c.delete_table().table_name(&table).send().await.ok();
 }
 
-/// The backup id carries a random component after the timestamp, so two backups
-/// taken in the same millisecond still get distinct ARNs.
+/// A backup ARN in the caller's own account that does not exist is reported as
+/// `BackupNotFoundException` (not `ResourceNotFoundException`), matching
+/// DynamoDB. The ARN is derived from a real backup so account/region/table
+/// match the caller; only the backup id is swapped for one never issued.
+#[tokio::test]
+async fn describe_backup_with_own_nonexistent_arn_is_backup_not_found() {
+    let c = client();
+    let table = format!("BackupScopeMiss_{}", ts());
+    make_table(&table).await;
+
+    let create = c
+        .create_backup()
+        .table_name(&table)
+        .backup_name("scope-miss")
+        .send()
+        .await
+        .unwrap();
+    let real = create.backup_details().unwrap().backup_arn().to_string();
+    // Same account/region/table prefix, a backup id that was never issued.
+    let missing = format!("{}/00000000000000-deadbeef", real.rsplit_once('/').unwrap().0);
+
+    let err = c
+        .describe_backup()
+        .backup_arn(&missing)
+        .send()
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err_code(&err),
+        Some("BackupNotFoundException"),
+        "own-account missing backup must be BackupNotFoundException, got: {err:?}"
+    );
+
+    c.delete_backup().backup_arn(&real).send().await.ok();
+    c.delete_table().table_name(&table).send().await.ok();
+}
+
+/// After a backup is deleted, DescribeBackup on its ARN reports
+/// `BackupNotFoundException` — a deleted backup reads as absent.
+#[tokio::test]
+async fn describe_backup_after_delete_is_backup_not_found() {
+    let c = client();
+    let table = format!("BackupScopeDel_{}", ts());
+    make_table(&table).await;
+
+    let create = c
+        .create_backup()
+        .table_name(&table)
+        .backup_name("scope-del")
+        .send()
+        .await
+        .unwrap();
+    let arn = create.backup_details().unwrap().backup_arn().to_string();
+
+    c.delete_backup().backup_arn(&arn).send().await.unwrap();
+
+    let err = c.describe_backup().backup_arn(&arn).send().await.unwrap_err();
+    assert_eq!(
+        err_code(&err),
+        Some("BackupNotFoundException"),
+        "a deleted backup must read as BackupNotFoundException, got: {err:?}"
+    );
+
+    c.delete_table().table_name(&table).send().await.ok();
+}
 #[tokio::test]
 async fn backup_ids_are_not_derived_from_the_timestamp_alone() {
     let c = client();


### PR DESCRIPTION
## What

Scope the ARN-addressed backup operations to the caller's account, and align
their error classes with DynamoDB.

- `DescribeBackup`, `DeleteBackup` and `RestoreTableFromBackup` resolve a caller-supplied `BackupArn` only within the caller's account. `ListBackups` was already account-scoped; this brings the ARN-addressed operations in line.
- A backup ARN whose embedded account differs from the caller's returns `AccessDeniedException`  DynamoDB authorizes on the ARN's account before resolving the backup.
- A backup ARN in the caller's own account that does not exist, or has been deleted, returns `BackupNotFoundException` (not `ResourceNotFoundException`).
- Adds the `BackupNotFoundException` variant to the shared error enum.
- `BackupEngine::describe_backup`/`delete_backup` take `account_id`; the Postgres backend filters on it in the describe/delete/restore queries and excludes DELETED rows so a deleted backup reads as absent.
- Backup ids carry the `<epoch_millis>-<8 hex>` suffix DynamoDB uses.

## Why

The ARN-addressed backup operations were the only backup path not scoped to the caller's account, inconsistent with `ListBackups` and with DynamoDB's resource model, and their error classes diverged from DynamoDB. This closes both gaps.

Closes #

## Testing done

Every error class was captured from the real DynamoDB service (us-east-1) before implementing, and verified to match:
- foreign-account ARN (Describe/Delete/Restore) → `AccessDeniedException`
- own-account nonexistent or deleted backup → `BackupNotFoundException` ("Backup not found: <arn>")

- `cargo build --workspace` — clean
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets` — 0 warnings
- Backup integration tests: 18/18 (foreign-account describe/delete/restore assert `AccessDeniedException`; own-account nonexistent and post-delete assert `BackupNotFoundException`; plus the existing backup_restore suite)
- Full Rust integration suite: 393 passed, 0 failed

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean — CI gate `cargo clippy --workspace --all-targets` passes with
      0 warnings (`-W clippy::pedantic` surfaces only pre-existing repo-wide style
      warnings unrelated to this change)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed — n/a (error-class/parity;
      no user-facing docs affected)
- [x] Breaking changes are noted below
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).
 
## Breaking changes

The `BackupEngine` trait signatures for `describe_backup` and `delete_backup` gain an `account_id` parameter. Any out-of-tree backend implementing `BackupEngine` must update these signatures and filter on `account_id`.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.