### PR TITLE
fix: authorize batch and transaction operations per-table

### DIFF
--- a/crates/server/src/request_helpers.rs
+++ b/crates/server/src/request_helpers.rs
@@ -62,6 +62,32 @@ pub(crate) async fn authorize_request(
     operation: &str,
     account_id: &str,
 ) -> Result<Option<extenddb_core::types::TableKeyInfo>, DynamoDbError> {
+    // Batch and transaction operations address multiple tables in nested request
+    // structures with no top-level TableName. DynamoDB authorizes each of them
+    // per table, against that table's specific ARN, using the IAM action the
+    // operation maps to (BatchGetItem/BatchWriteItem are their own actions;
+    // TransactGetItems decomposes to GetItem; TransactWriteItems decomposes to
+    // the per-sub-op action). Authorizing the whole request against a single
+    // `table/*` wildcard — as the generic path below does — lets an explicit
+    // Deny on one table be bypassed. Evaluate every (action, table) pair and
+    // reject the entire request if any is denied (all-or-nothing), matching
+    // DynamoDB. Verified against the AWS IAM Service Authorization Reference.
+    if let Some(targets) = batch_transact_authz_targets(operation, input) {
+        for (action_op, table) in targets {
+            let resource_arn = build_resource_arn(&state.region, account_id, Some(&table));
+            authorization::check_authorization(
+                state.authz_cache.as_ref(),
+                identity,
+                &action_op,
+                &resource_arn,
+                false,
+                extenddb_auth::policy::context::RequestParams::default(),
+            )
+            .await?;
+        }
+        return Ok(None);
+    }
+
     let table_name = extract_table_name(input);
     let resource_arn = build_resource_arn(&state.region, account_id, table_name.as_deref());
 
@@ -175,6 +201,69 @@ pub(crate) fn extract_attributes(input: &Value) -> Option<Vec<String>> {
         })
         .collect();
     if names.is_empty() { None } else { Some(names) }
+}
+
+/// IAM `(action, table)` pairs to authorize for a batch/transact operation.
+///
+/// Returns `None` for non-batch/transact operations (the caller uses the
+/// single-table path). Actions follow the AWS IAM Service Authorization
+/// Reference: `BatchGetItem`/`BatchWriteItem` authorize under their own action
+/// per table; `TransactGetItems` authorizes as `GetItem` per item's table;
+/// `TransactWriteItems` authorizes per sub-op (`Put`→`PutItem`,
+/// `Delete`→`DeleteItem`, `Update`→`UpdateItem`, `ConditionCheck`→
+/// `ConditionCheckItem`). Pairs are de-duplicated. Table names are the bare
+/// operation-string form (no `dynamodb:` prefix), matching `check_authorization`
+/// which prepends `dynamodb:`.
+fn batch_transact_authz_targets(operation: &str, input: &Value) -> Option<Vec<(String, String)>> {
+    let mut out: Vec<(String, String)> = Vec::new();
+    let mut push = |action: &str, table: &str| {
+        let pair = (action.to_owned(), table.to_owned());
+        if !out.contains(&pair) {
+            out.push(pair);
+        }
+    };
+    match operation {
+        "BatchGetItem" | "BatchWriteItem" => {
+            // RequestItems is a map keyed by table name.
+            let items = input.get("RequestItems")?.as_object()?;
+            for table in items.keys() {
+                push(operation, table);
+            }
+        }
+        "TransactGetItems" => {
+            let items = input.get("TransactItems")?.as_array()?;
+            for entry in items {
+                if let Some(t) = entry
+                    .get("Get")
+                    .and_then(|g| g.get("TableName"))
+                    .and_then(Value::as_str)
+                {
+                    push("GetItem", t);
+                }
+            }
+        }
+        "TransactWriteItems" => {
+            let items = input.get("TransactItems")?.as_array()?;
+            for entry in items {
+                for (sub, action) in [
+                    ("Put", "PutItem"),
+                    ("Delete", "DeleteItem"),
+                    ("Update", "UpdateItem"),
+                    ("ConditionCheck", "ConditionCheckItem"),
+                ] {
+                    if let Some(t) = entry
+                        .get(sub)
+                        .and_then(|s| s.get("TableName"))
+                        .and_then(Value::as_str)
+                    {
+                        push(action, t);
+                    }
+                }
+            }
+        }
+        _ => return None,
+    }
+    Some(out)
 }
 
 /// Build a `DynamoDB` table ARN for authorization.

--- a/tests/rust/Cargo.lock
+++ b/tests/rust/Cargo.lock
@@ -590,6 +590,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "reqwest",
+ "serde_json",
  "tokio",
  "uuid",
 ]

--- a/tests/rust/Cargo.toml
+++ b/tests/rust/Cargo.toml
@@ -28,3 +28,4 @@ aws-smithy-http-client = { version = "1", features = ["rustls-ring"] }
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }
 reqwest = { version = "0.12.15", features = ["rustls-tls", "json"], default-features = false }
+serde_json = "1"

--- a/tests/rust/src/batch_transact_authz.rs
+++ b/tests/rust/src/batch_transact_authz.rs
@@ -203,8 +203,26 @@ async fn tables() -> (String, String, String) {
 
 // --- A: Deny dynamodb:* on the secret table -------------------------------
 
+/// Skip when admin creds are unavailable, matching the Python auth suite
+/// (`test_abac.py`, `test_auth_integration.py`). `devtools/run-tests --extenddb
+/// --rust-integration` sets `EXTENDDB_ADMIN_PASSWORD`, so CI still runs these
+/// for real; a bare `cargo test` without it skips rather than hard-failing.
+fn skip_no_admin() -> bool {
+    if std::env::var("EXTENDDB_ADMIN_PASSWORD").is_err() {
+        eprintln!(
+            "SKIP: EXTENDDB_ADMIN_PASSWORD not set; run via \
+             devtools/run-tests --extenddb --rust-integration"
+        );
+        return true;
+    }
+    false
+}
+
 #[tokio::test]
 async fn batch_get_including_denied_table_is_denied() {
+    if skip_no_admin() {
+        return;
+    }
     let (allowed, secret, secret_arn) = tables().await;
     let u = user_with_policy(deny_policy("dynamodb:*", &secret_arn)).await;
     let err = u
@@ -228,6 +246,9 @@ async fn batch_get_including_denied_table_is_denied() {
 
 #[tokio::test]
 async fn batch_write_including_denied_table_is_denied() {
+    if skip_no_admin() {
+        return;
+    }
     let (_allowed, secret, secret_arn) = tables().await;
     let u = user_with_policy(deny_policy("dynamodb:*", &secret_arn)).await;
     let err = u
@@ -246,6 +267,9 @@ async fn batch_write_including_denied_table_is_denied() {
 
 #[tokio::test]
 async fn transact_get_including_denied_table_is_denied() {
+    if skip_no_admin() {
+        return;
+    }
     let (_allowed, secret, secret_arn) = tables().await;
     let u = user_with_policy(deny_policy("dynamodb:*", &secret_arn)).await;
     let err = u
@@ -269,6 +293,9 @@ async fn transact_get_including_denied_table_is_denied() {
 
 #[tokio::test]
 async fn transact_write_including_denied_table_is_denied() {
+    if skip_no_admin() {
+        return;
+    }
     let (_allowed, secret, secret_arn) = tables().await;
     let u = user_with_policy(deny_policy("dynamodb:*", &secret_arn)).await;
     let err = u
@@ -291,6 +318,9 @@ async fn transact_write_including_denied_table_is_denied() {
 
 #[tokio::test]
 async fn getitem_deny_does_not_block_batch_get() {
+    if skip_no_admin() {
+        return;
+    }
     let (_allowed, secret, secret_arn) = tables().await;
     let u = user_with_policy(deny_policy("dynamodb:GetItem", &secret_arn)).await;
     // BatchGetItem is its own action; a GetItem deny does not apply.
@@ -303,6 +333,9 @@ async fn getitem_deny_does_not_block_batch_get() {
 
 #[tokio::test]
 async fn getitem_deny_blocks_transact_get() {
+    if skip_no_admin() {
+        return;
+    }
     let (_allowed, secret, secret_arn) = tables().await;
     let u = user_with_policy(deny_policy("dynamodb:GetItem", &secret_arn)).await;
     // TransactGetItems decomposes to GetItem, so the deny applies.
@@ -327,6 +360,9 @@ async fn getitem_deny_blocks_transact_get() {
 
 #[tokio::test]
 async fn putitem_deny_does_not_block_batch_write() {
+    if skip_no_admin() {
+        return;
+    }
     let (_allowed, secret, secret_arn) = tables().await;
     let u = user_with_policy(deny_policy("dynamodb:PutItem", &secret_arn)).await;
     u.batch_write_item()
@@ -343,6 +379,9 @@ async fn putitem_deny_does_not_block_batch_write() {
 
 #[tokio::test]
 async fn putitem_deny_blocks_transact_write_put() {
+    if skip_no_admin() {
+        return;
+    }
     let (_allowed, secret, secret_arn) = tables().await;
     let u = user_with_policy(deny_policy("dynamodb:PutItem", &secret_arn)).await;
     let err = u

--- a/tests/rust/src/batch_transact_authz.rs
+++ b/tests/rust/src/batch_transact_authz.rs
@@ -1,0 +1,359 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Batch and transaction operations authorize each table individually.
+//!
+//! A `Deny` on one table must block a `BatchGetItem`/`BatchWriteItem`/
+//! `TransactGetItems`/`TransactWriteItems` that touches it, even when the same
+//! request also touches an allowed table (all-or-nothing) — the request must
+//! not be evaluated against a single `table/*` wildcard.
+//!
+//! The IAM action evaluated per table follows the AWS IAM Service Authorization
+//! Reference: `BatchGetItem`/`BatchWriteItem` are their own actions;
+//! `TransactGetItems` decomposes to `GetItem`; `TransactWriteItems` decomposes
+//! to `PutItem`/`DeleteItem`/`UpdateItem`/`ConditionCheckItem` per sub-op. The
+//! guard tests assert that distinction (a `GetItem` deny must NOT block
+//! `BatchGetItem`, but MUST block `TransactGetItems`).
+
+use crate::test_base::*;
+use aws_credential_types::provider::SharedCredentialsProvider;
+use aws_credential_types::Credentials;
+use aws_sdk_dynamodb::config::Region;
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition, BillingMode, KeySchemaElement, KeyType, KeysAndAttributes, Put,
+    PutRequest, ScalarAttributeType, TransactGetItem, TransactWriteItem, WriteRequest,
+};
+use aws_sdk_dynamodb::Client;
+use aws_smithy_http_client::tls;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+
+const TEST_ACCOUNT: &str = "123456789012";
+
+fn endpoint() -> String {
+    std::env::var("EXTENDDB_TEST_ENDPOINT").expect("EXTENDDB_TEST_ENDPOINT must be set")
+}
+
+/// Build a SigV4 DynamoDB client for an arbitrary access key / secret.
+fn client_for(access_key: &str, secret_key: &str) -> Client {
+    let region = std::env::var("AWS_DEFAULT_REGION").unwrap_or_else(|_| "us-east-1".into());
+    let mut trust_store = tls::TrustStore::empty().with_native_roots(true);
+    if let Ok(ca_path) = std::env::var("EXTENDDB_CA_CERT") {
+        if let Ok(pem) = std::fs::read(&ca_path) {
+            trust_store = trust_store.with_pem_certificate(pem);
+        }
+    }
+    let tls_context = tls::TlsContext::builder()
+        .with_trust_store(trust_store)
+        .build()
+        .expect("TLS context build failed");
+    let http_client = aws_smithy_http_client::Builder::new()
+        .tls_provider(tls::Provider::Rustls(tls::rustls_provider::CryptoMode::Ring))
+        .tls_context(tls_context)
+        .build_https();
+    let conf = aws_sdk_dynamodb::Config::builder()
+        .behavior_version_latest()
+        .region(Region::new(region))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
+            access_key, secret_key, None, None, "test",
+        )))
+        .http_client(http_client)
+        .endpoint_url(endpoint())
+        .build();
+    Client::from_conf(conf)
+}
+
+/// Management HTTP client (admin Basic auth, self-signed cert accepted).
+fn mgmt() -> (reqwest::Client, String, (String, String)) {
+    let base = format!("{}/management", endpoint().trim_end_matches('/'));
+    let user = std::env::var("EXTENDDB_ADMIN_USER").unwrap_or_else(|_| "admin".into());
+    let pass = std::env::var("EXTENDDB_ADMIN_PASSWORD").expect("EXTENDDB_ADMIN_PASSWORD must be set");
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true) // localhost self-signed; test only
+        .build()
+        .expect("reqwest build");
+    (client, base, (user, pass))
+}
+
+/// Create a fresh IAM user with the given inline policy and return a SigV4
+/// client authenticated as that user.
+async fn user_with_policy(policy: Value) -> Client {
+    let (http, base, (au, ap)) = mgmt();
+    let user = format!("bta-{}", ts());
+
+    let r = http
+        .post(format!("{base}/accounts/{TEST_ACCOUNT}/users"))
+        .basic_auth(&au, Some(&ap))
+        .json(&json!({ "user_name": user }))
+        .send()
+        .await
+        .expect("create_user send");
+    assert!(
+        r.status().is_success(),
+        "create_user failed: {}",
+        r.text().await.unwrap_or_default()
+    );
+
+    let r = http
+        .put(format!("{base}/accounts/{TEST_ACCOUNT}/users/{user}/policy/p"))
+        .basic_auth(&au, Some(&ap))
+        .json(&policy)
+        .send()
+        .await
+        .expect("put_user_policy send");
+    assert!(
+        r.status().is_success(),
+        "put_user_policy failed: {}",
+        r.text().await.unwrap_or_default()
+    );
+
+    let r = http
+        .post(format!("{base}/accounts/{TEST_ACCOUNT}/users/{user}/access-keys"))
+        .basic_auth(&au, Some(&ap))
+        .send()
+        .await
+        .expect("create_access_key send");
+    assert!(r.status().is_success(), "create_access_key failed");
+    let creds: Value = r.json().await.expect("access key json");
+    let ak = creds["access_key_id"].as_str().expect("access_key_id");
+    let sk = creds["secret_access_key"].as_str().expect("secret_access_key");
+    client_for(ak, sk)
+}
+
+async fn make_table(c: &Client, name: &str) {
+    c.create_table()
+        .table_name(name)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+    wait_for_active(c, name).await;
+}
+
+fn deny_policy(action: &str, table_arn: &str) -> Value {
+    json!({
+        "Version": "2012-10-17",
+        "Statement": [
+            { "Effect": "Allow", "Action": "dynamodb:*", "Resource": "*" },
+            { "Effect": "Deny", "Action": action, "Resource": table_arn }
+        ]
+    })
+}
+
+fn key(pk: &str) -> HashMap<String, aws_sdk_dynamodb::types::AttributeValue> {
+    HashMap::from([(
+        "pk".to_owned(),
+        aws_sdk_dynamodb::types::AttributeValue::S(pk.to_owned()),
+    )])
+}
+
+fn is_denied(code: Option<&str>) -> bool {
+    code == Some("AccessDeniedException")
+}
+
+/// Two shared tables for the suite; items seeded by the admin client.
+/// Returns `(allowed_name, secret_name, secret_table_arn)`.
+async fn tables() -> (String, String, String) {
+    let admin = client();
+    let allowed = format!("BtaAllowed_{}", ts());
+    let secret = format!("BtaSecret_{}", ts());
+    make_table(admin, &allowed).await;
+    make_table(admin, &secret).await;
+    admin
+        .put_item()
+        .table_name(&allowed)
+        .set_item(Some(key("a1")))
+        .send()
+        .await
+        .unwrap();
+    admin
+        .put_item()
+        .table_name(&secret)
+        .set_item(Some(key("s1")))
+        .send()
+        .await
+        .unwrap();
+    let secret_arn = admin
+        .describe_table()
+        .table_name(&secret)
+        .send()
+        .await
+        .unwrap()
+        .table()
+        .unwrap()
+        .table_arn()
+        .unwrap()
+        .to_owned();
+    (allowed, secret, secret_arn)
+}
+
+// --- A: Deny dynamodb:* on the secret table -------------------------------
+
+#[tokio::test]
+async fn batch_get_including_denied_table_is_denied() {
+    let (allowed, secret, secret_arn) = tables().await;
+    let u = user_with_policy(deny_policy("dynamodb:*", &secret_arn)).await;
+    let err = u
+        .batch_get_item()
+        .request_items(&allowed, KeysAndAttributes::builder().keys(key("a1")).build().unwrap())
+        .request_items(&secret, KeysAndAttributes::builder().keys(key("s1")).build().unwrap())
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        is_denied(err_code(&err)),
+        "batch touching denied table must be AccessDenied, got {err:?}"
+    );
+    // Positive control: allowed-only batch succeeds.
+    u.batch_get_item()
+        .request_items(&allowed, KeysAndAttributes::builder().keys(key("a1")).build().unwrap())
+        .send()
+        .await
+        .expect("allowed-only batch must succeed");
+}
+
+#[tokio::test]
+async fn batch_write_including_denied_table_is_denied() {
+    let (_allowed, secret, secret_arn) = tables().await;
+    let u = user_with_policy(deny_policy("dynamodb:*", &secret_arn)).await;
+    let err = u
+        .batch_write_item()
+        .request_items(
+            &secret,
+            vec![WriteRequest::builder()
+                .put_request(PutRequest::builder().set_item(Some(key("z1"))).build().unwrap())
+                .build()],
+        )
+        .send()
+        .await
+        .unwrap_err();
+    assert!(is_denied(err_code(&err)), "got {err:?}");
+}
+
+#[tokio::test]
+async fn transact_get_including_denied_table_is_denied() {
+    let (_allowed, secret, secret_arn) = tables().await;
+    let u = user_with_policy(deny_policy("dynamodb:*", &secret_arn)).await;
+    let err = u
+        .transact_get_items()
+        .transact_items(
+            TransactGetItem::builder()
+                .get(
+                    aws_sdk_dynamodb::types::Get::builder()
+                        .table_name(&secret)
+                        .set_key(Some(key("s1")))
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap_err();
+    assert!(is_denied(err_code(&err)), "got {err:?}");
+}
+
+#[tokio::test]
+async fn transact_write_including_denied_table_is_denied() {
+    let (_allowed, secret, secret_arn) = tables().await;
+    let u = user_with_policy(deny_policy("dynamodb:*", &secret_arn)).await;
+    let err = u
+        .transact_write_items()
+        .transact_items(
+            TransactWriteItem::builder()
+                .put(Put::builder().table_name(&secret).set_item(Some(key("z2"))).build().unwrap())
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap_err();
+    assert!(is_denied(err_code(&err)), "got {err:?}");
+}
+
+// --- B/C: action-decomposition guards -------------------------------------
+// These pin that we authorize each op under the CORRECT IAM action, not a
+// naive one. A GetItem/PutItem deny must NOT leak onto the distinct batch
+// actions, but MUST hit the transaction sub-op actions.
+
+#[tokio::test]
+async fn getitem_deny_does_not_block_batch_get() {
+    let (_allowed, secret, secret_arn) = tables().await;
+    let u = user_with_policy(deny_policy("dynamodb:GetItem", &secret_arn)).await;
+    // BatchGetItem is its own action; a GetItem deny does not apply.
+    u.batch_get_item()
+        .request_items(&secret, KeysAndAttributes::builder().keys(key("s1")).build().unwrap())
+        .send()
+        .await
+        .expect("GetItem deny must not block BatchGetItem");
+}
+
+#[tokio::test]
+async fn getitem_deny_blocks_transact_get() {
+    let (_allowed, secret, secret_arn) = tables().await;
+    let u = user_with_policy(deny_policy("dynamodb:GetItem", &secret_arn)).await;
+    // TransactGetItems decomposes to GetItem, so the deny applies.
+    let err = u
+        .transact_get_items()
+        .transact_items(
+            TransactGetItem::builder()
+                .get(
+                    aws_sdk_dynamodb::types::Get::builder()
+                        .table_name(&secret)
+                        .set_key(Some(key("s1")))
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap_err();
+    assert!(is_denied(err_code(&err)), "got {err:?}");
+}
+
+#[tokio::test]
+async fn putitem_deny_does_not_block_batch_write() {
+    let (_allowed, secret, secret_arn) = tables().await;
+    let u = user_with_policy(deny_policy("dynamodb:PutItem", &secret_arn)).await;
+    u.batch_write_item()
+        .request_items(
+            &secret,
+            vec![WriteRequest::builder()
+                .put_request(PutRequest::builder().set_item(Some(key("z3"))).build().unwrap())
+                .build()],
+        )
+        .send()
+        .await
+        .expect("PutItem deny must not block BatchWriteItem");
+}
+
+#[tokio::test]
+async fn putitem_deny_blocks_transact_write_put() {
+    let (_allowed, secret, secret_arn) = tables().await;
+    let u = user_with_policy(deny_policy("dynamodb:PutItem", &secret_arn)).await;
+    let err = u
+        .transact_write_items()
+        .transact_items(
+            TransactWriteItem::builder()
+                .put(Put::builder().table_name(&secret).set_item(Some(key("z4"))).build().unwrap())
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap_err();
+    assert!(is_denied(err_code(&err)), "got {err:?}");
+}

--- a/tests/rust/src/batch_transact_authz.rs
+++ b/tests/rust/src/batch_transact_authz.rs
@@ -20,8 +20,8 @@ use aws_credential_types::provider::SharedCredentialsProvider;
 use aws_credential_types::Credentials;
 use aws_sdk_dynamodb::config::Region;
 use aws_sdk_dynamodb::types::{
-    AttributeDefinition, BillingMode, KeySchemaElement, KeyType, KeysAndAttributes, Put,
-    PutRequest, ScalarAttributeType, TransactGetItem, TransactWriteItem, WriteRequest,
+    AttributeDefinition, BillingMode, ConditionCheck, KeySchemaElement, KeyType, KeysAndAttributes,
+    Put, PutRequest, ScalarAttributeType, TransactGetItem, TransactWriteItem, WriteRequest,
 };
 use aws_sdk_dynamodb::Client;
 use aws_smithy_http_client::tls;
@@ -395,4 +395,69 @@ async fn putitem_deny_blocks_transact_write_put() {
         .await
         .unwrap_err();
     assert!(is_denied(err_code(&err)), "got {err:?}");
+}
+
+// --- D: ConditionCheck authorizes as the exact IAM action -----------------
+// These pin the ConditionCheck sub-op to `dynamodb:ConditionCheckItem` (per the
+// AWS IAM Service Authorization Reference / "Using IAM with DynamoDB
+// transactions": "For the ConditionCheck action, you can use the
+// dynamodb:ConditionCheckItem permission"). The all-or-nothing tests above use
+// `dynamodb:*`, which matches any action string, so they cannot pin the exact
+// name; these two do.
+
+#[tokio::test]
+async fn conditioncheckitem_deny_blocks_transact_write_condition_check() {
+    if skip_no_admin() {
+        return;
+    }
+    let (_allowed, secret, secret_arn) = tables().await;
+    // ConditionCheck decomposes to dynamodb:ConditionCheckItem, so a deny on
+    // that exact action must block the transaction.
+    let u = user_with_policy(deny_policy("dynamodb:ConditionCheckItem", &secret_arn)).await;
+    let err = u
+        .transact_write_items()
+        .transact_items(
+            TransactWriteItem::builder()
+                .condition_check(
+                    ConditionCheck::builder()
+                        .table_name(&secret)
+                        .set_key(Some(key("s1")))
+                        .condition_expression("attribute_exists(pk)")
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap_err();
+    assert!(is_denied(err_code(&err)), "got {err:?}");
+}
+
+#[tokio::test]
+async fn conditioncheck_action_string_does_not_block_transact_write() {
+    if skip_no_admin() {
+        return;
+    }
+    let (_allowed, secret, secret_arn) = tables().await;
+    // `dynamodb:ConditionCheck` is NOT a real IAM action (the sub-op authorizes
+    // as `dynamodb:ConditionCheckItem`). A deny on the wrong string must NOT
+    // block the operation, proving we authorize under the correct action.
+    let u = user_with_policy(deny_policy("dynamodb:ConditionCheck", &secret_arn)).await;
+    u.transact_write_items()
+        .transact_items(
+            TransactWriteItem::builder()
+                .condition_check(
+                    ConditionCheck::builder()
+                        .table_name(&secret)
+                        .set_key(Some(key("s1")))
+                        .condition_expression("attribute_exists(pk)")
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("a deny on the non-existent dynamodb:ConditionCheck action must not block ConditionCheck");
 }

--- a/tests/rust/src/main.rs
+++ b/tests/rust/src/main.rs
@@ -20,6 +20,8 @@ mod batch_get_item;
 #[cfg(test)]
 mod batch_write_item;
 #[cfg(test)]
+mod batch_transact_authz;
+#[cfg(test)]
 mod binary_sort_key;
 #[cfg(test)]
 mod capacity_throttling;


### PR DESCRIPTION
## What

Authorize batch and transaction operations against each table they touch, instead of a single wildcard resource.

- `BatchGetItem`, `BatchWriteItem`, `TransactGetItems` and `TransactWriteItems` previously authorized once against the `table/*` wildcard, because table names were only extracted from a top-level `TableName`. These operations carry their
  tables in `RequestItems` / `TransactItems`, so a policy scoped to a specific table was not evaluated for them.
- `authorize_request` now extracts every `(action, table)` pair for these four operations, authorizes each against its real per-table ARN, and denies the whole request if any single table is denied (all-or-nothing).
- Actions follow the AWS IAM Service Authorization Reference: `BatchGetItem`/`BatchWriteItem` use their own action per table; `TransactGetItems` maps to `GetItem` per table; `TransactWriteItems` decomposes to `PutItem`/`DeleteItem`/`UpdateItem`/`ConditionCheckItem` per sub-item. Non-batch operations are unchanged.

## Why

The ARN-addressed batch and transaction operations were the only data-plane paths not authorized per table, inconsistent with the single-item operations and with DynamoDB's IAM model. A policy statement scoped to one table had no effect on these operations. This brings them in line.

Closes #

## Testing done

- Rust integration tests (new, `tests/rust/src/batch_transact_authz.rs`): provision a user with an explicit `Deny` on one table via the management API and assert each of the four operations is denied all-or-nothing when it touches that table, with positive controls (a request touching only allowed tables succeeds). Guard tests confirm the action decomposition: a `GetItem` deny does not block `BatchGetItem` but does block `TransactGetItems`; a `PutItem` deny does not block
  `BatchWriteItem` but does block `TransactWriteItems`. 8/8 pass against a live ExtendDB server.
- Full Rust integration suite: 399 passed, 0 failed (no regression on the shared authz path).
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets` 0 warnings.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean -- CI gate `cargo clippy --workspace --all-targets` passes with 0 warnings 
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed -- n/a (authorization correctness fix; no user-facing docs or config surface affected)
- [ ] Breaking changes are noted below (if any) -- none
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface, an RFC has been accepted or is linked below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a -- no trait, wire, on-disk, or CLI change. This is a correctness
fix that enforces the existing authorization model on the batch/transact paths
(no new auth model); an ADR can be added if a reviewer wants the decision recorded.

## Breaking changes

None. No public interface changes; behavior change is limited to correctly
denying batch/transaction requests that touch a table the caller is denied.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.