### PR TITLE
fix: accept string-valued env overrides for typed backend config fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,7 @@ dependencies = [
  "futures",
  "inventory",
  "rand 0.9.4",
+ "serde",
  "serde_json",
  "thiserror",
  "time",

--- a/crates/storage-postgres/src/config.rs
+++ b/crates/storage-postgres/src/config.rs
@@ -10,11 +10,20 @@ use serde::Deserialize;
 pub struct PostgresStorageConfig {
     #[serde(default = "default_connection_string")]
     pub connection_string: String,
-    #[serde(default = "default_pool_size")]
+    // string_coerce: environment-variable overrides
+    // (EXTENDDB__STORAGE__POSTGRES__POOL_SIZE=10) arrive as strings; accept
+    // both forms (issue #222).
+    #[serde(
+        default = "default_pool_size",
+        deserialize_with = "extenddb_storage::config::string_coerce::u32"
+    )]
     pub pool_size: u32,
     /// Maximum connections for the management/catalog pool (authz, IAM, console).
     /// Defaults to `pool_size` if not set.
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "extenddb_storage::config::string_coerce::opt_u32"
+    )]
     pub catalog_pool_size: Option<u32>,
 }
 
@@ -111,5 +120,36 @@ impl extenddb_storage::config::StorageConfig for PostgresStorageConfig {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+#[cfg(test)]
+mod env_override_tests {
+    use super::PostgresStorageConfig;
+
+    /// Issue #222: `EXTENDDB__STORAGE__POSTGRES__CATALOG_POOL_SIZE=10` reaches
+    /// this deserializer as the string "10". The typed fields must accept it.
+    #[test]
+    fn string_valued_numeric_fields_deserialize() {
+        let cfg: PostgresStorageConfig = toml::from_str(
+            r#"connection_string = "postgresql://u:p@localhost:5432/db"
+pool_size = "25"
+catalog_pool_size = "10""#,
+        )
+        .expect("string-valued numeric fields must deserialize");
+        assert_eq!(cfg.pool_size, 25);
+        assert_eq!(cfg.catalog_pool_size, Some(10));
+    }
+
+    #[test]
+    fn native_numeric_fields_still_deserialize() {
+        let cfg: PostgresStorageConfig = toml::from_str(
+            r#"connection_string = "postgresql://u:p@localhost:5432/db"
+pool_size = 25
+catalog_pool_size = 10"#,
+        )
+        .expect("native numeric fields must deserialize");
+        assert_eq!(cfg.pool_size, 25);
+        assert_eq!(cfg.catalog_pool_size, Some(10));
     }
 }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -18,6 +18,7 @@ extenddb-core = { workspace = true }
 futures = { workspace = true }
 inventory = { workspace = true }
 rand = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }

--- a/crates/storage/src/config.rs
+++ b/crates/storage/src/config.rs
@@ -37,6 +37,92 @@ impl Clone for Box<dyn StorageConfig> {
     }
 }
 
+/// Serde helpers for typed backend-config fields that may arrive as strings.
+///
+/// Environment-variable overrides (`EXTENDDB__STORAGE__<BACKEND>__...`) always
+/// enter the config as strings; the top-level `AppConfig` fields are coerced by
+/// the `config` crate, but a backend's storage subtree is re-deserialized from
+/// a raw `toml::Table`, which is strict about types (issue #222). These helpers
+/// accept either the native type or its string form, so
+/// `EXTENDDB__STORAGE__POSTGRES__POOL_SIZE=10` deserializes like
+/// `pool_size = 10`. String fields are untouched — coercion applies only where
+/// a backend explicitly opts a numeric or boolean field in with
+/// `#[serde(deserialize_with = ...)]`, so a password of `"12345"` is never
+/// reinterpreted.
+pub mod string_coerce {
+    use serde::{Deserialize, Deserializer, de::Error};
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum MaybeString<T> {
+        Native(T),
+        Text(String),
+    }
+
+    fn coerce<'de, T, D>(deserializer: D, what: &str) -> Result<T, D::Error>
+    where
+        T: Deserialize<'de> + std::str::FromStr,
+        <T as std::str::FromStr>::Err: std::fmt::Display,
+        D: Deserializer<'de>,
+    {
+        match MaybeString::<T>::deserialize(deserializer)? {
+            MaybeString::Native(v) => Ok(v),
+            MaybeString::Text(s) => s
+                .trim()
+                .parse()
+                .map_err(|e| D::Error::custom(format!("invalid {what} value \"{s}\": {e}"))),
+        }
+    }
+
+    /// Deserialize a `u32` from either a number or its string form.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the value is neither a `u32` nor a string that
+    /// parses as one.
+    pub fn u32<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u32, D::Error> {
+        coerce(deserializer, "u32")
+    }
+
+    /// Deserialize an `Option<u32>` from a number, its string form, or absent.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a present value is neither a `u32` nor a string
+    /// that parses as one.
+    pub fn opt_u32<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<u32>, D::Error> {
+        Option::<MaybeString<u32>>::deserialize(deserializer)?
+            .map(|v| match v {
+                MaybeString::Native(n) => Ok(n),
+                MaybeString::Text(s) => s.trim().parse().map_err(|e| {
+                    serde::de::Error::custom(format!("invalid u32 value \"{s}\": {e}"))
+                }),
+            })
+            .transpose()
+    }
+
+    /// Deserialize a `bool` from either a boolean or its string form
+    /// (`"true"`/`"false"`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the value is neither a `bool` nor a string that
+    /// parses as one.
+    pub fn bool<'de, D: Deserializer<'de>>(deserializer: D) -> Result<bool, D::Error> {
+        coerce(deserializer, "bool")
+    }
+
+    /// Deserialize a `u16` from either a number or its string form.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the value is neither a `u16` nor a string that
+    /// parses as one.
+    pub fn u16<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u16, D::Error> {
+        coerce(deserializer, "u16")
+    }
+}
+
 /// Deserializer function type for storage configurations.
 ///
 /// Takes a TOML table and returns a boxed `StorageConfig` trait object.
@@ -64,4 +150,108 @@ pub fn deserialize_storage_config(
         }
     }
     Err(format!("Unknown backend: {backend}"))
+}
+
+#[cfg(test)]
+mod string_coerce_tests {
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize)]
+    struct Sample {
+        #[serde(deserialize_with = "super::string_coerce::u32")]
+        count: u32,
+        #[serde(default, deserialize_with = "super::string_coerce::opt_u32")]
+        optional: Option<u32>,
+        #[serde(deserialize_with = "super::string_coerce::bool")]
+        flag: bool,
+        #[serde(deserialize_with = "super::string_coerce::u16")]
+        port: u16,
+        // Deliberately NOT coerced: a numeric-looking string field must stay a string.
+        password: String,
+    }
+
+    #[test]
+    fn native_types_deserialize_unchanged() {
+        let s: Sample = toml::from_str(
+            r#"count = 7
+optional = 9
+flag = true
+port = 8443
+password = "12345""#,
+        )
+        .expect("native types must deserialize");
+        assert_eq!(s.count, 7);
+        assert_eq!(s.optional, Some(9));
+        assert!(s.flag);
+        assert_eq!(s.port, 8443);
+        assert_eq!(s.password, "12345");
+    }
+
+    /// Issue #222: env-var overrides arrive as strings.
+    #[test]
+    fn string_forms_coerce_to_the_native_type() {
+        let s: Sample = toml::from_str(
+            r#"count = "7"
+optional = "9"
+flag = "true"
+port = " 8443 "
+password = "12345""#,
+        )
+        .expect("string forms must coerce");
+        assert_eq!(s.count, 7);
+        assert_eq!(s.optional, Some(9));
+        assert!(s.flag);
+        assert_eq!(s.port, 8443);
+        // The plain String field is never reinterpreted.
+        assert_eq!(s.password, "12345");
+    }
+
+    #[test]
+    fn absent_optional_stays_none() {
+        let s: Sample = toml::from_str(
+            r#"count = 1
+flag = false
+port = 1
+password = "x""#,
+        )
+        .expect("absent optional must deserialize");
+        assert_eq!(s.optional, None);
+    }
+
+    #[test]
+    fn garbage_strings_are_rejected_with_the_value_in_the_error() {
+        let err = toml::from_str::<Sample>(
+            r#"count = "seven"
+flag = false
+port = 1
+password = "x""#,
+        )
+        .expect_err("non-numeric string must be rejected");
+        assert!(
+            err.to_string().contains("seven"),
+            "error should quote the bad value, got: {err}"
+        );
+    }
+
+    #[test]
+    fn negative_and_overflow_values_are_rejected() {
+        assert!(
+            toml::from_str::<Sample>(
+                r#"count = "-1"
+flag = false
+port = 1
+password = "x""#
+            )
+            .is_err()
+        );
+        assert!(
+            toml::from_str::<Sample>(
+                r#"count = 1
+flag = false
+port = "70000"
+password = "x""#
+            )
+            .is_err()
+        );
+    }
 }


### PR DESCRIPTION
## What

Adds `string_coerce` serde helpers (`u32`, `opt_u32`, `u16`, `bool`) to `extenddb-storage` and opts the postgres `pool_size` / `catalog_pool_size` fields in, so environment-variable overrides targeting typed backend config fields deserialize.

## Why

Fixes #222. Environment-variable overrides (`EXTENDDB__STORAGE__POSTGRES__...`) always enter the config as strings. Top-level `AppConfig` fields survive because the `config` crate coerces strings into primitive targets, but a backend's storage subtree is re-deserialized from a raw `toml::Table`, which is strict — so `EXTENDDB__STORAGE__POSTGRES__CATALOG_POOL_SIZE=10` failed with `invalid type: string "10", expected u32` while `EXTENDDB__SERVER__PORT=9000` worked.

Coercion is field-level opt-in rather than a blanket `try_parsing` on the env source, so a string field whose value looks numeric (a password of `"12345"`) is never reinterpreted. The helpers live in the shared storage crate so other backends get the same behaviour without repeating the bug.

A garbage override now fails with the offending value quoted: `invalid u32 value "lots": invalid digit found in string`.

## Testing done

- Live repro of the issue: `EXTENDDB__STORAGE__POSTGRES__CATALOG_POOL_SIZE=10` previously failed config loading and now works; a native TOML value still loads; a garbage value produces the quoted error above.
- New unit tests in the storage crate: native types unchanged, string forms coerce (including whitespace trim), plain `String` fields never reinterpreted, absent `Option` stays `None`, garbage/negative/overflow rejected with the value named.
- New unit tests in the postgres crate covering `PostgresStorageConfig` both ways.
- 613 workspace unit tests pass, fmt and clippy clean.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean
- [x] I have added or updated tests for new functionality
- [x] Documentation: no behaviour contradicts the docs after this change

## Breaking changes

None.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.