### PR TITLE
fix(server): authorize batch and transaction operations under dev-mode

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -126,6 +126,58 @@ jobs:
           EXTENDDB_ADMIN_PASSWORD: ${{ steps.init.outputs.admin_password }}
         run: devtools/run-tests --extenddb --pytest --comprehensive --parallel --filter "not import_export"
 
+  run-integration-dev-mode:
+    # dev-mode was shipped with no CI coverage at all, which is how the batch and
+    # transaction authorization regression reached main: the build compiled, so
+    # a feature-matrix check passed, while nothing ever issued a request against
+    # a dev-mode server. This job starts one and exercises the data plane.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Build release (dev mode, in-memory SQLite)
+        run: cargo build --release -p extenddb --no-default-features --features sqlite-memory,dev-mode
+
+      - name: Start ExtendDB in dev mode
+        run: |
+          # No config file on purpose: dev mode falls back to built-in defaults,
+          # which is the zero-config path a user gets, and the one the profile
+          # documents as a DynamoDB Local replacement.
+          ./target/release/extenddb serve --foreground --port 18444 --config /nonexistent.toml &
+          for i in $(seq 1 30); do
+            if curl -s http://127.0.0.1:18444/health | grep -q healthy; then
+              echo "Server ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server failed to start"
+          exit 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run dev-mode authorization tests
+        env:
+          EXTENDDB_TEST_ENDPOINT: http://127.0.0.1:18444
+          EXTENDDB_TEST_DEV_MODE: "1"
+          AWS_DEFAULT_REGION: us-east-1
+          # The seeded zero-config dev credential. AWS's documented example key,
+          # which grants nothing anywhere; it exists so SigV4 has a key to verify.
+          AWS_ACCESS_KEY_ID: AKIAIOSFODNN7EXAMPLE
+          AWS_SECRET_ACCESS_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+        run: python3 -m pytest tests/test_dev_mode_authorization.py -v
+
   run-rust-integration:
     runs-on: ubuntu-latest
     services:
@@ -213,12 +265,19 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
-    needs: [run-integration, run-integration-sqlite, run-rust-integration]
+    needs:
+      [
+        run-integration,
+        run-integration-sqlite,
+        run-integration-dev-mode,
+        run-rust-integration,
+      ]
     if: always()
     steps:
       - run: |
           if [ "${{ needs.run-integration.result }}" != "success" ] || \
              [ "${{ needs.run-integration-sqlite.result }}" != "success" ] || \
+             [ "${{ needs.run-integration-dev-mode.result }}" != "success" ] || \
              [ "${{ needs.run-rust-integration.result }}" != "success" ]; then
             exit 1
           fi

--- a/crates/server/src/request_helpers.rs
+++ b/crates/server/src/request_helpers.rs
@@ -62,34 +62,7 @@ pub(crate) async fn authorize_request(
     operation: &str,
     account_id: &str,
 ) -> Result<Option<extenddb_core::types::TableKeyInfo>, DynamoDbError> {
-    // Batch and transaction operations address multiple tables in nested request
-    // structures with no top-level TableName. DynamoDB authorizes each of them
-    // per table, against that table's specific ARN, using the IAM action the
-    // operation maps to (BatchGetItem/BatchWriteItem are their own actions;
-    // TransactGetItems decomposes to GetItem; TransactWriteItems decomposes to
-    // the per-sub-op action). Authorizing the whole request against a single
-    // `table/*` wildcard — as the generic path below does — lets an explicit
-    // Deny on one table be bypassed. Evaluate every (action, table) pair and
-    // reject the entire request if any is denied (all-or-nothing), matching
-    // DynamoDB. Verified against the AWS IAM Service Authorization Reference.
-    if let Some(targets) = batch_transact_authz_targets(operation, input) {
-        for (action_op, table) in targets {
-            let resource_arn = build_resource_arn(&state.region, account_id, Some(&table));
-            authorization::check_authorization(
-                state.authz_cache.as_ref(),
-                identity,
-                &action_op,
-                &resource_arn,
-                false,
-                extenddb_auth::policy::context::RequestParams::default(),
-            )
-            .await?;
-        }
-        return Ok(None);
-    }
-
     let table_name = extract_table_name(input);
-    let resource_arn = build_resource_arn(&state.region, account_id, table_name.as_deref());
 
     // P118: Fetch table_key_info for item-level operations via the SWR cache.
     // The result is used for LeadingKeys extraction here AND returned to the
@@ -112,9 +85,44 @@ pub(crate) async fn authorize_request(
     // verification already ran upstream, so the request is authenticated; only
     // the IAM policy decision is skipped. key_info is still returned so the
     // engine layer can reuse it.
+    //
+    // This check is deliberately positioned ahead of EVERY authorization branch
+    // below, not merely the generic one. It previously sat after the batch and
+    // transaction branch, which returns early, so those four operations were
+    // still evaluated against IAM and denied in a dev-mode build while single
+    // item operations passed. Any future operation-specific branch must be added
+    // below this point, or it will reintroduce that defect.
     if state.dev_mode {
         return Ok(key_info);
     }
+
+    // Batch and transaction operations address multiple tables in nested request
+    // structures with no top-level TableName. DynamoDB authorizes each of them
+    // per table, against that table's specific ARN, using the IAM action the
+    // operation maps to (BatchGetItem/BatchWriteItem are their own actions;
+    // TransactGetItems decomposes to GetItem; TransactWriteItems decomposes to
+    // the per-sub-op action). Authorizing the whole request against a single
+    // `table/*` wildcard, as the generic path below does, lets an explicit
+    // Deny on one table be bypassed. Evaluate every (action, table) pair and
+    // reject the entire request if any is denied (all-or-nothing), matching
+    // DynamoDB. Verified against the AWS IAM Service Authorization Reference.
+    if let Some(targets) = batch_transact_authz_targets(operation, input) {
+        for (action_op, table) in targets {
+            let resource_arn = build_resource_arn(&state.region, account_id, Some(&table));
+            authorization::check_authorization(
+                state.authz_cache.as_ref(),
+                identity,
+                &action_op,
+                &resource_arn,
+                false,
+                extenddb_auth::policy::context::RequestParams::default(),
+            )
+            .await?;
+        }
+        return Ok(None);
+    }
+
+    let resource_arn = build_resource_arn(&state.region, account_id, table_name.as_deref());
 
     let pk_attr = key_info
         .as_ref()

--- a/tests/test_dev_mode_authorization.py
+++ b/tests/test_dev_mode_authorization.py
@@ -1,0 +1,161 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Developer-mode authorization tests.
+
+`dev-mode` opens the IAM policy decision for an authenticated caller: SigV4 is
+still verified, but no `dynamodb:*` policy is required. The seeded `dev` user
+holds only `SelfServicePolicy` (four `iam:*` actions on its own ARN), so any
+operation that still reaches the IAM evaluator is denied. That makes an
+`AccessDeniedException` here proof that an operation is bypassing the dev-mode
+gate, not a policy misconfiguration.
+
+Batch and transaction operations regressed exactly this way: their per-table
+authorization branch returned before the dev-mode check was reached, so
+`BatchGetItem`, `BatchWriteItem`, `TransactGetItems` and `TransactWriteItems`
+failed while every single-item operation succeeded.
+
+These require a server built and started in dev mode, so they are gated on
+EXTENDDB_TEST_DEV_MODE and excluded from the backend-agnostic suite, which runs
+against a production-mode server where these operations are correctly denied.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from botocore.exceptions import ClientError
+
+from conftest import wait_for_active
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("EXTENDDB_TEST_DEV_MODE", "").strip() != "1",
+    reason="requires a dev-mode server (set EXTENDDB_TEST_DEV_MODE=1)",
+)
+
+
+def _assert_not_denied(op_name: str, call):
+    """Run `call`, failing loudly if the operation was denied rather than served.
+
+    Any other ClientError is re-raised: this test is about the authorization
+    decision, so a genuine request error should not be swallowed into a pass.
+    """
+    try:
+        return call()
+    except ClientError as exc:
+        code = exc.response["Error"]["Code"]
+        if code in ("AccessDeniedException", "UnrecognizedClientException"):
+            pytest.fail(
+                f"{op_name} was denied in dev mode with {code}: "
+                f"{exc.response['Error'].get('Message', '')}"
+            )
+        raise
+
+
+@pytest.fixture()
+def dev_table(dynamodb_client, unique_table_name):
+    dynamodb_client.create_table(
+        TableName=unique_table_name,
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    wait_for_active(dynamodb_client, unique_table_name)
+    yield unique_table_name
+    try:
+        dynamodb_client.delete_table(TableName=unique_table_name)
+    except ClientError:
+        pass
+
+
+class TestDevModeOpensAuthorization:
+    """Every data-plane operation is served in dev mode, not just single-item ones."""
+
+    def test_single_item_operations_are_not_denied(self, dynamodb_client, dev_table):
+        # These already worked. They are kept so a regression that closes
+        # authorization altogether is distinguishable from one that affects only
+        # the batch and transaction branch.
+        _assert_not_denied(
+            "PutItem",
+            lambda: dynamodb_client.put_item(
+                TableName=dev_table, Item={"pk": {"S": "a"}, "v": {"N": "1"}}
+            ),
+        )
+        _assert_not_denied(
+            "GetItem",
+            lambda: dynamodb_client.get_item(TableName=dev_table, Key={"pk": {"S": "a"}}),
+        )
+        _assert_not_denied(
+            "UpdateItem",
+            lambda: dynamodb_client.update_item(
+                TableName=dev_table,
+                Key={"pk": {"S": "a"}},
+                UpdateExpression="SET #v = :v",
+                ExpressionAttributeNames={"#v": "v"},
+                ExpressionAttributeValues={":v": {"N": "2"}},
+            ),
+        )
+        _assert_not_denied(
+            "Query",
+            lambda: dynamodb_client.query(
+                TableName=dev_table,
+                KeyConditionExpression="pk = :p",
+                ExpressionAttributeValues={":p": {"S": "a"}},
+            ),
+        )
+        _assert_not_denied("Scan", lambda: dynamodb_client.scan(TableName=dev_table))
+        _assert_not_denied(
+            "DeleteItem",
+            lambda: dynamodb_client.delete_item(
+                TableName=dev_table, Key={"pk": {"S": "a"}}
+            ),
+        )
+
+    def test_batch_write_item_is_not_denied(self, dynamodb_client, dev_table):
+        resp = _assert_not_denied(
+            "BatchWriteItem",
+            lambda: dynamodb_client.batch_write_item(
+                RequestItems={
+                    dev_table: [
+                        {"PutRequest": {"Item": {"pk": {"S": "b1"}}}},
+                        {"PutRequest": {"Item": {"pk": {"S": "b2"}}}},
+                    ]
+                }
+            ),
+        )
+        assert not resp.get("UnprocessedItems", {}).get(dev_table)
+
+    def test_batch_get_item_is_not_denied(self, dynamodb_client, dev_table):
+        dynamodb_client.put_item(TableName=dev_table, Item={"pk": {"S": "g1"}})
+        resp = _assert_not_denied(
+            "BatchGetItem",
+            lambda: dynamodb_client.batch_get_item(
+                RequestItems={dev_table: {"Keys": [{"pk": {"S": "g1"}}]}}
+            ),
+        )
+        assert len(resp["Responses"][dev_table]) == 1
+
+    def test_transact_write_items_is_not_denied(self, dynamodb_client, dev_table):
+        _assert_not_denied(
+            "TransactWriteItems",
+            lambda: dynamodb_client.transact_write_items(
+                TransactItems=[
+                    {"Put": {"TableName": dev_table, "Item": {"pk": {"S": "t1"}}}}
+                ]
+            ),
+        )
+        got = dynamodb_client.get_item(TableName=dev_table, Key={"pk": {"S": "t1"}})
+        assert "Item" in got
+
+    def test_transact_get_items_is_not_denied(self, dynamodb_client, dev_table):
+        dynamodb_client.put_item(TableName=dev_table, Item={"pk": {"S": "tg1"}})
+        resp = _assert_not_denied(
+            "TransactGetItems",
+            lambda: dynamodb_client.transact_get_items(
+                TransactItems=[
+                    {"Get": {"TableName": dev_table, "Key": {"pk": {"S": "tg1"}}}}
+                ]
+            ),
+        )
+        assert resp["Responses"][0]["Item"]["pk"]["S"] == "tg1"


### PR DESCRIPTION
## What

**`crates/server/src/request_helpers.rs`** - the dev-mode gate in `authorize_request` now precedes every authorization branch instead of only the generic one. Batch and transaction operations address multiple tables in nested request structures, so they are authorized per table in a branch that returns early, and that branch sat above the gate. `BatchGetItem`, `BatchWriteItem`, `TransactGetItems` and `TransactWriteItems` were therefore still evaluated against IAM and denied.

The obvious fix is a second `if state.dev_mode` inside that branch. I did not do that. The defect is one of ordering, so a fix that leaves the ordering hazard in place invites the next operation-specific branch to reintroduce it. `key_info` is still computed before the gate so the engine layer keeps its cache reuse, and both `check_authorization` call sites now sit below it. There are only two such call sites in the tree, both in this function, so the gate is now structurally unbypassable rather than merely correct today. The comment at the gate says so, for whoever adds the next branch.

**`tests/test_dev_mode_authorization.py`** - new. Asserts that all four previously denied operations are served, with the single-item operations kept alongside them so a regression that closes authorization altogether is distinguishable from one that affects only the batch and transaction branch. The seeded `dev` user holds only `SelfServicePolicy`, four `iam:*` actions on its own ARN and no `dynamodb:*`, which is what makes an `AccessDeniedException` here proof that an operation bypassed the gate rather than evidence of a policy misconfiguration.

**`.github/workflows/integration.yml`** - new `run-integration-dev-mode` job, and the `integration` aggregator now gates on it.

## Why

`dev-mode` is documented as opening authorization. `crates/storage-sqlite/README.md` calls the profile "a drop-in replacement for DynamoDB Local: plain HTTP on loopback, open authorization, and a seeded credential", and the startup banner says "authorization open (SigV4 still enforced)". That held for single-item operations and not for the four above, so anyone evaluating the profile as a DynamoDB Local replacement hit `AccessDeniedException` on the first batch write.

The reason this shipped is worth stating plainly, because it is the part that generalises. The only thing that sets `dev_mode = true` is `cfg!(feature = "dev-mode")` in `cmd_serve.rs`. Across every workflow, CI runs exactly four cargo invocations: `cargo build --release`, `cargo build --release -p extenddb --no-default-features --features sqlite`, `cargo test --workspace`, and `cargo clippy --all-targets`. None of them enable `dev-mode`, so every server CI has ever started ran with `dev_mode = false` and the broken branch was unreachable. Independently, `git grep` finds nothing in the
tree that sets `dev_mode: true`, so no unit test covered the gate either. The feature combination did get compiled during review, which is exactly the trap: a compile check cannot catch an ordering bug.

That is why this PR adds the CI job rather than only the code fix. Without it the next regression is invisible in the same way.

Closes #237

## Testing done

**The fix, with a negative control.** Built the same dev-mode binary from unmodified `main` and from this branch
(`--no-default-features --features sqlite-memory,dev-mode`), started each with no config file so it uses the built-in defaults, and ran the new tests against both:

| | result |
|---|---|
| unmodified `main` | 4 failed, 1 passed |
| with this change | 5 passed |

The failures on `main` carry the exact error from the report, for example `AccessDeniedException: User: arn:aws:iam::...:user/dev is not authorized to perform: dynamodb:BatchWriteItem`. The one test that passes on both is the
single-item one, which is the control.

**Production authorization is unchanged.** With `dev_mode` false the batch branch runs exactly as before, but since this moves code in the authorization path I verified the direction that matters rather than asserting it. Stood up a production-mode server on the postgres backend, minted a SigV4 key pair the way CI does, and ran the batch and transaction authorization suite, which asserts these operations are denied per table when the caller's policy does not allow
them: `cd tests/rust && cargo test batch_transact_authz -- --test-threads=1` gives 10 passed, 0 failed.

**Gates.**

- `cargo test --workspace`: 668 passed, 0 failed, 0 filtered out.
- `cargo fmt --all -- --check`: clean, zero diffs.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo clippy --workspace --all-targets -- -W clippy::pedantic`: 421 warnings,
  identical to the count on `main`. The two in `request_helpers.rs` are
  `large future with a size of 20176 bytes`, present on `main` at the same size,
  so this change adds none.

**The new CI job has never run.** It builds the dev-mode target, starts a zero-config dev-mode server and runs the new tests. It is gated on `EXTENDDB_TEST_DEV_MODE` so the file skips against the production-mode servers
the other jobs start, where these operations are correctly denied. If anything in the job definition is wrong it will surface on this PR, which is the right place for it.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`) - 668 passed, 0 filtered out
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`) - no new warnings
      versus `main`, 421 on both sides
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed - no doc change needed:
      the documented behaviour was already "authorization open", and this makes
      the implementation match it. The comment at the gate now records the
      ordering constraint
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a, and since this sits in the authorization path that deserves a
sentence rather than a bare "n/a". The auth model itself is unchanged and already
documented: in a `dev-mode` build SigV4 is verified and the IAM policy decision is
skipped for the authenticated caller. Production authorization is untouched, as
the 10-test suite above confirms. What changes is that the implementation now
matches the documented model for four operations where it did not.

## Breaking changes

None for any production build. `dev_mode` is only ever true in a `dev-mode` build, and `crates/bin/src/main.rs` fails compilation if `dev-mode` is paired with a production backend such as `postgres`, so the flag cannot be reached in a
production binary. I verified that guard still holds: `cargo check -p extenddb --no-default-features --features postgres,dev-mode` fails with "the `dev-mode` feature requires a dev/CI backend such as `sqlite`".

Worth stating explicitly for reviewers of an auth change: this widens what a `dev-mode` build permits. Four operations that were denied are now served. That is the documented intent of the profile, and the surface is bounded by three independent constraints, all pre-existing: `dev-mode` is a compile-time feature gated to the sqlite backends, the serve path binds loopback only, and SigV4 verification still runs, so an unauthenticated request is still rejected.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
