### PR TITLE
chore(release): Bump version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "extenddb-app",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-app"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-auth"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-cache"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "futures",
  "moka",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-config"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "config",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-engine"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base64 0.22.1",
  "crc32fast",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-server"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-postgres"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-sqlite"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"


### PR DESCRIPTION
### What
  
Bump the ExtendDB workspace version from `0.1.2` to `0.1.3`.
  
This updates:
  - `[workspace.package].version` in the root `Cargo.toml`.
  - The 11 ExtendDB workspace package records in the root `Cargo.lock`.
  
No external dependency versions were changed. Unrelated dependencies that also use version `0.1.2`, such as `toml_write`, remain unchanged.
  
  ### Why
  
The existing `v0.1.2` tag predates the upcoming container release and must not be reused or moved.
  
`0.1.3` is the next available patch version and will provide a unique version for the release candidate and subsequent stable artifacts.
  
This PR only establishes the project version. It does not create a Git tag, GitHub Release, or publish any artifacts.
  
  ### Testing done
  
  cargo fmt --all -- --check
  
  cargo clippy --all-targets -- -D warnings
  
  cargo test --workspace
  
  cargo build --locked --release \
    -p extenddb \
    --no-default-features \
    --features postgres
  
  Additional verification:
  
  - Cargo metadata reports all 11 workspace packages at version 0.1.3.
  - The locked PostgreSQL release binary builds successfully.
  - The lockfile diff contains only the 11 ExtendDB workspace package version changes.
  - git diff --check passes.
  
  **Checklist**
  
  - [x] I have read CONTRIBUTING.md (../CONTRIBUTING.md)
  - [x] All tests pass (cargo test --workspace)
  - [x] Code is formatted (cargo fmt --all -- --check)
  - [x] Clippy is clean (cargo clippy --all-targets -- -D warnings)
  - [x] No test changes are required for this metadata-only version bump
  - [x] No documentation changes are required
  - [x] Breaking changes are noted below
  - [x] This does not change the wire protocol, Storage trait, auth model, or on-disk format
  
  ADR / RFC: n/a — this is a release metadata change only.
  
  **Breaking changes**
  
  None.
  
  ---
  By submitting this pull request, I confirm that my contribution is made under
  the terms of the Apache License 2.0 and I agree to the Developer Certificate of
  Origin (DCO). See CONTRIBUTING.md (../CONTRIBUTING.md) for details.