### PR TITLE
fix(storage): read GSI propagation delay live so runtime changes apply

### DIFF
--- a/crates/storage-postgres/src/data/delete_item.rs
+++ b/crates/storage-postgres/src/data/delete_item.rs
@@ -39,8 +39,7 @@ impl PostgresEngine {
         let sys_delay = if indexes.is_empty() {
             0
         } else {
-            self.gsi_default_delay_ms
-                .load(std::sync::atomic::Ordering::Relaxed)
+            self.gsi_default_delay().await
         };
 
         let needs_tx = condition.is_some() || return_old || !indexes.is_empty() || stream.is_some();

--- a/crates/storage-postgres/src/data/put_item.rs
+++ b/crates/storage-postgres/src/data/put_item.rs
@@ -59,8 +59,7 @@ impl PostgresEngine {
         let sys_delay = if indexes.is_empty() {
             0
         } else {
-            self.gsi_default_delay_ms
-                .load(std::sync::atomic::Ordering::Relaxed)
+            self.gsi_default_delay().await
         };
 
         // When there's a condition, return_old, indexes, or stream capture, we need a transaction

--- a/crates/storage-postgres/src/data/transactions.rs
+++ b/crates/storage-postgres/src/data/transactions.rs
@@ -83,10 +83,9 @@ impl PostgresEngine {
             }
         }
 
-        // D-4: Read system default delay from cache (P119).
-        let sys_delay = self
-            .gsi_default_delay_ms
-            .load(std::sync::atomic::Ordering::Relaxed);
+        // D-4: Read the system default delay live (P119), so a runtime change
+        // applies to this transaction rather than up to 30 s later.
+        let sys_delay = self.gsi_default_delay().await;
 
         let mut tx = self
             .data_pool

--- a/crates/storage-postgres/src/data/update_item.rs
+++ b/crates/storage-postgres/src/data/update_item.rs
@@ -50,8 +50,7 @@ impl PostgresEngine {
         let sys_delay = if indexes.is_empty() {
             0
         } else {
-            self.gsi_default_delay_ms
-                .load(std::sync::atomic::Ordering::Relaxed)
+            self.gsi_default_delay().await
         };
 
         // Fetch existing item

--- a/crates/storage-postgres/src/gsi_queue.rs
+++ b/crates/storage-postgres/src/gsi_queue.rs
@@ -273,13 +273,22 @@ async fn worker(worker_id: u64, q: Arc<GsiQueue>) {
 /// backstop interval). A row already due maps to a near-zero wait so the loop
 /// re-claims promptly.
 async fn next_ready_wait(pool: &PgPool, worker_id: u64) -> Option<std::time::Duration> {
+    // The ::float8 cast is load-bearing. Since PostgreSQL 14, EXTRACT returns
+    // `numeric`, which sqlx refuses to decode into f64. Without the cast this
+    // query fails on every partition that has a pending row, and the error was
+    // swallowed into `None` below, indistinguishable from "no rows". The worker
+    // then slept its full idle backstop instead of until `ready_at`, so every
+    // asynchronous GSI propagation took ~1 s regardless of the configured
+    // delay. Errors are logged now so a decode or connection failure can never
+    // silently degrade propagation latency again.
     let secs: Option<f64> = sqlx::query_scalar(
-        "SELECT EXTRACT(EPOCH FROM (MIN(ready_at) - NOW())) FROM gsi_pending \
+        "SELECT EXTRACT(EPOCH FROM (MIN(ready_at) - NOW()))::float8 FROM gsi_pending \
          WHERE worker_partition = $1",
     )
     .bind(worker_id as i32)
     .fetch_one(pool)
     .await
+    .map_err(|e| tracing::error!("GSI worker {worker_id}: next_ready_wait failed: {e}"))
     .ok()
     .flatten();
     secs.map(|s| {

--- a/crates/storage-postgres/src/lib.rs
+++ b/crates/storage-postgres/src/lib.rs
@@ -134,6 +134,12 @@ pub struct PostgresConfig {
 /// settings, accounts, IAM) and `data_pool` for per-DynamoDB-table data
 /// (`_ddb_*` tables, GSI tables). This separation allows the catalog and
 /// data to live in different `PostgreSQL` databases (Bug 1, P54).
+/// Default GSI propagation delay (milliseconds) when the
+/// `gsi_propagation_delay_ms` setting is absent. Mirrors the value seeded by
+/// the catalog schema, and is the single definition used by both the live read
+/// on the write path and the background refresh worker.
+pub(crate) const DEFAULT_GSI_PROPAGATION_DELAY_MS: u64 = 10;
+
 pub struct PostgresEngine {
     pub(crate) pool: PgPool,
     /// Connection pool for the data database where `_ddb_*` tables live.
@@ -145,8 +151,10 @@ pub struct PostgresEngine {
     pub(crate) control_plane_notify: Arc<tokio::sync::Notify>,
     /// D-4: Async GSI update queue. `None` until `start_gsi_workers()` is called.
     pub(crate) gsi_queue: Option<Arc<gsi_queue::GsiQueue>>,
-    /// P119: Cached GSI default propagation delay (milliseconds). Updated by
-    /// background poller every 30s. Avoids per-request DB query on write path.
+    /// P119: Cached GSI default propagation delay (milliseconds). Refreshed by
+    /// the background poller every 30s and re-warmed by `gsi_default_delay`.
+    /// This is only a fallback for when the live read fails; the write path
+    /// reads the setting live so a runtime change applies to the next write.
     pub gsi_default_delay_ms: Arc<std::sync::atomic::AtomicU64>,
 }
 
@@ -208,7 +216,7 @@ impl PostgresEngine {
         .ok()
         .flatten()
         .and_then(|(v,)| v.parse::<u64>().ok())
-        .unwrap_or(10);
+        .unwrap_or(DEFAULT_GSI_PROPAGATION_DELAY_MS);
 
         Ok(Self {
             pool,
@@ -226,6 +234,39 @@ impl PostgresEngine {
     /// Must be called after construction, before serving requests.
     /// Returns `&Self` for chaining.
     #[must_use]
+    /// Current GSI propagation delay (ms); `0` means synchronous.
+    ///
+    /// Reads the `gsi_propagation_delay_ms` setting live from the catalog so an
+    /// out-of-process change (`extenddb settings set`) applies to the next write
+    /// rather than up to 30 s later when the poll worker refreshes the cache.
+    /// Callers skip this entirely for tables with no secondary indexes, so a
+    /// table that cannot propagate pays nothing.
+    ///
+    /// On a read error the cached value is used and the error is logged, so a
+    /// degraded catalog serves a stale delay loudly rather than silently. On
+    /// success the cache is re-warmed, keeping the fallback fresh.
+    pub(crate) async fn gsi_default_delay(&self) -> u64 {
+        use std::sync::atomic::Ordering;
+        let live = sqlx::query_as::<_, (String,)>(
+            "SELECT value FROM settings WHERE key = 'gsi_propagation_delay_ms'",
+        )
+        .fetch_optional(&self.pool)
+        .await;
+        match live {
+            Ok(row) => {
+                let ms = row
+                    .and_then(|(v,)| v.parse::<u64>().ok())
+                    .unwrap_or(DEFAULT_GSI_PROPAGATION_DELAY_MS);
+                self.gsi_default_delay_ms.store(ms, Ordering::Relaxed);
+                ms
+            }
+            Err(e) => {
+                tracing::debug!("gsi_default_delay: live read failed, using cache: {e:?}");
+                self.gsi_default_delay_ms.load(Ordering::Relaxed)
+            }
+        }
+    }
+
     pub fn start_gsi_workers(mut self) -> Self {
         self.gsi_queue = Some(gsi_queue::GsiQueue::spawn(self.data_pool.clone()));
         self

--- a/crates/storage-postgres/src/workers.rs
+++ b/crates/storage-postgres/src/workers.rs
@@ -183,7 +183,10 @@ pub(crate) async fn poll_gsi_delay<S: SettingsStore + ?Sized>(
             }
             Ok(None) => {
                 // Setting removed - revert to default
-                gsi_delay.store(10, std::sync::atomic::Ordering::Relaxed);
+                gsi_delay.store(
+                    crate::DEFAULT_GSI_PROPAGATION_DELAY_MS,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
             }
             Err(e) => {
                 tracing::debug!("Failed to query gsi_propagation_delay_ms: {e:?}");

--- a/crates/storage-sqlite/src/data/delete_item.rs
+++ b/crates/storage-sqlite/src/data/delete_item.rs
@@ -23,11 +23,15 @@ impl SqliteEngine {
         maps: &ExpressionMaps,
         stream: Option<&StreamCapture>,
     ) -> Result<Option<Item>, StorageError> {
+        // Read the propagation delay BEFORE taking the write lock. It is a
+        // runtime setting, not an invariant of this write, so it does not need
+        // to be read under the lock, and the lock serialises every write in the
+        // process: work done inside it is the backend's throughput bottleneck.
+        let system_delay = self.gsi_default_delay().await;
         let _writer = self.write_lock.lock().await;
         // Read the index set after acquiring the write lock so a concurrently
         // added GSI (UpdateTable holds the same lock) is not missed.
         let indexes = fetch_indexes_for_table(&key_info.table_id, &self.pool).await?;
-        let system_delay = self.gsi_default_delay().await;
 
         let mut tx = self
             .pool

--- a/crates/storage-sqlite/src/data/delete_item.rs
+++ b/crates/storage-sqlite/src/data/delete_item.rs
@@ -5,8 +5,8 @@
 
 use extenddb_core::expression::{Expr, ExpressionMaps};
 use extenddb_core::types::{Item, TableKeyInfo};
-use extenddb_storage::error::StorageError;
 use extenddb_storage::StreamCapture;
+use extenddb_storage::error::StorageError;
 
 use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
 use super::query::check_condition;

--- a/crates/storage-sqlite/src/data/delete_item.rs
+++ b/crates/storage-sqlite/src/data/delete_item.rs
@@ -5,8 +5,8 @@
 
 use extenddb_core::expression::{Expr, ExpressionMaps};
 use extenddb_core::types::{Item, TableKeyInfo};
-use extenddb_storage::StreamCapture;
 use extenddb_storage::error::StorageError;
+use extenddb_storage::StreamCapture;
 
 use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
 use super::query::check_condition;
@@ -27,7 +27,7 @@ impl SqliteEngine {
         // Read the index set after acquiring the write lock so a concurrently
         // added GSI (UpdateTable holds the same lock) is not missed.
         let indexes = fetch_indexes_for_table(&key_info.table_id, &self.pool).await?;
-        let system_delay = self.gsi_default_delay();
+        let system_delay = self.gsi_default_delay().await;
 
         let mut tx = self
             .pool

--- a/crates/storage-sqlite/src/data/put_item.rs
+++ b/crates/storage-sqlite/src/data/put_item.rs
@@ -10,9 +10,9 @@
 
 use extenddb_core::expression::{Expr, ExpressionMaps};
 use extenddb_core::types::{Item, TableKeyInfo};
-use extenddb_storage::StreamCapture;
 use extenddb_storage::error::StorageError;
 use extenddb_storage::util::{pk_to_text, sk_column, sk_info};
+use extenddb_storage::StreamCapture;
 
 use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
 use super::query::check_condition;
@@ -56,7 +56,7 @@ impl SqliteEngine {
             .map_err(|e| StorageError::Validation(e.to_string()))?;
         }
 
-        let system_delay = self.gsi_default_delay();
+        let system_delay = self.gsi_default_delay().await;
         let need_old = condition.is_some() || return_old || !indexes.is_empty() || stream.is_some();
 
         let mut tx = self

--- a/crates/storage-sqlite/src/data/put_item.rs
+++ b/crates/storage-sqlite/src/data/put_item.rs
@@ -10,9 +10,9 @@
 
 use extenddb_core::expression::{Expr, ExpressionMaps};
 use extenddb_core::types::{Item, TableKeyInfo};
+use extenddb_storage::StreamCapture;
 use extenddb_storage::error::StorageError;
 use extenddb_storage::util::{pk_to_text, sk_column, sk_info};
-use extenddb_storage::StreamCapture;
 
 use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
 use super::query::check_condition;

--- a/crates/storage-sqlite/src/data/put_item.rs
+++ b/crates/storage-sqlite/src/data/put_item.rs
@@ -33,6 +33,11 @@ impl SqliteEngine {
         // Read the index set only after acquiring the write lock, so a GSI added
         // by a concurrent UpdateTable (which holds the same lock) cannot be missed
         // and left unmaintained by this write.
+        // Read the propagation delay BEFORE taking the write lock. It is a
+        // runtime setting, not an invariant of this write, so it does not need
+        // to be read under the lock, and the lock serialises every write in the
+        // process: work done inside it is the backend's throughput bottleneck.
+        let system_delay = self.gsi_default_delay().await;
         let _writer = self.write_lock.lock().await;
         let indexes = fetch_indexes_for_table(&key_info.table_id, &self.pool).await?;
 
@@ -56,7 +61,6 @@ impl SqliteEngine {
             .map_err(|e| StorageError::Validation(e.to_string()))?;
         }
 
-        let system_delay = self.gsi_default_delay().await;
         let need_old = condition.is_some() || return_old || !indexes.is_empty() || stream.is_some();
 
         let mut tx = self

--- a/crates/storage-sqlite/src/data/transactions.rs
+++ b/crates/storage-sqlite/src/data/transactions.rs
@@ -15,7 +15,7 @@ use extenddb_core::validation;
 use extenddb_storage::error::StorageError;
 use extenddb_storage::{IdempotencyKey, TransactGetOp, TransactWriteOp};
 
-use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes, IndexMeta};
+use super::index::{IndexMeta, enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
 use super::tx_helpers::{
     check_idempotency_token_in_tx, delete_item_in_tx, fetch_item_for_update, fetch_item_in_tx,
     upsert_item_in_tx, write_stream_record_in_tx,

--- a/crates/storage-sqlite/src/data/transactions.rs
+++ b/crates/storage-sqlite/src/data/transactions.rs
@@ -15,7 +15,7 @@ use extenddb_core::validation;
 use extenddb_storage::error::StorageError;
 use extenddb_storage::{IdempotencyKey, TransactGetOp, TransactWriteOp};
 
-use super::index::{IndexMeta, enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
+use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes, IndexMeta};
 use super::tx_helpers::{
     check_idempotency_token_in_tx, delete_item_in_tx, fetch_item_for_update, fetch_item_in_tx,
     upsert_item_in_tx, write_stream_record_in_tx,
@@ -81,7 +81,7 @@ impl SqliteEngine {
             }
         }
 
-        let system_delay = self.gsi_default_delay();
+        let system_delay = self.gsi_default_delay().await;
         let mut tx = self
             .pool
             .begin_with("BEGIN IMMEDIATE")

--- a/crates/storage-sqlite/src/data/transactions.rs
+++ b/crates/storage-sqlite/src/data/transactions.rs
@@ -68,6 +68,11 @@ impl SqliteEngine {
         ops: &[TransactWriteOp<'_>],
         idempotency: Option<IdempotencyKey<'_>>,
     ) -> Result<(), StorageError> {
+        // Read the propagation delay BEFORE taking the write lock. It is a
+        // runtime setting, not an invariant of this write, so it does not need
+        // to be read under the lock, and the lock serialises every write in the
+        // process: work done inside it is the backend's throughput bottleneck.
+        let system_delay = self.gsi_default_delay().await;
         let _writer = self.write_lock.lock().await;
         // Fetch index metadata per distinct table AFTER acquiring the write lock,
         // so a GSI added by a concurrent UpdateTable (same lock) is not missed and
@@ -81,7 +86,6 @@ impl SqliteEngine {
             }
         }
 
-        let system_delay = self.gsi_default_delay().await;
         let mut tx = self
             .pool
             .begin_with("BEGIN IMMEDIATE")

--- a/crates/storage-sqlite/src/data/update_item.rs
+++ b/crates/storage-sqlite/src/data/update_item.rs
@@ -33,11 +33,15 @@ impl SqliteEngine {
         maps: &ExpressionMaps,
         stream: Option<&StreamCapture>,
     ) -> Result<(Option<Item>, Option<Item>), StorageError> {
+        // Read the propagation delay BEFORE taking the write lock. It is a
+        // runtime setting, not an invariant of this write, so it does not need
+        // to be read under the lock, and the lock serialises every write in the
+        // process: work done inside it is the backend's throughput bottleneck.
+        let system_delay = self.gsi_default_delay().await;
         let _writer = self.write_lock.lock().await;
         // Read the index set after acquiring the write lock so a concurrently
         // added GSI (UpdateTable holds the same lock) is not missed.
         let indexes = fetch_indexes_for_table(&key_info.table_id, &self.pool).await?;
-        let system_delay = self.gsi_default_delay().await;
 
         let mut tx = self
             .pool

--- a/crates/storage-sqlite/src/data/update_item.rs
+++ b/crates/storage-sqlite/src/data/update_item.rs
@@ -11,8 +11,8 @@
 use extenddb_core::expression::{self, Expr, ExpressionMaps, UpdateAction};
 use extenddb_core::types::{Item, TableKeyInfo};
 use extenddb_core::validation;
-use extenddb_storage::error::StorageError;
 use extenddb_storage::StreamCapture;
+use extenddb_storage::error::StorageError;
 
 use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
 use super::query::check_condition;

--- a/crates/storage-sqlite/src/data/update_item.rs
+++ b/crates/storage-sqlite/src/data/update_item.rs
@@ -11,8 +11,8 @@
 use extenddb_core::expression::{self, Expr, ExpressionMaps, UpdateAction};
 use extenddb_core::types::{Item, TableKeyInfo};
 use extenddb_core::validation;
-use extenddb_storage::StreamCapture;
 use extenddb_storage::error::StorageError;
+use extenddb_storage::StreamCapture;
 
 use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
 use super::query::check_condition;
@@ -37,7 +37,7 @@ impl SqliteEngine {
         // Read the index set after acquiring the write lock so a concurrently
         // added GSI (UpdateTable holds the same lock) is not missed.
         let indexes = fetch_indexes_for_table(&key_info.table_id, &self.pool).await?;
-        let system_delay = self.gsi_default_delay();
+        let system_delay = self.gsi_default_delay().await;
 
         let mut tx = self
             .pool

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -45,6 +45,12 @@ mod update_table;
 mod worker;
 mod workers;
 
+/// Default GSI propagation delay (milliseconds) when the
+/// `gsi_propagation_delay_ms` setting is absent. Mirrors the value seeded by
+/// the catalog schema, and is the single definition used by both the live read
+/// on the write path and the background refresh worker.
+pub(crate) const DEFAULT_GSI_PROPAGATION_DELAY_MS: u64 = 10;
+
 pub use bootstrapper::SqliteBootstrapper;
 pub use catalog_store::SqliteCatalogStore;
 pub use config::SqliteConfig;

--- a/crates/storage-sqlite/src/store.rs
+++ b/crates/storage-sqlite/src/store.rs
@@ -18,12 +18,12 @@
 //! invalidated by another pool committing) rather than surfacing it as a 500.
 //! Reads run concurrently from the pool against WAL snapshots and take no lock.
 
-use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 
 use extenddb_storage::error::StorageError;
-use sqlx::sqlite::SqlitePoolOptions;
 use sqlx::SqlitePool;
+use sqlx::sqlite::SqlitePoolOptions;
 use tokio::sync::Mutex;
 
 use crate::schema::CATALOG_VERSION;

--- a/crates/storage-sqlite/src/store.rs
+++ b/crates/storage-sqlite/src/store.rs
@@ -237,7 +237,7 @@ impl SqliteEngine {
     /// Reads the `gsi_propagation_delay_ms` setting live from the catalog so
     /// out-of-process changes (`extenddb settings set`) take effect on the
     /// next write, not up to 30 s later when the poll worker refreshes the
-    /// cache. SQLite is a local file, so this is an indexed point lookup with
+    /// cache. `SQLite` is a local file, so this is an indexed point lookup with
     /// negligible cost next to the write it precedes. On a read error the
     /// cached value (still refreshed by the poll worker) is the fallback; on
     /// success the cache is re-warmed so fallback reads stay fresh.
@@ -250,11 +250,16 @@ impl SqliteEngine {
         match live {
             Ok(row) => {
                 // Missing row means the default, matching poll_gsi_delay.
-                let ms = row.and_then(|(v,)| v.parse::<u64>().ok()).unwrap_or(10);
+                let ms = row
+                    .and_then(|(v,)| v.parse::<u64>().ok())
+                    .unwrap_or(crate::DEFAULT_GSI_PROPAGATION_DELAY_MS);
                 self.gsi_default_delay_ms.store(ms, Ordering::Relaxed);
                 ms
             }
-            Err(_) => self.gsi_default_delay_ms.load(Ordering::Relaxed),
+            Err(e) => {
+                tracing::debug!("gsi_default_delay: live read failed, using cache: {e:?}");
+                self.gsi_default_delay_ms.load(Ordering::Relaxed)
+            }
         }
     }
 

--- a/crates/storage-sqlite/src/store.rs
+++ b/crates/storage-sqlite/src/store.rs
@@ -18,12 +18,12 @@
 //! invalidated by another pool committing) rather than surfacing it as a 500.
 //! Reads run concurrently from the pool against WAL snapshots and take no lock.
 
-use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
 
 use extenddb_storage::error::StorageError;
-use sqlx::SqlitePool;
 use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::SqlitePool;
 use tokio::sync::Mutex;
 
 use crate::schema::CATALOG_VERSION;
@@ -232,10 +232,30 @@ impl SqliteEngine {
         Ok(if from_env { None } else { Some(password) })
     }
 
-    /// Current cached GSI propagation delay (ms); `0` means synchronous.
-    pub(crate) fn gsi_default_delay(&self) -> u64 {
-        self.gsi_default_delay_ms
-            .load(std::sync::atomic::Ordering::Relaxed)
+    /// Current GSI propagation delay (ms); `0` means synchronous.
+    ///
+    /// Reads the `gsi_propagation_delay_ms` setting live from the catalog so
+    /// out-of-process changes (`extenddb settings set`) take effect on the
+    /// next write, not up to 30 s later when the poll worker refreshes the
+    /// cache. SQLite is a local file, so this is an indexed point lookup with
+    /// negligible cost next to the write it precedes. On a read error the
+    /// cached value (still refreshed by the poll worker) is the fallback; on
+    /// success the cache is re-warmed so fallback reads stay fresh.
+    pub(crate) async fn gsi_default_delay(&self) -> u64 {
+        use std::sync::atomic::Ordering;
+        let live: Result<Option<(String,)>, _> =
+            sqlx::query_as("SELECT value FROM settings WHERE key = 'gsi_propagation_delay_ms'")
+                .fetch_optional(&self.pool)
+                .await;
+        match live {
+            Ok(row) => {
+                // Missing row means the default, matching poll_gsi_delay.
+                let ms = row.and_then(|(v,)| v.parse::<u64>().ok()).unwrap_or(10);
+                self.gsi_default_delay_ms.store(ms, Ordering::Relaxed);
+                ms
+            }
+            Err(_) => self.gsi_default_delay_ms.load(Ordering::Relaxed),
+        }
     }
 
     /// Handle to the GSI propagation notifier, woken after an enqueue.

--- a/crates/storage-sqlite/src/workers.rs
+++ b/crates/storage-sqlite/src/workers.rs
@@ -540,7 +540,9 @@ pub(crate) async fn poll_gsi_delay<S: SettingsStore + ?Sized>(
                     gsi_default.store(ms, Ordering::Relaxed);
                 }
             }
-            Ok(None) => gsi_default.store(10, Ordering::Relaxed),
+            Ok(None) => {
+                gsi_default.store(crate::DEFAULT_GSI_PROPAGATION_DELAY_MS, Ordering::Relaxed)
+            }
             Err(e) => tracing::debug!("poll_gsi_delay: {e:?}"),
         }
     }


### PR DESCRIPTION
## What

Makes both storage backends honour a runtime change of the GSI propagation delay
immediately. The delay getter now reads `gsi_propagation_delay_ms` from the catalog
on each write instead of serving a value cached with a 30-second refresh, in
`crates/storage-sqlite/src/store.rs` and `crates/storage-postgres/src/lib.rs`, with
the four write paths in each backend updated to await it.

PostgreSQL callers keep their `indexes.is_empty()` short-circuit, so a table with no
secondary indexes performs no extra query at all.

Three further changes, from reviewing the SQLite half:

- The delay is read **before** `write_lock.lock().await` at all four SQLite call
  sites. It is a runtime setting rather than an invariant of the write, so it does
  not need to be read under the lock, and that lock serialises every write in the
  process, so work inside it is the backend's throughput bottleneck.
- The error arm logs instead of swallowing. Both poll workers already log through
  `tracing::debug!`; now a live read that falls back to the cache does too, so a
  degraded catalog serves a stale delay loudly rather than silently.
- The default is a named constant, `DEFAULT_GSI_PROPAGATION_DELAY_MS`, per backend
  crate, shared by the live read and the poll worker. The literal was previously
  duplicated and the live read had added a third copy.

## Why

Setting `gsi_propagation_delay_ms` to 0 at runtime is supposed to make index updates
synchronously visible. With the cached value, writes kept using the stale non-zero
delay for up to 30 seconds, so the index update stayed async and queries against the
GSI returned 0 items immediately after a write. This is one of the red CI jobs on
#207, where the zero-delay GSI sync test sets the delay to 0 and immediately expects
synchronous visibility.

PostgreSQL had the identical defect. Both backends are fixed here rather than in two
PRs, following #248 where the same shared defect was corrected in both backends in
one change.

Closes # <!-- no standing issue; surfaced by the zero-delay GSI sync test in #207's CI -->

## Testing done

Every claim below was executed, on a fresh deployment per backend and on ports away
from any other local instance.

- **SQLite**: `test_gsi_sync_path_with_zero_delay` passes **20/20** consecutive runs.
  Full `TestGsiAsyncPropagation` class 5/5.
- **PostgreSQL**: the same test **failed twice before this change** with the same
  symptom as SQLite, `assert 0 == 1`, and now passes **20/20** consecutive runs.
- **Negative control**: reverting only the SQLite getter body to the cached read,
  keeping the `async` signature so it still compiles, reproduces the failure exactly.
  So the test discriminates and the fix is what makes it pass.
- Crate unit tests: 16/16 SQLite, 14/14 PostgreSQL, 0 filtered out.
- `cargo fmt --all -- --check` exit 0. `cargo clippy -D warnings` exit 0 on both the
  `sqlite` and `postgres` feature sets.

**One pre-existing failure found and deliberately not touched.**
`test_gsi_configured_delay_range` fails on PostgreSQL, observing about 1010 ms against
a 500 ms bound with the delay set to 50 ms. An A/B on a fresh server shows it failing
identically with and without this change, so it is not a regression here. It looks
like worker scheduling granularity dominating the configured delay, which deserves its
own investigation.

**Worth knowing about CI.** `run-integration` (PostgreSQL) was green on the previous
revision of this PR while PostgreSQL was still broken, so CI did not catch this class
of defect. Whether that is because the harness restarts the server, letting PostgreSQL
pick the setting up at construction, is unconfirmed.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -D warnings` on both feature sets; the repo
      carries pre-existing `-W clippy::pedantic` warnings and this change adds none)
- [ ] I have added or updated tests for new functionality — no new test: the existing
      zero-delay test in the Python suite already covers the behaviour on both
      backends, and it is what the fix makes pass
- [ ] I have updated documentation if behavior changed — no doc change; the setting's
      documented meaning is unchanged, it is now actually honoured
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a. Internal bug fix, no contract surface changed.

## Breaking changes

None.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
