### PR TITLE
fix(streams): pad ShardId to meet AWS SDK 28-char minimum

### DIFF
--- a/crates/storage-postgres/src/stream_engine.rs
+++ b/crates/storage-postgres/src/stream_engine.rs
@@ -55,7 +55,10 @@ impl PostgresEngine {
             .map_err(|e| StorageError::Internal(e.to_string()))?;
 
         for i in 0..SHARDS_PER_STREAM {
-            let shard_id = format!("shardId-{table_name}-{i:012}");
+            // Zero-padded to 16 digits so the shard ID is always at
+            // least 28 characters (minimum length the AWS SDKs enforce for ShardId)
+            // even for the shortest legal table name.
+            let shard_id = format!("shardId-{table_name}-{i:016}");
             let start_seq = format!("{:021}", 0);
             sqlx::query(
                 "INSERT INTO stream_shards (shard_id, table_id, starting_sequence_number) \

--- a/crates/storage-sqlite/src/stream.rs
+++ b/crates/storage-sqlite/src/stream.rs
@@ -44,7 +44,10 @@ impl SqliteEngine {
         .map_err(|e| StorageError::Internal(e.to_string()))?;
 
         for i in 0..SHARDS_PER_STREAM {
-            let shard_id = format!("shardId-{table_name}-{i:012}");
+            // Zero-padded to 16 digits so the shard ID is always at
+            // least 28 characters (minimum length the AWS SDKs enforce for ShardId)
+            // even for the shortest legal table name.
+            let shard_id = format!("shardId-{table_name}-{i:016}");
             let start_seq = format!("{:021}", 0);
             sqlx::query(
                 "INSERT INTO stream_shards (shard_id, table_id, starting_sequence_number) \

--- a/docs/manuals/02-design-guide.md
+++ b/docs/manuals/02-design-guide.md
@@ -138,7 +138,7 @@ For UpdateItem, the `new_image` is not known until after `apply_update` runs ins
 
 ### Shard Model
 
-Each stream has a fixed set of shards (currently 4 shards per stream). Shard IDs are deterministic (`shardId-<table>-000000000000` through `shardId-<table>-000000000003`). Sequence numbers are monotonically increasing integers.
+Each stream has a fixed set of shards (currently 4 shards per stream). Shard IDs are deterministic (`shardId-<table>-0000000000000000` through `shardId-<table>-0000000000000003`), zero-padded to 16 digits so every shard ID meets the AWS SDKs' 28-character minimum for `ShardId`, regardless of table name length. Sequence numbers are monotonically increasing integers.
 
 ### Iterator Types
 

--- a/tests/python/test_streams.py
+++ b/tests/python/test_streams.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import os
 import time
+import uuid
 
 import boto3
 import botocore.config
@@ -46,9 +47,9 @@ def streams_client(endpoint_url):
     return boto3.client(**kwargs)
 
 
-def _create_stream_table(dynamodb_client) -> tuple[str, str]:
+def _create_stream_table(dynamodb_client, name: str | None = None) -> tuple[str, str]:
     """Create a table with streams enabled, return (table_name, stream_arn)."""
-    name = unique_name("stream")
+    name = name or unique_name("stream")
     resp = dynamodb_client.create_table(
         TableName=name,
         AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
@@ -93,6 +94,25 @@ def _read_all_shards(
             if not iterator or not resp["Records"]:
                 break
     return all_records
+
+
+class TestShortTableName:
+    """Regression: short table names produced under-length ShardIds."""
+
+    def test_get_shard_iterator_with_short_table_name(
+        self, dynamodb_client, streams_client
+    ):
+        name = f"t{uuid.uuid4().hex[:5]}"  # 6 chars, well inside the old danger zone
+        _, stream_arn = _create_stream_table(dynamodb_client, name=name)
+        try:
+            dynamodb_client.put_item(TableName=name, Item={"pk": {"S": "a1"}})
+            records = _read_all_shards(streams_client, stream_arn)
+            assert any(
+                r["dynamodb"]["Keys"] == {"pk": {"S": "a1"}} for r in records
+            )
+        finally:
+            dynamodb_client.delete_table(TableName=name)
+            wait_for_deleted(dynamodb_client, name)
 
 
 class TestListStreams:


### PR DESCRIPTION
## What
Pad Stream `ShardId` to 16-digit index width (was 12) so it always meets the AWS SDKs' 28-char client-side minimum, regardless of table name length.

## Why
Closes #247.
Tables named 3-6 chars produced shard IDs under 28 chars. Every AWS SDK rejects `ShardId` shorter than 28 chars client-side, so `GetShardIterator`/`GetRecords` failed before reaching the server.

## Testing done
- New test: `tests/python/test_streams.py::TestShortTableName::test_get_shard_iterator_with_short_table_name`
- Verified fails pre-fix with the exact reported error (`Invalid length for parameter ShardId, value: 27, valid min length: 28`), passes post-fix.
- Full `test_streams.py` suite: 15/15 pass, no regression.
- `cargo build --workspace`, `cargo fmt --check` clean.

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface, an RFC has been accepted or is linked below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a - shard IDs are opaque and internal, not part of the `Storage` trait's public surface or the wire protocol.

## Breaking changes
None. Shard IDs are opaque tokens matched by equality everywhere in the codebase; no client parses their length or content.