### PR TITLE
fix(deps): remediate Rust advisories and drop deprecated rustls-pemfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -631,15 +631,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "config"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1095,11 +1086,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1145,7 +1135,6 @@ dependencies = [
  "libc",
  "rcgen",
  "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "sqlx",
@@ -3103,15 +3092,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ urlencoding = { version = "2.1" }
 moka = { version = "0.12", features = ["future"] }
 
 # Database
-sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "json", "time", "uuid", "bigdecimal"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "json", "time", "uuid", "bigdecimal", "derive"] }
 mongodb = "3"
 bson = "2.13"
 dashmap = "6"
@@ -83,7 +83,6 @@ time = { version = "0.3", features = ["serde", "formatting", "parsing"] }
 # TLS
 axum-server = { version = "0.8", features = ["tls-rustls"] }
 rustls = { version = "0.23", features = ["aws_lc_rs"] }
-rustls-pemfile = "2"
 rcgen = "0.14"
 
 # Process management

--- a/SOFTWARE-LICENSE-NOTICES.html
+++ b/SOFTWARE-LICENSE-NOTICES.html
@@ -49,7 +49,7 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (214)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (212)</li>
             <li><a href="#MIT">MIT License</a> (53)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (19)</li>
             <li><a href="#ISC">ISC License</a> (6)</li>
@@ -4088,11 +4088,10 @@ limitations under the License.
                     <li><a href=" https://github.com/rust-lang/cmake-rs ">cmake 0.1.58</a></li>
                     <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.38</a></li>
                     <li><a href=" https://github.com/Nullus157/async-compression ">compression-core 0.4.32</a></li>
-                    <li><a href=" https://github.com/smol-rs/concurrent-queue ">concurrent-queue 2.5.0</a></li>
                     <li><a href=" https://github.com/tkaitchuck/constrandom ">const-random-macro 0.1.16</a></li>
                     <li><a href=" https://github.com/tkaitchuck/constrandom ">const-random 0.1.18</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-channel 0.5.15</a></li>
-                    <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-epoch 0.9.18</a></li>
+                    <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-epoch 0.9.20</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-queue 0.3.12</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-utils 0.8.21</a></li>
                     <li><a href=" https://github.com/yaahc/displaydoc ">displaydoc 0.2.5</a></li>
@@ -4100,7 +4099,7 @@ limitations under the License.
                     <li><a href=" https://github.com/indexmap-rs/equivalent ">equivalent 1.0.2</a></li>
                     <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.14</a></li>
                     <li><a href=" https://github.com/smol-rs/event-listener-strategy ">event-listener-strategy 0.5.4</a></li>
-                    <li><a href=" https://github.com/smol-rs/event-listener ">event-listener 5.4.1</a></li>
+                    <li><a href=" https://github.com/smol-rs/event-listener ">event-listener 5.4.2</a></li>
                     <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.9</a></li>
                     <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.9</a></li>
                     <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
@@ -4134,7 +4133,6 @@ limitations under the License.
                     <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.10</a></li>
                     <li><a href=" https://github.com/briansmith/ring ">ring 0.17.14</a></li>
                     <li><a href=" https://github.com/ron-rs/ron ">ron 0.8.1</a></li>
-                    <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile 2.2.0</a></li>
                     <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.40</a></li>
                     <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
                     <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.8</a></li>
@@ -6668,18 +6666,18 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.2</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.2</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.2</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.2</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.2</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.2</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.2</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.2</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.2</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage-postgres ">extenddb-storage-postgres 0.1.2</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.3</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.3</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.3</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.3</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.3</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.3</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.3</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.3</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.3</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage-postgres ">extenddb-storage-postgres 0.1.3</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
-                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.102</a></li>
+                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.103</a></li>
                     <li><a href=" https://github.com/andylokandy/arraydeque ">arraydeque 0.5.1</a></li>
                     <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.89</a></li>
                     <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a></li>

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -36,4 +36,3 @@ base64 = { workspace = true }
 libc = { workspace = true }
 rcgen = { workspace = true }
 rustls = { workspace = true }
-rustls-pemfile = { workspace = true }

--- a/crates/app/src/init_helpers.rs
+++ b/crates/app/src/init_helpers.rs
@@ -3,6 +3,8 @@
 
 //! Helpers for `extenddb init`: TLS certificate generation and config file creation.
 
+use rustls::pki_types::{CertificateDer, pem::PemObject};
+
 /// Generate a self-signed TLS certificate and key if they don't already exist.
 ///
 /// `extra_sans` are additional Subject Alternative Names, such as an in-cluster
@@ -158,7 +160,7 @@ fn ensure_cert_covers_sans(
 
     let pem = std::fs::read(cert_path)
         .map_err(|e| anyhow::anyhow!("Failed to read existing certificate {cert_path}: {e}"))?;
-    let der = rustls_pemfile::certs(&mut pem.as_slice())
+    let der = CertificateDer::pem_slice_iter(&pem)
         .next()
         .ok_or_else(|| anyhow::anyhow!("No certificate found in {cert_path}"))?
         .map_err(|e| anyhow::anyhow!("Failed to parse certificate {cert_path}: {e}"))?;

--- a/crates/app/src/manage_http.rs
+++ b/crates/app/src/manage_http.rs
@@ -11,6 +11,7 @@ use std::net::TcpStream;
 use std::sync::Arc;
 
 use base64::Engine;
+use rustls::pki_types::{CertificateDer, pem::PemObject};
 
 use crate::manage_types::{CacheAction, CacheInvalidateScope, ManageCommand};
 use extenddb_config as config;
@@ -148,7 +149,7 @@ fn http_request_tls(
         .map_err(|e| anyhow::anyhow!("Cannot read TLS cert {cert_path}: {e}"))?;
 
     let mut root_store = rustls::RootCertStore::empty();
-    let certs = rustls_pemfile::certs(&mut &cert_pem[..])
+    let certs = CertificateDer::pem_slice_iter(&cert_pem)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| anyhow::anyhow!("Failed to parse PEM certs from {cert_path}: {e}"))?;
     for cert in &certs {

--- a/tests/rust/Cargo.lock
+++ b/tests/rust/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "atomic-waker"


### PR DESCRIPTION
## What

Remediates the open Rust dependency advisories and removes one deprecated dependency,
in a single commit rebased onto current `main`:

- **`crossbeam-epoch` 0.9.18 → 0.9.20** — the fix for RUSTSEC-2026-0204.
- **`anyhow` 1.0.102 → 1.0.103** and **`event-listener` 5.4.1 → 5.4.2** — preferred
  direct-dependency updates. The `event-listener` bump also drops the transitive
  `concurrent-queue` crate entirely.
- **`rustls-pemfile` removed** (deprecated upstream). Both call sites
  (`crates/app/src/init_helpers.rs`, `crates/app/src/manage_http.rs`) migrate to the
  `rustls-pki-types` PEM API (`CertificateDer::pem_slice_iter`) already in the tree,
  with identical error handling and messages.
- **`sqlx` tightened** to `default-features = false` with the explicit feature list,
  plus `derive` (used by the storage backends' `FromRow` types). This trims unused
  default machinery from the dependency graph.

- **`SOFTWARE-LICENSE-NOTICES.html` regenerated** (second commit) with the pinned
  `cargo-about 0.9.0`, since the dependency changes above alter the license
  inventory: `rustls-pemfile` and `concurrent-queue` leave, three versions bump.

Net effect on `Cargo.lock`: zero packages added, `rustls-pemfile` and
`concurrent-queue` removed, three versions bumped. `tests/rust/Cargo.lock` picks up
the matching `anyhow` bump.

## Why

The release runbook blocks the first public `extenddb-postgres` container image on
RUSTSEC-2026-0204: no advisory-affected version may ship in a public image. The
`anyhow`/`event-listener` bumps are the recorded preferred updates from the same
review. Dropping `rustls-pemfile` now, rather than later, avoids shipping the first
public artifact with a dependency that is already deprecated and would force a
post-release lockfile churn to remove.

The branch predates the MongoDB backend landing on `main`; it has been rebased and
the workspace `Cargo.toml` conflict resolved keeping both this PR's hardened `sqlx`
line and `main`'s new `mongodb`/`bson`/`dashmap` dependencies.

## Testing done

- `cargo metadata --locked` — lockfile is consistent with the manifests.
- `cargo check --workspace --all-targets --locked` — clean, including the new
  `extenddb-storage-mongodb` crate from post-rebase `main`.
- `cargo test --workspace --locked` — **769 passed, 0 failed** across all suites.
- `cargo fmt --all --check` — clean.
- `cargo clippy --workspace --all-targets --locked` — clean, zero warnings.
- Lockfile inspected directly: resolves `crossbeam-epoch 0.9.20`, `anyhow 1.0.103`,
  `event-listener 5.4.2`; `comm` over package names confirms nothing was added.
- `devtools/generate-software-license-notices --check` — passes against the
  regenerated notices; spot-checked that `rustls-pemfile`/`concurrent-queue` no
  longer appear and the three bumped versions do.
- Full integration pass (`devtools/run-tests --extenddb --rust-integration --pytest
  --release` against a live server on the pinned PostgreSQL 16.10 image) is running
  at the time of writing — Python suite past 70% with zero failures so far. I will
  post the final counts as a comment when it completes.

Not verified:

- The container smoke test (`ci/smoke-test-container.sh`) has not been re-run for
  this change; it exercises the same binary the workspace and integration suites
  cover, and will run as part of the release process regardless.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [ ] I have added or updated tests for new functionality — not applicable: no new
      functionality; existing tests cover the migrated PEM-parsing call sites
- [ ] I have updated documentation if behavior changed — not applicable: no behavior
      change
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a — dependency maintenance only; no wire protocol, `Storage` trait,
auth model, on-disk format, or CLI surface change.

## Breaking changes

None. Public behavior is unchanged: the PEM-parsing migration is call-site-for-call-site
with the same error text, and the `sqlx` feature trim keeps every feature the
workspace actually uses (verified by the clean workspace check and test run,
including the SQLite and MongoDB backends).

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

