### PR TITLE
chore(release): bump version to 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "extenddb-app",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-app"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-auth"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "axum",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-cache"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "futures",
  "moka",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-config"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "config",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-engine"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64 0.22.1",
  "crc32fast",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-server"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-mongodb"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-postgres"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-sqlite"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SOFTWARE-LICENSE-NOTICES.html
+++ b/SOFTWARE-LICENSE-NOTICES.html
@@ -6666,16 +6666,16 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.3</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.3</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.3</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.3</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.3</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.3</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.3</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.3</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.3</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage-postgres ">extenddb-storage-postgres 0.1.3</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.4</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.4</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.4</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.4</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.4</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.4</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.4</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.4</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.4</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage-postgres ">extenddb-storage-postgres 0.1.4</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.103</a></li>
                     <li><a href=" https://github.com/andylokandy/arraydeque ">arraydeque 0.5.1</a></li>


### PR DESCRIPTION
## What

Bumps the workspace version from `0.1.3` to `0.1.4` (one line in the root
`Cargo.toml`), refreshes the workspace-member entries in `Cargo.lock`, and
regenerates `SOFTWARE-LICENSE-NOTICES.html` for the crate version strings.
No dependency or source change.

## Why

`v0.1.3` is already tagged and published as a GitHub release (2026-08-10),
pointing at `3961c63a` — a commit that predates the dependency advisory
remediation in #254 (`RUSTSEC-2026-0204`). The first public container image
must ship the fixed dependency graph, so its release commit cannot be the one
`v0.1.3` names.

Release tags and published releases are immutable: moving or deleting
`v0.1.3` would rewrite something public since Aug 10. The clean path is the
next patch version. This also satisfies the release workflow's version gate
(#251), which requires the release tag to match the workspace version at the
tagged commit.

After this merges, the release flow is: tag `v0.1.4` on the merged commit,
dispatch the release workflow for the Docker Hub candidate, then the manual
mirror/sign/promote steps per the release runbook.

## Testing done

- `cargo check --workspace --all-targets --locked` — clean.
- Verified the `Cargo.lock` diff touches only the twelve `extenddb-*`
  workspace crates (version `0.1.3` → `0.1.4`); no third-party entries moved.
- Verified the `SOFTWARE-LICENSE-NOTICES.html` diff contains only
  `extenddb* 0.1.3` → `0.1.4` version strings;
  `devtools/generate-software-license-notices --check` passes.

## Checklist

- [ ] All tests pass (`cargo test --workspace`) — not re-run: no source or
      dependency change; the identical code was fully tested in #254
- [ ] Code is formatted (`cargo fmt --check`) — not applicable, no Rust source changed
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`) — not applicable, no Rust source changed
- [ ] I have added or updated tests for new functionality — not applicable
- [ ] I have updated documentation if behavior changed — not applicable
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a — version metadata only.

## Breaking changes

None.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
