### PR TITLE
fix: merge UpdateTable AttributeDefinitions instead of replacing them

### DIFF
--- a/crates/storage-postgres/src/update_table.rs
+++ b/crates/storage-postgres/src/update_table.rs
@@ -265,6 +265,9 @@ impl PostgresEngine {
         }
 
         // Apply GSI updates (create/delete).
+        let mut merged_attr_defs: Vec<AttributeDefinition> =
+            serde_json::from_value(ad_json.clone())
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
         let mut created_index_ids: Vec<String> = Vec::new();
         let mut deleted_index_ids: Vec<String> = Vec::new();
         if let Some(updates) = &input.global_secondary_index_updates {
@@ -344,12 +347,27 @@ impl PostgresEngine {
                 }
             }
 
-            // Update attribute_definitions on the table if new ones were provided.
+            // Merge new attribute definitions into the existing ones.
+            // UpdateTable's AttributeDefinitions only needs to describe the
+            // attributes referenced by the new indexes; replacing the stored
+            // definitions wholesale would drop the table's own key attribute
+            // definitions and break sort-key handling on the base table
+            // (issue #259).
             if let Some(new_attr_defs) = &input.attribute_definitions {
-                let ad_json = serde_json::to_value(new_attr_defs)
+                for new_def in new_attr_defs {
+                    if let Some(existing) = merged_attr_defs
+                        .iter_mut()
+                        .find(|d| d.attribute_name == new_def.attribute_name)
+                    {
+                        *existing = new_def.clone();
+                    } else {
+                        merged_attr_defs.push(new_def.clone());
+                    }
+                }
+                let merged_json = serde_json::to_value(&merged_attr_defs)
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
                 sqlx::query("UPDATE tables SET attribute_definitions = $1 WHERE account_id = $2 AND table_name = $3")
-                    .bind(&ad_json)
+                    .bind(&merged_json)
                     .bind(account_id)
                     .bind(&input.table_name)
                     .execute(&mut *tx)
@@ -368,10 +386,7 @@ impl PostgresEngine {
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
             let base_attr_defs: Vec<AttributeDefinition> = serde_json::from_value(ad_json.clone())
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
-            let effective_attr_defs = input
-                .attribute_definitions
-                .as_deref()
-                .unwrap_or(&base_attr_defs);
+            let effective_attr_defs: &[AttributeDefinition] = &merged_attr_defs;
 
             let mut create_idx = 0usize;
             let mut delete_idx = 0usize;

--- a/crates/storage-sqlite/src/update_table.rs
+++ b/crates/storage-sqlite/src/update_table.rs
@@ -215,6 +215,8 @@ impl SqliteEngine {
         }
 
         // GSI create/delete.
+        let mut merged_attr_defs: Vec<AttributeDefinition> =
+            serde_json::from_str(&ad_json).map_err(|e| StorageError::Internal(e.to_string()))?;
         let mut created: Vec<String> = Vec::new();
         let mut deleted: Vec<String> = Vec::new();
         if let Some(updates) = &input.global_secondary_index_updates {
@@ -279,8 +281,24 @@ impl SqliteEngine {
                     deleted.push(del_id);
                 }
             }
+            // Merge new attribute definitions into the existing ones.
+            // UpdateTable's AttributeDefinitions only needs to describe the
+            // attributes referenced by the new indexes; replacing the stored
+            // definitions wholesale would drop the table's own key attribute
+            // definitions and break sort-key handling on the base table
+            // (issue #259).
             if let Some(new_attr_defs) = &input.attribute_definitions {
-                let j = serde_json::to_string(new_attr_defs)
+                for new_def in new_attr_defs {
+                    if let Some(existing) = merged_attr_defs
+                        .iter_mut()
+                        .find(|d| d.attribute_name == new_def.attribute_name)
+                    {
+                        *existing = new_def.clone();
+                    } else {
+                        merged_attr_defs.push(new_def.clone());
+                    }
+                }
+                let j = serde_json::to_string(&merged_attr_defs)
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
                 update_col(
                     &mut tx,
@@ -303,7 +321,7 @@ impl SqliteEngine {
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
             let base_ad: Vec<AttributeDefinition> = serde_json::from_str(&ad_json)
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
-            let effective_ad = input.attribute_definitions.as_deref().unwrap_or(&base_ad);
+            let effective_ad: &[AttributeDefinition] = &merged_attr_defs;
 
             let mut ci = 0usize;
             let mut di = 0usize;

--- a/tests/test_gsi_attribute_definitions.py
+++ b/tests/test_gsi_attribute_definitions.py
@@ -1,0 +1,115 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for issue #259.
+
+Creating a GSI via UpdateTable must not corrupt the base table's stored
+AttributeDefinitions. UpdateTable's AttributeDefinitions only describes the
+attributes referenced by the new index; replacing the stored definitions
+wholesale dropped the table's own key attribute definitions, after which
+base-table GetItem/UpdateItem/DeleteItem lost the sort key and targeted an
+arbitrary item under the same partition key.
+"""
+
+from __future__ import annotations
+
+import time
+
+from conftest import wait_for_active
+
+
+def wait_for_gsi_active(client, table_name: str, index_name: str, timeout: float = 120.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        desc = client.describe_table(TableName=table_name)["Table"]
+        indexes = {i["IndexName"]: i for i in desc.get("GlobalSecondaryIndexes", [])}
+        if (
+            desc["TableStatus"] == "ACTIVE"
+            and indexes.get(index_name, {}).get("IndexStatus") == "ACTIVE"
+        ):
+            return
+        time.sleep(0.2)
+    raise TimeoutError(f"GSI {index_name} on {table_name} did not become ACTIVE within {timeout}s")
+
+
+class TestGsiCreatePreservesAttributeDefinitions:
+    def test_get_item_after_gsi_create_on_composite_table(
+        self, create_and_cleanup_table, dynamodb_client, unique_table_name
+    ):
+        """Issue #259: base-table GetItem must honor the sort key after a GSI is added."""
+        create_and_cleanup_table(
+            unique_table_name,
+            AttributeDefinitions=[
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "sk", "AttributeType": "S"},
+            ],
+            KeySchema=[
+                {"AttributeName": "pk", "KeyType": "HASH"},
+                {"AttributeName": "sk", "KeyType": "RANGE"},
+            ],
+        )
+
+        items = []
+        for i in range(10):
+            item = {
+                "pk": {"S": "shared"},
+                "sk": {"S": f"sk-{i:03d}"},
+                "gpk": {"S": f"gpk-{i % 3}"},
+                "gsk": {"S": f"gsk-{i:03d}"},
+                "payload": {"S": f"payload-{i:03d}"},
+            }
+            dynamodb_client.put_item(TableName=unique_table_name, Item=item)
+            items.append(item)
+
+        # UpdateTable carries only the new index key attributes, per DynamoDB
+        # semantics — the stored pk/sk definitions must survive the merge.
+        dynamodb_client.update_table(
+            TableName=unique_table_name,
+            AttributeDefinitions=[
+                {"AttributeName": "gpk", "AttributeType": "S"},
+                {"AttributeName": "gsk", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexUpdates=[
+                {
+                    "Create": {
+                        "IndexName": "gsi01",
+                        "KeySchema": [
+                            {"AttributeName": "gpk", "KeyType": "HASH"},
+                            {"AttributeName": "gsk", "KeyType": "RANGE"},
+                        ],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
+                }
+            ],
+        )
+        wait_for_gsi_active(dynamodb_client, unique_table_name, "gsi01")
+
+        # DescribeTable must report the union of old and new definitions.
+        desc = dynamodb_client.describe_table(TableName=unique_table_name)["Table"]
+        defined = {ad["AttributeName"] for ad in desc["AttributeDefinitions"]}
+        assert {"pk", "sk", "gpk", "gsk"} <= defined
+
+        # Every base-table read must return exactly the requested item.
+        for item in items:
+            got = dynamodb_client.get_item(
+                TableName=unique_table_name,
+                Key={"pk": item["pk"], "sk": item["sk"]},
+                ConsistentRead=True,
+            ).get("Item")
+            assert got == item
+
+        # DeleteItem must also target the exact key, not another row in the
+        # same partition.
+        victim = items[5]
+        dynamodb_client.delete_item(
+            TableName=unique_table_name,
+            Key={"pk": victim["pk"], "sk": victim["sk"]},
+        )
+        for item in items:
+            got = dynamodb_client.get_item(
+                TableName=unique_table_name,
+                Key={"pk": item["pk"], "sk": item["sk"]},
+                ConsistentRead=True,
+            ).get("Item")
+            assert got == (None if item is victim else item)
+        wait_for_active(dynamodb_client, unique_table_name)


### PR DESCRIPTION
## Summary

Fixes #259 — after creating a GSI on a composite-key table, base-table `GetItem` (and `UpdateItem`/`DeleteItem`) ignored the sort key and silently targeted an arbitrary item under the same partition key.

## Root cause

`UpdateTable` persisted the request's `AttributeDefinitions` by **replacing** the stored definitions wholesale. Per DynamoDB semantics that list only needs to describe the attributes referenced by the new index, so the base table's own key attribute definitions (`pk`/`sk`) were dropped from the catalog. `sk_info()` could then no longer resolve the sort key type and returned `None`, causing key lookups to degrade to `WHERE pk = $1` — a partition-key-only query returning an arbitrary row.

## Fix

Merge the incoming definitions into the stored ones by attribute name (replace same-name entries, append new ones), in both the PostgreSQL and SQLite backends. The merged set is also used for GSI data-table creation and backfill.

The MongoDB backend does not have this bug (it never updates the stored definitions on UpdateTable), though it has a separate gap — new GSI key attribute definitions are not recorded at all — which is out of scope here.

## Verification

- The issue's reproduction script against PostgreSQL 16: **1/100** correct reads on unpatched v0.1.3 → **100/100** with this fix; catalog `attribute_definitions` now contains the full union (`pk, sk, f01, f02`).
- New regression test `tests/test_gsi_attribute_definitions.py` covering GetItem correctness, DeleteItem key targeting, and DescribeTable reporting the merged definitions.
- `cargo test --workspace`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` all pass.

Existing tables already corrupted by this bug can be repaired without rebuilding: the data rows and GSI entries are intact; only `tables.attribute_definitions` in the catalog needs the missing key definitions restored (e.g. via another UpdateTable carrying the full definitions after this fix, or direct SQL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)