### PR TITLE
fix: update table must merge attribute definitions

### DIFF
--- a/crates/app/src/cmd_migrate.rs
+++ b/crates/app/src/cmd_migrate.rs
@@ -107,9 +107,46 @@ async fn apply_migrations(
         println!("  Pending: {}", data_pending.join(", "));
     }
 
-    if !catalog_pending && data_pending.is_empty() {
+    // Detect table metadata damaged by the pre-fix UpdateTable (#259), which
+    // deleted a table's own key attribute definitions when a GSI was added.
+    //
+    // Detection is read-only and runs even when the catalog version is already
+    // current: the damage is in a row's contents, not in the schema, so an
+    // up-to-date deployment is exactly the case that needs checking. Nothing is
+    // written until --yes has been given, below.
+    println!("--- Checking table key metadata...");
+    let detected = bootstrap
+        .repair_lost_sort_key_definitions(false)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    let repair_pending = !detected.repaired.is_empty();
+    if !repair_pending && detected.needs_attention.is_empty() {
+        println!("  Table key metadata intact.");
+    } else {
+        for line in &detected.repaired {
+            println!("  Repairable: {line}");
+        }
+        for line in &detected.needs_attention {
+            println!("  NEEDS ATTENTION: {line}");
+        }
+    }
+
+    if !catalog_pending && data_pending.is_empty() && !repair_pending {
         println!();
-        println!("Everything is up to date (catalog version {expected}). No migrations needed.");
+        if detected.needs_attention.is_empty() {
+            println!(
+                "Everything is up to date (catalog version {expected}). No migrations needed."
+            );
+        } else {
+            // Nothing is automatically applicable, but saying "everything is up
+            // to date" straight after a NEEDS ATTENTION line would be
+            // contradictory: those tables require a human.
+            println!(
+                "No migrations needed (catalog version {expected}), but {} item(s) above \
+                 need manual attention.",
+                detected.needs_attention.len()
+            );
+        }
         return Ok(());
     }
 
@@ -120,6 +157,12 @@ async fn apply_migrations(
         }
         if !data_pending.is_empty() {
             what.push(format!("data migrations [{}]", data_pending.join(", ")));
+        }
+        if repair_pending {
+            what.push(format!(
+                "table key metadata repairs [{}]",
+                detected.repaired.join("; ")
+            ));
         }
         anyhow::bail!(
             "--yes is required to apply migrations. Pending: {}.",
@@ -141,6 +184,18 @@ async fn apply_migrations(
         .run_data_migrations()
         .await
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+
+    // Apply the table key metadata repair after the schema migrations, so it never
+    // reads or writes a pre-migration catalog shape.
+    if repair_pending {
+        let applied = bootstrap
+            .repair_lost_sort_key_definitions(true)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+        for line in &applied.repaired {
+            println!("  Restored sort key definition: {line}");
+        }
+    }
 
     // Read new catalog version.
     let new = bootstrap

--- a/crates/core/src/types/key_schema.rs
+++ b/crates/core/src/types/key_schema.rs
@@ -100,6 +100,55 @@ pub struct TableKeyInfo {
     pub stream_specification: Option<super::StreamSpecification>,
 }
 
+impl TableKeyInfo {
+    /// Check the one invariant the keyed read paths depend on: every RANGE
+    /// element of the table's own key schema has a matching entry in
+    /// `attribute_definitions`.
+    ///
+    /// The storage backends derive the sort key's physical column from its
+    /// attribute definition, so a key schema whose RANGE attribute has no
+    /// definition makes them treat the table as partition-key-only and return an
+    /// arbitrary item from the partition. That is a silent wrong-answer read, so
+    /// the condition is checked where catalog metadata enters the system and
+    /// reported as an error instead of being inferred away (issue #259).
+    ///
+    /// Only `base_key_schema` is checked. Secondary index key schemas are
+    /// deliberately not, because a table written by an older build may carry an
+    /// index whose key attributes were never persisted, and refusing to load its
+    /// metadata would take the whole table offline rather than degrade that one
+    /// index.
+    ///
+    /// # Errors
+    ///
+    /// Returns the offending attribute name and the definitions that were present
+    /// when a RANGE attribute has no definition.
+    pub fn validate_sort_key_definitions(&self) -> Result<(), String> {
+        for element in &self.base_key_schema {
+            if element.key_type != KeyType::Range {
+                continue;
+            }
+            if !self
+                .attribute_definitions
+                .iter()
+                .any(|ad| ad.attribute_name == element.attribute_name)
+            {
+                return Err(format!(
+                    "table {} has sort key '{}' in its key schema with no matching \
+                     AttributeDefinition (definitions present: [{}])",
+                    self.table_name,
+                    element.attribute_name,
+                    self.attribute_definitions
+                        .iter()
+                        .map(|ad| ad.attribute_name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
 /// Extract all HASH key elements from a key schema (preserving order).
 #[must_use]
 pub fn hash_key_elements(key_schema: &[KeySchemaElement]) -> Vec<&KeySchemaElement> {
@@ -165,6 +214,96 @@ mod tests {
             attribute_name: name.into(),
             key_type,
         }
+    }
+
+    fn key_info_with(
+        base_key_schema: Vec<KeySchemaElement>,
+        attribute_definitions: Vec<AttributeDefinition>,
+    ) -> TableKeyInfo {
+        TableKeyInfo {
+            table_name: "TestTable".into(),
+            account_id: "123".into(),
+            table_id: "t1".into(),
+            key_schema: base_key_schema.clone(),
+            base_key_schema,
+            attribute_definitions,
+            has_lsi: false,
+            global_secondary_indexes: vec![],
+            local_secondary_indexes: vec![],
+            stream_specification: None,
+        }
+    }
+
+    fn ad(name: &str, attr_type: ScalarAttributeType) -> AttributeDefinition {
+        AttributeDefinition {
+            attribute_name: name.into(),
+            attribute_type: attr_type,
+        }
+    }
+
+    /// The state issue #259 left behind: the key schema still names a sort key but
+    /// its definition was dropped, which is what made the read path fall back to a
+    /// partition-only lookup. Loading such metadata must fail loudly.
+    #[test]
+    fn validate_sort_key_definitions_rejects_a_range_key_with_no_definition() {
+        let info = key_info_with(
+            vec![ks("pk", KeyType::Hash), ks("sk", KeyType::Range)],
+            vec![ad("pk", ScalarAttributeType::S)],
+        );
+
+        let err = info
+            .validate_sort_key_definitions()
+            .expect_err("a sort key with no attribute definition must be rejected");
+        assert!(
+            err.contains("sk"),
+            "error should name the sort key, got: {err}"
+        );
+        assert!(
+            err.contains("TestTable"),
+            "error should name the table, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_sort_key_definitions_accepts_a_complete_composite_key() {
+        let info = key_info_with(
+            vec![ks("pk", KeyType::Hash), ks("sk", KeyType::Range)],
+            vec![
+                ad("pk", ScalarAttributeType::S),
+                ad("sk", ScalarAttributeType::S),
+            ],
+        );
+
+        assert!(info.validate_sort_key_definitions().is_ok());
+    }
+
+    /// A hash-only table has no RANGE element, so there is nothing to check. It
+    /// must not be rejected for the absence of a sort key definition.
+    #[test]
+    fn validate_sort_key_definitions_accepts_a_hash_only_table() {
+        let info = key_info_with(
+            vec![ks("pk", KeyType::Hash)],
+            vec![ad("pk", ScalarAttributeType::S)],
+        );
+
+        assert!(info.validate_sort_key_definitions().is_ok());
+    }
+
+    /// Secondary index key schemas are deliberately out of scope: a table written
+    /// by an older build may carry an index whose key attributes were never
+    /// persisted, and refusing to load the table would take it entirely offline.
+    #[test]
+    fn validate_sort_key_definitions_ignores_index_key_schemas() {
+        let mut info = key_info_with(
+            vec![ks("pk", KeyType::Hash), ks("sk", KeyType::Range)],
+            vec![
+                ad("pk", ScalarAttributeType::S),
+                ad("sk", ScalarAttributeType::S),
+            ],
+        );
+        info.key_schema = vec![ks("f01", KeyType::Hash), ks("f02", KeyType::Range)];
+
+        assert!(info.validate_sort_key_definitions().is_ok());
     }
 
     #[test]

--- a/crates/storage-mongodb/src/table_engine.rs
+++ b/crates/storage-mongodb/src/table_engine.rs
@@ -17,7 +17,9 @@ use extenddb_core::types::{
 };
 use extenddb_storage::TableEngine;
 use extenddb_storage::error::StorageError;
-use extenddb_storage::util::{index_arn, sk_info, stream_arn, table_arn};
+use extenddb_storage::util::{
+    index_arn, merge_attribute_definitions, sk_info, stream_arn, table_arn,
+};
 
 use crate::MongoEngine;
 use crate::data::data_collection_name;
@@ -797,6 +799,33 @@ impl MongoEngine {
 
         // Handle GSI updates
         if let Some(gsi_updates) = &input.global_secondary_index_updates {
+            // Persist the request's attribute definitions, merged into the stored
+            // set. This backend previously never wrote them at all, so a created
+            // index's key attributes were missing from the catalog and `sk_info`
+            // resolved the index's own sort key to `None`, making it behave as
+            // hash-only. Merging (rather than replacing) is what keeps the base
+            // table's pk/sk definitions intact, which is issue #259 on the SQL
+            // backends. Read-modify-write without a transaction, matching the rest
+            // of this method; the catalog row is only written by UpdateTable.
+            let merged_attr_defs = if let Some(new_attr_defs) = &input.attribute_definitions {
+                let current = self
+                    .describe_table_impl(account_id, &input.table_name)
+                    .await?;
+                let merged =
+                    merge_attribute_definitions(&current.attribute_definitions, new_attr_defs);
+                let merged_bson =
+                    bson::to_bson(&merged).map_err(|e| StorageError::Internal(e.to_string()))?;
+                tables_coll
+                    .update_one(
+                        doc! { "_id": { "account_id": account_id, "table_name": &input.table_name } },
+                        doc! { "$set": { "attribute_definitions": merged_bson } },
+                    )
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                Some(merged)
+            } else {
+                None
+            };
             for update in gsi_updates {
                 if let Some(create) = &update.create {
                     // Fetch table_id
@@ -854,7 +883,9 @@ impl MongoEngine {
                         &index_id,
                         &create.key_schema,
                         &desc.key_schema,
-                        &desc.attribute_definitions,
+                        merged_attr_defs
+                            .as_deref()
+                            .unwrap_or(&desc.attribute_definitions),
                     )
                     .await?;
 
@@ -1000,7 +1031,7 @@ impl MongoEngine {
         }
         let has_lsi = !local_secondary_indexes.is_empty();
 
-        Ok(TableKeyInfo {
+        let key_info = TableKeyInfo {
             table_name,
             account_id,
             table_id,
@@ -1011,7 +1042,14 @@ impl MongoEngine {
             global_secondary_indexes,
             local_secondary_indexes,
             stream_specification,
-        })
+        };
+        // Catalog metadata that cannot describe its own sort key would make the
+        // keyed read paths fall back to a partition-only lookup and return the
+        // wrong item, so refuse it here rather than serve a wrong answer (#259).
+        key_info
+            .validate_sort_key_definitions()
+            .map_err(StorageError::Internal)?;
+        Ok(key_info)
     }
 
     async fn index_info_impl(

--- a/crates/storage-mongodb/src/table_engine.rs
+++ b/crates/storage-mongodb/src/table_engine.rs
@@ -808,11 +808,26 @@ impl MongoEngine {
             // backends. Read-modify-write without a transaction, matching the rest
             // of this method; the catalog row is only written by UpdateTable.
             let merged_attr_defs = if let Some(new_attr_defs) = &input.attribute_definitions {
-                let current = self
-                    .describe_table_impl(account_id, &input.table_name)
-                    .await?;
-                let merged =
-                    merge_attribute_definitions(&current.attribute_definitions, new_attr_defs);
+                // Read just the stored definitions rather than a full describe_table_impl,
+                // which would also load every index. Two concurrent UpdateTables on one
+                // table can still interleave here and lose one side's additions; that is
+                // inherent to this backend's UpdateTable, which is non-transactional
+                // throughout (the index inserts and collection creation below are not
+                // atomic with this write either), so the window is narrowed rather than
+                // closed.
+                let current_defs: Vec<extenddb_core::types::AttributeDefinition> = tables_coll
+                    .find_one(
+                        doc! { "_id": { "account_id": account_id, "table_name": &input.table_name } },
+                    )
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?
+                    .as_ref()
+                    .and_then(|d| d.get("attribute_definitions"))
+                    .map(|b| bson::from_bson(b.clone()))
+                    .transpose()
+                    .map_err(|e| StorageError::Internal(format!("attr_defs parse error: {e}")))?
+                    .unwrap_or_default();
+                let merged = merge_attribute_definitions(&current_defs, new_attr_defs);
                 let merged_bson =
                     bson::to_bson(&merged).map_err(|e| StorageError::Internal(e.to_string()))?;
                 tables_coll

--- a/crates/storage-postgres/src/bootstrapper.rs
+++ b/crates/storage-postgres/src/bootstrapper.rs
@@ -10,14 +10,16 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
+use extenddb_core::types::{AttributeDefinition, KeySchemaElement};
 use extenddb_storage::bootstrapper::{
-    AdminBootstrapResult, BootstrapConfig, Bootstrapper,
+    AdminBootstrapResult, BootstrapConfig, Bootstrapper, KeyDefinitionRepair,
     helpers::{
         check_conflict, extract_arg, generate_account_id, generate_encryption_key,
         generate_random_password, hash_password_async,
     },
 };
 use extenddb_storage::management_store::{OpError, OpResult};
+use extenddb_storage::util::recover_sort_key_definitions;
 use sqlx::PgPool;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use tokio::sync::{Mutex, OnceCell};
@@ -520,6 +522,147 @@ impl Bootstrapper for PostgresBootstrapper {
     async fn is_catalog_initialized(&self) -> OpResult<bool> {
         let pool = self.app_pool(&self.config.catalog_db).await?;
         migrations::table_exists(&pool, "settings").await
+    }
+
+    /// Repair table metadata damaged by the pre-fix `UpdateTable` (#259).
+    ///
+    /// Reads the catalog's key schemas and attribute definitions, and for any base
+    /// sort key with no definition recovers the type from the data table's
+    /// physical sort key column (`sk_s`/`sk_n`/`sk_b`, or the numbered variants for
+    /// multiple sort keys). Runs under the migration lock the caller holds.
+    async fn repair_lost_sort_key_definitions(&self, apply: bool) -> OpResult<KeyDefinitionRepair> {
+        let mut report = KeyDefinitionRepair::default();
+        let Ok(catalog) = self.app_pool(&self.config.catalog_db).await else {
+            return Ok(report);
+        };
+        let Some(data_db) = self.get_data_db_name().await? else {
+            return Ok(report);
+        };
+        let data = self.app_pool(&data_db).await?;
+
+        let rows: Vec<(String, String, String, serde_json::Value, serde_json::Value)> =
+            sqlx::query_as(
+                "SELECT account_id, table_name, table_id, key_schema, attribute_definitions \
+                 FROM tables ORDER BY table_name",
+            )
+            .fetch_all(&catalog)
+            .await
+            .map_err(|e| OpError::Internal(format!("Cannot read tables: {e}")))?;
+
+        for (account_id, table_name, table_id, ks_json, ad_json) in rows {
+            let key_schema: Vec<KeySchemaElement> = match serde_json::from_value(ks_json) {
+                Ok(v) => v,
+                Err(e) => {
+                    report
+                        .needs_attention
+                        .push(format!("{table_name}: unreadable key_schema ({e})"));
+                    continue;
+                }
+            };
+            let attr_defs: Vec<AttributeDefinition> =
+                serde_json::from_value(ad_json).unwrap_or_default();
+
+            // Nothing to do unless a sort key has lost its definition.
+            // Reported for every table on every run, not only when a sort key is
+            // repaired: the partition key definition is dropped by the same write and
+            // is not recoverable from the schema, because the pk column is always TEXT.
+            // It is not needed for correctness either, since partition key values are
+            // encoded from the key schema alone, so it is reported rather than guessed
+            // and keeps being reported until a human restores it.
+            let pk_missing: Vec<&str> = key_schema
+                .iter()
+                .filter(|ks| ks.key_type == extenddb_core::types::KeyType::Hash)
+                .filter(|ks| {
+                    !attr_defs
+                        .iter()
+                        .any(|ad| ad.attribute_name == ks.attribute_name)
+                })
+                .map(|ks| ks.attribute_name.as_str())
+                .collect();
+            if !pk_missing.is_empty() {
+                report.needs_attention.push(format!(
+                    "{table_name}: partition key definition(s) [{}] are absent; reads and \
+                     writes are unaffected, but index key type validation cannot check them",
+                    pk_missing.join(", ")
+                ));
+            }
+
+            let missing: Vec<&KeySchemaElement> = key_schema
+                .iter()
+                .filter(|ks| ks.key_type == extenddb_core::types::KeyType::Range)
+                .filter(|ks| {
+                    !attr_defs
+                        .iter()
+                        .any(|ad| ad.attribute_name == ks.attribute_name)
+                })
+                .collect();
+            if missing.is_empty() {
+                continue;
+            }
+
+            // PRIMARY KEY columns only, in key order. Every data table carries all
+            // three typed columns for each sort key position (sk_s, sk_n, sk_b), so
+            // column existence says nothing about the declared type: only PRIMARY KEY
+            // membership does. `to_regclass` resolves the name through the current
+            // search_path, so this cannot match a same-named table in another schema,
+            // and returns NULL (no rows) rather than raising when the data table is
+            // absent.
+            let columns: Vec<String> = sqlx::query_as::<_, (String,)>(
+                "SELECT a.attname \
+                 FROM pg_index i \
+                 JOIN unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord) ON TRUE \
+                 JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = k.attnum \
+                 WHERE i.indrelid = to_regclass($1) AND i.indisprimary \
+                 ORDER BY k.ord",
+            )
+            .bind(format!("\"_ddb_{table_id}\""))
+            .fetch_all(&data)
+            .await
+            .map_err(|e| OpError::Internal(format!("Cannot read columns of {table_name}: {e}")))?
+            .into_iter()
+            .map(|(c,)| c)
+            .collect();
+
+            let recovered = recover_sort_key_definitions(&key_schema, &attr_defs, &columns);
+            if recovered.is_empty() {
+                report.needs_attention.push(format!(
+                    "{table_name}: sort key(s) [{}] have no attribute definition and no \
+                     matching PRIMARY KEY column was found to recover the type from",
+                    missing
+                        .iter()
+                        .map(|ks| ks.attribute_name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+                continue;
+            }
+
+            let mut merged = attr_defs;
+            merged.extend(recovered.iter().cloned());
+            let merged_json = serde_json::to_value(&merged)
+                .map_err(|e| OpError::Internal(format!("Cannot serialize definitions: {e}")))?;
+            if apply {
+                sqlx::query(
+                    "UPDATE tables SET attribute_definitions = $1 \
+                     WHERE account_id = $2 AND table_name = $3",
+                )
+                .bind(&merged_json)
+                .bind(&account_id)
+                .bind(&table_name)
+                .execute(&catalog)
+                .await
+                .map_err(|e| OpError::Internal(format!("Cannot repair {table_name}: {e}")))?;
+            }
+
+            for def in &recovered {
+                report.repaired.push(format!(
+                    "{table_name}: {} ({:?})",
+                    def.attribute_name, def.attribute_type
+                ));
+            }
+        }
+
+        Ok(report)
     }
 
     async fn list_table_names(&self) -> OpResult<Vec<String>> {

--- a/crates/storage-postgres/src/data/ddl.rs
+++ b/crates/storage-postgres/src/data/ddl.rs
@@ -304,7 +304,7 @@ impl PostgresEngine {
             self.fetch_all_index_info(&table_id).await?;
         let has_lsi = !local_secondary_indexes.is_empty();
 
-        Ok(TableKeyInfo {
+        let key_info = TableKeyInfo {
             table_name: table_name.to_owned(),
             account_id: account_id.to_owned(),
             table_id,
@@ -315,7 +315,14 @@ impl PostgresEngine {
             global_secondary_indexes,
             local_secondary_indexes,
             stream_specification,
-        })
+        };
+        // Catalog metadata that cannot describe its own sort key would make the
+        // keyed read paths fall back to a partition-only lookup and return the
+        // wrong item, so refuse it here rather than serve a wrong answer (#259).
+        key_info
+            .validate_sort_key_definitions()
+            .map_err(StorageError::Internal)?;
+        Ok(key_info)
     }
 
     /// Fetch every secondary index defined on a table, split into

--- a/crates/storage-postgres/src/update_table.rs
+++ b/crates/storage-postgres/src/update_table.rs
@@ -7,6 +7,7 @@ use extenddb_core::types::{
     AttributeDefinition, BillingMode, KeySchemaElement, TableDescription, UpdateTableInput,
 };
 use extenddb_storage::error::StorageError;
+use extenddb_storage::util::merge_attribute_definitions;
 
 use crate::PostgresEngine;
 
@@ -267,6 +268,10 @@ impl PostgresEngine {
         // Apply GSI updates (create/delete).
         let mut created_index_ids: Vec<String> = Vec::new();
         let mut deleted_index_ids: Vec<String> = Vec::new();
+        // The merged attribute definitions persisted by this UpdateTable, carried
+        // out of the catalog transaction so the post-commit index DDL builds its
+        // columns from the same set the catalog now holds.
+        let mut merged_attr_defs_for_ddl: Option<Vec<AttributeDefinition>> = None;
         if let Some(updates) = &input.global_secondary_index_updates {
             for update in updates {
                 if let Some(create) = &update.create {
@@ -344,18 +349,32 @@ impl PostgresEngine {
                 }
             }
 
-            // Update attribute_definitions on the table if new ones were provided.
-            if let Some(new_attr_defs) = &input.attribute_definitions {
-                let ad_json = serde_json::to_value(new_attr_defs)
+            // Merge the request's attribute definitions into the stored set.
+            //
+            // The request carries only the attributes it needs (a created index's
+            // key attributes), so replacing the column would drop the base
+            // table's own pk/sk definitions and silently degrade keyed reads to a
+            // partition-only lookup (issue #259). The existing set was read under
+            // the FOR UPDATE lock above, so the read-modify-write is atomic with
+            // respect to a concurrent UpdateTable.
+            let merged_attr_defs = if let Some(new_attr_defs) = &input.attribute_definitions {
+                let existing: Vec<AttributeDefinition> = serde_json::from_value(ad_json.clone())
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                let merged = merge_attribute_definitions(&existing, new_attr_defs);
+                let merged_json = serde_json::to_value(&merged)
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
                 sqlx::query("UPDATE tables SET attribute_definitions = $1 WHERE account_id = $2 AND table_name = $3")
-                    .bind(&ad_json)
+                    .bind(&merged_json)
                     .bind(account_id)
                     .bind(&input.table_name)
                     .execute(&mut *tx)
                     .await
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
-            }
+                Some(merged)
+            } else {
+                None
+            };
+            merged_attr_defs_for_ddl = merged_attr_defs;
         }
 
         tx.commit()
@@ -368,8 +387,10 @@ impl PostgresEngine {
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
             let base_attr_defs: Vec<AttributeDefinition> = serde_json::from_value(ad_json.clone())
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
-            let effective_attr_defs = input
-                .attribute_definitions
+            // Build index columns from the merged set, not the request's subset: a
+            // new index may key on an attribute the base table already defined, and
+            // the request is not required to re-declare it.
+            let effective_attr_defs = merged_attr_defs_for_ddl
                 .as_deref()
                 .unwrap_or(&base_attr_defs);
 

--- a/crates/storage-sqlite/src/bootstrapper.rs
+++ b/crates/storage-sqlite/src/bootstrapper.rs
@@ -9,9 +9,13 @@
 //! user. Destruction removes the database file and its WAL/SHM sidecars.
 
 use async_trait::async_trait;
-use extenddb_storage::bootstrapper::{AdminBootstrapResult, Bootstrapper, helpers};
+use extenddb_core::types::{AttributeDefinition, KeySchemaElement, KeyType};
+use extenddb_storage::bootstrapper::{
+    AdminBootstrapResult, Bootstrapper, KeyDefinitionRepair, helpers,
+};
 use extenddb_storage::error::StorageError;
 use extenddb_storage::management_store::{OpError, OpResult};
+use extenddb_storage::util::recover_sort_key_definitions;
 use sqlx::SqlitePool;
 use sqlx::sqlite::SqlitePoolOptions;
 
@@ -250,6 +254,154 @@ impl Bootstrapper for SqliteBootstrapper {
             return Ok(false);
         };
         schema::table_exists(&pool, "settings").await
+    }
+
+    /// Repair table metadata damaged by the pre-fix `UpdateTable` (#259).
+    ///
+    /// SQLite keeps the catalog and the data tables in one file, so the physical
+    /// sort key columns are read with `PRAGMA table_info`. Otherwise identical to
+    /// the PostgreSQL implementation: for any base sort key with no attribute
+    /// definition, recover the type from its column name.
+    async fn repair_lost_sort_key_definitions(&self, apply: bool) -> OpResult<KeyDefinitionRepair> {
+        let mut report = KeyDefinitionRepair::default();
+        let Ok(pool) = self.pool().await else {
+            return Ok(report);
+        };
+        // A never-initialised catalog has no `tables` table, and `pool()` opens
+        // with mode=rwc, which silently creates an empty database file, so the
+        // SELECT below would hard-error rather than find nothing. PostgreSQL
+        // degrades gracefully through its get_data_db_name() guard; this is the
+        // SQLite equivalent.
+        if !schema::table_exists(&pool, "tables").await? {
+            return Ok(report);
+        }
+
+        let rows: Vec<(String, String, String, String, String)> = sqlx::query_as(
+            "SELECT account_id, table_name, table_id, key_schema, attribute_definitions \
+             FROM tables ORDER BY table_name",
+        )
+        .fetch_all(&pool)
+        .await
+        .map_err(|e| OpError::Internal(format!("Cannot read tables: {e}")))?;
+
+        for (account_id, table_name, table_id, ks_json, ad_json) in rows {
+            let key_schema: Vec<KeySchemaElement> = match serde_json::from_str(&ks_json) {
+                Ok(v) => v,
+                Err(e) => {
+                    report
+                        .needs_attention
+                        .push(format!("{table_name}: unreadable key_schema ({e})"));
+                    continue;
+                }
+            };
+            let attr_defs: Vec<AttributeDefinition> =
+                serde_json::from_str(&ad_json).unwrap_or_default();
+
+            // Reported for every table on every run, not only when a sort key is
+            // repaired: the partition key definition is dropped by the same write and
+            // is not recoverable from the schema, because the pk column is always TEXT.
+            // It is not needed for correctness either, since partition key values are
+            // encoded from the key schema alone, so it is reported rather than guessed
+            // and keeps being reported until a human restores it.
+            let pk_missing: Vec<&str> = key_schema
+                .iter()
+                .filter(|ks| ks.key_type == KeyType::Hash)
+                .filter(|ks| {
+                    !attr_defs
+                        .iter()
+                        .any(|ad| ad.attribute_name == ks.attribute_name)
+                })
+                .map(|ks| ks.attribute_name.as_str())
+                .collect();
+            if !pk_missing.is_empty() {
+                report.needs_attention.push(format!(
+                    "{table_name}: partition key definition(s) [{}] are absent; reads and \
+                     writes are unaffected, but index key type validation cannot check them",
+                    pk_missing.join(", ")
+                ));
+            }
+
+            let missing: Vec<&KeySchemaElement> = key_schema
+                .iter()
+                .filter(|ks| ks.key_type == KeyType::Range)
+                .filter(|ks| {
+                    !attr_defs
+                        .iter()
+                        .any(|ad| ad.attribute_name == ks.attribute_name)
+                })
+                .collect();
+            if missing.is_empty() {
+                continue;
+            }
+
+            // PRIMARY KEY columns only, in key order. Every data table carries all
+            // three typed columns for each sort key position (sk_s, sk_n, sk_b), so
+            // column existence says nothing about the declared type: only the pk
+            // position reported by table_info does. `table_id` is interpolated
+            // because PRAGMA takes no bind parameters; it is checked as a UUID first
+            // so a malformed catalog row cannot reach the statement.
+            if uuid::Uuid::parse_str(&table_id).is_err() {
+                report
+                    .needs_attention
+                    .push(format!("{table_name}: table_id {table_id:?} is not a UUID"));
+                continue;
+            }
+            let mut key_columns: Vec<(i64, String)> = sqlx::query_as::<
+                _,
+                (i64, String, String, i64, Option<String>, i64),
+            >(&format!(
+                "PRAGMA table_info(\"_ddb_{table_id}\")"
+            ))
+            .fetch_all(&pool)
+            .await
+            .map_err(|e| OpError::Internal(format!("Cannot read columns of {table_name}: {e}")))?
+            .into_iter()
+            .filter(|(.., pk_pos)| *pk_pos > 0)
+            .map(|(_, name, _, _, _, pk_pos)| (pk_pos, name))
+            .collect();
+            key_columns.sort_unstable();
+            let columns: Vec<String> = key_columns.into_iter().map(|(_, name)| name).collect();
+
+            let recovered = recover_sort_key_definitions(&key_schema, &attr_defs, &columns);
+            if recovered.is_empty() {
+                report.needs_attention.push(format!(
+                    "{table_name}: sort key(s) [{}] have no attribute definition and no \
+                     matching PRIMARY KEY column was found to recover the type from",
+                    missing
+                        .iter()
+                        .map(|ks| ks.attribute_name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+                continue;
+            }
+
+            let mut merged = attr_defs;
+            merged.extend(recovered.iter().cloned());
+            let merged_json = serde_json::to_string(&merged)
+                .map_err(|e| OpError::Internal(format!("Cannot serialize definitions: {e}")))?;
+            if apply {
+                sqlx::query(
+                    "UPDATE tables SET attribute_definitions = ?1 \
+                     WHERE account_id = ?2 AND table_name = ?3",
+                )
+                .bind(&merged_json)
+                .bind(&account_id)
+                .bind(&table_name)
+                .execute(&pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("Cannot repair {table_name}: {e}")))?;
+            }
+
+            for def in &recovered {
+                report.repaired.push(format!(
+                    "{table_name}: {} ({:?})",
+                    def.attribute_name, def.attribute_type
+                ));
+            }
+        }
+
+        Ok(report)
     }
 
     async fn list_table_names(&self) -> OpResult<Vec<String>> {

--- a/crates/storage-sqlite/src/data/ddl.rs
+++ b/crates/storage-sqlite/src/data/ddl.rs
@@ -230,7 +230,7 @@ impl SqliteEngine {
             self.fetch_all_index_info(&table_id).await?;
         let has_lsi = !local_secondary_indexes.is_empty();
 
-        Ok(TableKeyInfo {
+        let key_info = TableKeyInfo {
             table_name: table_name.to_owned(),
             account_id: account_id.to_owned(),
             table_id,
@@ -241,7 +241,14 @@ impl SqliteEngine {
             global_secondary_indexes,
             local_secondary_indexes,
             stream_specification,
-        })
+        };
+        // Catalog metadata that cannot describe its own sort key would make the
+        // keyed read paths fall back to a partition-only lookup and return the
+        // wrong item, so refuse it here rather than serve a wrong answer (#259).
+        key_info
+            .validate_sort_key_definitions()
+            .map_err(StorageError::Internal)?;
+        Ok(key_info)
     }
 
     /// Fetch every secondary index defined on a table, split into

--- a/crates/storage-sqlite/src/update_table.rs
+++ b/crates/storage-sqlite/src/update_table.rs
@@ -14,6 +14,7 @@ use extenddb_core::types::{
     AttributeDefinition, BillingMode, KeySchemaElement, TableDescription, UpdateTableInput,
 };
 use extenddb_storage::error::StorageError;
+use extenddb_storage::util::merge_attribute_definitions;
 
 use crate::store::SqliteEngine;
 
@@ -217,6 +218,10 @@ impl SqliteEngine {
         // GSI create/delete.
         let mut created: Vec<String> = Vec::new();
         let mut deleted: Vec<String> = Vec::new();
+        // The merged attribute definitions persisted by this UpdateTable, carried
+        // out of the catalog transaction so the post-commit index DDL builds its
+        // columns from the same set the catalog now holds.
+        let mut merged_attr_defs_for_ddl: Option<Vec<AttributeDefinition>> = None;
         if let Some(updates) = &input.global_secondary_index_updates {
             for update in updates {
                 if let Some(create) = &update.create {
@@ -279,8 +284,18 @@ impl SqliteEngine {
                     deleted.push(del_id);
                 }
             }
+            // Merge the request's attribute definitions into the stored set.
+            //
+            // The request carries only the attributes it needs (a created index's
+            // key attributes), so replacing the column would drop the base table's
+            // own pk/sk definitions and silently degrade keyed reads to a
+            // partition-only lookup (issue #259). The existing set was read inside
+            // this BEGIN IMMEDIATE transaction, so the read-modify-write is atomic.
             if let Some(new_attr_defs) = &input.attribute_definitions {
-                let j = serde_json::to_string(new_attr_defs)
+                let existing: Vec<AttributeDefinition> = serde_json::from_str(&ad_json)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                let merged = merge_attribute_definitions(&existing, new_attr_defs);
+                let j = serde_json::to_string(&merged)
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
                 update_col(
                     &mut tx,
@@ -290,6 +305,7 @@ impl SqliteEngine {
                     &j,
                 )
                 .await?;
+                merged_attr_defs_for_ddl = Some(merged);
             }
         }
 
@@ -303,7 +319,10 @@ impl SqliteEngine {
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
             let base_ad: Vec<AttributeDefinition> = serde_json::from_str(&ad_json)
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
-            let effective_ad = input.attribute_definitions.as_deref().unwrap_or(&base_ad);
+            // Build index columns from the merged set, not the request's subset: a
+            // new index may key on an attribute the base table already defined, and
+            // the request is not required to re-declare it.
+            let effective_ad = merged_attr_defs_for_ddl.as_deref().unwrap_or(&base_ad);
 
             let mut ci = 0usize;
             let mut di = 0usize;

--- a/crates/storage/src/bootstrapper.rs
+++ b/crates/storage/src/bootstrapper.rs
@@ -41,6 +41,19 @@ pub struct AdminBootstrapResult {
     pub from_env: bool,
 }
 
+/// Outcome of [`Bootstrapper::repair_lost_sort_key_definitions`].
+#[derive(Debug, Default, Clone)]
+pub struct KeyDefinitionRepair {
+    /// Tables whose sort key definitions were restored, as
+    /// `table_name: attribute (TYPE)` lines. When the caller passed `apply =
+    /// false` these are the repairs that WOULD be made.
+    pub repaired: Vec<String>,
+    /// Tables that are damaged but could not be repaired automatically, because
+    /// no physical sort key column was found to read the type back from. These
+    /// need a human: guessing a type would resolve the key to the wrong column.
+    pub needs_attention: Vec<String>,
+}
+
 /// High-level bootstrap operations for storage backends.
 ///
 /// Covers the init, destroy, and migrate command paths. Implementations
@@ -65,6 +78,31 @@ pub trait Bootstrapper: Send + Sync {
 
     /// Run data schema migrations (stream tables, sequences, etc.).
     async fn run_data_migrations(&self) -> OpResult<()>;
+
+    /// Restore sort key attribute definitions that issue #259 deleted from table
+    /// metadata, reading each type back from the physical sort key column.
+    ///
+    /// Before the fix, `UpdateTable` replaced a table's stored attribute
+    /// definitions with the request's subset, so adding a GSI dropped the base
+    /// table's own key definitions and keyed reads silently returned another item
+    /// in the same partition. The write path no longer does that, but a table
+    /// damaged by an older build stays damaged, and it now fails its reads loudly
+    /// instead (see `TableKeyInfo::validate_sort_key_definitions`). This repairs
+    /// such tables so they serve correct reads again.
+    ///
+    /// With `apply` false this only detects and reports, writing nothing, so a
+    /// `migrate` run that has not been confirmed with `--yes` never mutates the
+    /// catalog. With `apply` true the repair is written.
+    ///
+    /// Idempotent: a table whose definitions are intact is left untouched, so
+    /// running it on a healthy deployment reports nothing and changes nothing.
+    ///
+    /// The default implementation repairs nothing, which is correct for a backend
+    /// that never wrote the definitions in the first place.
+    async fn repair_lost_sort_key_definitions(&self, apply: bool) -> OpResult<KeyDefinitionRepair> {
+        let _ = apply;
+        Ok(KeyDefinitionRepair::default())
+    }
 
     /// Acquire a cross-process lock so that concurrent `migrate` runs, such as
     /// several replicas starting at once, don't race each other applying schema

--- a/crates/storage/src/util/key.rs
+++ b/crates/storage/src/util/key.rs
@@ -171,6 +171,73 @@ pub fn merge_attribute_definitions(
     merged
 }
 
+/// Recover sort key attribute definitions that were lost from a table's stored
+/// metadata, using the data table's PRIMARY KEY columns as the source of truth.
+///
+/// A table whose base key schema names a RANGE attribute with no matching
+/// attribute definition cannot be read correctly: [`sk_info`] returns `None` and
+/// keyed reads degrade to a partition-only lookup. Issue #259 produced exactly
+/// that state, by having `UpdateTable` replace the stored attribute definitions
+/// with the request's subset. The write path is fixed by
+/// [`merge_attribute_definitions`]; this recovers tables already damaged by it.
+///
+/// The lost information is the attribute's scalar type. `primary_key_columns`
+/// must be the data table's PRIMARY KEY column names, because that, and only that,
+/// records the type: every table is created with all three typed columns for each
+/// sort key position (`sk_s`, `sk_n`, `sk_b`) and only the one matching the
+/// declared type joins the PRIMARY KEY. Passing the table's full column list here
+/// would match `sk_s` on every table and silently mistype every numeric and binary
+/// sort key, which would put the table straight back into the wrong-answer state
+/// this is meant to repair.
+///
+/// Returns the definitions to add, in key schema order. Attributes that already
+/// have a definition are left untouched, and a RANGE attribute with no matching
+/// PRIMARY KEY column is skipped rather than guessed: the caller reports it so the
+/// table can be looked at by hand instead of being silently given a wrong type.
+///
+/// Only sort keys are recovered. A missing HASH definition is not recoverable this
+/// way, because the partition key column is always `TEXT` regardless of the
+/// declared type, and it is not needed for correctness: partition key values are
+/// encoded by [`composite_pk_to_text`], which takes only the key schema.
+#[must_use]
+pub fn recover_sort_key_definitions(
+    base_key_schema: &[KeySchemaElement],
+    attr_defs: &[AttributeDefinition],
+    primary_key_columns: &[String],
+) -> Vec<AttributeDefinition> {
+    let mut recovered = Vec::new();
+    let range_elements: Vec<&KeySchemaElement> = base_key_schema
+        .iter()
+        .filter(|ks| ks.key_type == KeyType::Range)
+        .collect();
+
+    for (position, element) in range_elements.iter().enumerate() {
+        if attr_defs
+            .iter()
+            .any(|ad| ad.attribute_name == element.attribute_name)
+        {
+            continue;
+        }
+        let attr_type = [
+            ScalarAttributeType::S,
+            ScalarAttributeType::N,
+            ScalarAttributeType::B,
+        ]
+        .into_iter()
+        .find(|candidate| {
+            let expected = sk_column_n(position, *candidate);
+            primary_key_columns.iter().any(|c| c == &expected)
+        });
+        if let Some(attr_type) = attr_type {
+            recovered.push(AttributeDefinition {
+                attribute_name: element.attribute_name.clone(),
+                attribute_type: attr_type,
+            });
+        }
+    }
+    recovered
+}
+
 /// Encode multiple string parts into a single netstring-encoded composite key.
 ///
 /// Format: `<len>:<value>,<len>:<value>,...` — e.g., `"abc"` + `"de"` → `"3:abc,2:de,"`.
@@ -280,6 +347,106 @@ mod tests {
         let merged = merge_attribute_definitions(&existing, &[]);
 
         assert_eq!(merged, existing);
+    }
+
+    fn ks(name: &str, key_type: KeyType) -> KeySchemaElement {
+        KeySchemaElement {
+            attribute_name: name.into(),
+            key_type,
+        }
+    }
+
+    fn cols(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    /// Every data table is created with all three typed columns for each sort key
+    /// position, so column existence says nothing about the type; only PRIMARY KEY
+    /// membership does. This is the test that discriminates: an implementation
+    /// probing existence would answer `S` here, silently mistyping the key and
+    /// putting the table back into the wrong-answer state of #259.
+    #[test]
+    fn recover_sort_key_defs_uses_primary_key_membership_not_column_existence() {
+        let schema = vec![ks("pk", KeyType::Hash), ks("sk", KeyType::Range)];
+
+        // The real table has sk_s, sk_n and sk_b; only sk_n is in the PRIMARY KEY.
+        let recovered = recover_sort_key_definitions(&schema, &[], &cols(&["pk", "sk_n"]));
+
+        assert_eq!(
+            recovered,
+            vec![ad("sk", ScalarAttributeType::N)],
+            "the type must come from the PRIMARY KEY column, not from which typed \
+             column happens to exist"
+        );
+    }
+
+    #[test]
+    fn recover_sort_key_defs_recovers_each_scalar_type_from_the_key_column() {
+        let schema = vec![ks("pk", KeyType::Hash), ks("sk", KeyType::Range)];
+
+        for (col, expected) in [
+            ("sk_s", ScalarAttributeType::S),
+            ("sk_n", ScalarAttributeType::N),
+            ("sk_b", ScalarAttributeType::B),
+        ] {
+            assert_eq!(
+                recover_sort_key_definitions(&schema, &[], &cols(&["pk", col])),
+                vec![ad("sk", expected)],
+                "PRIMARY KEY column {col} must recover {expected:?}"
+            );
+        }
+    }
+
+    /// Multiple sort keys use the 1-indexed column suffix, so each position must be
+    /// matched against its own column rather than the first one found.
+    #[test]
+    fn recover_sort_key_defs_handles_multiple_sort_keys_by_position() {
+        let schema = vec![
+            ks("pk", KeyType::Hash),
+            ks("sk", KeyType::Range),
+            ks("sk2", KeyType::Range),
+        ];
+
+        let recovered = recover_sort_key_definitions(&schema, &[], &cols(&["pk", "sk_s", "sk2_n"]));
+
+        assert_eq!(
+            recovered,
+            vec![
+                ad("sk", ScalarAttributeType::S),
+                ad("sk2", ScalarAttributeType::N)
+            ]
+        );
+    }
+
+    #[test]
+    fn recover_sort_key_defs_leaves_intact_metadata_alone() {
+        let schema = vec![ks("pk", KeyType::Hash), ks("sk", KeyType::Range)];
+        let defs = vec![
+            ad("pk", ScalarAttributeType::S),
+            ad("sk", ScalarAttributeType::S),
+        ];
+
+        assert!(recover_sort_key_definitions(&schema, &defs, &cols(&["pk", "sk_s"])).is_empty());
+    }
+
+    #[test]
+    fn recover_sort_key_defs_ignores_a_hash_only_table() {
+        let schema = vec![ks("pk", KeyType::Hash)];
+
+        assert!(recover_sort_key_definitions(&schema, &[], &cols(&["pk"])).is_empty());
+    }
+
+    /// No sort key column in the PRIMARY KEY means no evidence. Skipping keeps the
+    /// loud failure in place instead of writing a guessed type that would resolve
+    /// the key to the wrong physical column.
+    #[test]
+    fn recover_sort_key_defs_skips_a_range_key_with_no_primary_key_column() {
+        let schema = vec![ks("pk", KeyType::Hash), ks("sk", KeyType::Range)];
+
+        assert!(
+            recover_sort_key_definitions(&schema, &[], &cols(&["pk"])).is_empty(),
+            "a type must never be invented when no sort key column is in the PRIMARY KEY"
+        );
     }
 
     #[test]

--- a/crates/storage/src/util/key.rs
+++ b/crates/storage/src/util/key.rs
@@ -128,6 +128,49 @@ pub fn sk_info<'a>(
     Some((&sk_element.attribute_name, attr_def.attribute_type))
 }
 
+/// Merge the attribute definitions supplied by an `UpdateTable` request into the
+/// table's persisted set, returning the union.
+///
+/// `UpdateTable` carries only the attribute definitions the request itself needs,
+/// which for a GSI creation is that index's key attributes. The service unions
+/// them into the stored set rather than replacing it.
+///
+/// Replacing rather than merging is issue #259: it drops the base table's own key
+/// definitions, [`sk_info`] then finds no definition for the sort key and returns
+/// `None`, and keyed reads silently degrade to a partition-only lookup that
+/// returns another item under the same partition key.
+///
+/// Measured against real DynamoDB (us-east-1, 2026-08-13) on a table created with
+/// `[pk S, sk S]`:
+///
+/// - `UpdateTable` supplying only `[f01, f02]` is accepted and the next
+///   `DescribeTable` reports all four definitions, so the set is a union.
+/// - Supplying the full set, base definitions included, is accepted and does not
+///   duplicate them.
+/// - Re-declaring `pk` as `N` while the table holds it as `S` is **accepted** and
+///   the stored type stays `S`. The service neither applies the new type nor
+///   rejects the request, so this keeps the existing definition and ignores the
+///   conflicting one rather than inventing an error the service does not return.
+///
+/// Existing definitions keep their order and are never rewritten; new ones are
+/// appended in request order.
+#[must_use]
+pub fn merge_attribute_definitions(
+    existing: &[AttributeDefinition],
+    incoming: &[AttributeDefinition],
+) -> Vec<AttributeDefinition> {
+    let mut merged = existing.to_vec();
+    for new_def in incoming {
+        let already_defined = merged
+            .iter()
+            .any(|ad| ad.attribute_name == new_def.attribute_name);
+        if !already_defined {
+            merged.push(new_def.clone());
+        }
+    }
+    merged
+}
+
 /// Encode multiple string parts into a single netstring-encoded composite key.
 ///
 /// Format: `<len>:<value>,<len>:<value>,...` — e.g., `"abc"` + `"de"` → `"3:abc,2:de,"`.
@@ -147,6 +190,97 @@ pub fn encode_netstring_composite(parts: &[String]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn ad(name: &str, attr_type: ScalarAttributeType) -> AttributeDefinition {
+        AttributeDefinition {
+            attribute_name: name.into(),
+            attribute_type: attr_type,
+        }
+    }
+
+    /// The #259 case: `UpdateTable` supplies only the new index's key attributes,
+    /// so the base table's own pk/sk definitions must survive the merge. Replacing
+    /// instead is what made `sk_info` return `None` and keyed reads return the
+    /// wrong item.
+    #[test]
+    fn merge_attr_defs_keeps_base_keys_when_request_carries_only_new_attrs() {
+        let existing = vec![
+            ad("pk", ScalarAttributeType::S),
+            ad("sk", ScalarAttributeType::S),
+        ];
+        let incoming = vec![
+            ad("f01", ScalarAttributeType::S),
+            ad("f02", ScalarAttributeType::S),
+        ];
+
+        let merged = merge_attribute_definitions(&existing, &incoming);
+
+        let names: Vec<&str> = merged.iter().map(|a| a.attribute_name.as_str()).collect();
+        assert_eq!(names, vec!["pk", "sk", "f01", "f02"]);
+        // The sort key must still be resolvable, which is the property the read
+        // path depends on.
+        let schema = vec![
+            KeySchemaElement {
+                attribute_name: "pk".into(),
+                key_type: KeyType::Hash,
+            },
+            KeySchemaElement {
+                attribute_name: "sk".into(),
+                key_type: KeyType::Range,
+            },
+        ];
+        assert_eq!(
+            sk_info(&schema, &merged),
+            Some(("sk", ScalarAttributeType::S))
+        );
+    }
+
+    /// A client may send the full set instead of only the new attributes; the
+    /// service accepts that without duplicating anything (measured 2026-08-13).
+    #[test]
+    fn merge_attr_defs_is_idempotent_for_redeclared_identical_defs() {
+        let existing = vec![
+            ad("pk", ScalarAttributeType::S),
+            ad("sk", ScalarAttributeType::S),
+        ];
+        let incoming = vec![
+            ad("pk", ScalarAttributeType::S),
+            ad("sk", ScalarAttributeType::S),
+            ad("f01", ScalarAttributeType::S),
+        ];
+
+        let merged = merge_attribute_definitions(&existing, &incoming);
+
+        let names: Vec<&str> = merged.iter().map(|a| a.attribute_name.as_str()).collect();
+        assert_eq!(names, vec!["pk", "sk", "f01"]);
+    }
+
+    /// Real DynamoDB accepts a conflicting redeclaration and keeps the stored
+    /// type (measured: `pk` held as `S`, re-declared as `N`, still `S` afterwards).
+    /// Applying the new type would silently move the key to a different physical
+    /// column.
+    #[test]
+    fn merge_attr_defs_keeps_the_stored_type_on_a_conflicting_redeclaration() {
+        let existing = vec![ad("pk", ScalarAttributeType::S)];
+        let incoming = vec![ad("pk", ScalarAttributeType::N)];
+
+        let merged = merge_attribute_definitions(&existing, &incoming);
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].attribute_type, ScalarAttributeType::S);
+    }
+
+    #[test]
+    fn merge_attr_defs_with_no_incoming_defs_is_a_no_op() {
+        let existing = vec![
+            ad("pk", ScalarAttributeType::S),
+            ad("sk", ScalarAttributeType::N),
+        ];
+
+        let merged = merge_attribute_definitions(&existing, &[]);
+
+        assert_eq!(merged, existing);
+    }
 
     #[test]
     fn encode_netstring_single() {

--- a/crates/storage/src/util/mod.rs
+++ b/crates/storage/src/util/mod.rs
@@ -12,6 +12,6 @@ mod key;
 pub use arn::{index_arn, parse_stream_arn, stream_arn, table_arn};
 pub use key::SortKeyValue;
 pub use key::{
-    composite_pk_to_text, encode_netstring_composite, parse_sk, pk_to_text, sk_column, sk_column_n,
-    sk_info,
+    composite_pk_to_text, encode_netstring_composite, merge_attribute_definitions, parse_sk,
+    pk_to_text, sk_column, sk_column_n, sk_info,
 };

--- a/crates/storage/src/util/mod.rs
+++ b/crates/storage/src/util/mod.rs
@@ -13,5 +13,5 @@ pub use arn::{index_arn, parse_stream_arn, stream_arn, table_arn};
 pub use key::SortKeyValue;
 pub use key::{
     composite_pk_to_text, encode_netstring_composite, merge_attribute_definitions, parse_sk,
-    pk_to_text, sk_column, sk_column_n, sk_info,
+    pk_to_text, recover_sort_key_definitions, sk_column, sk_column_n, sk_info,
 };

--- a/tests/rust/src/gsi_update_table_attr_defs.rs
+++ b/tests/rust/src/gsi_update_table_attr_defs.rs
@@ -1,0 +1,276 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression tests for issue #259: adding a GSI to a populated composite-key
+//! table must not disturb the base table's own key metadata.
+//!
+//! `UpdateTable` carries only the attribute definitions the request needs, so the
+//! backends must merge them into the stored set. Replacing the set dropped the
+//! base table's `pk`/`sk` definitions, `sk_info` then found no definition for the
+//! sort key, and `GetItem` silently degraded to a partition-only lookup that
+//! returned a different item under the same partition key with HTTP 200.
+//!
+//! The merge behaviour is measured against real DynamoDB (us-east-1, 2026-08-13):
+//! a table created with `[pk, sk]` whose `UpdateTable` supplied only `[f01, f02]`
+//! reported all four definitions in the next `DescribeTable`.
+
+use crate::test_base::*;
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition, CreateGlobalSecondaryIndexAction, GlobalSecondaryIndexUpdate, IndexStatus,
+    KeySchemaElement, KeyType, Projection, ProjectionType, ScalarAttributeType,
+};
+use std::collections::HashMap;
+use std::time::Duration;
+
+/// Items per partition. More than one is what makes a partition-only read
+/// observably wrong; a handful keeps the test fast while still failing on the
+/// pre-fix code, where every read but one returned the first physical row.
+const ITEM_COUNT: usize = 8;
+
+/// Shared by every item, so the GSI's hash key alone never narrows to one row.
+const GSI_HASH_VALUE: &str = "gpk-shared";
+
+/// Poll DescribeTable until the named index reports ACTIVE (up to 60s).
+async fn wait_for_index_active(c: &aws_sdk_dynamodb::Client, table: &str, index_name: &str) {
+    for _ in 0..60 {
+        if let Ok(resp) = c.describe_table().table_name(table).send().await {
+            if let Some(t) = resp.table() {
+                let active = t.global_secondary_indexes().iter().any(|i| {
+                    i.index_name() == Some(index_name)
+                        && i.index_status() == Some(&IndexStatus::Active)
+                });
+                if active {
+                    return;
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    panic!("Index {index_name} on {table} did not become ACTIVE within 60s");
+}
+
+/// Create a composite-key table and populate one partition with `ITEM_COUNT`
+/// items whose sort keys are distinct, then add a GSI keyed on two non-key
+/// attributes supplying only those attributes' definitions.
+async fn table_with_gsi_added_after_population(label: &str) -> (String, String) {
+    let c = client();
+    let table = format!("Gsi259_{label}_{}", ts());
+
+    c.create_table()
+        .table_name(&table)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("sk")
+                .key_type(KeyType::Range)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("sk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(aws_sdk_dynamodb::types::BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+    wait_for_active(c, &table).await;
+
+    for i in 0..ITEM_COUNT {
+        let mut item = HashMap::new();
+        item.insert("pk".into(), s("shared"));
+        item.insert("sk".into(), s(&format!("sk-{i:05}")));
+        // Every item shares one GSI hash key so a query that matched on the hash
+        // key alone would return all of them. That is what makes the sort-key
+        // assertion below discriminating: an index whose sort key was not
+        // resolved behaves as hash-only and returns ITEM_COUNT rows, not one.
+        item.insert("f01".into(), s(GSI_HASH_VALUE));
+        item.insert("f02".into(), s(&format!("gsk-{i:05}")));
+        item.insert("payload".into(), s(&format!("payload-{i:05}")));
+        c.put_item()
+            .table_name(&table)
+            .set_item(Some(item))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // Only the new index's key attributes are supplied, exactly as the SDK and
+    // real DynamoDB expect. The stored set must end up as the union.
+    c.update_table()
+        .table_name(&table)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("f01")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("f02")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .global_secondary_index_updates(
+            GlobalSecondaryIndexUpdate::builder()
+                .create(
+                    CreateGlobalSecondaryIndexAction::builder()
+                        .index_name("gsi259")
+                        .key_schema(
+                            KeySchemaElement::builder()
+                                .attribute_name("f01")
+                                .key_type(KeyType::Hash)
+                                .build()
+                                .unwrap(),
+                        )
+                        .key_schema(
+                            KeySchemaElement::builder()
+                                .attribute_name("f02")
+                                .key_type(KeyType::Range)
+                                .build()
+                                .unwrap(),
+                        )
+                        .projection(
+                            Projection::builder()
+                                .projection_type(ProjectionType::All)
+                                .build(),
+                        )
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    wait_for_index_active(c, &table, "gsi259").await;
+
+    (table, "gsi259".to_owned())
+}
+
+/// #259: after the GSI is ACTIVE, every strongly consistent base-table GetItem
+/// must still return the item its sort key names. Before the fix this returned
+/// `sk-00000` for every request.
+#[tokio::test]
+async fn adding_a_gsi_must_not_change_base_table_get_item() {
+    let c = client();
+    let (table, _index) = table_with_gsi_added_after_population("get").await;
+
+    for i in 0..ITEM_COUNT {
+        let requested = format!("sk-{i:05}");
+        let mut key = HashMap::new();
+        key.insert("pk".into(), s("shared"));
+        key.insert("sk".into(), s(&requested));
+
+        let resp = c
+            .get_item()
+            .table_name(&table)
+            .set_key(Some(key))
+            .consistent_read(true)
+            .send()
+            .await
+            .unwrap();
+
+        let item = resp
+            .item()
+            .unwrap_or_else(|| panic!("GetItem for {requested} returned no item"));
+        assert_eq!(
+            item.get("sk").unwrap(),
+            &s(&requested),
+            "GetItem returned a different sort key than the one requested ({requested}); \
+             the base table's sort key metadata was lost when the GSI was added"
+        );
+        assert_eq!(
+            item.get("payload").unwrap(),
+            &s(&format!("payload-{i:05}")),
+            "GetItem returned another item's payload for {requested}"
+        );
+    }
+}
+
+/// The stored attribute definitions must be the union of the base table's and the
+/// request's, which is what DescribeTable reports on real DynamoDB.
+#[tokio::test]
+async fn adding_a_gsi_merges_attribute_definitions() {
+    let c = client();
+    let (table, _index) = table_with_gsi_added_after_population("merge").await;
+
+    let resp = c.describe_table().table_name(&table).send().await.unwrap();
+    let mut names: Vec<&str> = resp
+        .table()
+        .unwrap()
+        .attribute_definitions()
+        .iter()
+        .map(aws_sdk_dynamodb::types::AttributeDefinition::attribute_name)
+        .collect();
+    names.sort_unstable();
+
+    assert_eq!(
+        names,
+        vec!["f01", "f02", "pk", "sk"],
+        "UpdateTable must merge the request's attribute definitions into the stored set, \
+         not replace it"
+    );
+}
+
+/// The created index must be usable through its own sort key. The index DDL is
+/// built from the merged definitions, so a backend that passed only the request's
+/// subset (or, on MongoDB, never persisted them at all) would resolve the index's
+/// sort key to nothing and behave as hash-only.
+#[tokio::test]
+async fn a_gsi_created_by_update_table_is_queryable_by_its_sort_key() {
+    let c = client();
+    let (table, index) = table_with_gsi_added_after_population("query").await;
+
+    let resp = c
+        .query()
+        .table_name(&table)
+        .index_name(&index)
+        .key_condition_expression("#h = :h AND #r = :r")
+        .expression_attribute_names("#h", "f01")
+        .expression_attribute_names("#r", "f02")
+        .expression_attribute_values(":h", s(GSI_HASH_VALUE))
+        .expression_attribute_values(":r", s("gsk-00003"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.count(),
+        1,
+        "the GSI must apply its sort key: all {ITEM_COUNT} items share the hash key, so an \
+         index whose sort key was not resolved returns every one of them"
+    );
+    assert_eq!(resp.items()[0].get("sk").unwrap(), &s("sk-00003"));
+
+    // The index is fully populated: the hash key alone reaches every item.
+    let all = c
+        .query()
+        .table_name(&table)
+        .index_name(&index)
+        .key_condition_expression("#h = :h")
+        .expression_attribute_names("#h", "f01")
+        .expression_attribute_values(":h", s(GSI_HASH_VALUE))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(all.count(), i32::try_from(ITEM_COUNT).unwrap());
+}

--- a/tests/rust/src/gsi_update_table_attr_defs.rs
+++ b/tests/rust/src/gsi_update_table_attr_defs.rs
@@ -166,6 +166,139 @@ async fn table_with_gsi_added_after_population(label: &str) -> (String, String) 
     (table, "gsi259".to_owned())
 }
 
+/// Same drill on a NUMERIC sort key. The merge is type-agnostic, but the
+/// `extenddb migrate` repair recovers the lost type from the data table's PRIMARY
+/// KEY column, and every table carries all three typed columns (`sk_s`, `sk_n`,
+/// `sk_b`), so a numeric sort key is the case that catches a recovery keying off
+/// column existence instead of key membership.
+#[tokio::test]
+async fn adding_a_gsi_must_not_change_get_item_on_a_numeric_sort_key() {
+    let c = client();
+    let table = format!("Gsi259N_{}", ts());
+
+    c.create_table()
+        .table_name(&table)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("sk")
+                .key_type(KeyType::Range)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("sk")
+                .attribute_type(ScalarAttributeType::N)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(aws_sdk_dynamodb::types::BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+    wait_for_active(c, &table).await;
+
+    for i in 0..ITEM_COUNT {
+        let mut item = HashMap::new();
+        item.insert("pk".into(), s("shared"));
+        item.insert("sk".into(), n(i64::try_from(i).unwrap()));
+        item.insert("f01".into(), s(GSI_HASH_VALUE));
+        item.insert("f02".into(), s(&format!("gsk-{i:05}")));
+        c.put_item()
+            .table_name(&table)
+            .set_item(Some(item))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    c.update_table()
+        .table_name(&table)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("f01")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("f02")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .global_secondary_index_updates(
+            GlobalSecondaryIndexUpdate::builder()
+                .create(
+                    CreateGlobalSecondaryIndexAction::builder()
+                        .index_name("gsi259n")
+                        .key_schema(
+                            KeySchemaElement::builder()
+                                .attribute_name("f01")
+                                .key_type(KeyType::Hash)
+                                .build()
+                                .unwrap(),
+                        )
+                        .key_schema(
+                            KeySchemaElement::builder()
+                                .attribute_name("f02")
+                                .key_type(KeyType::Range)
+                                .build()
+                                .unwrap(),
+                        )
+                        .projection(
+                            Projection::builder()
+                                .projection_type(ProjectionType::All)
+                                .build(),
+                        )
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    wait_for_index_active(c, &table, "gsi259n").await;
+
+    for i in 0..ITEM_COUNT {
+        let mut key = HashMap::new();
+        key.insert("pk".into(), s("shared"));
+        key.insert("sk".into(), n(i64::try_from(i).unwrap()));
+        let resp = c
+            .get_item()
+            .table_name(&table)
+            .set_key(Some(key))
+            .consistent_read(true)
+            .send()
+            .await
+            .unwrap();
+        let item = resp
+            .item()
+            .unwrap_or_else(|| panic!("GetItem for numeric sort key {i} returned no item"));
+        assert_eq!(
+            item.get("sk").unwrap(),
+            &n(i64::try_from(i).unwrap()),
+            "GetItem returned a different numeric sort key than the one requested ({i})"
+        );
+    }
+}
+
 /// #259: after the GSI is ACTIVE, every strongly consistent base-table GetItem
 /// must still return the item its sort key names. Before the fix this returned
 /// `sk-00000` for every request.

--- a/tests/rust/src/main.rs
+++ b/tests/rust/src/main.rs
@@ -54,6 +54,8 @@ mod gsi;
 #[cfg(test)]
 mod gsi_more;
 #[cfg(test)]
+mod gsi_update_table_attr_defs;
+#[cfg(test)]
 mod index_key_validation;
 #[cfg(test)]
 mod lsi;

--- a/tests/test_gsi_attribute_definitions.py
+++ b/tests/test_gsi_attribute_definitions.py
@@ -1,0 +1,115 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for issue #259.
+
+Creating a GSI via UpdateTable must not corrupt the base table's stored
+AttributeDefinitions. UpdateTable's AttributeDefinitions only describes the
+attributes referenced by the new index; replacing the stored definitions
+wholesale dropped the table's own key attribute definitions, after which
+base-table GetItem/UpdateItem/DeleteItem lost the sort key and targeted an
+arbitrary item under the same partition key.
+"""
+
+from __future__ import annotations
+
+import time
+
+from conftest import wait_for_active
+
+
+def wait_for_gsi_active(client, table_name: str, index_name: str, timeout: float = 120.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        desc = client.describe_table(TableName=table_name)["Table"]
+        indexes = {i["IndexName"]: i for i in desc.get("GlobalSecondaryIndexes", [])}
+        if (
+            desc["TableStatus"] == "ACTIVE"
+            and indexes.get(index_name, {}).get("IndexStatus") == "ACTIVE"
+        ):
+            return
+        time.sleep(0.2)
+    raise TimeoutError(f"GSI {index_name} on {table_name} did not become ACTIVE within {timeout}s")
+
+
+class TestGsiCreatePreservesAttributeDefinitions:
+    def test_get_item_after_gsi_create_on_composite_table(
+        self, create_and_cleanup_table, dynamodb_client, unique_table_name
+    ):
+        """Issue #259: base-table GetItem must honor the sort key after a GSI is added."""
+        create_and_cleanup_table(
+            unique_table_name,
+            AttributeDefinitions=[
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "sk", "AttributeType": "S"},
+            ],
+            KeySchema=[
+                {"AttributeName": "pk", "KeyType": "HASH"},
+                {"AttributeName": "sk", "KeyType": "RANGE"},
+            ],
+        )
+
+        items = []
+        for i in range(10):
+            item = {
+                "pk": {"S": "shared"},
+                "sk": {"S": f"sk-{i:03d}"},
+                "gpk": {"S": f"gpk-{i % 3}"},
+                "gsk": {"S": f"gsk-{i:03d}"},
+                "payload": {"S": f"payload-{i:03d}"},
+            }
+            dynamodb_client.put_item(TableName=unique_table_name, Item=item)
+            items.append(item)
+
+        # UpdateTable carries only the new index key attributes, per DynamoDB
+        # semantics — the stored pk/sk definitions must survive the merge.
+        dynamodb_client.update_table(
+            TableName=unique_table_name,
+            AttributeDefinitions=[
+                {"AttributeName": "gpk", "AttributeType": "S"},
+                {"AttributeName": "gsk", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexUpdates=[
+                {
+                    "Create": {
+                        "IndexName": "gsi01",
+                        "KeySchema": [
+                            {"AttributeName": "gpk", "KeyType": "HASH"},
+                            {"AttributeName": "gsk", "KeyType": "RANGE"},
+                        ],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
+                }
+            ],
+        )
+        wait_for_gsi_active(dynamodb_client, unique_table_name, "gsi01")
+
+        # DescribeTable must report the union of old and new definitions.
+        desc = dynamodb_client.describe_table(TableName=unique_table_name)["Table"]
+        defined = {ad["AttributeName"] for ad in desc["AttributeDefinitions"]}
+        assert {"pk", "sk", "gpk", "gsk"} <= defined
+
+        # Every base-table read must return exactly the requested item.
+        for item in items:
+            got = dynamodb_client.get_item(
+                TableName=unique_table_name,
+                Key={"pk": item["pk"], "sk": item["sk"]},
+                ConsistentRead=True,
+            ).get("Item")
+            assert got == item
+
+        # DeleteItem must also target the exact key, not another row in the
+        # same partition.
+        victim = items[5]
+        dynamodb_client.delete_item(
+            TableName=unique_table_name,
+            Key={"pk": victim["pk"], "sk": victim["sk"]},
+        )
+        for item in items:
+            got = dynamodb_client.get_item(
+                TableName=unique_table_name,
+                Key={"pk": item["pk"], "sk": item["sk"]},
+                ConsistentRead=True,
+            ).get("Item")
+            assert got == (None if item is victim else item)
+        wait_for_active(dynamodb_client, unique_table_name)


### PR DESCRIPTION
> **Credit.** Reported by @ivyxjc in #259, with a reproduction script and the key
> observation that the stored rows and the GSI relation were both correct so only the read
> path was at fault. @ivyxjc also independently diagnosed the same root cause and proposed a
> fix in #260, which reaches the same conclusion for the two SQL backends. This PR supersedes
> it with wider scope (MongoDB, the invariant check, and the `migrate` repair) and different
> conflicting-redeclaration semantics, explained in #260.

# PR body: fix/update-table-must-merge-attribute-definitions

## What

Two commits.

**1. `UpdateTable` merges attribute definitions instead of replacing them**, on all three backends.

- `crates/storage/src/util/key.rs`: new `merge_attribute_definitions`, a union keyed on attribute name.
- `crates/storage-postgres/src/update_table.rs`, `crates/storage-sqlite/src/update_table.rs`: merge into the set already read under the write lock these methods hold, so the read-modify-write is atomic against a concurrent `UpdateTable` with no new locking. Both also now build the index DDL from the merged set rather than the request's subset.
- `crates/storage-mongodb/src/table_engine.rs`: persist the merged set, which this backend never wrote on this path at all.
- `crates/core/src/types/key_schema.rs`: `TableKeyInfo::validate_sort_key_definitions`, called where each backend loads key info, refuses catalog metadata whose base key schema names a RANGE attribute with no matching definition.

**2. `extenddb migrate` repairs tables already damaged by the pre-fix write path.** The merge stops new damage; a table damaged by an older build stays damaged and, with the invariant check in place, now fails its reads loudly instead of silently returning another item.

- `recover_sort_key_definitions` (`crates/storage/src/util/key.rs`) reads the lost scalar type back out of the physical column name: the data table's sort key columns were created from the original definition and are named by `sk_column_n`, so `sk_s` means the first sort key was `S` and `sk3_n` means the third was `N`. A recovery, not a guess.
- `Bootstrapper::repair_lost_sort_key_definitions` applies it, implemented for PostgreSQL (`information_schema.columns`) and SQLite (`PRAGMA table_info`). The default no-op is correct for MongoDB, which never wrote these definitions and so never destroyed any.
- `cmd_migrate` calls it under the migration lock the command already takes, deliberately before the up-to-date early return: the damage is in a row's contents rather than the schema, so a deployment whose catalog version is already current is exactly the case that needs checking.

Two conditions are reported rather than fixed. A sort key with no matching physical column is left alone, because a guessed type would resolve the key to the wrong column. The partition key definition, dropped by the same write, is not recoverable from the schema (the `pk` column is always `TEXT`) and is not needed for correctness, since partition key values are encoded from the key schema alone; only index key type validation is weaker without it. It is reported on every run until a human restores it.

## Why

Closes #259.

A GSI added to a populated composite-key table made a strongly consistent base-table `GetItem` return a different item under the same partition key, with HTTP 200 and no error.

An `UpdateTable` request carries only the attribute definitions it needs, which for a GSI creation is that index's key attributes. Both SQL backends wrote that set over the stored one, so a request supplying `[f01, f02]` deleted the base table's own `pk` and `sk` definitions. `sk_info()` derives the sort key's physical column from its attribute definition, so with the definition gone it returned `None` even though the key schema still named a RANGE element, and `get_item_impl` took its partition-only branch:

```
before: SELECT item_data FROM t WHERE pk = $1 AND sk_s = $2
after:  SELECT item_data FROM t WHERE pk = $1
```

The stored rows and the GSI backfill were both correct, as the reporter said; only the metadata describing them was wrong.

MongoDB never persisted attribute definitions here, so its base table kept working but a created index's key attributes were absent from the catalog and the index resolved its own sort key to nothing. Measured on the pre-fix binary, a GSI query qualified by both hash and sort key returned all 8 items in the partition instead of 1.

Merge semantics are measured against real DynamoDB (us-east-1, 2026-08-13) on a table created with `[pk S, sk S]`: supplying only `[f01, f02]` is accepted and the next `DescribeTable` reports all four; supplying the full set does not duplicate anything; and re-declaring `pk` as `N` while the table holds it as `S` is accepted with the stored type
left as `S`, so a conflicting redeclaration keeps the existing definition rather than raising an error the service does not raise.

## Testing done

All integration runs via `devtools/run-tests --extenddb --rust-integration`.

Three new integration tests, green on all three backends with 0 filtered out:

```
postgres  test result: ok. 3 passed; 0 failed; 0 filtered out
sqlite    test result: ok. 3 passed; 0 failed; 0 filtered out
mongodb   test result: ok. 3 passed; 0 failed; 0 filtered out
```

Negative controls on pre-fix binaries, per backend:

- postgres and sqlite fail the reported read, `GetItem returned a different sort key than the one requested (sk-00001)`, and fail the merge assertion;
- mongodb passes the base-table read, as expected since it was never affected, and fails the merge assertion (`["pk","sk"]` vs `["f01","f02","pk","sk"]`) and the index sort-key  assertion (8 rows returned where 1 was expected).

A second control keeps `validate_sort_key_definitions` while reverting only the merge: the read then fails with a 500 instead of returning another item's data, which is the point of the check.

Full suites with the fix: postgres 426/429, sqlite 425/429, 0 filtered out in both. The non-passing tests are pre-existing and unrelated:

- three `capacity_throttling` tests fail identically on the pre-fix binary; they need throttling settings this ad-hoc config does not enable;
- `binary_sort_key::query_binary_sort_key_begins_with_empty_prefix` on sqlite is the `vec![0xFF; prefix.len() + 1]` upper bound at `crates/storage-sqlite/src/data/query.rs:128`, untouched by this change.

Unit tests: 375 (`extenddb-core`) and 42 (`extenddb-storage`) passing, 0 filtered out. Covering the merge (base keys preserved when only new attributes are sent, idempotent on a full set, conflicting redeclaration keeps the stored type), the invariant check (rejects a RANGE key with no definition, accepts hash-only tables, ignores index key schemas), and the
recovery (S/N/B columns, multiple sort keys matched by position, intact metadata left alone, hash-only tables ignored, and no type invented when the column is absent).

The repair is verified end to end against a SQLite deployment holding one healthy table and one corrupted by a genuine pre-fix binary (`attribute_definitions` = `[f01, f02]`, both base key definitions gone, and the reported wrong-item read reproduced on it):

```
--- Checking table key metadata...
  Restored sort key definition: Gsi259_get_...: sk (S)
  NEEDS ATTENTION: Gsi259_get_...: partition key definition(s) [pk] are absent; ...
```

The healthy table was left untouched, a second run reported no further repair, and a fresh deployment reports `Table key metadata intact.` The partition key note keeps appearing on later runs, which is what an unresolved condition should do. The read-path consequence of correct metadata is covered by the integration tests above rather than re-proved on the
repaired table.

The GSI query test deliberately gives every item the same index hash key. Without that the assertion passed against the broken MongoDB path and proved nothing.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a. No wire, trait, auth, on-disk-format or CLI change. The `Storage` trait is untouched; `merge_attribute_definitions` is a new helper in the shared storage crate and `TableKeyInfo` gains one method. The catalog schema is unchanged, so `CATALOG_VERSION` is not bumped and no migration is needed: the fix corrects what
`UpdateTable` writes into an existing column.

Documentation is unchecked deliberately. The corrected behaviour is what `docs/differences-from-dynamodb.md` already implies by not listing a divergence here, so there is nothing to remove; one observed parity detail is left unimplemented and noted under Breaking changes rather than documented as intentional.

## Breaking changes

None for clients. `UpdateTable` requests that were previously destroying metadata now preserve it, and `DescribeTable` reports the union where it previously reported only the last request's attributes, which is what real DynamoDB reports.

Two notes for reviewers:

- A table already damaged by a pre-fix `UpdateTable` fails its keyed reads with a 500 until `extenddb migrate` is run, rather than silently returning the wrong item as before. That is the better failure, but it is a behaviour change for an already-damaged table, and it means an upgrade should run `migrate` before taking traffic. On MongoDB there is nothing to repair.
- Out of scope, noted for the record: on MongoDB, tables whose GSIs were created before this change still have no persisted definitions for those index key attributes, so those indexes continue to behave as hash-only until the index is recreated. That is the pre-existing MongoDB gap rather than #259, and repairing it needs the index key types rather than the base table's.
- Measured but not implemented: real DynamoDB does not persist attribute definitions that no key uses. Supplying `[f01, f02, zz9]` for a GSI keyed on `f01`/`f02` is accepted and `zz9` is absent from the next `DescribeTable`. We keep it. That is a cosmetic `DescribeTable` divergence with no effect on reads or writes, so it is out of scope here.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
