### PR TITLE
ci: two-person promotion of a verified candidate to version + latest

### DIFF
--- a/.github/workflows/promote-image.yml
+++ b/.github/workflows/promote-image.yml
@@ -1,0 +1,195 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Promotes ONE verified, commit-addressed candidate to the human tags
+# (`X.Y.Z` and `latest`) on Docker Hub, by digest, with no rebuild.
+#
+# This replaces the runbook's manual `docker buildx imagetools create` step
+# with a two-person action: the operator who verified the candidate dispatches
+# with the digest they verified, and a DIFFERENT maintainer approves the
+# `dockerhub` environment gate (prevent-self-review). The registry credential
+# never leaves the protected environment, so promotion no longer depends on
+# any individual holding the token locally.
+#
+# The release flow this slots into:
+#
+#   1. release-image     builds + smoke tests + pushes the candidate
+#                        (reviewer-gated; candidate tags only)
+#   2. manual test       ANYONE pulls the public candidate tag, runs both
+#                        arches, records the index digest (no credentials
+#                        needed; candidates are public)
+#   3. ghcr-mirror /     copy the verified digest to the mirror registries
+#      ECR mirror
+#   4. signing           per runbook
+#   5. promote-image     THIS workflow: verified digest -> `X.Y.Z` + `latest`
+#
+# The digest input is the contract with step 2: this job refuses to promote
+# anything but the digest the tester verified, even if the candidate tag has
+# moved since. It also refuses to overwrite an existing version tag, so a
+# released version is immutable through this path.
+
+name: promote-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to promote to, e.g. 0.1.4 (must match Cargo.toml at the candidate commit)'
+        required: true
+      candidate_tag:
+        description: 'Verified Docker Hub candidate tag, e.g. sha-<full 40-char commit>'
+        required: true
+      expected_digest:
+        description: 'The verified multi-arch index digest, e.g. sha256:<64 hex>'
+        required: true
+
+permissions:
+  contents: read
+
+# Two promotions must never race on the same repository.
+concurrency:
+  group: promote-image-extenddb-postgres
+  cancel-in-progress: false
+
+env:
+  IMAGE_REPO: docker.io/extenddb/extenddb-postgres
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Required reviewers + prevent-self-review + main-only branch rule: the
+    # dispatcher cannot approve their own promotion.
+    environment: dockerhub
+    steps:
+      - name: Check out main (ancestry and version gates need history)
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          fetch-depth: 0
+
+      - name: Gate - validate inputs strictly
+        env:
+          # Dispatch inputs are untrusted; they reach the shell only through
+          # the environment, never by interpolation into script source.
+          RAW_VERSION: ${{ inputs.version }}
+          RAW_TAG: ${{ inputs.candidate_tag }}
+          RAW_DIGEST: ${{ inputs.expected_digest }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$RAW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version '$RAW_VERSION' is not strict semver (MAJOR.MINOR.PATCH)"
+            exit 1
+          fi
+          if [[ ! "$RAW_TAG" =~ ^sha-[0-9a-f]{40}$ ]]; then
+            echo "::error::candidate_tag '$RAW_TAG' is not a commit-addressed candidate tag (sha-<40 hex>)"
+            exit 1
+          fi
+          if [[ ! "$RAW_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::expected_digest is not a sha256:<64 hex> digest"
+            exit 1
+          fi
+          {
+            echo "VERSION=$RAW_VERSION"
+            echo "TAG=$RAW_TAG"
+            echo "DIGEST=$RAW_DIGEST"
+          } >> "$GITHUB_ENV"
+
+      - name: Gate - the candidate commit must be released code at this version
+        run: |
+          set -euo pipefail
+          SHA="${TAG#sha-}"
+
+          # The commit must be on main: a candidate built from an unmerged
+          # branch must never receive a public version tag.
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$SHA" origin/main; then
+            echo "::error::candidate commit ${SHA} is not contained in origin/main"
+            exit 1
+          fi
+
+          # The version being promoted to must be the version the code at
+          # that commit believes it is.
+          CARGO_VERSION=$(git show "${SHA}:Cargo.toml" | grep -m1 '^version' | sed 's/.*"\(.*\)".*/\1/')
+          if [[ "$VERSION" != "$CARGO_VERSION" ]]; then
+            echo "::error::promoting to ${VERSION} but Cargo.toml at ${SHA} says ${CARGO_VERSION}"
+            exit 1
+          fi
+
+      - name: Gate - skopeo present (preinstalled on ubuntu-latest)
+        run: |
+          set -euo pipefail
+          command -v skopeo >/dev/null || sudo apt-get install -y --no-install-recommends skopeo
+          skopeo --version
+
+      - name: Gate - the candidate must still resolve to the verified digest
+        run: |
+          set -euo pipefail
+          SRC_DIGEST=$(skopeo inspect --format '{{.Digest}}' "docker://${IMAGE_REPO}:${TAG}")
+          if [[ "$SRC_DIGEST" != "$DIGEST" ]]; then
+            echo "::error::${IMAGE_REPO}:${TAG} now resolves to ${SRC_DIGEST}, not the verified ${DIGEST}; refusing to promote an unverified artifact"
+            exit 1
+          fi
+
+      - name: Gate - refuse to overwrite a released version
+        run: |
+          set -euo pipefail
+          if EXISTING=$(skopeo inspect --format '{{.Digest}}' "docker://${IMAGE_REPO}:${VERSION}" 2>/dev/null); then
+            if [[ "$EXISTING" == "$DIGEST" ]]; then
+              echo "ALREADY_PROMOTED=true" >> "$GITHUB_ENV"
+              echo "::notice::${IMAGE_REPO}:${VERSION} already exists with the exact verified digest; will only ensure latest"
+            else
+              echo "::error::${IMAGE_REPO}:${VERSION} already exists with different digest ${EXISTING}; released versions are immutable through this workflow"
+              exit 1
+            fi
+          fi
+
+      - name: Log in to Docker Hub (the only step chain with the credential)
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          skopeo login docker.io -u "$DOCKERHUB_USERNAME" --password-stdin <<< "$DOCKERHUB_TOKEN"
+
+      - name: Promote by digest to the version tag and latest
+        run: |
+          set -euo pipefail
+          # Source is the immutable digest, not the tag, so what is promoted
+          # is byte-identical to what was verified. --preserve-digests fails
+          # rather than rewrite any manifest.
+          if [[ "${ALREADY_PROMOTED:-}" != "true" ]]; then
+            skopeo copy --all --preserve-digests \
+              "docker://${IMAGE_REPO}@${DIGEST}" \
+              "docker://${IMAGE_REPO}:${VERSION}"
+          fi
+          skopeo copy --all --preserve-digests \
+            "docker://${IMAGE_REPO}@${DIGEST}" \
+            "docker://${IMAGE_REPO}:latest"
+
+      - name: Verify the promotion
+        run: |
+          set -euo pipefail
+          for t in "${VERSION}" latest; do
+            GOT=$(skopeo inspect --format '{{.Digest}}' "docker://${IMAGE_REPO}:${t}")
+            if [[ "$GOT" != "$DIGEST" ]]; then
+              echo "::error::${IMAGE_REPO}:${t} resolves to ${GOT}, expected ${DIGEST}"
+              exit 1
+            fi
+          done
+
+      - name: Log out
+        if: always()
+        run: skopeo logout docker.io || true
+
+      - name: Summarise for the release checklist
+        run: |
+          {
+            echo "### Promoted to ${VERSION} and latest"
+            echo ""
+            echo "| field | value |"
+            echo "|---|---|"
+            echo "| repository | \`${IMAGE_REPO}\` |"
+            echo "| candidate | \`${TAG}\` |"
+            echo "| digest | \`${DIGEST}\` |"
+            echo "| tags | \`${VERSION}\`, \`latest\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-image.yml
+++ b/.github/workflows/promote-image.yml
@@ -27,6 +27,13 @@
 # anything but the digest the tester verified, even if the candidate tag has
 # moved since. It also refuses to overwrite an existing version tag, so a
 # released version is immutable through this path.
+#
+# `latest` may only move forwards. Promoting a back-line hotfix once a newer
+# line has shipped is legitimate, but making it `latest` would silently
+# downgrade every user who does not pin, so the version tag is promoted either
+# way while `latest` is guarded: it moves only when the promoted version is the
+# highest released one, and `move_latest` is the explicit escape hatch for a
+# hotfix that must not become `latest`.
 
 name: promote-image
 
@@ -42,6 +49,10 @@ on:
       expected_digest:
         description: 'The verified multi-arch index digest, e.g. sha256:<64 hex>'
         required: true
+      move_latest:
+        description: 'Move `latest` to this digest. Uncheck for a back-line hotfix that must not become latest.'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -74,6 +85,7 @@ jobs:
           RAW_VERSION: ${{ inputs.version }}
           RAW_TAG: ${{ inputs.candidate_tag }}
           RAW_DIGEST: ${{ inputs.expected_digest }}
+          RAW_MOVE_LATEST: ${{ inputs.move_latest }}
         run: |
           set -euo pipefail
           if [[ ! "$RAW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -88,10 +100,17 @@ jobs:
             echo "::error::expected_digest is not a sha256:<64 hex> digest"
             exit 1
           fi
+          # A boolean input arrives as the literal string true/false. Anything
+          # else means the dispatch payload was not what this workflow models.
+          if [[ "$RAW_MOVE_LATEST" != "true" && "$RAW_MOVE_LATEST" != "false" ]]; then
+            echo "::error::move_latest '$RAW_MOVE_LATEST' is not a boolean"
+            exit 1
+          fi
           {
             echo "VERSION=$RAW_VERSION"
             echo "TAG=$RAW_TAG"
             echo "DIGEST=$RAW_DIGEST"
+            echo "MOVE_LATEST=$RAW_MOVE_LATEST"
           } >> "$GITHUB_ENV"
 
       - name: Gate - the candidate commit must be released code at this version
@@ -143,6 +162,53 @@ jobs:
             fi
           fi
 
+      - name: Gate - latest must never move backwards
+        run: |
+          set -euo pipefail
+
+          # `latest` is the tag users get by default, so moving it to an older
+          # line is a silent downgrade for everyone who does not pin. Promoting
+          # a back-line hotfix is legitimate; making it `latest` afterwards is
+          # not. So the version tag is promoted either way and `latest` is
+          # guarded: it may only move forwards.
+          #
+          # Anonymous read, like the gates above, so this still runs before the
+          # registry credential exists in the job.
+          TAGS_JSON=$(skopeo list-tags "docker://${IMAGE_REPO}")
+
+          # Compare only against released X.Y.Z tags. Candidate (sha-*) tags,
+          # `latest` and anything else are not version lines. The promoted
+          # version is excluded so a re-run that only ensures `latest` (the
+          # ALREADY_PROMOTED path) is not blocked by its own tag.
+          #
+          # `|| true` on the pipeline because grep exits 1 when it matches
+          # nothing, which under `set -o pipefail` would kill the step on a
+          # repository that has no released versions yet.
+          HIGHEST=$(printf '%s' "$TAGS_JSON" \
+            | jq -r '.Tags[]' \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+            | grep -vxF "$VERSION" \
+            | sort -V \
+            | tail -1 || true)
+
+          if [[ -z "$HIGHEST" ]]; then
+            echo "::notice::no other released version tags; ${VERSION} is the highest"
+          else
+            # sort -V is a version sort, so 0.1.10 correctly beats 0.1.9.
+            TOP=$(printf '%s\n%s\n' "$VERSION" "$HIGHEST" | sort -V | tail -1)
+            if [[ "$TOP" != "$VERSION" ]]; then
+              if [[ "$MOVE_LATEST" == "true" ]]; then
+                echo "::error::${VERSION} is not the highest released version (${HIGHEST} is), so moving latest to it would downgrade every unpinned user. Re-dispatch with move_latest unchecked to publish the ${VERSION} tag without touching latest."
+                exit 1
+              fi
+              echo "::notice::${VERSION} is behind ${HIGHEST}; promoting the version tag only, latest untouched"
+            fi
+          fi
+
+          if [[ "$MOVE_LATEST" != "true" ]]; then
+            echo "::notice::move_latest is unchecked; latest will not be touched"
+          fi
+
       - name: Log in to Docker Hub (the only step chain with the credential)
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -151,7 +217,7 @@ jobs:
           set -euo pipefail
           skopeo login docker.io -u "$DOCKERHUB_USERNAME" --password-stdin <<< "$DOCKERHUB_TOKEN"
 
-      - name: Promote by digest to the version tag and latest
+      - name: Promote by digest to the version tag (and latest when allowed)
         run: |
           set -euo pipefail
           # Source is the immutable digest, not the tag, so what is promoted
@@ -162,14 +228,18 @@ jobs:
               "docker://${IMAGE_REPO}@${DIGEST}" \
               "docker://${IMAGE_REPO}:${VERSION}"
           fi
-          skopeo copy --all --preserve-digests \
-            "docker://${IMAGE_REPO}@${DIGEST}" \
-            "docker://${IMAGE_REPO}:latest"
+          if [[ "$MOVE_LATEST" == "true" ]]; then
+            skopeo copy --all --preserve-digests \
+              "docker://${IMAGE_REPO}@${DIGEST}" \
+              "docker://${IMAGE_REPO}:latest"
+          fi
 
       - name: Verify the promotion
         run: |
           set -euo pipefail
-          for t in "${VERSION}" latest; do
+          TAGS=("${VERSION}")
+          [[ "$MOVE_LATEST" == "true" ]] && TAGS+=(latest)
+          for t in "${TAGS[@]}"; do
             GOT=$(skopeo inspect --format '{{.Digest}}' "docker://${IMAGE_REPO}:${t}")
             if [[ "$GOT" != "$DIGEST" ]]; then
               echo "::error::${IMAGE_REPO}:${t} resolves to ${GOT}, expected ${DIGEST}"
@@ -183,13 +253,20 @@ jobs:
 
       - name: Summarise for the release checklist
         run: |
+          if [[ "$MOVE_LATEST" == "true" ]]; then
+            HEADING="Promoted to ${VERSION} and latest"
+            TAGLIST="\`${VERSION}\`, \`latest\`"
+          else
+            HEADING="Promoted to ${VERSION} (latest untouched)"
+            TAGLIST="\`${VERSION}\`"
+          fi
           {
-            echo "### Promoted to ${VERSION} and latest"
+            echo "### ${HEADING}"
             echo ""
             echo "| field | value |"
             echo "|---|---|"
             echo "| repository | \`${IMAGE_REPO}\` |"
             echo "| candidate | \`${TAG}\` |"
             echo "| digest | \`${DIGEST}\` |"
-            echo "| tags | \`${VERSION}\`, \`latest\` |"
+            echo "| tags | ${TAGLIST} |"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Replaces the runbook's manual 'docker buildx imagetools create' promotion with a dispatchable workflow behind the dockerhub protected environment, so promotion gains the same two-person property as the candidate push: the operator who verified the candidate dispatches with the digest they verified, and a different maintainer approves the gate. The registry credential never leaves the environment, removing the dependency on any individual holding the Docker Hub token locally.

Gates, in order, before any credential exists in the job: strict input shapes (semver, sha-<40 hex> candidate tag, sha256 digest); the candidate commit must be contained in origin/main; the version promoted to must equal Cargo.toml's version at that commit; the candidate tag must still resolve to the verified digest (refuses if the tag moved); an existing version tag with a different digest is refused, making released versions immutable through this path. Promotion copies by digest with skopeo --preserve-digests (no rebuild, byte-identical), tags version and latest, and verifies both resolve to the verified digest afterwards.

Gate logic simulated locally with adversarial inputs (injection shapes, malformed tags and digests all rejected); happy path validated against the live sha-c34aac1 candidate (ancestry and Cargo version 0.1.4 agree).

## What

<!-- Describe what this PR changes. -->

## Why

<!-- Link the issue this addresses. Explain the motivation. -->

Closes #

## Testing done

<!-- How did you verify this change works? Include test commands or output. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] All tests pass (`cargo test --workspace`)
- [ ] Code is formatted (`cargo fmt --check`)
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [ ] I have added or updated tests for new functionality
- [ ] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: <!-- link or "n/a" -->

## Breaking changes

<!-- If this PR introduces breaking changes, describe them here. Otherwise delete this section. -->

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
