### PR TITLE
ci: mirror Cosign signature artifacts through the GHCR mirror job

### DIFF
--- a/.github/workflows/ghcr-mirror.yml
+++ b/.github/workflows/ghcr-mirror.yml
@@ -17,6 +17,12 @@
 # The digest input is the contract with the manual verification that precedes
 # this job: the operator supplies the digest they verified, and this job
 # refuses to mirror anything else, even if the Docker Hub tag has moved since.
+#
+# Two artifact kinds are supported, distinguished by tag shape:
+#   sha-<40 hex>              an image candidate (multi-arch index)
+#   sha256-<64 hex>.sig       the Cosign signature artifact for an image digest
+# A signature may only be mirrored after the image it signs is already in
+# GHCR, so a dangling signature cannot exist through this path.
 
 name: ghcr-mirror
 
@@ -24,10 +30,10 @@ on:
   workflow_dispatch:
     inputs:
       candidate_tag:
-        description: 'Verified Docker Hub candidate tag, e.g. sha-<full 40-char commit>'
+        description: 'Verified Docker Hub tag: image candidate (sha-<full 40-char commit>) or Cosign signature artifact (sha256-<64 hex>.sig)'
         required: true
       expected_digest:
-        description: 'The verified multi-arch index digest, e.g. sha256:<64 hex>'
+        description: 'The verified manifest digest of that tag, e.g. sha256:<64 hex>'
         required: true
 
 # Copying between registries needs no repository content at all.
@@ -57,8 +63,17 @@ jobs:
           RAW_DIGEST: ${{ inputs.expected_digest }}
         run: |
           set -euo pipefail
-          if [[ ! "$RAW_TAG" =~ ^sha-[0-9a-f]{40}$ ]]; then
-            echo "::error::candidate_tag '$RAW_TAG' is not a commit-addressed candidate tag (sha-<40 hex>)"
+          KIND=''
+          SUBJECT_DIGEST=''
+          if [[ "$RAW_TAG" =~ ^sha-[0-9a-f]{40}$ ]]; then
+            KIND=image
+          elif [[ "$RAW_TAG" =~ ^sha256-[0-9a-f]{64}\.sig$ ]]; then
+            KIND=signature
+            # sha256-<hex>.sig  ->  sha256:<hex>  (the image digest it signs)
+            SUBJECT_DIGEST="${RAW_TAG%.sig}"
+            SUBJECT_DIGEST="${SUBJECT_DIGEST/-/:}"
+          else
+            echo "::error::candidate_tag '$RAW_TAG' is neither an image candidate (sha-<40 hex>) nor a signature artifact (sha256-<64 hex>.sig)"
             exit 1
           fi
           if [[ ! "$RAW_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
@@ -68,6 +83,8 @@ jobs:
           {
             echo "TAG=$RAW_TAG"
             echo "DIGEST=$RAW_DIGEST"
+            echo "KIND=$KIND"
+            echo "SUBJECT_DIGEST=$SUBJECT_DIGEST"
           } >> "$GITHUB_ENV"
 
       - name: Gate - skopeo present (preinstalled on ubuntu-latest)
@@ -101,6 +118,15 @@ jobs:
             fi
           fi
 
+      - name: Gate - a signature may only follow its image (signature artifacts only)
+        if: env.KIND == 'signature'
+        run: |
+          set -euo pipefail
+          if ! skopeo inspect --format '{{.Digest}}' "docker://${DST_REPO}@${SUBJECT_DIGEST}" >/dev/null 2>&1; then
+            echo "::error::signature subject ${DST_REPO}@${SUBJECT_DIGEST} is not present in GHCR; mirror the image before its signature"
+            exit 1
+          fi
+
       - name: Mirror the exact artifact (no rebuild, digests preserved)
         if: env.already-mirrored != 'true'
         run: |
@@ -119,9 +145,11 @@ jobs:
             echo "::error::published ${DST_REPO}:${TAG} digest ${DST_DIGEST} does not match verified ${DIGEST}"
             exit 1
           fi
-          RAW=$(skopeo inspect --raw "docker://${DST_REPO}:${TAG}")
-          echo "$RAW" | grep -q '"architecture": *"amd64"' || { echo "::error::amd64 missing from mirrored index"; exit 1; }
-          echo "$RAW" | grep -q '"architecture": *"arm64"' || { echo "::error::arm64 missing from mirrored index"; exit 1; }
+          if [[ "$KIND" == "image" ]]; then
+            RAW=$(skopeo inspect --raw "docker://${DST_REPO}:${TAG}")
+            echo "$RAW" | grep -q '"architecture": *"amd64"' || { echo "::error::amd64 missing from mirrored index"; exit 1; }
+            echo "$RAW" | grep -q '"architecture": *"arm64"' || { echo "::error::arm64 missing from mirrored index"; exit 1; }
+          fi
 
       - name: Log out
         if: always()
@@ -130,7 +158,7 @@ jobs:
       - name: Summarise for the release checklist
         run: |
           {
-            echo "### GHCR candidate mirrored (NOT promoted, NOT signed)"
+            echo "### GHCR ${KIND} mirrored (NOT promoted)"
             echo ""
             echo "| field | value |"
             echo "|---|---|"

--- a/.github/workflows/ghcr-mirror.yml
+++ b/.github/workflows/ghcr-mirror.yml
@@ -23,6 +23,10 @@
 #   sha256-<64 hex>.sig       the Cosign signature artifact for an image digest
 # A signature may only be mirrored after the image it signs is already in
 # GHCR, so a dangling signature cannot exist through this path.
+#
+# Signatures are expected in cosign's default tag-based storage mode. OCI-1.1
+# referrers mode produces a bare sha256-<hex> tag (no .sig suffix), which this
+# gate rejects; pin tag-based mode in the signing procedure.
 
 name: ghcr-mirror
 
@@ -54,6 +58,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: ghcr          # required reviewers, prevent self-review, main only
+    # The workflow-level permissions block pins GITHUB_TOKEN read-only; this
+    # job is the only thing that pushes, so it alone gets packages: write.
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Gate - validate inputs strictly
         env:
@@ -90,7 +99,7 @@ jobs:
       - name: Gate - skopeo present (preinstalled on ubuntu-latest)
         run: |
           set -euo pipefail
-          command -v skopeo >/dev/null || sudo apt-get install -y --no-install-recommends skopeo
+          command -v skopeo >/dev/null || { sudo apt-get update -y && sudo apt-get install -y --no-install-recommends skopeo; }
           skopeo --version
 
       - name: Gate - the source tag must still resolve to the verified digest
@@ -99,6 +108,21 @@ jobs:
           SRC_DIGEST=$(skopeo inspect --format '{{.Digest}}' "docker://${SRC_REPO}:${TAG}")
           if [[ "$SRC_DIGEST" != "$DIGEST" ]]; then
             echo "::error::${SRC_REPO}:${TAG} now resolves to ${SRC_DIGEST}, not the verified ${DIGEST}; refusing to mirror an unverified artifact"
+            exit 1
+          fi
+
+      - name: Gate - the artifact must really be a Cosign signature (signature artifacts only)
+        if: env.KIND == 'signature'
+        run: |
+          set -euo pipefail
+          RAW=$(skopeo inspect --raw "docker://${SRC_REPO}:${TAG}")
+          MEDIA_TYPE=$(jq -r '.mediaType // empty' <<< "$RAW")
+          if [[ "$MEDIA_TYPE" != "application/vnd.oci.image.manifest.v1+json" ]]; then
+            echo "::error::${SRC_REPO}:${TAG} has mediaType '${MEDIA_TYPE}', not a single OCI image manifest; a .sig-shaped tag must not carry an image index"
+            exit 1
+          fi
+          if ! jq -e 'all(.layers[]; .mediaType == "application/vnd.dev.cosign.simplesigning.v1+json")' <<< "$RAW" >/dev/null; then
+            echo "::error::${SRC_REPO}:${TAG} layers are not Cosign simplesigning payloads; refusing to mirror it as a signature"
             exit 1
           fi
 


### PR DESCRIPTION
## What

Extends the GHCR mirror job (#256) to also mirror **Cosign signature
artifacts**. The `candidate_tag` input now accepts two shapes:

- `sha-<40 hex>` — an image candidate (existing behavior, unchanged), or
- `sha256-<64 hex>.sig` — the Cosign signature artifact for an image digest.

For signature artifacts the job additionally derives the subject image digest
from the tag and **refuses to mirror a signature whose image is not already in
GHCR** — a dangling signature cannot exist through this path. The
architecture assertions (amd64/arm64 present) now apply only to image
indexes, since a signature artifact has no platforms. Everything else is
shared and unchanged: strict input validation via environment, the
source-must-still-match-verified-digest gate, overwrite refusal with
idempotent same-digest no-op, `skopeo copy --all --preserve-digests`, and
post-publish digest verification. Same protected `ghcr` environment, so every
signature mirror is reviewer-approved like every image mirror.

## Why

We are moving from detached signature bundles to **registry-attached** Cosign
signatures, so users get the standard verification UX
(`cosign verify --key …`) and policy engines (e.g. Kubernetes admission
controllers) can enforce signatures at deploy time.

Cosign stores a signature as an ordinary OCI artifact tagged
`sha256-<image digest>.sig` in the same repository. For Docker Hub and ECR we
attach signatures directly at signing time, but GHCR's only acceptable
credential is the workflow-scoped `GITHUB_TOKEN` — the same constraint that
motivated the mirror job for images applies to their signatures. Signing flow
becomes: sign the Docker Hub copy → dispatch this job once for the image,
once for its `.sig` artifact.

## Testing done

- YAML parses (`yaml.safe_load`).
- The tag→subject-digest derivation (`sha256-<hex>.sig` → `sha256:<hex>`) and
  both regexes were desk-checked; hex cannot contain the delimiter so the
  single-substitution rewrite is unambiguous.
- **The new path has not executed** (dispatch-only, reviewer-gated, and no
  signed candidate exists yet). It will be exercised in the signing rehearsal
  against the abandoned `sha-c34aac11…` candidate before the next release
  uses it in earnest.

Not verified: same runtime caveats as #256 (skopeo presence asserted with an
apt fallback; org package settings unverifiable without org admin).

## Checklist

- [ ] All tests pass (`cargo test --workspace`) — not applicable, no Rust source changed
- [ ] Code is formatted (`cargo fmt --check`) — not applicable, no Rust source changed
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`) — not applicable, no Rust source changed
- [ ] I have added or updated tests for new functionality — no workflow test harness; the gates are the assertions
- [ ] I have updated documentation if behavior changed — release runbook (internal) is the operating document and is being updated with the attached-signing procedure
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a — release plumbing.

## Breaking changes

None. The existing image-candidate input shape and behavior are byte-for-byte
unchanged; the new shape is additive. Nothing runs without a manual dispatch
plus an environment reviewer's approval.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
