### PR TITLE
chore(release): bump version to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "extenddb-app",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-app"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-auth"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-cache"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "futures",
  "moka",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-config"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "config",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-engine"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "base64 0.22.1",
  "crc32fast",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-server"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-mongodb"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-postgres"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-sqlite"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SOFTWARE-LICENSE-NOTICES.html
+++ b/SOFTWARE-LICENSE-NOTICES.html
@@ -6666,16 +6666,16 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.4</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.4</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.4</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.4</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.4</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.4</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.4</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.4</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.4</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage-postgres ">extenddb-storage-postgres 0.1.4</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.5</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.5</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.5</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.5</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.5</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.5</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.5</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.5</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.5</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage-postgres ">extenddb-storage-postgres 0.1.5</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.103</a></li>
                     <li><a href=" https://github.com/andylokandy/arraydeque ">arraydeque 0.5.1</a></li>


### PR DESCRIPTION
## What

Bumps the workspace version from `0.1.4` to `0.1.5` (one line in the root
`Cargo.toml`), refreshes the twelve workspace-member entries in `Cargo.lock`,
and regenerates `SOFTWARE-LICENSE-NOTICES.html` for the crate version strings.
No dependency or source change.

## Why

The `v0.1.4` release attempt was paused before promotion so the fixes in
#250, #255, and #261 could land — its candidate (`sha-c34aac11…`) predates
them all. The `v0.1.4` tag is already public on the remote, and release tags
are immutable, so the relaunched container release takes the next patch
version. Same reasoning as #257, one version later.

After this merges, the relaunch is: tag `v0.1.5` on the merged commit,
dispatch `release-image`, verify, mirror (`ghcr-mirror` + manual ECR), sign,
and promote via the new `promote-image` workflow.

## Testing done

- `cargo check --workspace --all-targets --locked` — clean on top of all five
  freshly merged PRs (#250, #255, #261, #262, #264).
- `Cargo.lock` diff verified: only the twelve `extenddb-*` workspace crates
  moved `0.1.4` → `0.1.5`; no third-party entries changed.
- `SOFTWARE-LICENSE-NOTICES.html` diff verified: only `extenddb*` version
  strings; `devtools/generate-software-license-notices --check` passes.

## Checklist

- [ ] All tests pass (`cargo test --workspace`) — not re-run: no source or
      dependency change; the merged code was tested by its own PRs' CI
- [ ] Code is formatted (`cargo fmt --check`) — not applicable, no Rust source changed
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`) — not applicable, no Rust source changed
- [ ] I have added or updated tests for new functionality — not applicable
- [ ] I have updated documentation if behavior changed — not applicable
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a — version metadata only.

## Breaking changes

None.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
