### PR TITLE
ci: accept promoted release tags in the GHCR mirror job

### DIFF
--- a/.github/workflows/ghcr-mirror.yml
+++ b/.github/workflows/ghcr-mirror.yml
@@ -3,10 +3,11 @@
 #
 # Minimal GHCR candidate mirror.
 #
-# Copies ONE already-verified, commit-addressed candidate from Docker Hub to
-# GHCR, byte-for-byte, and nothing else: no builds, no Docker Hub publication,
-# no ECR, no version tags, no `latest`, no signing. Promotion and signing are
-# manual, recorded runbook steps.
+# Copies ONE already-verified tag from Docker Hub to GHCR, byte-for-byte,
+# and nothing else: no builds, no Docker Hub publication, no ECR, no signing.
+# Signing is a manual, recorded runbook step; GHCR promotion happens through
+# this job (dispatched once per release tag, after Docker Hub promotes),
+# because GHCR has no other sanctioned write path.
 #
 # Why this exists at all: GHCR's only acceptable credential is the
 # workflow-scoped GITHUB_TOKEN, which exists only inside an Actions run, so
@@ -18,9 +19,15 @@
 # this job: the operator supplies the digest they verified, and this job
 # refuses to mirror anything else, even if the Docker Hub tag has moved since.
 #
-# Two artifact kinds are supported, distinguished by tag shape:
+# Three artifact kinds are supported, distinguished by tag shape:
 #   sha-<40 hex>              an image candidate (multi-arch index)
 #   sha256-<64 hex>.sig       the Cosign signature artifact for an image digest
+#   X.Y.Z or latest           a release tag already promoted on Docker Hub
+#
+# Known limitation, deliberate: re-pointing `latest` at a NEW digest hits the
+# no-overwrite gate and fails closed. Fine for the first release (no `latest`
+# exists); the second release needs a guarded move-latest carve-out mirroring
+# promote-image's never-move-backwards rule, or the Track 2 pipeline.
 # A signature may only be mirrored after the image it signs is already in
 # GHCR, so a dangling signature cannot exist through this path.
 #
@@ -34,7 +41,7 @@ on:
   workflow_dispatch:
     inputs:
       candidate_tag:
-        description: 'Verified Docker Hub tag: image candidate (sha-<full 40-char commit>) or Cosign signature artifact (sha256-<64 hex>.sig)'
+        description: 'Verified Docker Hub tag: image candidate (sha-<full 40-char commit>), Cosign signature artifact (sha256-<64 hex>.sig), or promoted release tag (X.Y.Z / latest)'
         required: true
       expected_digest:
         description: 'The verified manifest digest of that tag, e.g. sha256:<64 hex>'
@@ -76,13 +83,17 @@ jobs:
           SUBJECT_DIGEST=''
           if [[ "$RAW_TAG" =~ ^sha-[0-9a-f]{40}$ ]]; then
             KIND=image
+          elif [[ "$RAW_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ || "$RAW_TAG" == latest ]]; then
+            # A release tag is an image index like a candidate; every image
+            # gate (digest pin, no-overwrite, platform assertions) applies.
+            KIND=image
           elif [[ "$RAW_TAG" =~ ^sha256-[0-9a-f]{64}\.sig$ ]]; then
             KIND=signature
             # sha256-<hex>.sig  ->  sha256:<hex>  (the image digest it signs)
             SUBJECT_DIGEST="${RAW_TAG%.sig}"
             SUBJECT_DIGEST="${SUBJECT_DIGEST/-/:}"
           else
-            echo "::error::candidate_tag '$RAW_TAG' is neither an image candidate (sha-<40 hex>) nor a signature artifact (sha256-<64 hex>.sig)"
+            echo "::error::candidate_tag '$RAW_TAG' is not an image candidate (sha-<40 hex>), a signature artifact (sha256-<64 hex>.sig), or a release tag (X.Y.Z / latest)"
             exit 1
           fi
           if [[ ! "$RAW_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
@@ -182,7 +193,7 @@ jobs:
       - name: Summarise for the release checklist
         run: |
           {
-            echo "### GHCR ${KIND} mirrored (NOT promoted)"
+            echo "### GHCR ${KIND} mirrored: \`${TAG}\`"
             echo ""
             echo "| field | value |"
             echo "|---|---|"


### PR DESCRIPTION
## What

Extends `ghcr-mirror`'s strict tag allowlist with a third shape: promoted
release tags (`X.Y.Z` and `latest`), classified as images so every existing
image gate applies unchanged — source-digest pin, refuse-to-overwrite,
platform assertions, reviewer-gated environment. Also updates the header,
input description, error message, and run summary to match. +19/−8, no new
steps, no new permissions.

## Why

GHCR's only sanctioned write path is this job's workflow-scoped
`GITHUB_TOKEN` (no PATs; the Packages UI/API cannot create tags — registry
tags exist only via manifest push). The release tags that Docker Hub
promotion creates therefore cannot reach GHCR through any other mechanism,
and the input gate — correctly strict — rejected them. This closes a gap in
the original plan, which said "GHCR promotion is a manual retag" in the same
header that explains manual pushes are impossible.

Intended use, per release, after `promote-image` promotes Docker Hub:
dispatch twice (`0.1.5` then `latest`), each pinned to the verified digest,
each reviewer-approved.

Known limitation, deliberate: re-pointing `latest` at a NEW digest on a
future release hits the no-overwrite gate and fails closed. First release is
unaffected (no `latest` exists on GHCR). The guarded move-latest carve-out
(mirroring promote-image's never-move-backwards rule) is deferred — small,
fails safe, and likely superseded by the Track 2 pipeline.

## Testing done

- `yaml.safe_load` passes on the resulting file.
- Regex traced against the gate's env-only input handling (tag values reach
  the shell only via `$RAW_TAG`, never interpolation): `0.1.5` and `latest`
  → image branch; `0.1.5.4`, `v0.1.5`, `latest2`, `Latest`, empty → rejected;
  the existing `sha-*`/`*.sig` behavior is byte-identical.
- Not executed in Actions: same pre-merge limitation as #256/#264 (the
  `ghcr` environment is main-only by design). First dispatch for `0.1.5`
  serves as the live verification, and fails closed if I am wrong.

## Checklist

- [ ] All tests pass (`cargo test --workspace`) — not applicable, workflow-only change
- [ ] Code is formatted (`cargo fmt --check`) — not applicable
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`) — not applicable
- [x] I have added or updated tests for new functionality — gate rejection covered by the validation regexes themselves; traced above
- [x] I have updated documentation if behavior changed — header + input description + summary updated in this diff
- [x] Breaking changes are noted below (if any)

ADR / RFC: n/a — CI tooling only; no wire protocol, Storage trait, auth model, on-disk format, or CLI surface change.

## Breaking changes

None. Existing dispatch inputs behave identically.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
