### PR TITLE
ci: sign the published image in CI via OIDC-federated KMS

### DIFF
--- a/.github/workflows/sign-image.yml
+++ b/.github/workflows/sign-image.yml
@@ -1,0 +1,147 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Production container signing, in CI instead of on a laptop.
+#
+# Signs ONE already-verified, already-published image digest on Docker Hub
+# with the production KMS key, as an attached Cosign signature in legacy
+# tag-based storage (sha256-<digest>.sig) — the storage mode the GHCR mirror
+# job and the published verify instructions require.
+#
+# Why CI: no human ever holds the registry credential and a KMS signing
+# session together. AWS access is OIDC-federated (no stored AWS secrets):
+# the ExtendDBContainerSigningCI role's trust policy only accepts runs of
+# this repository in the `dockerhub` environment, and the key policy allows
+# kms:Sign to exactly that role and the manual break-glass operator role.
+# The `dockerhub` environment supplies the registry credential and enforces
+# the two-person rule mechanically: reviewer approval, no self-review,
+# main only.
+#
+# Transparency log: OFF this release, for consistency with the ECR
+# signature (made from a corp machine that cannot reach Rekor). Runners CAN
+# reach Rekor, so enabling it next release is a one-flag change here.
+#
+# cosign v3 storage-mode trap, learned the hard way: with the default
+# signing-config machinery, cosign writes a new-format OCI referrer bundle
+# and NO .sig tag. All three flags below are required for tag-based mode;
+# the post-sign gate fails the run if the .sig tag did not appear.
+
+name: sign-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_digest:
+        description: 'The verified image index digest to sign, e.g. sha256:<64 hex>'
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sign-image-extenddb-postgres
+  cancel-in-progress: false
+
+env:
+  IMAGE_REPO: docker.io/extenddb/extenddb-postgres
+  KEY_ARN: arn:aws:kms:us-east-1:975306274793:key/654ab7f4-4a11-45e1-a313-3a6989f3721c
+  AWS_ROLE_ARN: arn:aws:iam::975306274793:role/ExtendDBContainerSigningCI
+  COSIGN_VERSION: v3.1.3
+  COSIGN_SHA256: 4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71
+
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: dockerhub     # required reviewers, prevent self-review, main only
+    permissions:
+      contents: read
+      id-token: write          # OIDC token for AWS role assumption
+    steps:
+      - name: Gate - validate input strictly
+        env:
+          RAW_DIGEST: ${{ inputs.expected_digest }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$RAW_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::expected_digest is not a sha256:<64 hex> digest"
+            exit 1
+          fi
+          echo "DIGEST=$RAW_DIGEST" >> "$GITHUB_ENV"
+
+      - name: Gate - the digest must exist on Docker Hub as a multi-arch index
+        run: |
+          set -euo pipefail
+          RAW=$(skopeo inspect --raw "docker://${IMAGE_REPO}@${DIGEST}")
+          grep -q '"architecture": *"amd64"' <<< "$RAW" || { echo "::error::amd64 missing from index"; exit 1; }
+          grep -q '"architecture": *"arm64"' <<< "$RAW" || { echo "::error::arm64 missing from index"; exit 1; }
+
+      - name: Install pinned cosign (checksum-verified)
+        run: |
+          set -euo pipefail
+          curl -sSfL -o /tmp/cosign \
+            "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64"
+          echo "${COSIGN_SHA256}  /tmp/cosign" | sha256sum --check --strict
+          install -m 0755 /tmp/cosign /usr/local/bin/cosign
+          cosign version
+
+      - name: Assume the signing role via OIDC (no stored AWS secrets)
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: arn:aws:iam::975306274793:role/ExtendDBContainerSigningCI
+          role-session-name: extenddb-sign-${{ github.run_id }}
+          aws-region: us-east-1
+
+      - name: Log in to Docker Hub (environment credential)
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          docker login docker.io -u "$DOCKERHUB_USERNAME" --password-stdin <<< "$DOCKERHUB_TOKEN"
+
+      - name: Sign - attached, legacy tag-based storage, no transparency log
+        run: |
+          set -euo pipefail
+          cosign sign --yes \
+            --key "awskms:///${KEY_ARN}" \
+            --use-signing-config=false \
+            --new-bundle-format=false \
+            --tlog-upload=false \
+            -a org.extenddb.release="${{ github.ref_name }}" \
+            -a org.extenddb.signed-digest="${DIGEST}" \
+            "${IMAGE_REPO}@${DIGEST}"
+
+      - name: Gate - the .sig TAG must exist (catches the storage-mode trap)
+        run: |
+          set -euo pipefail
+          SIG_TAG="sha256-${DIGEST#sha256:}.sig"
+          SIG_DIGEST=$(skopeo inspect --format '{{.Digest}}' "docker://${IMAGE_REPO}:${SIG_TAG}")
+          MEDIA=$(skopeo inspect --raw "docker://${IMAGE_REPO}:${SIG_TAG}" | jq -r .mediaType)
+          [[ "$MEDIA" == "application/vnd.oci.image.manifest.v1+json" ]] || { echo "::error::signature is not a single OCI manifest"; exit 1; }
+          echo "SIG_TAG=$SIG_TAG" >> "$GITHUB_ENV"
+          echo "SIG_DIGEST=$SIG_DIGEST" >> "$GITHUB_ENV"
+
+      - name: Verify the signature with the public key
+        run: |
+          set -euo pipefail
+          cosign verify --key "awskms:///${KEY_ARN}" --insecure-ignore-tlog=true \
+            "${IMAGE_REPO}@${DIGEST}" | head -1
+
+      - name: Log out
+        if: always()
+        run: docker logout docker.io || true
+
+      - name: Summarise for the release checklist
+        run: |
+          {
+            echo "### Docker Hub image signed"
+            echo ""
+            echo "| field | value |"
+            echo "|---|---|"
+            echo "| image | \`${IMAGE_REPO}@${DIGEST}\` |"
+            echo "| signature | \`${IMAGE_REPO}:${SIG_TAG}\` |"
+            echo "| signature digest | \`${SIG_DIGEST}\` |"
+            echo ""
+            echo "Next: dispatch ghcr-mirror with the signature tag and digest above."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sign-image.yml
+++ b/.github/workflows/sign-image.yml
@@ -34,6 +34,9 @@ on:
       expected_digest:
         description: 'The verified image index digest to sign, e.g. sha256:<64 hex>'
         required: true
+      release_tag:
+        description: 'The release this digest belongs to, e.g. v0.1.5 (annotation only)'
+        required: true
 
 permissions:
   contents: read
@@ -61,13 +64,21 @@ jobs:
       - name: Gate - validate input strictly
         env:
           RAW_DIGEST: ${{ inputs.expected_digest }}
+          RAW_RELEASE: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
           if [[ ! "$RAW_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             echo "::error::expected_digest is not a sha256:<64 hex> digest"
             exit 1
           fi
-          echo "DIGEST=$RAW_DIGEST" >> "$GITHUB_ENV"
+          if [[ ! "$RAW_RELEASE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::release_tag is not a vMAJOR.MINOR.PATCH release tag"
+            exit 1
+          fi
+          {
+            echo "DIGEST=$RAW_DIGEST"
+            echo "RELEASE=$RAW_RELEASE"
+          } >> "$GITHUB_ENV"
 
       - name: Gate - the digest must exist on Docker Hub as a multi-arch index
         run: |
@@ -108,8 +119,7 @@ jobs:
             --use-signing-config=false \
             --new-bundle-format=false \
             --tlog-upload=false \
-            -a org.extenddb.release="${{ github.ref_name }}" \
-            -a org.extenddb.signed-digest="${DIGEST}" \
+            -a org.extenddb.release="${RELEASE}" \
             "${IMAGE_REPO}@${DIGEST}"
 
       - name: Gate - the .sig TAG must exist (catches the storage-mode trap)


### PR DESCRIPTION
## What

A `sign-image` workflow: dispatch it with a verified image digest and an
approved run signs that digest on Docker Hub with the production KMS key —
attached Cosign signature, legacy tag-based storage, no transparency log
(deliberate, see below). AWS access is OIDC-federated (`id-token: write`);
there are no new secrets anywhere. cosign is pinned by checksum, the
credentials action by commit SHA. A post-sign gate fails the run unless the
`sha256-<digest>.sig` TAG exists and is a single OCI manifest — the exact
failure mode cosign v3's defaults produce (new-format referrer, no tag),
which we hit live on ECR tonight.

## Why

Manual signing requires one person to simultaneously hold a production KMS
session and the team registry credential on a laptop. Nobody should be
comfortable with that. This moves the act into the `dockerhub` environment,
which supplies the registry credential it already holds and enforces the
two-person rule mechanically (required reviewers, no self-review, main
only) instead of by chat message.

The AWS side is already live and verified: `ExtendDBContainerSigningCI`
can be assumed only via GitHub OIDC by runs of this repository in the
`dockerhub` environment, and the key policy (both its Allow and its
explicit Deny) admits exactly that role plus the manual break-glass
operator role. This is Phase 1 of the pipeline consolidation plan, pulled
forward — nothing here is launch-throwaway.

Transparency log is off this release for consistency with the ECR
signature (signed from a corp machine, which cannot reach Rekor — it is
DNS-sinkholed). Runners can reach Rekor, so next release this becomes a
one-flag change plus runbook update.

## Testing done

- `yaml.safe_load` passes; input gate follows the env-only pattern from
  ghcr-mirror (digest regex is the same one fuzzed on #264).
- The exact cosign flag set (`--use-signing-config=false
  --new-bundle-format=false --tlog-upload=false`) was proven live against
  ECR Public tonight: produced the `.sig` tag, single OCI manifest,
  simplesigning layer, verified with the production key.
- The IAM trust chain was verified by read-back (role trust condition,
  key policy Allow + Deny); policy before/after archived in release
  evidence.
- Not executed in Actions pre-merge (main-only environment, as with #256,
  #264, #266). First dispatch is the live verification; every gate fails
  closed.

## Checklist

- [ ] All tests pass (`cargo test --workspace`) — not applicable, workflow-only change
- [ ] Code is formatted (`cargo fmt --check`) — not applicable
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`) — not applicable
- [x] I have added or updated tests for new functionality — gates traced above; post-sign tag gate is the regression test for the storage-mode trap
- [x] I have updated documentation if behavior changed — header documents rationale, trust chain, and the Rekor plan; runbook update follows merge
- [x] Breaking changes are noted below (if any)

ADR / RFC: n/a — CI tooling only.

## Breaking changes

None. The manual signing path remains available as break-glass.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
