### PR TITLE
fix: declare --sqlite-path on init and make the documented path selection real

### DIFF
--- a/crates/app/src/cmd_init.rs
+++ b/crates/app/src/cmd_init.rs
@@ -29,6 +29,12 @@ pub struct InitArgs {
     #[arg(long)]
     catalog_db: Option<String>,
 
+    /// SQLite database file path (default: extenddb.sqlite). The chosen path
+    /// is written to the generated config file, so `serve` finds it without
+    /// further flags. SQLite backend only.
+    #[arg(long)]
+    sqlite_path: Option<String>,
+
     /// PostgreSQL host (hostname, IP address, or absolute Unix socket directory path)
     #[arg(long)]
     pg_host: Option<String>,
@@ -342,4 +348,37 @@ async fn run_init_migrations(
 /// Extract a CLI argument value by flag name.
 fn extract_arg(args: &[String], flag: &str) -> Option<String> {
     args.windows(2).find(|w| w[0] == flag).map(|w| w[1].clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InitArgs;
+    use clap::Args as _;
+    use clap::FromArgMatches as _;
+
+    fn parse(args: &[&str]) -> Result<InitArgs, clap::Error> {
+        let cmd = InitArgs::augment_args(clap::Command::new("init"));
+        let matches =
+            cmd.try_get_matches_from(std::iter::once("init").chain(args.iter().copied()))?;
+        InitArgs::from_arg_matches(&matches)
+    }
+
+    /// Regression test for issue #267: `--sqlite-path` was documented and read
+    /// by the SQLite bootstrapper via `extract_arg`, but never declared to
+    /// clap, so every invocation was rejected with "unexpected argument"
+    /// before the bootstrapper could run.
+    #[test]
+    fn init_accepts_sqlite_path() {
+        let args =
+            parse(&["--backend", "sqlite", "--sqlite-path", "/data/x.sqlite"]).expect("parse");
+        assert_eq!(args.sqlite_path.as_deref(), Some("/data/x.sqlite"));
+    }
+
+    /// The control: an actually-unknown flag must still be rejected, proving
+    /// the test above discriminates on the declaration rather than on clap
+    /// somehow accepting arbitrary arguments.
+    #[test]
+    fn init_rejects_unknown_flags() {
+        assert!(parse(&["--sqlite-pathological", "/data/x.sqlite"]).is_err());
+    }
 }

--- a/crates/storage-sqlite/src/bootstrapper.rs
+++ b/crates/storage-sqlite/src/bootstrapper.rs
@@ -38,9 +38,11 @@ impl SqliteBootstrapper {
 
     /// Build a `SqliteBootstrapper` from the config file and CLI args.
     ///
-    /// Resolution order for the database path: `--sqlite-path <p>` CLI flag,
-    /// then `[storage.sqlite].path` in the config file, then the default
-    /// `extenddb.sqlite`.
+    /// Resolution order for the database path (bootstrapper commands: init,
+    /// destroy, migrate): the `--sqlite-path <p>` CLI flag (declared on
+    /// `InitArgs`), then `[storage.sqlite].path` in the config file, then the
+    /// default `extenddb.sqlite`. `serve` does not use this path; it reads
+    /// the config (with `EXTENDDB__STORAGE__SQLITE__PATH` overriding).
     pub async fn from_config(config_path: &str, cli_args: &[String]) -> Result<Self, StorageError> {
         if let Some(p) = helpers::extract_arg(cli_args, "--sqlite-path") {
             return Ok(Self::new(p));
@@ -70,7 +72,21 @@ impl SqliteBootstrapper {
     }
 
     /// Open a short-lived single-connection pool with the standard PRAGMAs.
+    /// For a real filesystem path, the parent directory is created first:
+    /// `init --sqlite-path` may point into a directory that does not exist
+    /// yet, and bootstrapping it is exactly init's job.
     async fn pool(&self) -> OpResult<SqlitePool> {
+        if self.path != ":memory:"
+            && let Some(parent) = std::path::Path::new(&self.path).parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                OpError::Internal(format!(
+                    "create parent directory for SQLite database '{}': {e}",
+                    self.path
+                ))
+            })?;
+        }
         SqlitePoolOptions::new()
             .max_connections(1)
             .after_connect(|conn, _| {

--- a/docs/design/08-component-config.md
+++ b/docs/design/08-component-config.md
@@ -50,6 +50,7 @@ Environment variables use double-underscore (`__`) as a nesting separator, prefi
 | `server.bind_addr` | `EXTENDDB__SERVER__BIND_ADDR` |
 | `storage.postgres.connection_string` | `EXTENDDB__STORAGE__POSTGRES__CONNECTION_STRING` |
 | `storage.postgres.read_replica_url` | `EXTENDDB__STORAGE__POSTGRES__READ_REPLICA_URL` |
+| `storage.sqlite.path` | `EXTENDDB__STORAGE__SQLITE__PATH` |
 | `auth.provider` | `EXTENDDB__AUTH__PROVIDER` |
 | `auth.encryption_key` | `EXTENDDB__AUTH__ENCRYPTION_KEY` |
 | `auth.aws_iam.region` | `EXTENDDB__AUTH__AWS_IAM__REGION` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,16 +135,20 @@ location is configured (default `extenddb.sqlite`):
 path = "extenddb.sqlite"   # or ":memory:" for an ephemeral in-memory database
 ```
 
-At serve time the path can be overridden with `--sqlite-path`. The resolution
-order is: the `--sqlite-path` flag, then `[storage.sqlite].path` in the config,
-then the default `extenddb.sqlite`:
+At init time the path can be chosen with `--sqlite-path`, which also writes it
+into the generated config. At serve time the path comes from
+`[storage.sqlite].path` in the config, or the `EXTENDDB__STORAGE__SQLITE__PATH`
+environment variable, which overrides the config:
 
 ```bash
-./target/release/extenddb serve --config extenddb.toml --sqlite-path /data/extenddb.sqlite
+./target/release/extenddb init --backend sqlite --sqlite-path /data/extenddb.sqlite
+./target/release/extenddb serve --config extenddb.toml
+# or, overriding at serve time:
+EXTENDDB__STORAGE__SQLITE__PATH=/data/other.sqlite ./target/release/extenddb serve --config extenddb.toml
 ```
 
-Use `:memory:` (in the config or via `--sqlite-path`) for an ephemeral database
-that is discarded on shutdown.
+Use `:memory:` (in the config, the environment variable, or `init
+--sqlite-path`) for an ephemeral database that is discarded on shutdown.
 
 ### Generating a self-signed certificate manually
 

--- a/extenddb.sample.toml
+++ b/extenddb.sample.toml
@@ -33,8 +33,9 @@
 
 # --- SQLite backend (developer mode) ---
 # Select with `extenddb init --backend sqlite`. The database path can be given
-# at serve time (`extenddb serve --sqlite-path <path>`) or here. Resolution order:
-#   --sqlite-path flag  ->  [storage.sqlite].path  ->  default "extenddb.sqlite".
+# at init time (`extenddb init --sqlite-path <path>`, written into this file)
+# or set here. At serve time, the EXTENDDB__STORAGE__SQLITE__PATH environment
+# variable overrides this value.
 # Use ":memory:" for an ephemeral in-memory database (data lost on shutdown).
 # [storage.sqlite]
 # path = "extenddb.sqlite"


### PR DESCRIPTION
## What

Makes the documented `--sqlite-path` real. It is declared on `init` (where the genuinely unworkaround-able gap was: no way to choose the SQLite path before a config file exists), the bootstrapper now creates the parent directory for new paths, and the docs are corrected to describe what actually works at serve time (`[storage.sqlite].path`, or the previously undocumented `EXTENDDB__STORAGE__SQLITE__PATH` override). `serve` stays backend-agnostic, matching the Postgres convention of no serve-time storage flags.

## Why

The flag was documented and half-implemented (the bootstrapper reads it via `extract_arg`) from the original SQLite backend commit, but never declared to clap, so it was rejected on every command and the extraction was unreachable dead code. Postgres's init flags work only because `InitArgs` declares them too.

Closes #267

## Testing done

- Clap-level regression test with a discriminating negative control: removing the declaration reproduces the pre-fix rejection; a genuinely unknown flag is still rejected.
- Live end-to-end on the built binary: `init --backend sqlite --sqlite-path <fresh-dir>/place.sqlite` creates the database there, writes the path into the generated `[storage.sqlite]` section, and `serve` opens it. The parent-directory fix was itself found by this live run (SQLite error 14 on a not-yet-existing directory).
- `cargo fmt --check` clean, `cargo clippy --workspace -D warnings` clean, workspace suite 787 passed / 0 failed / 0 filtered out.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any) - none
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface, an RFC has been accepted or is linked below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a - adds one already-documented flag to `init`'s existing per-backend flag set, mirroring the Postgres flags; no protocol, trait, auth, or format change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
