### PR TITLE
Docs/docker compose local dev

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,6 +27,13 @@ The scripts report missing dependencies and exit — they never install
 software on your behalf. After the script completes, continue from
 [Step 2: Initialize the deployment](#2-initialize-the-deployment) below.
 
+## Quick start with Docker Compose
+
+If you have Docker, the fastest way to get a local ExtendDB stack running is with
+the included `docker-compose.yml`. It wires the official image to a PostgreSQL
+container and handles initialization automatically — no build or manual init required.
+See [Local Development with Docker Compose](local-dev-docker-compose.md).
+
 ## Prerequisites
 
 - **Storage backend** (one of):

--- a/docs/local-dev-docker-compose.md
+++ b/docs/local-dev-docker-compose.md
@@ -1,0 +1,148 @@
+# Local Development with Docker Compose
+
+A `docker-compose.yml` is included at the repository root. It wires the official
+`extenddb/extenddb-postgres` image to a PostgreSQL container and handles
+initialization automatically — no manual `extenddb init` required.
+
+## Prerequisites
+
+- Docker Engine 20.10+ with Compose plugin (`docker compose`)
+- AWS CLI v2 (for testing)
+
+## Start the stack
+
+```bash
+EXTENDDB_IMAGE=extenddb/extenddb-postgres:latest docker compose up -d
+```
+
+This starts four services in order:
+
+1. `postgres` — PostgreSQL 16
+2. `extenddb-volume-init` — sets up the state volume (runs once)
+3. `extenddb-bootstrap` — runs `extenddb init` and applies migrations (runs once)
+4. `extenddb` — the ExtendDB server
+
+Wait for the stack to be ready:
+
+```bash
+docker compose ps
+```
+
+All services should show `healthy` or `exited` (bootstrap services exit after completing).
+
+Verify ExtendDB is responding:
+
+```bash
+curl -sk https://127.0.0.1:18443/health
+# {"status":"healthy"}
+```
+
+## Default credentials
+
+| Setting | Value |
+|---------|-------|
+| Admin user | `admin` |
+| Admin password | `ExtendDBLocalAdmin123` |
+| Port | `18443` |
+
+Override any value with environment variables before running `docker compose up`:
+
+```bash
+EXTENDDB_ADMIN_PASSWORD=mysecret EXTENDDB_IMAGE=extenddb/extenddb-postgres:latest docker compose up -d
+```
+
+See the comments in `docker-compose.yml` for all available variables.
+
+## TLS certificate
+
+ExtendDB generates a self-signed certificate on first boot. Extract it to trust
+it locally:
+
+```bash
+docker compose exec extenddb cat /var/lib/extenddb/.extenddb/tls/cert.pem > /tmp/extenddb-cert.pem
+export AWS_CA_BUNDLE=/tmp/extenddb-cert.pem
+```
+
+## Manage users and access keys
+
+Use `extenddb manage` via `docker compose exec`:
+
+```bash
+# List accounts (use the account ID printed in bootstrap logs)
+docker compose exec extenddb extenddb manage \
+  --user admin --password 'ExtendDBLocalAdmin123' \
+  list-accounts
+
+# Create an IAM user
+docker compose exec extenddb extenddb manage \
+  --user admin --password 'ExtendDBLocalAdmin123' \
+  create-user --account-id <account-id> --user-name myuser
+
+# Attach a policy
+docker compose exec extenddb extenddb manage \
+  --user admin --password 'ExtendDBLocalAdmin123' \
+  put-user-policy --account-id <account-id> --user-name myuser \
+  --policy-name full-access \
+  --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"dynamodb:*","Resource":"*"}]}'
+
+# Create an access key (shown once — save it)
+docker compose exec extenddb extenddb manage \
+  --user admin --password 'ExtendDBLocalAdmin123' \
+  create-access-key --account-id <account-id> --user-name myuser
+```
+
+For the full management API reference, see [Admin Guide](manuals/05-admin-guide.md).
+
+## Configure AWS CLI
+
+```bash
+export AWS_ACCESS_KEY_ID=<access-key-id>
+export AWS_SECRET_ACCESS_KEY=<secret-access-key>
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_CA_BUNDLE=/tmp/extenddb-cert.pem
+
+aws dynamodb list-tables --endpoint-url https://127.0.0.1:18443
+```
+
+For more CLI examples, see [Getting Started](getting-started.md#6-try-it-out).
+
+## View logs
+
+```bash
+# Bootstrap logs (init output)
+docker compose logs extenddb-bootstrap
+
+# Server logs
+docker compose logs -f extenddb
+```
+
+## Stop and clean up
+
+```bash
+# Stop (preserves data)
+docker compose down
+
+# Stop and delete all data
+docker compose down -v
+```
+
+## ECR authentication
+
+The PostgreSQL image is pulled from Amazon ECR Public. If the pull fails with an
+authorization error, reauthenticate:
+
+```bash
+aws ecr-public get-login-password --region us-east-1 | \
+  docker login --username AWS --password-stdin public.ecr.aws
+```
+
+---
+
+## License
+
+Copyright 2026 ExtendDB contributors. Licensed under the Apache License, Version 2.0.
+See [LICENSE](../LICENSE) for the full text.
+
+This software is provided "as is" without warranty of any kind. ExtendDB is not
+affiliated with, endorsed by, or sponsored by Amazon Web Services. "DynamoDB" is a trademark
+of Amazon.com, Inc.


### PR DESCRIPTION
## What

Add `docs/local-dev-docker-compose.md` with a local development guide using Docker Compose and the official `extenddb/extenddb-postgres` image. Add a "Quick start with Docker Compose" section to `docs/getting-started.md` pointing to it.

## Why

Follow-up to #70 as suggested by @LeeroyHannigan — reworks the original contribution as a "local development with Docker Compose" docs section, wiring the official image to a PostgreSQL container.

Closes #

## Testing done

Validated the full flow locally: `docker compose up -d`, automatic bootstrap, TLS cert extraction, IAM user creation via `docker compose exec`, and `aws dynamodb list-tables` returning successfully.

<img width="965" height="203" alt="image" src="https://github.com/user-attachments/assets/9fd368a4-6d86-4fdf-be28-3878a932993d" />

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`) — no code changes
- [x] Code is formatted (`cargo fmt --check`) — no code changes
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`) — no code changes
- [ ] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [ ] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface, an RFC has been accepted or is linked below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.