### PR TITLE
chore(licenses): regenerate notices for 0.1.6

### DIFF
--- a/SOFTWARE-LICENSE-NOTICES.html
+++ b/SOFTWARE-LICENSE-NOTICES.html
@@ -6666,16 +6666,16 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.5</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.5</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.5</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.5</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.5</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.5</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.5</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.5</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.5</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage-postgres ">extenddb-storage-postgres 0.1.5</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.6</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.6</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.6</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.6</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.6</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.6</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.6</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.6</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.6</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage-postgres ">extenddb-storage-postgres 0.1.6</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.103</a></li>
                     <li><a href=" https://github.com/andylokandy/arraydeque ">arraydeque 0.5.1</a></li>


### PR DESCRIPTION
Regenerates `SOFTWARE-LICENSE-NOTICES.html` for 0.1.6. **Release-blocking:** main cannot currently produce a container candidate.

## Why

The notices file embeds the version of every workspace crate, so it goes stale on any version bump. The 0.1.6 bump in #271 (`75e1685`) changed `Cargo.toml` and `Cargo.lock` but did not regenerate the notices, so all ten entries still read `0.1.5`.

`release-image`'s gate runs `devtools/generate-software-license-notices --check`, which failed for tag `v0.1.6` before either architecture built ([run 31845065835](https://github.com/ExtendDB/extenddb/actions/runs/31845065835)):

```
error: SOFTWARE-LICENSE-NOTICES.html is stale
run: devtools/generate-software-license-notices
```

## What changed

Regenerated with `cargo-about 0.9.0`. The diff is exactly ten lines, the workspace crates' own versions. The three remaining `0.1.5` strings in the file are unrelated third-party crates (`stringprep`, `potential_utf`, `foldhash`). Ten entries rather than twelve because the generator builds `crates/bin` with `--no-default-features --features postgres`, which excludes the mongodb and sqlite backends.

## Verification

Discriminating control, run locally:

| commit | `--check` result |
|---|---|
| `75e1685` (main) | fails, exact CI message |
| this commit | `SOFTWARE-LICENSE-NOTICES.html is current` |

## Process gap worth a follow-up

The licence check runs **only** in `release-image.yml`, never in `fmt`/`clippy`/`test`. That is why #271 merged 32/32 green while leaving main unreleasable. The v0.1.4 and v0.1.5 bumps regenerated the notices inside the bump commit itself; #271's bump rode along with a feature change and skipped it. Either moving the check into regular CI or adding it to the release checklist would prevent a repeat. Not done here to keep this PR to the unblock.

Once this merges, the `v0.1.6` tag needs to move to the merge commit (nothing has consumed it: no image, no release) and `release-image` can be re-dispatched.
