### PR TITLE
fix: adding a GSI to a table with no sort key fails with a 500

### DIFF
--- a/crates/storage-postgres/src/table_helpers.rs
+++ b/crates/storage-postgres/src/table_helpers.rs
@@ -80,8 +80,22 @@ impl PostgresEngine {
         let idx_sks = data::all_sort_key_info(index_key_schema, attr_defs);
         let base_sks = data::all_sort_key_info(base_key_schema, base_attr_defs);
 
+        // Order by whatever key columns the base table actually has. A
+        // hash-only base table has no sort-key columns at all, so naming them
+        // unconditionally makes the backfill fail with "column sk_s does not
+        // exist" and the whole GSI add is rolled back.
+        let mut order_cols = vec!["pk".to_owned()];
+        for (i, _) in base_sks.iter().enumerate() {
+            if i == 0 {
+                order_cols.extend(["sk_s".to_owned(), "sk_n".to_owned(), "sk_b".to_owned()]);
+            } else {
+                let n = i + 1;
+                order_cols.extend([format!("sk{n}_s"), format!("sk{n}_n"), format!("sk{n}_b")]);
+            }
+        }
         let sql = format!(
-            "SELECT item_data FROM {base_table} ORDER BY pk, sk_s, sk_n, sk_b LIMIT $1 OFFSET $2"
+            "SELECT item_data FROM {base_table} ORDER BY {} LIMIT $1 OFFSET $2",
+            order_cols.join(", ")
         );
         let mut offset: i64 = 0;
         loop {

--- a/tests/rust/src/gsi_on_hash_only_table.rs
+++ b/tests/rust/src/gsi_on_hash_only_table.rs
@@ -1,0 +1,145 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Adding a GSI to a table that has no sort key.
+//!
+//! The backfill that copies existing rows into a new index reads the base table
+//! ordered by its key columns. Naming the sort-key columns unconditionally makes
+//! that query fail with `column "sk_s" does not exist` on a hash-only base
+//! table, and because the backfill runs inside the index creation the whole
+//! `UpdateTable` is rolled back and the caller sees `InternalServerError`. A
+//! partition-key-only table is the simplest table DynamoDB allows, so this
+//! covers the add end to end: the call succeeds, the index reaches ACTIVE, and a
+//! row written before the index existed is visible through it afterwards.
+
+use crate::test_base::*;
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition, CreateGlobalSecondaryIndexAction, GlobalSecondaryIndexUpdate,
+    KeySchemaElement, KeyType, Projection, ProjectionType, ScalarAttributeType,
+};
+use std::time::Duration;
+
+#[tokio::test]
+async fn gsi_can_be_added_to_a_table_with_no_sort_key() {
+    let c = client();
+    let table = format!("GsiHashOnly{}", ts());
+
+    c.create_table()
+        .table_name(&table)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(aws_sdk_dynamodb::types::BillingMode::PayPerRequest)
+        .send()
+        .await
+        .expect("hash-only table creation must succeed");
+    wait_for_active(c, &table).await;
+
+    // Written before the index exists, so it can only appear through the index
+    // if the backfill ran. Without it the query below would pass on an index
+    // that copied nothing.
+    c.put_item()
+        .table_name(&table)
+        .item("pk", s("item-1"))
+        .item("gsiKey", s("gsi-value"))
+        .send()
+        .await
+        .expect("seed write must succeed");
+
+    c.update_table()
+        .table_name(&table)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("gsiKey")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .global_secondary_index_updates(
+            GlobalSecondaryIndexUpdate::builder()
+                .create(
+                    CreateGlobalSecondaryIndexAction::builder()
+                        .index_name("hashOnlyIdx")
+                        .key_schema(
+                            KeySchemaElement::builder()
+                                .attribute_name("gsiKey")
+                                .key_type(KeyType::Hash)
+                                .build()
+                                .unwrap(),
+                        )
+                        .projection(
+                            Projection::builder()
+                                .projection_type(ProjectionType::All)
+                                .build(),
+                        )
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap_or_else(|e| {
+            panic!(
+                "adding a GSI to a hash-only table must succeed: {}",
+                err_msg(&e)
+            )
+        });
+    wait_for_active(c, &table).await;
+
+    // The index must exist on the table description, not merely have been
+    // accepted by UpdateTable.
+    let described = c
+        .describe_table()
+        .table_name(&table)
+        .send()
+        .await
+        .expect("describe must succeed");
+    let gsis = described
+        .table()
+        .expect("table description")
+        .global_secondary_indexes();
+    assert!(
+        gsis.iter().any(|g| g.index_name() == Some("hashOnlyIdx")),
+        "the new index must appear on the table description, got: {:?}",
+        gsis.iter().map(|g| g.index_name()).collect::<Vec<_>>()
+    );
+
+    // The pre-existing row must be readable through the index, which is what
+    // proves the backfill query ran rather than silently copying nothing. The
+    // index is eventually consistent, so poll rather than read once.
+    let mut count = 0;
+    for _ in 0..30 {
+        count = c
+            .query()
+            .table_name(&table)
+            .index_name("hashOnlyIdx")
+            .key_condition_expression("gsiKey = :v")
+            .expression_attribute_values(":v", s("gsi-value"))
+            .send()
+            .await
+            .expect("query on the new index must succeed")
+            .count();
+        if count >= 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    assert_eq!(
+        count, 1,
+        "the row written before the index existed must be backfilled into it"
+    );
+
+    c.delete_table().table_name(&table).send().await.ok();
+}

--- a/tests/rust/src/main.rs
+++ b/tests/rust/src/main.rs
@@ -54,6 +54,8 @@ mod gsi;
 #[cfg(test)]
 mod gsi_more;
 #[cfg(test)]
+mod gsi_on_hash_only_table;
+#[cfg(test)]
 mod gsi_update_table_attr_defs;
 #[cfg(test)]
 mod index_key_validation;


### PR DESCRIPTION
`UpdateTable` cannot add a GSI to **any partition-key-only table** on the PostgreSQL backend. The caller gets `InternalServerError` with nothing to go on.

## Root cause

The backfill that copies existing rows into a new index read the base table with a hardcoded ordering:

```sql
SELECT item_data FROM {base_table} ORDER BY pk, sk_s, sk_n, sk_b LIMIT $1 OFFSET $2
```

A hash-only table has no sort-key columns at all, so PostgreSQL rejects this with `column "sk_s" does not exist`. The backfill runs inside index creation, so the failure rolls the whole `UpdateTable` back and surfaces as a 500.

A partition-key-only table is the simplest table DynamoDB allows, so this makes GSIs unreachable for a large and entirely ordinary class of tables.

This is the same defect family as #259 and the sort-key handling in the restore path: key layout inferred from a fixed column list instead of the table's real schema.

## Fix

Order by only the key columns the base table actually has: `pk`, plus the three typed columns for each sort-key position that exists.

## Verification

`tests/rust/src/gsi_on_hash_only_table.rs` covers the add end to end on a hash-only table: `UpdateTable` succeeds, the index appears on `DescribeTable`, and a row written **before** the index existed is readable through it afterwards. That last assertion is the one that matters, since it distinguishes a real backfill from an index that copied nothing.

Proven discriminating rather than merely green:

| binary | result |
|---|---|
| hardcoded ordering restored | test **fails** on the `UpdateTable` call with `InternalServerError` |
| this fix | passes, and the pre-index row is returned through the index |

`cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --workspace` (798 passed, 0 failed, 0 filtered out) are all clean.

## Note for sequencing

A follow-up PR adds `AttributeDefinitions` pruning on `UpdateTable`. Its integ tests use hash-only tables, so they cannot pass until this lands. This one should go first.
