### PR TITLE
fix: prune unreferenced AttributeDefinitions on UpdateTable

### DIFF
--- a/crates/storage-mongodb/src/table_engine.rs
+++ b/crates/storage-mongodb/src/table_engine.rs
@@ -18,7 +18,8 @@ use extenddb_core::types::{
 use extenddb_storage::TableEngine;
 use extenddb_storage::error::StorageError;
 use extenddb_storage::util::{
-    index_arn, merge_attribute_definitions, sk_info, stream_arn, table_arn,
+    effective_attribute_definitions, index_arn, merge_attribute_definitions, sk_info, stream_arn,
+    table_arn,
 };
 
 use crate::MongoEngine;
@@ -923,6 +924,53 @@ impl MongoEngine {
                     // Invalidate cache — may still have other GSIs
                     self.gsi_cache_invalidate(&desc.table_id);
                 }
+            }
+
+            // Prune definitions that no key and no surviving index references.
+            //
+            // The merge above is only half of DynamoDB's behaviour: the stored set
+            // is also pruned to the attributes still referenced by the table key
+            // schema or by an index that survives this update, so an unused
+            // definition supplied with a GSI add is not stored and deleting a GSI
+            // drops the definitions only that index used. See
+            // effective_attribute_definitions.
+            //
+            // This runs after the create/delete loop, which is what makes a
+            // deletion prune: describe_table_impl reports exactly the indexes that
+            // exist now. It is a second write rather than being folded into the
+            // merge above because index creation inside the loop needs the merged
+            // set before the surviving set is known. This backend's UpdateTable is
+            // non-transactional throughout, so this widens no window the merge did
+            // not already have.
+            let desc = self
+                .describe_table_impl(account_id, &input.table_name)
+                .await?;
+            let mut surviving_index_key_schemas: Vec<Vec<KeySchemaElement>> = Vec::new();
+            for gsi in desc.global_secondary_indexes.iter().flatten() {
+                surviving_index_key_schemas.push(gsi.key_schema.clone());
+            }
+            for lsi in desc.local_secondary_indexes.iter().flatten() {
+                surviving_index_key_schemas.push(lsi.key_schema.clone());
+            }
+
+            // The request's definitions are already folded into the stored set by
+            // the merge above, so nothing further is contributed here.
+            let effective = effective_attribute_definitions(
+                &desc.attribute_definitions,
+                &[],
+                &desc.key_schema,
+                &surviving_index_key_schemas,
+            );
+            if effective != desc.attribute_definitions {
+                let effective_bson =
+                    bson::to_bson(&effective).map_err(|e| StorageError::Internal(e.to_string()))?;
+                tables_coll
+                    .update_one(
+                        doc! { "_id": { "account_id": account_id, "table_name": &input.table_name } },
+                        doc! { "$set": { "attribute_definitions": effective_bson } },
+                    )
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
             }
         }
 

--- a/crates/storage-postgres/src/update_table.rs
+++ b/crates/storage-postgres/src/update_table.rs
@@ -268,9 +268,9 @@ impl PostgresEngine {
         // Apply GSI updates (create/delete).
         let mut created_index_ids: Vec<String> = Vec::new();
         let mut deleted_index_ids: Vec<String> = Vec::new();
-        // The merged attribute definitions persisted by this UpdateTable, carried
-        // out of the catalog transaction so the post-commit index DDL builds its
-        // columns from the same set the catalog now holds.
+        // The merged and pruned attribute definitions persisted by this
+        // UpdateTable, carried out of the catalog transaction so the post-commit
+        // index DDL builds its columns from the same set the catalog now holds.
         let mut merged_attr_defs_for_ddl: Option<Vec<AttributeDefinition>> = None;
         if let Some(updates) = &input.global_secondary_index_updates {
             for update in updates {
@@ -349,32 +349,83 @@ impl PostgresEngine {
                 }
             }
 
-            // Merge the request's attribute definitions into the stored set.
+            // Recompute attribute_definitions for the post-update table.
             //
-            // The request carries only the attributes it needs (a created index's
-            // key attributes), so replacing the column would drop the base
-            // table's own pk/sk definitions and silently degrade keyed reads to a
-            // partition-only lookup (issue #259). The existing set was read under
-            // the FOR UPDATE lock above, so the read-modify-write is atomic with
-            // respect to a concurrent UpdateTable.
-            let merged_attr_defs = if let Some(new_attr_defs) = &input.attribute_definitions {
-                let existing: Vec<AttributeDefinition> = serde_json::from_value(ad_json.clone())
+            // DynamoDB treats the request's AttributeDefinitions as neither a
+            // replacement for the stored set nor a pure addition to it. The
+            // effective set is the stored definitions merged with the request's,
+            // then pruned to the attributes still referenced by the table key
+            // schema or by an index that survives this update:
+            //
+            //   * replacing rather than merging would drop the base table's own
+            //     pk/sk definitions and silently degrade keyed reads to a
+            //     partition-only lookup (issue #259);
+            //   * a definition no key and no surviving index references is
+            //     dropped, so supplying an unused definition alongside a GSI add
+            //     is a no-op rather than a stored row;
+            //   * definitions referenced only by a deleted index are dropped;
+            //   * redeclaring an existing attribute keeps the STORED type, so a
+            //     conflicting redeclaration cannot silently retype a live index
+            //     key;
+            //   * sequential adds accumulate, because the stored set is the base
+            //     of the merge.
+            //
+            // This runs whether or not the request carried AttributeDefinitions,
+            // because a GSI deletion prunes definitions without the request
+            // naming any. The index rows were created and deleted above in this
+            // same transaction, so `indexes` already holds exactly the surviving
+            // set; the stored definitions were read under the FOR UPDATE lock, so
+            // the read-modify-write is atomic against a concurrent UpdateTable.
+            let stored_attr_defs: Vec<AttributeDefinition> =
+                serde_json::from_value(ad_json.clone())
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
-                let merged = merge_attribute_definitions(&existing, new_attr_defs);
-                let merged_json = serde_json::to_value(&merged)
+            let table_key_schema: Vec<KeySchemaElement> =
+                serde_json::from_value(ks_json.clone())
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
-                sqlx::query("UPDATE tables SET attribute_definitions = $1 WHERE account_id = $2 AND table_name = $3")
-                    .bind(&merged_json)
-                    .bind(account_id)
-                    .bind(&input.table_name)
-                    .execute(&mut *tx)
+
+            let surviving_index_key_schemas: Vec<(serde_json::Value,)> =
+                sqlx::query_as("SELECT key_schema FROM indexes WHERE table_id = $1")
+                    .bind(&table_id)
+                    .fetch_all(&mut *tx)
                     .await
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
-                Some(merged)
-            } else {
-                None
-            };
-            merged_attr_defs_for_ddl = merged_attr_defs;
+
+            let mut referenced: std::collections::BTreeSet<String> = table_key_schema
+                .into_iter()
+                .map(|ks| ks.attribute_name)
+                .collect();
+            for (ks_value,) in surviving_index_key_schemas {
+                let ks: Vec<KeySchemaElement> = serde_json::from_value(ks_value)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                referenced.extend(ks.into_iter().map(|k| k.attribute_name));
+            }
+
+            // merge_attribute_definitions keeps the stored definition when both
+            // sides name the same attribute, which is what preserves the stored
+            // type on a conflicting redeclaration.
+            let effective: Vec<AttributeDefinition> = merge_attribute_definitions(
+                &stored_attr_defs,
+                input.attribute_definitions.as_deref().unwrap_or(&[]),
+            )
+            .into_iter()
+            .filter(|def| referenced.contains(&def.attribute_name))
+            .collect();
+
+            if effective != stored_attr_defs {
+                let effective_json = serde_json::to_value(&effective)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                sqlx::query(
+                    "UPDATE tables SET attribute_definitions = $1 \
+                     WHERE account_id = $2 AND table_name = $3",
+                )
+                .bind(&effective_json)
+                .bind(account_id)
+                .bind(&input.table_name)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            }
+            merged_attr_defs_for_ddl = Some(effective);
         }
 
         tx.commit()
@@ -387,9 +438,11 @@ impl PostgresEngine {
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
             let base_attr_defs: Vec<AttributeDefinition> = serde_json::from_value(ad_json.clone())
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
-            // Build index columns from the merged set, not the request's subset: a
-            // new index may key on an attribute the base table already defined, and
-            // the request is not required to re-declare it.
+            // Build index columns from the merged and pruned set rather than the
+            // request's subset: a new index may key on an attribute the base
+            // table already defined and the request need not re-declare it, and
+            // on a conflicting redeclaration the stored type is the one the data
+            // table must be built from.
             let effective_attr_defs = merged_attr_defs_for_ddl
                 .as_deref()
                 .unwrap_or(&base_attr_defs);

--- a/crates/storage-postgres/src/update_table.rs
+++ b/crates/storage-postgres/src/update_table.rs
@@ -7,7 +7,7 @@ use extenddb_core::types::{
     AttributeDefinition, BillingMode, KeySchemaElement, TableDescription, UpdateTableInput,
 };
 use extenddb_storage::error::StorageError;
-use extenddb_storage::util::merge_attribute_definitions;
+use extenddb_storage::util::effective_attribute_definitions;
 
 use crate::PostgresEngine;
 
@@ -351,31 +351,18 @@ impl PostgresEngine {
 
             // Recompute attribute_definitions for the post-update table.
             //
-            // DynamoDB treats the request's AttributeDefinitions as neither a
-            // replacement for the stored set nor a pure addition to it. The
-            // effective set is the stored definitions merged with the request's,
-            // then pruned to the attributes still referenced by the table key
-            // schema or by an index that survives this update:
-            //
-            //   * replacing rather than merging would drop the base table's own
-            //     pk/sk definitions and silently degrade keyed reads to a
-            //     partition-only lookup (issue #259);
-            //   * a definition no key and no surviving index references is
-            //     dropped, so supplying an unused definition alongside a GSI add
-            //     is a no-op rather than a stored row;
-            //   * definitions referenced only by a deleted index are dropped;
-            //   * redeclaring an existing attribute keeps the STORED type, so a
-            //     conflicting redeclaration cannot silently retype a live index
-            //     key;
-            //   * sequential adds accumulate, because the stored set is the base
-            //     of the merge.
+            // The effective set is the stored definitions merged with the
+            // request's, then pruned to the attributes still referenced by the
+            // table key schema or by an index surviving this update. See
+            // effective_attribute_definitions for the measured behaviour and the
+            // reason merging alone is not enough (issue #259).
             //
             // This runs whether or not the request carried AttributeDefinitions,
-            // because a GSI deletion prunes definitions without the request
-            // naming any. The index rows were created and deleted above in this
-            // same transaction, so `indexes` already holds exactly the surviving
-            // set; the stored definitions were read under the FOR UPDATE lock, so
-            // the read-modify-write is atomic against a concurrent UpdateTable.
+            // because a GSI deletion prunes without the request naming anything.
+            // The index rows were created and deleted above in this same
+            // transaction, so `indexes` already holds exactly the surviving set;
+            // the stored definitions were read under the FOR UPDATE lock, so the
+            // read-modify-write is atomic against a concurrent UpdateTable.
             let stored_attr_defs: Vec<AttributeDefinition> =
                 serde_json::from_value(ad_json.clone())
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
@@ -383,33 +370,27 @@ impl PostgresEngine {
                 serde_json::from_value(ks_json.clone())
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
 
-            let surviving_index_key_schemas: Vec<(serde_json::Value,)> =
+            let surviving_rows: Vec<(serde_json::Value,)> =
                 sqlx::query_as("SELECT key_schema FROM indexes WHERE table_id = $1")
                     .bind(&table_id)
                     .fetch_all(&mut *tx)
                     .await
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
-
-            let mut referenced: std::collections::BTreeSet<String> = table_key_schema
-                .into_iter()
-                .map(|ks| ks.attribute_name)
-                .collect();
-            for (ks_value,) in surviving_index_key_schemas {
-                let ks: Vec<KeySchemaElement> = serde_json::from_value(ks_value)
-                    .map_err(|e| StorageError::Internal(e.to_string()))?;
-                referenced.extend(ks.into_iter().map(|k| k.attribute_name));
+            let mut surviving_index_key_schemas: Vec<Vec<KeySchemaElement>> =
+                Vec::with_capacity(surviving_rows.len());
+            for (ks_value,) in surviving_rows {
+                surviving_index_key_schemas.push(
+                    serde_json::from_value(ks_value)
+                        .map_err(|e| StorageError::Internal(e.to_string()))?,
+                );
             }
 
-            // merge_attribute_definitions keeps the stored definition when both
-            // sides name the same attribute, which is what preserves the stored
-            // type on a conflicting redeclaration.
-            let effective: Vec<AttributeDefinition> = merge_attribute_definitions(
+            let effective = effective_attribute_definitions(
                 &stored_attr_defs,
                 input.attribute_definitions.as_deref().unwrap_or(&[]),
-            )
-            .into_iter()
-            .filter(|def| referenced.contains(&def.attribute_name))
-            .collect();
+                &table_key_schema,
+                &surviving_index_key_schemas,
+            );
 
             if effective != stored_attr_defs {
                 let effective_json = serde_json::to_value(&effective)

--- a/crates/storage-sqlite/src/update_table.rs
+++ b/crates/storage-sqlite/src/update_table.rs
@@ -14,7 +14,7 @@ use extenddb_core::types::{
     AttributeDefinition, BillingMode, KeySchemaElement, TableDescription, UpdateTableInput,
 };
 use extenddb_storage::error::StorageError;
-use extenddb_storage::util::merge_attribute_definitions;
+use extenddb_storage::util::effective_attribute_definitions;
 
 use crate::store::SqliteEngine;
 
@@ -284,18 +284,48 @@ impl SqliteEngine {
                     deleted.push(del_id);
                 }
             }
-            // Merge the request's attribute definitions into the stored set.
+            // Recompute attribute_definitions for the post-update table.
             //
-            // The request carries only the attributes it needs (a created index's
-            // key attributes), so replacing the column would drop the base table's
-            // own pk/sk definitions and silently degrade keyed reads to a
-            // partition-only lookup (issue #259). The existing set was read inside
-            // this BEGIN IMMEDIATE transaction, so the read-modify-write is atomic.
-            if let Some(new_attr_defs) = &input.attribute_definitions {
-                let existing: Vec<AttributeDefinition> = serde_json::from_str(&ad_json)
+            // The effective set is the stored definitions merged with the
+            // request's, then pruned to the attributes still referenced by the
+            // table key schema or by an index surviving this update. See
+            // effective_attribute_definitions for the measured behaviour and the
+            // reason merging alone is not enough (issue #259).
+            //
+            // This runs whether or not the request carried AttributeDefinitions,
+            // because a GSI deletion prunes without the request naming anything.
+            // The index rows were created and deleted above inside this BEGIN
+            // IMMEDIATE transaction, so `indexes` already holds exactly the
+            // surviving set and the read-modify-write is atomic.
+            let stored_attr_defs: Vec<AttributeDefinition> = serde_json::from_str(&ad_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let table_key_schema: Vec<KeySchemaElement> = serde_json::from_str(&ks_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let surviving_rows: Vec<(String,)> =
+                sqlx::query_as("SELECT key_schema FROM indexes WHERE table_id = ?")
+                    .bind(&table_id)
+                    .fetch_all(&mut *tx)
+                    .await
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
-                let merged = merge_attribute_definitions(&existing, new_attr_defs);
-                let j = serde_json::to_string(&merged)
+            let mut surviving_index_key_schemas: Vec<Vec<KeySchemaElement>> =
+                Vec::with_capacity(surviving_rows.len());
+            for (ks_text,) in &surviving_rows {
+                surviving_index_key_schemas.push(
+                    serde_json::from_str(ks_text)
+                        .map_err(|e| StorageError::Internal(e.to_string()))?,
+                );
+            }
+
+            let effective = effective_attribute_definitions(
+                &stored_attr_defs,
+                input.attribute_definitions.as_deref().unwrap_or(&[]),
+                &table_key_schema,
+                &surviving_index_key_schemas,
+            );
+
+            if effective != stored_attr_defs {
+                let j = serde_json::to_string(&effective)
                     .map_err(|e| StorageError::Internal(e.to_string()))?;
                 update_col(
                     &mut tx,
@@ -305,8 +335,8 @@ impl SqliteEngine {
                     &j,
                 )
                 .await?;
-                merged_attr_defs_for_ddl = Some(merged);
             }
+            merged_attr_defs_for_ddl = Some(effective);
         }
 
         tx.commit()

--- a/crates/storage/src/util/key.rs
+++ b/crates/storage/src/util/key.rs
@@ -10,6 +10,7 @@ use extenddb_core::types::{
     AttributeDefinition, AttributeValue, Item, KeySchemaElement, KeyType, ScalarAttributeType,
 };
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 /// Parsed sort key value ready for SQL binding.
 pub enum SortKeyValue {
@@ -169,6 +170,50 @@ pub fn merge_attribute_definitions(
         }
     }
     merged
+}
+
+/// The attribute definitions a table should hold after an `UpdateTable`.
+///
+/// DynamoDB treats the request's `AttributeDefinitions` as neither a replacement
+/// for the stored set nor a pure addition to it. The effective set is the stored
+/// definitions merged with the request's (see [`merge_attribute_definitions`]),
+/// then pruned to the attributes still referenced by the table key schema or by
+/// an index that survives the update.
+///
+/// Measured against real DynamoDB on top of the merge behaviour documented above:
+///
+/// - An unused definition supplied alongside a GSI add is dropped, so the next
+///   `DescribeTable` does not report it.
+/// - Deleting a GSI drops the definitions only that index referenced, while every
+///   definition another index or the table key still uses survives.
+///
+/// `surviving_index_key_schemas` must be the key schemas of the indexes that exist
+/// *after* the update is applied: an index being created is included, an index
+/// being deleted is not. Callers read this from their own catalog after applying
+/// the index changes, which is what makes a deletion prune.
+///
+/// Pruning can never remove a definition the table key schema names, so a table
+/// cannot lose its own pk/sk definitions through this path (issue #259). Merge
+/// order is preserved: stored definitions keep their order, surviving new ones are
+/// appended in request order.
+#[must_use]
+pub fn effective_attribute_definitions(
+    stored: &[AttributeDefinition],
+    requested: &[AttributeDefinition],
+    table_key_schema: &[KeySchemaElement],
+    surviving_index_key_schemas: &[Vec<KeySchemaElement>],
+) -> Vec<AttributeDefinition> {
+    let mut referenced: BTreeSet<&str> = table_key_schema
+        .iter()
+        .map(|ks| ks.attribute_name.as_str())
+        .collect();
+    for ks in surviving_index_key_schemas {
+        referenced.extend(ks.iter().map(|k| k.attribute_name.as_str()));
+    }
+    merge_attribute_definitions(stored, requested)
+        .into_iter()
+        .filter(|def| referenced.contains(def.attribute_name.as_str()))
+        .collect()
 }
 
 /// Recover sort key attribute definitions that were lost from a table's stored
@@ -476,5 +521,126 @@ mod tests {
             encode_netstring_composite(&a),
             encode_netstring_composite(&b)
         );
+    }
+
+    /// An unused definition supplied alongside a GSI add is dropped: DynamoDB
+    /// stores only what a key or a live index references.
+    #[test]
+    fn effective_attr_defs_drops_a_definition_no_key_or_index_uses() {
+        let stored = vec![ad("pk", ScalarAttributeType::S)];
+        let requested = vec![
+            ad("g1", ScalarAttributeType::S),
+            ad("extraUnused", ScalarAttributeType::S),
+        ];
+        let table_ks = vec![ks("pk", KeyType::Hash)];
+        let surviving = vec![vec![ks("g1", KeyType::Hash)]];
+
+        let effective = effective_attribute_definitions(&stored, &requested, &table_ks, &surviving);
+
+        let names: Vec<&str> = effective
+            .iter()
+            .map(|a| a.attribute_name.as_str())
+            .collect();
+        assert_eq!(names, vec!["pk", "g1"]);
+    }
+
+    /// Removing an index drops the definitions only that index referenced, and
+    /// keeps the ones another surviving index still uses.
+    #[test]
+    fn effective_attr_defs_prunes_only_the_removed_index_attributes() {
+        let stored = vec![
+            ad("pk", ScalarAttributeType::S),
+            ad("goneAttr", ScalarAttributeType::S),
+            ad("keepAttr", ScalarAttributeType::S),
+        ];
+        let table_ks = vec![ks("pk", KeyType::Hash)];
+        // Only the index on keepAttr survives; the one on goneAttr was deleted.
+        let surviving = vec![vec![ks("keepAttr", KeyType::Hash)]];
+
+        let effective = effective_attribute_definitions(&stored, &[], &table_ks, &surviving);
+
+        let names: Vec<&str> = effective
+            .iter()
+            .map(|a| a.attribute_name.as_str())
+            .collect();
+        assert_eq!(names, vec!["pk", "keepAttr"]);
+    }
+
+    /// The table's own key definitions can never be pruned, whatever the indexes
+    /// do. This is the #259 property: losing pk/sk makes keyed reads degrade to a
+    /// partition-only lookup.
+    #[test]
+    fn effective_attr_defs_never_prunes_the_table_key() {
+        let stored = vec![
+            ad("pk", ScalarAttributeType::S),
+            ad("sk", ScalarAttributeType::N),
+        ];
+        let table_ks = vec![ks("pk", KeyType::Hash), ks("sk", KeyType::Range)];
+
+        // No indexes at all: both table key definitions must still survive.
+        let effective = effective_attribute_definitions(&stored, &[], &table_ks, &[]);
+
+        let names: Vec<&str> = effective
+            .iter()
+            .map(|a| a.attribute_name.as_str())
+            .collect();
+        assert_eq!(names, vec!["pk", "sk"]);
+        assert!(sk_info(&table_ks, &effective).is_some());
+    }
+
+    /// A conflicting redeclaration keeps the STORED type, so a live index key
+    /// cannot be silently retyped. Inherited from `merge_attribute_definitions`
+    /// and asserted here because pruning must not disturb it.
+    #[test]
+    fn effective_attr_defs_keeps_the_stored_type_on_a_conflicting_redeclaration() {
+        let stored = vec![ad("pk", ScalarAttributeType::S)];
+        let requested = vec![ad("pk", ScalarAttributeType::N)];
+        let table_ks = vec![ks("pk", KeyType::Hash)];
+
+        let effective = effective_attribute_definitions(&stored, &requested, &table_ks, &[]);
+
+        assert_eq!(effective.len(), 1);
+        assert_eq!(effective[0].attribute_type, ScalarAttributeType::S);
+    }
+
+    /// Sequential adds accumulate: the stored set is the base of the merge, so an
+    /// earlier index's attribute is not lost when a later index is added.
+    #[test]
+    fn effective_attr_defs_accumulate_across_sequential_adds() {
+        let stored = vec![
+            ad("pk", ScalarAttributeType::S),
+            ad("g1", ScalarAttributeType::S),
+        ];
+        let requested = vec![ad("g2", ScalarAttributeType::S)];
+        let table_ks = vec![ks("pk", KeyType::Hash)];
+        let surviving = vec![vec![ks("g1", KeyType::Hash)], vec![ks("g2", KeyType::Hash)]];
+
+        let effective = effective_attribute_definitions(&stored, &requested, &table_ks, &surviving);
+
+        let names: Vec<&str> = effective
+            .iter()
+            .map(|a| a.attribute_name.as_str())
+            .collect();
+        assert_eq!(names, vec!["pk", "g1", "g2"]);
+    }
+
+    /// An index sort key is referenced just like its hash key.
+    #[test]
+    fn effective_attr_defs_keeps_index_sort_key_attributes() {
+        let stored = vec![
+            ad("pk", ScalarAttributeType::S),
+            ad("gh", ScalarAttributeType::S),
+            ad("gr", ScalarAttributeType::N),
+        ];
+        let table_ks = vec![ks("pk", KeyType::Hash)];
+        let surviving = vec![vec![ks("gh", KeyType::Hash), ks("gr", KeyType::Range)]];
+
+        let effective = effective_attribute_definitions(&stored, &[], &table_ks, &surviving);
+
+        let names: Vec<&str> = effective
+            .iter()
+            .map(|a| a.attribute_name.as_str())
+            .collect();
+        assert_eq!(names, vec!["pk", "gh", "gr"]);
     }
 }

--- a/crates/storage/src/util/mod.rs
+++ b/crates/storage/src/util/mod.rs
@@ -12,6 +12,7 @@ mod key;
 pub use arn::{index_arn, parse_stream_arn, stream_arn, table_arn};
 pub use key::SortKeyValue;
 pub use key::{
-    composite_pk_to_text, encode_netstring_composite, merge_attribute_definitions, parse_sk,
-    pk_to_text, recover_sort_key_definitions, sk_column, sk_column_n, sk_info,
+    composite_pk_to_text, effective_attribute_definitions, encode_netstring_composite,
+    merge_attribute_definitions, parse_sk, pk_to_text, recover_sort_key_definitions, sk_column,
+    sk_column_n, sk_info,
 };

--- a/tests/rust/src/main.rs
+++ b/tests/rust/src/main.rs
@@ -116,6 +116,7 @@ mod update_item_more;
 #[cfg(test)]
 mod update_item_number_validation;
 #[cfg(test)]
+mod update_table_attribute_definitions;
 mod update_table_billing_validation;
 #[cfg(test)]
 mod wording_parity_validation;

--- a/tests/rust/src/update_table_attribute_definitions.rs
+++ b/tests/rust/src/update_table_attribute_definitions.rs
@@ -1,0 +1,258 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `UpdateTable` attribute-definition lifecycle across GSI add and remove.
+//!
+//! `AttributeDefinitions` supplied with a `GlobalSecondaryIndexUpdate` is not a
+//! replacement for the table's stored set. The stored set is merged with the
+//! request, then pruned to the attributes the table key schema or a surviving
+//! index still references. That produces four observable behaviours, each
+//! covered below:
+//!
+//! * sequential GSI adds accumulate definitions rather than overwriting them;
+//! * a definition for an attribute no key or index uses is dropped;
+//! * redeclaring an existing key attribute with a different type is accepted
+//!   and the stored type is kept;
+//! * removing a GSI drops the definitions only that index used.
+
+use crate::test_base::*;
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition, GlobalSecondaryIndexUpdate, KeySchemaElement, KeyType, Projection,
+    ProjectionType, ScalarAttributeType, CreateGlobalSecondaryIndexAction,
+    DeleteGlobalSecondaryIndexAction,
+};
+use std::collections::BTreeMap;
+
+/// Create a fresh hash-only table for a single test and return its name.
+async fn fresh_table(label: &str) -> String {
+    let c = client();
+    let name = format!("UtAttrDefs{label}{}", ts());
+    c.create_table()
+        .table_name(&name)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(aws_sdk_dynamodb::types::BillingMode::PayPerRequest)
+        .send()
+        .await
+        .expect("table creation must succeed");
+    wait_for_active(client(), &name).await;
+    name
+}
+
+/// Add a GSI keyed on `attr` (type S), declaring `extra_defs` alongside it.
+async fn add_gsi(table: &str, index: &str, attr: &str, extra_defs: Vec<AttributeDefinition>) {
+    let c = client();
+    let mut req = c
+        .update_table()
+        .table_name(table)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name(attr)
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        );
+    for d in extra_defs {
+        req = req.attribute_definitions(d);
+    }
+    req.global_secondary_index_updates(
+        GlobalSecondaryIndexUpdate::builder()
+            .create(
+                CreateGlobalSecondaryIndexAction::builder()
+                    .index_name(index)
+                    .key_schema(
+                        KeySchemaElement::builder()
+                            .attribute_name(attr)
+                            .key_type(KeyType::Hash)
+                            .build()
+                            .unwrap(),
+                    )
+                    .projection(
+                        Projection::builder()
+                            .projection_type(ProjectionType::All)
+                            .build(),
+                    )
+                    .build()
+                    .unwrap(),
+            )
+            .build(),
+    )
+    .send()
+    .await
+    .unwrap_or_else(|e| panic!("adding GSI {index} must succeed: {}", err_msg(&e)));
+    wait_for_active(client(), table).await;
+}
+
+/// Stored attribute definitions as a name -> type map.
+async fn stored_defs(table: &str) -> BTreeMap<String, String> {
+    let c = client();
+    let d = c
+        .describe_table()
+        .table_name(table)
+        .send()
+        .await
+        .expect("describe must succeed");
+    d.table()
+        .expect("table description")
+        .attribute_definitions()
+        .iter()
+        .map(|ad| {
+            (
+                ad.attribute_name().to_owned(),
+                ad.attribute_type().as_str().to_owned(),
+            )
+        })
+        .collect()
+}
+
+/// Each GSI add contributes its key attribute; earlier definitions survive.
+#[tokio::test]
+async fn sequential_gsi_adds_accumulate_attribute_definitions() {
+    let table = fresh_table("Seq").await;
+    add_gsi(&table, "g1idx", "g1", vec![]).await;
+    add_gsi(&table, "g2idx", "g2", vec![]).await;
+    add_gsi(&table, "g3idx", "g3", vec![]).await;
+
+    let defs = stored_defs(&table).await;
+    for attr in ["pk", "g1", "g2", "g3"] {
+        assert!(
+            defs.contains_key(attr),
+            "definition for {attr} must survive later GSI adds, got: {defs:?}"
+        );
+    }
+}
+
+/// A definition for an attribute no key or index references is not stored.
+#[tokio::test]
+async fn unused_attribute_definition_supplied_with_a_gsi_add_is_dropped() {
+    let table = fresh_table("Unused").await;
+    add_gsi(
+        &table,
+        "usedidx",
+        "used",
+        vec![AttributeDefinition::builder()
+            .attribute_name("neverIndexed")
+            .attribute_type(ScalarAttributeType::S)
+            .build()
+            .unwrap()],
+    )
+    .await;
+
+    let defs = stored_defs(&table).await;
+    assert!(
+        defs.contains_key("used"),
+        "the index key definition must be stored, got: {defs:?}"
+    );
+    assert!(
+        !defs.contains_key("neverIndexed"),
+        "a definition no key or index uses must be dropped, got: {defs:?}"
+    );
+}
+
+/// Redeclaring an existing key attribute with a different type is accepted, and
+/// the stored type is kept so a live index key cannot be retyped underneath.
+#[tokio::test]
+async fn conflicting_redeclaration_keeps_the_stored_attribute_type() {
+    let table = fresh_table("Conflict").await;
+    let c = client();
+
+    // Declare pk as N while adding a GSI: pk is already stored as S.
+    c.update_table()
+        .table_name(&table)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::N)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("cg")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .global_secondary_index_updates(
+            GlobalSecondaryIndexUpdate::builder()
+                .create(
+                    CreateGlobalSecondaryIndexAction::builder()
+                        .index_name("cgidx")
+                        .key_schema(
+                            KeySchemaElement::builder()
+                                .attribute_name("cg")
+                                .key_type(KeyType::Hash)
+                                .build()
+                                .unwrap(),
+                        )
+                        .projection(
+                            Projection::builder()
+                                .projection_type(ProjectionType::All)
+                                .build(),
+                        )
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("a conflicting redeclaration must be accepted");
+    wait_for_active(client(), &table).await;
+
+    let defs = stored_defs(&table).await;
+    assert_eq!(
+        defs.get("pk").map(String::as_str),
+        Some("S"),
+        "the stored type for pk must win over the redeclaration, got: {defs:?}"
+    );
+}
+
+/// Removing a GSI drops the definitions only that index referenced, and keeps
+/// the ones the table key or a surviving index still uses.
+#[tokio::test]
+async fn removing_a_gsi_drops_only_its_own_attribute_definitions() {
+    let table = fresh_table("Remove").await;
+    add_gsi(&table, "keepidx", "keepAttr", vec![]).await;
+    add_gsi(&table, "dropidx", "dropAttr", vec![]).await;
+
+    let c = client();
+    c.update_table()
+        .table_name(&table)
+        .global_secondary_index_updates(
+            GlobalSecondaryIndexUpdate::builder()
+                .delete(
+                    DeleteGlobalSecondaryIndexAction::builder()
+                        .index_name("dropidx")
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("removing a GSI must succeed");
+    wait_for_active(client(), &table).await;
+
+    let defs = stored_defs(&table).await;
+    assert!(
+        !defs.contains_key("dropAttr"),
+        "the removed index's definition must be dropped, got: {defs:?}"
+    );
+    assert!(
+        defs.contains_key("keepAttr") && defs.contains_key("pk"),
+        "definitions still referenced must survive, got: {defs:?}"
+    );
+}


### PR DESCRIPTION
Stacked on #273. Based on `fix/gsi-add-on-hash-only-table` so the diff shows only this change; retarget to `main` once #273 merges.

`UpdateTable` merged the request's `AttributeDefinitions` into the stored set but never removed any, so the stored set only ever grew. Real DynamoDB keeps it equal to the attributes actually referenced by the table key schema plus the key schemas of the live indexes, so two cases diverged, both visible to any client calling `DescribeTable` after an `UpdateTable`:

* an unused `AttributeDefinition` supplied alongside a GSI add was stored, where DynamoDB drops it;
* deleting a GSI left behind the definitions only that index referenced.

## Fix

The effective set is recomputed as the stored definitions merged with the request's, then pruned to those still referenced.

Merging is still required and is not being undone here: the request carries only the attributes it needs, so replacing the set drops the base table's own `pk`/`sk` and degrades keyed reads to a partition-only lookup (#259, fixed in #261). **Pruning is the half that was missing.**

Two details worth a reviewer's attention:

* the recompute reuses `merge_attribute_definitions` rather than reimplementing the merge, which keeps the stored definition when both sides name the same attribute, so a conflicting redeclaration cannot silently retype a live index key;
* it runs whether or not the request carried `AttributeDefinitions`, because a GSI deletion prunes without the request naming anything. It reads the surviving index key schemas after the create/delete rows are applied in the same catalog transaction, under the `FOR UPDATE` lock already held on the table row.

## Verification

`tests/rust/src/update_table_attribute_definitions.rs`, 4 tests, all passing:

```
unused_attribute_definition_supplied_with_a_gsi_add_is_dropped ... ok
removing_a_gsi_drops_only_its_own_attribute_definitions ....... ok
conflicting_redeclaration_keeps_the_stored_attribute_type ..... ok
sequential_gsi_adds_accumulate_attribute_definitions ......... ok
```

These use hash-only tables, which is why this stacks on #273: against `main` they fail at table setup with the unrelated 500 that #273 fixes.

`cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --workspace` (798 passed, 0 failed, 0 filtered out) are clean.
