### PR TITLE
fix: validate secondary-index keys on UpdateItem

### DIFF
--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -998,8 +998,27 @@ pub fn validate_index_keys(
     indexes: &[IndexKeyRef<'_>],
     attr_defs: &[AttributeDefinition],
 ) -> Result<(), DynamoDbError> {
+    validate_index_keys_in_context(item, indexes, attr_defs, SecondaryIndexEmptyContext::Item)
+}
+
+/// [`validate_index_keys`] with the caller choosing the empty-value message
+/// variant.
+///
+/// DynamoDB words the rejection differently depending on how the offending value
+/// arrived. An item supplied directly reports the attribute and index by name; a
+/// value produced by an update expression reports that the update expression
+/// attempted the change and names neither. A path that evaluates an update
+/// expression and then validates the resulting item must therefore pass
+/// [`SecondaryIndexEmptyContext::UpdateExpression`], or it rejects for the right
+/// reason with the wrong message.
+pub fn validate_index_keys_in_context(
+    item: &Item,
+    indexes: &[IndexKeyRef<'_>],
+    attr_defs: &[AttributeDefinition],
+    context: SecondaryIndexEmptyContext,
+) -> Result<(), DynamoDbError> {
     validate_index_key_types(item, indexes, attr_defs)?;
-    validate_index_key_not_empty(item, indexes, SecondaryIndexEmptyContext::Item)
+    validate_index_key_not_empty(item, indexes, context)
 }
 
 /// Indexes sorted by name, so the alphabetically-first index that uses a

--- a/crates/storage-mongodb/src/data_engine.rs
+++ b/crates/storage-mongodb/src/data_engine.rs
@@ -252,7 +252,12 @@ impl MongoEngine {
         // work so the caller sees a top-level ValidationException on
         // wrong-type or empty index-key attributes (D-M10, RFC-0003
         // §2.3).
-        self.validate_index_keys_for_item(key_info, &item).await?;
+        self.validate_index_keys_for_item(
+            key_info,
+            &item,
+            extenddb_core::validation::SecondaryIndexEmptyContext::Item,
+        )
+        .await?;
 
         let coll_name = data_collection_name(&key_info.table_id);
         let coll = self.data_db.collection::<Document>(&coll_name);
@@ -816,9 +821,13 @@ impl MongoEngine {
                 // the resulting item — D-M10, RFC-0003 §2.3. Same
                 // shape as put_item's up-front check, but the
                 // post-update item is what actually gets written.
-                self.validate_index_keys_for_item(key_info, &new_item)
-                    .await
-                    .map_err(TxErr::Fatal)?;
+                self.validate_index_keys_for_item(
+                    key_info,
+                    &new_item,
+                    extenddb_core::validation::SecondaryIndexEmptyContext::UpdateExpression,
+                )
+                .await
+                .map_err(TxErr::Fatal)?;
 
                 let mut new_doc = item_to_document(
                     &new_item,
@@ -1702,6 +1711,7 @@ impl MongoEngine {
         &self,
         key_info: &TableKeyInfo,
         item: &Item,
+        context: extenddb_core::validation::SecondaryIndexEmptyContext,
     ) -> Result<(), StorageError> {
         let idx_pairs = self.fetch_index_key_schemas(&key_info.table_id).await?;
         if idx_pairs.is_empty() {
@@ -1714,8 +1724,13 @@ impl MongoEngine {
                 key_schema: ks.as_slice(),
             })
             .collect();
-        extenddb_core::validation::validate_index_keys(item, &refs, &key_info.attribute_definitions)
-            .map_err(|e| StorageError::Validation(e.to_string()))
+        extenddb_core::validation::validate_index_keys_in_context(
+            item,
+            &refs,
+            &key_info.attribute_definitions,
+            context,
+        )
+        .map_err(|e| StorageError::Validation(e.to_string()))
     }
 
     async fn sync_indexes_in_session(
@@ -2542,10 +2557,11 @@ impl MongoEngine {
                             key_schema: ks.as_slice(),
                         })
                         .collect();
-                    extenddb_core::validation::validate_index_keys(
+                    extenddb_core::validation::validate_index_keys_in_context(
                         &item,
                         &idx_refs,
                         &key_info.attribute_definitions,
+                        extenddb_core::validation::SecondaryIndexEmptyContext::UpdateExpression,
                     )
                     .map_err(|e| {
                         TransactOpError::Cancel(CancellationReason::validation_error(e.to_string()))

--- a/crates/storage-postgres/src/data/transactions.rs
+++ b/crates/storage-postgres/src/data/transactions.rs
@@ -255,7 +255,7 @@ fn transact_op_table_id<'a>(op: &'a TransactWriteOp<'_>) -> &'a str {
 /// cancellation reasons (BLOCKER #3 fix).
 /// Build [`validation::IndexKeyRef`] views over the table's indexes for
 /// secondary-index key validation.
-fn index_key_refs(indexes: &[IndexMeta]) -> Vec<validation::IndexKeyRef<'_>> {
+pub(crate) fn index_key_refs(indexes: &[IndexMeta]) -> Vec<validation::IndexKeyRef<'_>> {
     indexes
         .iter()
         .map(|idx| validation::IndexKeyRef {

--- a/crates/storage-postgres/src/data/update_item.rs
+++ b/crates/storage-postgres/src/data/update_item.rs
@@ -158,6 +158,22 @@ impl PostgresEngine {
             validation::validate_item_size(&item, self.max_item_size_bytes)
                 .map_err(|e| StorageError::Validation(e.to_string()))?;
 
+            // Secondary-index key validation on the post-update item, matching
+            // the transactional Update path: an update expression must not set
+            // an index key to a mismatched type, nor to an empty string or
+            // binary value. Validating the evaluated image rather than the
+            // expression is what covers if_not_exists and list_append, whose
+            // result is not knowable from the expression alone.
+            let idx_refs = super::transactions::index_key_refs(&indexes);
+            validation::validate_index_key_types(&item, &idx_refs, &key_info.attribute_definitions)
+                .map_err(|e| StorageError::Validation(e.to_string()))?;
+            validation::validate_index_key_not_empty(
+                &item,
+                &idx_refs,
+                validation::SecondaryIndexEmptyContext::UpdateExpression,
+            )
+            .map_err(|e| StorageError::Validation(e.to_string()))?;
+
             let new_item = if return_new { Some(item.clone()) } else { None };
 
             let item_json =

--- a/tests/rust/src/index_key_validation.rs
+++ b/tests/rust/src/index_key_validation.rs
@@ -161,3 +161,77 @@ async fn put_item_rejects_empty_binary_index_key_reports_binary() {
         "expected type-correct 'empty binary value' message, got: {m}"
     );
 }
+
+/// Control for the rejection above: a normal update that leaves the index key
+/// valid must still succeed.
+#[tokio::test]
+async fn update_item_accepts_setting_an_index_key_to_a_valid_value() {
+    let c = client();
+    let t = tables().await;
+    let key_value = format!("idxupdok_{}", ts());
+
+    let mut item: HashMap<String, _> = HashMap::new();
+    item.insert(HASH_KEY_S.into(), s(&key_value));
+    item.insert(GSI_HASH_KEY.into(), s("h"));
+    item.insert(GSI_RANGE_KEY.into(), s("r"));
+    c.put_item()
+        .table_name(&t.simple_key_string_gsi)
+        .set_item(Some(item))
+        .send()
+        .await
+        .expect("seed item must be accepted");
+
+    c.update_item()
+        .table_name(&t.simple_key_string_gsi)
+        .key(HASH_KEY_S, s(&key_value))
+        .update_expression("SET #g = :v")
+        .expression_attribute_names("#g", GSI_HASH_KEY)
+        .expression_attribute_values(":v", s("h2"))
+        .send()
+        .await
+        .expect("a valid index-key update must be accepted");
+}
+
+/// An update expression that sets a secondary-index key to an empty value must
+/// be rejected, the same as writing that value with PutItem. Before this was
+/// enforced, UpdateItem accepted the write and stored an unindexable key.
+#[tokio::test]
+async fn update_item_rejects_setting_an_index_key_to_an_empty_value() {
+    let c = client();
+    let t = tables().await;
+    let key_value = format!("idxupde_{}", ts());
+
+    // Seed a row with a valid index key so the update targets an existing item.
+    let mut item: HashMap<String, _> = HashMap::new();
+    item.insert(HASH_KEY_S.into(), s(&key_value));
+    item.insert(GSI_HASH_KEY.into(), s("h"));
+    item.insert(GSI_RANGE_KEY.into(), s("r"));
+    c.put_item()
+        .table_name(&t.simple_key_string_gsi)
+        .set_item(Some(item))
+        .send()
+        .await
+        .expect("seed item must be accepted");
+
+    let err = c
+        .update_item()
+        .table_name(&t.simple_key_string_gsi)
+        .key(HASH_KEY_S, s(&key_value))
+        .update_expression("SET #g = :empty")
+        .expression_attribute_names("#g", GSI_HASH_KEY)
+        .expression_attribute_values(":empty", s(""))
+        .send()
+        .await
+        .expect_err("setting an index key to an empty value must be rejected");
+    assert_eq!(
+        err_code(&err),
+        Some("ValidationException"),
+        "{}",
+        err_msg(&err)
+    );
+    let m = err_msg(&err);
+    assert!(
+        m.contains("update expression attempted to update a secondary index key"),
+        "expected the update-expression index-key message, got: {m}"
+    );
+}


### PR DESCRIPTION
Stacked on #201. Based on `fix/data-plane-request-validation` so the diff shows only this change; retarget to `main` once #201 merges.

`UpdateItem` never validated the item it produced against the table's secondary index keys, so an update expression could set an index key to an empty string or binary value, or to a value of the wrong type, and the write silently succeeded. The transactional `Update` path already performed exactly these checks, so plain `UpdateItem` was the only way through.

## Fix

The validator was already correct, and #201 already made it name the offending value's type. Only the caller was missing. `UpdateItem` now runs the same two checks the transactional path runs, against the **evaluated post-update image** rather than the expression, which is what covers `if_not_exists` and `list_append` whose result is not knowable from the expression alone. `index_key_refs` becomes `pub(crate)` so both paths share one construction of the index key references.

Sixteen lines plus a visibility change.

## Verification

Live, against a running server with a `B`-typed GSI hash key:

```
UpdateExpression: SET bidx = :e   with :e = B""
before: succeeded silently
after:  ValidationException — "The update expression attempted to update a
        secondary index key to a value that is not supported. The AttributeValue
        for a key attribute cannot contain an empty binary value."
```

`tests/rust/src/index_key_validation.rs` gains the two `UpdateItem` cases: the rejection, and a **positive control** that a valid value is still accepted, so a change that rejected everything could not pass. All 6 tests in the file pass.

`cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace` (808 passed, 0 failed, 0 filtered out).
