### PR TITLE
chore: add @robinnsc to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,25 +8,25 @@
 # enable "Require review from Code Owners".
 
 # Default — any file not matched below.
-*                              @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen
+*                              @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen @robinnsc
 
 # Wire protocol & DynamoDB-compatible API surface.
-crates/server/                 @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen
-crates/core/                   @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen
+crates/server/                 @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen @robinnsc
+crates/core/                   @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen @robinnsc
 
 # Storage abstraction — breaking changes ripple to every backend.
-crates/storage/                @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen
-crates/storage-postgres/       @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen
-crates/engine/                 @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen
+crates/storage/                @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen @robinnsc
+crates/storage-postgres/       @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen @robinnsc
+crates/engine/                 @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen @robinnsc
 
 # Auth & SigV4 — security-sensitive.
-crates/auth/                   @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen
+crates/auth/                   @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen @robinnsc
 
 # Public CLI surface.
-crates/bin/                    @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen
+crates/bin/                    @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen @robinnsc
 
 # Process & governance documents.
-docs/adr/                      @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen
-docs/rfcs/                     @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen
-CONTRIBUTING.md                @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen
-.github/                       @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen
+docs/adr/                      @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen @robinnsc
+docs/rfcs/                     @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen @robinnsc
+CONTRIBUTING.md                @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen @robinnsc
+.github/                       @amrith @c33howard @jcshepherd @pdf-amzn @LeeroyHannigan @yesyayen @robinnsc


### PR DESCRIPTION
Scott owns the container release and CI signing work (`release-image`, `promote-image`, `ghcr-mirror`) but was not a code owner. `main` has **Require review from Code Owners** enabled, so his approvals registered without ever satisfying the gate. He now has **write** access, which is GitHub's requirement for a code owner's review to count.

### Why every pattern, not just `*`

CODEOWNERS resolves by **last matching pattern**, not by union. An entry on the `*` default alone would have made him an owner of unmatched files only, leaving every `crates/` path, the `docs/adr` and `docs/rfcs` governance paths, and `.github/` still without him. Since all twelve patterns currently carry an identical owner list, he is added to all twelve to keep it uniform.

### What this does and does not change

Owner lists are an **OR**: any single listed owner satisfies the requirement. This widens the pool of people who can unblock a review. It does not add a required approval, does not give anyone a veto, and does not change the required approving review count (still 1).

He will now be auto-requested as a reviewer on all PRs, which is the intended trade for him being able to unblock them.

Least privilege is preserved: write cannot modify branch protection, environment reviewer lists, repository secrets, or visibility, so he cannot weaken the gates he approves against. `enforce_admins` remains on.