### PR TITLE
fix(import-export): namespace files per account beneath each root

### DIFF
--- a/crates/engine/src/import_export.rs
+++ b/crates/engine/src/import_export.rs
@@ -12,7 +12,9 @@ use serde_json::Value;
 
 use crate::OperationContext;
 use crate::create_table::storage_err_to_dynamo;
-use crate::import_export_io::{read_items, validate_path, validate_path_parent};
+use crate::import_export_io::{
+    ensure_account_dirs, read_items, validate_path, validate_path_parent,
+};
 use crate::serialize_output;
 use extenddb_core::error::DynamoDbError;
 use extenddb_core::types::{
@@ -76,8 +78,17 @@ pub async fn handle_import_table(
         .await
         .map_err(storage_err_to_dynamo)?;
 
-    // Validate and canonicalize the source path.
-    let source_path = validate_path(&input.file_source.path, &ctx.import_paths)?;
+    // Validate and canonicalize the source path. Files are namespaced per
+    // account, so a caller can only read beneath its own subtree of a root.
+    let source_path = validate_path(&input.file_source.path, &ctx.import_paths, &ctx.account_id)?;
+
+    tracing::info!(
+        account_id = %ctx.account_id,
+        operation = "ImportTable",
+        table_name = %tcp.table_name,
+        resolved_path = %source_path.display(),
+        "import/export file access"
+    );
 
     // Check file size against limit.
     let file_meta = std::fs::metadata(&source_path).map_err(|_| {
@@ -213,20 +224,50 @@ pub async fn handle_export_table(
         .await
         .map_err(storage_err_to_dynamo)?;
 
+    // Export files are namespaced per account. The account's subtree has to
+    // exist before the output path can be canonicalized and jailed, so create
+    // it first; this is idempotent and keeps the first export for a new account
+    // from failing on a missing parent directory.
+    ensure_account_dirs(&ctx.export_paths, &ctx.account_id)?;
+
     let output_path = validate_path_parent(
         input
             .resolve_file_path()
             .map_err(|e| DynamoDbError::ValidationException(e.to_owned()))?,
         &ctx.export_paths,
+        &ctx.account_id,
     )?;
     if let Some(parent) = output_path.parent() {
         tokio::fs::create_dir_all(parent).await.map_err(|_| {
             DynamoDbError::ValidationException("Cannot create output directory".to_owned())
         })?;
     }
-    let mut file = tokio::fs::File::create(&output_path)
+
+    tracing::info!(
+        account_id = %ctx.account_id,
+        operation = "ExportTableToPointInTime",
+        table_name = %table_name,
+        resolved_path = %output_path.display(),
+        "import/export file access"
+    );
+
+    // `create_new` refuses to write when anything already exists at the path,
+    // so an export cannot truncate a file it did not create. It also refuses an
+    // existing symlink, including a dangling one, rather than following it.
+    let mut file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&output_path)
         .await
-        .map_err(|_| DynamoDbError::ValidationException("Cannot create export file".to_owned()))?;
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::AlreadyExists {
+                DynamoDbError::ValidationException(
+                    "Export file already exists; choose a different FilePath".to_owned(),
+                )
+            } else {
+                DynamoDbError::ValidationException("Cannot create export file".to_owned())
+            }
+        })?;
 
     let mut item_count: i64 = 0;
     let max_export_items = ctx.limits.max_export_item_count;

--- a/crates/engine/src/import_export.rs
+++ b/crates/engine/src/import_export.rs
@@ -51,6 +51,32 @@ pub async fn handle_import_table(
     let start_time = epoch_seconds();
     let tcp = &input.table_creation_parameters;
 
+    // Validate and canonicalize the source path before creating anything. Files
+    // are namespaced per account, so a caller can only read beneath its own
+    // subtree of a root. Validating first means a refused import leaves no
+    // orphaned destination table behind.
+    let source_path = validate_path(&input.file_source.path, &ctx.import_paths, &ctx.account_id)?;
+
+    tracing::info!(
+        account_id = %ctx.account_id,
+        operation = "ImportTable",
+        table_name = %tcp.table_name,
+        resolved_path = %source_path.display(),
+        "import/export file access"
+    );
+
+    // Check file size against limit.
+    let file_meta = std::fs::metadata(&source_path).map_err(|_| {
+        DynamoDbError::ValidationException("Cannot read source file metadata".to_owned())
+    })?;
+    if file_meta.len() > ctx.limits.max_import_file_bytes {
+        return Err(DynamoDbError::ValidationException(format!(
+            "Import file size ({} bytes) exceeds maximum ({} bytes)",
+            file_meta.len(),
+            ctx.limits.max_import_file_bytes
+        )));
+    }
+
     let create_input = create_table_input_from_params(tcp);
 
     let table_desc = ctx
@@ -77,30 +103,6 @@ pub async fn handle_import_table(
         .table_key_info(&ctx.account_id, &tcp.table_name)
         .await
         .map_err(storage_err_to_dynamo)?;
-
-    // Validate and canonicalize the source path. Files are namespaced per
-    // account, so a caller can only read beneath its own subtree of a root.
-    let source_path = validate_path(&input.file_source.path, &ctx.import_paths, &ctx.account_id)?;
-
-    tracing::info!(
-        account_id = %ctx.account_id,
-        operation = "ImportTable",
-        table_name = %tcp.table_name,
-        resolved_path = %source_path.display(),
-        "import/export file access"
-    );
-
-    // Check file size against limit.
-    let file_meta = std::fs::metadata(&source_path).map_err(|_| {
-        DynamoDbError::ValidationException("Cannot read source file metadata".to_owned())
-    })?;
-    if file_meta.len() > ctx.limits.max_import_file_bytes {
-        return Err(DynamoDbError::ValidationException(format!(
-            "Import file size ({} bytes) exceeds maximum ({} bytes)",
-            file_meta.len(),
-            ctx.limits.max_import_file_bytes
-        )));
-    }
 
     // Read items using spawn_blocking to avoid blocking the async runtime.
     let format = input.input_format;

--- a/crates/engine/src/import_export_io.rs
+++ b/crates/engine/src/import_export_io.rs
@@ -220,6 +220,20 @@ pub(crate) fn ensure_account_dirs(
     Ok(())
 }
 
+/// Whether `candidate` lies within the caller's subtree of some configured root.
+///
+/// The single containment predicate for import/export. `Path::starts_with` is
+/// component-wise rather than a string prefix, so `<root>/1111` does not match a
+/// caller scoped to `<root>/111`.
+fn is_under_scoped_root(
+    candidate: &Path,
+    jail_roots: &[Arc<PathBuf>],
+    account_id: &str,
+) -> Result<bool, DynamoDbError> {
+    let scoped = account_scoped_roots(jail_roots, account_id)?;
+    Ok(scoped.iter().any(|root| candidate.starts_with(root)))
+}
+
 /// Make `path` absolute without touching the filesystem, for a containment check
 /// that must not reveal whether the path exists.
 fn absolutize(path: &Path) -> Result<PathBuf, DynamoDbError> {
@@ -252,9 +266,7 @@ fn reject_outside_account_subtree(
     if jail_roots.is_empty() {
         return Ok(());
     }
-    let scoped = account_scoped_roots(jail_roots, account_id)?;
-    let absolute = absolutize(path)?;
-    if scoped.iter().any(|root| absolute.starts_with(root)) {
+    if is_under_scoped_root(&absolutize(path)?, jail_roots, account_id)? {
         return Ok(());
     }
     Err(DynamoDbError::ValidationException(
@@ -299,13 +311,10 @@ pub(crate) fn validate_path(
 
     // Re-checked after canonicalization: the lexical test above cannot see a
     // symlinked ancestor that redirects out of the subtree.
-    if !jail_roots.is_empty() {
-        let scoped = account_scoped_roots(jail_roots, account_id)?;
-        if !scoped.iter().any(|root| canonical.starts_with(root)) {
-            return Err(DynamoDbError::ValidationException(
-                "Path must resolve under one of the configured allowed paths".to_owned(),
-            ));
-        }
+    if !jail_roots.is_empty() && !is_under_scoped_root(&canonical, jail_roots, account_id)? {
+        return Err(DynamoDbError::ValidationException(
+            "Path must resolve under one of the configured allowed paths".to_owned(),
+        ));
     }
 
     Ok(canonical)
@@ -361,8 +370,7 @@ pub(crate) fn validate_path_parent(
                     )
                 })?;
                 let resolved = canonical_cwd.join(path);
-                let scoped = account_scoped_roots(jail_roots, account_id)?;
-                if !scoped.iter().any(|root| resolved.starts_with(root)) {
+                if !is_under_scoped_root(&resolved, jail_roots, account_id)? {
                     return Err(DynamoDbError::ValidationException(
                         "Path must resolve under one of the configured allowed paths".to_owned(),
                     ));
@@ -388,8 +396,7 @@ pub(crate) fn validate_path_parent(
                     "Parent directory does not exist or is not accessible".to_owned(),
                 )
             })?;
-            let scoped = account_scoped_roots(jail_roots, account_id)?;
-            if !scoped.iter().any(|root| canonical_parent.starts_with(root)) {
+            if !is_under_scoped_root(&canonical_parent, jail_roots, account_id)? {
                 return Err(DynamoDbError::ValidationException(
                     "Path must resolve under one of the configured allowed paths".to_owned(),
                 ));
@@ -443,6 +450,27 @@ mod tests {
     impl Drop for Root {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// A file outside every configured root, removed even if an assert panics.
+    struct Stray(PathBuf);
+
+    impl Stray {
+        fn new(contents: &[u8]) -> Self {
+            let path = std::env::temp_dir().join(format!("eb-stray-{}.json", uuid::Uuid::new_v4()));
+            std::fs::write(&path, contents).unwrap();
+            Self(path)
+        }
+
+        fn as_str(&self) -> &str {
+            self.0.to_str().unwrap()
+        }
+    }
+
+    impl Drop for Stray {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
         }
     }
 
@@ -525,13 +553,11 @@ mod tests {
     fn foreign_subtree_and_outside_jail_are_indistinguishable() {
         let root = Root::new();
         let foreign = root.file_for(OTHER, "a.json");
-        let outside = std::env::temp_dir().join(format!("eb-out-{}.json", uuid::Uuid::new_v4()));
-        std::fs::write(&outside, b"{}\n").unwrap();
+        let outside = Stray::new(b"{}\n");
 
         let a = validate_path(foreign.to_str().unwrap(), &root.roots(), OWNER).unwrap_err();
-        let b = validate_path(outside.to_str().unwrap(), &root.roots(), OWNER).unwrap_err();
+        let b = validate_path(outside.as_str(), &root.roots(), OWNER).unwrap_err();
         assert_eq!(message(&a), message(&b));
-        let _ = std::fs::remove_file(&outside);
     }
 
     /// A symlink planted at the export filename inside the caller's own subtree
@@ -541,10 +567,9 @@ mod tests {
     fn export_onto_a_symlink_is_rejected() {
         let root = Root::new();
         ensure_account_dirs(&root.roots(), OWNER).unwrap();
-        let outside = std::env::temp_dir().join(format!("eb-tgt-{}.json", uuid::Uuid::new_v4()));
-        std::fs::write(&outside, b"original\n").unwrap();
+        let outside = Stray::new(b"original\n");
         let link = root.0.join(OWNER).join("link.json");
-        std::os::unix::fs::symlink(&outside, &link).unwrap();
+        std::os::unix::fs::symlink(&outside.0, &link).unwrap();
 
         let err = validate_path_parent(link.to_str().unwrap(), &root.roots(), OWNER)
             .expect_err("a symlink at the target filename must be refused");
@@ -552,8 +577,7 @@ mod tests {
             message(&err),
             "Symbolic links are not allowed in import/export paths"
         );
-        assert_eq!(std::fs::read(&outside).unwrap(), b"original\n");
-        let _ = std::fs::remove_file(&outside);
+        assert_eq!(std::fs::read(&outside.0).unwrap(), b"original\n");
     }
 
     /// Defence in depth: a malformed account id must never widen the subtree.
@@ -604,6 +628,37 @@ mod tests {
             message(&b),
             "export path leaks foreign existence"
         );
+    }
+
+    /// A relative path is resolved against the working directory before the
+    /// containment test, so it cannot sidestep the account subtree.
+    #[test]
+    fn relative_path_is_resolved_before_the_containment_test() {
+        let root = Root::new();
+        let err = validate_path("relative-name.json", &root.roots(), OWNER)
+            .expect_err("a bare relative name is not inside the account subtree");
+        assert_eq!(
+            message(&err),
+            "Path must resolve under one of the configured allowed paths"
+        );
+
+        // And a relative path that does resolve into the subtree is accepted,
+        // so the branch is proven in both directions rather than just refusing.
+        let cwd = std::env::current_dir().unwrap().canonicalize().unwrap();
+        let nested = cwd.join(format!("eb-rel-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(nested.join(OWNER)).unwrap();
+        let file = nested.join(OWNER).join("in.json");
+        std::fs::write(&file, b"{}\n").unwrap();
+        let roots = vec![Arc::new(nested.clone())];
+        let relative = file
+            .strip_prefix(&cwd)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_owned();
+        assert!(!relative.starts_with('/'), "must be a relative path");
+        validate_path(&relative, &roots, OWNER).unwrap();
+        let _ = std::fs::remove_dir_all(&nested);
     }
 
     #[test]

--- a/crates/engine/src/import_export_io.rs
+++ b/crates/engine/src/import_export_io.rs
@@ -169,14 +169,108 @@ fn split_csv_line(line: &str, delim: u8) -> Vec<String> {
     fields
 }
 
+/// Derive the per-account subtree of every configured root.
+///
+/// Import/export files are namespaced by account: a caller in account `A` may
+/// only read and write beneath `<root>/A` for each configured root. Containment
+/// in the bare root is not sufficient, because a single root shared by several
+/// tenants would otherwise let any tenant name another tenant's file.
+///
+/// The account id is used as a single path component. It is supplied by the
+/// authenticated identity rather than the request (see `OperationContext`), and
+/// account ids are validated on ingress, but the separator check below is kept
+/// as a defence in depth so a malformed id can never widen the subtree.
+pub(crate) fn account_scoped_roots(
+    jail_roots: &[Arc<PathBuf>],
+    account_id: &str,
+) -> Result<Vec<PathBuf>, DynamoDbError> {
+    if account_id.is_empty()
+        || account_id.contains('/')
+        || account_id.contains('\\')
+        || account_id == "."
+        || account_id == ".."
+    {
+        return Err(DynamoDbError::ValidationException(
+            "Cannot resolve an account-scoped import/export path".to_owned(),
+        ));
+    }
+    Ok(jail_roots
+        .iter()
+        .map(|root| root.join(account_id))
+        .collect())
+}
+
+/// Create the calling account's subtree beneath each configured root.
+///
+/// Export writes to a file that does not exist yet, so the account subtree has
+/// to exist before the path can be canonicalized and jailed. Creating it is
+/// idempotent and cheap (one call per configured root), and it keeps the first
+/// export for a new account from failing on a missing parent directory.
+pub(crate) fn ensure_account_dirs(
+    jail_roots: &[Arc<PathBuf>],
+    account_id: &str,
+) -> Result<(), DynamoDbError> {
+    for scoped in account_scoped_roots(jail_roots, account_id)? {
+        std::fs::create_dir_all(&scoped).map_err(|_| {
+            DynamoDbError::ValidationException(
+                "Cannot create the account export directory".to_owned(),
+            )
+        })?;
+    }
+    Ok(())
+}
+
+/// Make `path` absolute without touching the filesystem, for a containment check
+/// that must not reveal whether the path exists.
+fn absolutize(path: &Path) -> Result<PathBuf, DynamoDbError> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    let cwd = std::env::current_dir()
+        .map_err(|_| {
+            DynamoDbError::ValidationException("Cannot determine current directory".to_owned())
+        })?
+        .canonicalize()
+        .map_err(|_| {
+            DynamoDbError::ValidationException("Cannot resolve current directory".to_owned())
+        })?;
+    Ok(cwd.join(path))
+}
+
+/// Reject a path that does not lie within the caller's subtree of some root.
+///
+/// This runs *before* any existence check, so a path belonging to another
+/// account answers identically whether or not the file is there. Deciding the
+/// jail after canonicalization would turn the error into an oracle for other
+/// tenants' filenames. `..` is rejected by the caller, so a lexical prefix test
+/// is sound here; the post-canonicalization check still catches symlink escapes.
+fn reject_outside_account_subtree(
+    path: &Path,
+    jail_roots: &[Arc<PathBuf>],
+    account_id: &str,
+) -> Result<(), DynamoDbError> {
+    if jail_roots.is_empty() {
+        return Ok(());
+    }
+    let scoped = account_scoped_roots(jail_roots, account_id)?;
+    let absolute = absolutize(path)?;
+    if scoped.iter().any(|root| absolute.starts_with(root)) {
+        return Ok(());
+    }
+    Err(DynamoDbError::ValidationException(
+        "Path must resolve under one of the configured allowed paths".to_owned(),
+    ))
+}
+
 /// Validate and canonicalize a filesystem path for import/export.
 ///
 /// Rejects symlinks and paths with `..` components to prevent path traversal.
-/// When `jail_roots` is non-empty, the canonical path must resolve under at
-/// least one of the allowed roots.
+/// When `jail_roots` is non-empty, the path must resolve under the calling
+/// account's subtree of at least one allowed root.
 pub(crate) fn validate_path(
     raw: &str,
     jail_roots: &[Arc<PathBuf>],
+    account_id: &str,
 ) -> Result<PathBuf, DynamoDbError> {
     let path = Path::new(raw);
 
@@ -188,10 +282,13 @@ pub(crate) fn validate_path(
         }
     }
 
+    // Decided before any filesystem access, so a path in another account's
+    // subtree cannot be distinguished from one that does not exist.
+    reject_outside_account_subtree(path, jail_roots, account_id)?;
+
     let canonical = path.canonicalize().map_err(|_| {
         DynamoDbError::ValidationException("Path does not exist or is not accessible".to_owned())
     })?;
-
     let meta = std::fs::symlink_metadata(path)
         .map_err(|_| DynamoDbError::ValidationException("Cannot read path metadata".to_owned()))?;
     if meta.file_type().is_symlink() {
@@ -200,14 +297,15 @@ pub(crate) fn validate_path(
         ));
     }
 
-    if !jail_roots.is_empty()
-        && !jail_roots
-            .iter()
-            .any(|root| canonical.starts_with(root.as_path()))
-    {
-        return Err(DynamoDbError::ValidationException(
-            "Path must resolve under one of the configured allowed paths".to_owned(),
-        ));
+    // Re-checked after canonicalization: the lexical test above cannot see a
+    // symlinked ancestor that redirects out of the subtree.
+    if !jail_roots.is_empty() {
+        let scoped = account_scoped_roots(jail_roots, account_id)?;
+        if !scoped.iter().any(|root| canonical.starts_with(root)) {
+            return Err(DynamoDbError::ValidationException(
+                "Path must resolve under one of the configured allowed paths".to_owned(),
+            ));
+        }
     }
 
     Ok(canonical)
@@ -215,11 +313,12 @@ pub(crate) fn validate_path(
 
 /// Validate an export output path. The file may not exist yet, so we validate
 /// the parent directory instead.
-/// When `jail_roots` is non-empty, the resolved path must be under at least
-/// one of the allowed roots.
+/// When `jail_roots` is non-empty, the resolved path must be under the calling
+/// account's subtree of at least one allowed root.
 pub(crate) fn validate_path_parent(
     raw: &str,
     jail_roots: &[Arc<PathBuf>],
+    account_id: &str,
 ) -> Result<PathBuf, DynamoDbError> {
     let path = Path::new(raw);
 
@@ -229,6 +328,22 @@ pub(crate) fn validate_path_parent(
                 "Path must not contain '..' components".to_owned(),
             ));
         }
+    }
+
+    // Decided before any filesystem access, so a path in another account's
+    // subtree cannot be distinguished from one that does not exist.
+    reject_outside_account_subtree(path, jail_roots, account_id)?;
+
+    // The final component is checked before the parent: a symlink pre-planted at
+    // the target filename inside an allowed directory would otherwise be followed
+    // on write, escaping the jail. `create_new` on the write itself also refuses
+    // an existing symlink, but checking here gives the caller a precise error.
+    if let Ok(meta) = std::fs::symlink_metadata(path)
+        && meta.file_type().is_symlink()
+    {
+        return Err(DynamoDbError::ValidationException(
+            "Symbolic links are not allowed in import/export paths".to_owned(),
+        ));
     }
 
     if let Some(parent) = path.parent() {
@@ -246,10 +361,8 @@ pub(crate) fn validate_path_parent(
                     )
                 })?;
                 let resolved = canonical_cwd.join(path);
-                if !jail_roots
-                    .iter()
-                    .any(|root| resolved.starts_with(root.as_path()))
-                {
+                let scoped = account_scoped_roots(jail_roots, account_id)?;
+                if !scoped.iter().any(|root| resolved.starts_with(root)) {
                     return Err(DynamoDbError::ValidationException(
                         "Path must resolve under one of the configured allowed paths".to_owned(),
                     ));
@@ -267,17 +380,16 @@ pub(crate) fn validate_path_parent(
                 "Symbolic links are not allowed in import/export paths".to_owned(),
             ));
         }
-        // Jail check: canonicalize parent and verify it's under at least one root.
+        // Jail check: canonicalize parent and verify it's under the calling
+        // account's subtree of at least one root.
         if !jail_roots.is_empty() {
             let canonical_parent = parent.canonicalize().map_err(|_| {
                 DynamoDbError::ValidationException(
                     "Parent directory does not exist or is not accessible".to_owned(),
                 )
             })?;
-            if !jail_roots
-                .iter()
-                .any(|root| canonical_parent.starts_with(root.as_path()))
-            {
+            let scoped = account_scoped_roots(jail_roots, account_id)?;
+            if !scoped.iter().any(|root| canonical_parent.starts_with(root)) {
                 return Err(DynamoDbError::ValidationException(
                     "Path must resolve under one of the configured allowed paths".to_owned(),
                 ));
@@ -286,4 +398,225 @@ pub(crate) fn validate_path_parent(
     }
 
     Ok(path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OWNER: &str = "111122223333";
+    const OTHER: &str = "999999999999";
+    /// An account whose subtree is never created on disk.
+    const FOREIGN_UNSEEN: &str = "888811112222";
+
+    /// A fresh directory acting as a configured import/export root.
+    struct Root(PathBuf);
+
+    impl Root {
+        fn new() -> Self {
+            let dir = std::env::temp_dir().join(format!("eb-ie-{}", uuid::Uuid::new_v4()));
+            std::fs::create_dir_all(&dir).unwrap();
+            Self(dir.canonicalize().unwrap())
+        }
+
+        fn roots(&self) -> Vec<Arc<PathBuf>> {
+            vec![Arc::new(self.0.clone())]
+        }
+
+        /// Create `<root>/<account>/<name>` with content and return its path.
+        fn file_for(&self, account: &str, name: &str) -> PathBuf {
+            let dir = self.0.join(account);
+            std::fs::create_dir_all(&dir).unwrap();
+            let path = dir.join(name);
+            std::fs::write(&path, b"{}\n").unwrap();
+            path
+        }
+
+        /// Create `<root>/<name>` directly under the bare root.
+        fn file_at_root(&self, name: &str) -> PathBuf {
+            let path = self.0.join(name);
+            std::fs::write(&path, b"{}\n").unwrap();
+            path
+        }
+    }
+
+    impl Drop for Root {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn message(err: &DynamoDbError) -> String {
+        match err {
+            DynamoDbError::ValidationException(m) => m.clone(),
+            other => panic!("expected ValidationException, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn import_from_own_account_subtree_is_accepted() {
+        let root = Root::new();
+        let path = root.file_for(OWNER, "mine.json");
+        let got = validate_path(path.to_str().unwrap(), &root.roots(), OWNER).unwrap();
+        assert_eq!(got, path.canonicalize().unwrap());
+    }
+
+    /// The reported read primitive. The victim's file genuinely exists, so a
+    /// rejection here can only come from the account scoping and not from the
+    /// path being absent.
+    #[test]
+    fn import_from_another_accounts_subtree_is_rejected() {
+        let root = Root::new();
+        let victim = root.file_for(OTHER, "secrets.json");
+        assert!(
+            victim.exists(),
+            "victim file must exist for this to discriminate"
+        );
+
+        let err = validate_path(victim.to_str().unwrap(), &root.roots(), OWNER)
+            .expect_err("reading another account's export must be refused");
+        assert_eq!(
+            message(&err),
+            "Path must resolve under one of the configured allowed paths"
+        );
+    }
+
+    /// Containment in the bare root is deliberately not sufficient: that is the
+    /// condition that made a shared root a cross-tenant channel.
+    #[test]
+    fn import_from_the_bare_root_is_rejected() {
+        let root = Root::new();
+        let stray = root.file_at_root("loose.json");
+        let err = validate_path(stray.to_str().unwrap(), &root.roots(), OWNER)
+            .expect_err("a path directly under the root is not account-scoped");
+        assert_eq!(
+            message(&err),
+            "Path must resolve under one of the configured allowed paths"
+        );
+    }
+
+    #[test]
+    fn export_into_own_account_subtree_is_accepted() {
+        let root = Root::new();
+        ensure_account_dirs(&root.roots(), OWNER).unwrap();
+        let target = root.0.join(OWNER).join("out.json");
+        validate_path_parent(target.to_str().unwrap(), &root.roots(), OWNER).unwrap();
+    }
+
+    /// The reported destruction primitive: an export naming a path inside
+    /// another account's subtree must be refused before any file is opened.
+    #[test]
+    fn export_into_another_accounts_subtree_is_rejected() {
+        let root = Root::new();
+        let victim = root.file_for(OTHER, "backup.json");
+        let err = validate_path_parent(victim.to_str().unwrap(), &root.roots(), OWNER)
+            .expect_err("writing into another account's subtree must be refused");
+        assert_eq!(
+            message(&err),
+            "Path must resolve under one of the configured allowed paths"
+        );
+        // The victim's file is untouched: refusal happens before the write.
+        assert_eq!(std::fs::read(&victim).unwrap(), b"{}\n");
+    }
+
+    /// "Not yours" and "not under any root at all" answer identically, so the
+    /// scoping does not itself become a probe for other tenants' directories.
+    #[test]
+    fn foreign_subtree_and_outside_jail_are_indistinguishable() {
+        let root = Root::new();
+        let foreign = root.file_for(OTHER, "a.json");
+        let outside = std::env::temp_dir().join(format!("eb-out-{}.json", uuid::Uuid::new_v4()));
+        std::fs::write(&outside, b"{}\n").unwrap();
+
+        let a = validate_path(foreign.to_str().unwrap(), &root.roots(), OWNER).unwrap_err();
+        let b = validate_path(outside.to_str().unwrap(), &root.roots(), OWNER).unwrap_err();
+        assert_eq!(message(&a), message(&b));
+        let _ = std::fs::remove_file(&outside);
+    }
+
+    /// A symlink planted at the export filename inside the caller's own subtree
+    /// is refused rather than followed.
+    #[cfg(unix)]
+    #[test]
+    fn export_onto_a_symlink_is_rejected() {
+        let root = Root::new();
+        ensure_account_dirs(&root.roots(), OWNER).unwrap();
+        let outside = std::env::temp_dir().join(format!("eb-tgt-{}.json", uuid::Uuid::new_v4()));
+        std::fs::write(&outside, b"original\n").unwrap();
+        let link = root.0.join(OWNER).join("link.json");
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+
+        let err = validate_path_parent(link.to_str().unwrap(), &root.roots(), OWNER)
+            .expect_err("a symlink at the target filename must be refused");
+        assert_eq!(
+            message(&err),
+            "Symbolic links are not allowed in import/export paths"
+        );
+        assert_eq!(std::fs::read(&outside).unwrap(), b"original\n");
+        let _ = std::fs::remove_file(&outside);
+    }
+
+    /// Defence in depth: a malformed account id must never widen the subtree.
+    #[test]
+    fn account_id_with_a_separator_cannot_widen_the_subtree() {
+        let root = Root::new();
+        for bad in ["", "../999999999999", "a/b", ".", ".."] {
+            let err = account_scoped_roots(&root.roots(), bad)
+                .expect_err("account id {bad} must not resolve to a path");
+            assert_eq!(
+                message(&err),
+                "Cannot resolve an account-scoped import/export path"
+            );
+        }
+    }
+
+    /// The jail verdict must not depend on whether the foreign file exists, or
+    /// the error becomes an oracle for other tenants' filenames.
+    #[test]
+    fn foreign_path_answers_the_same_whether_or_not_it_exists() {
+        let root = Root::new();
+        let present = root.file_for(OTHER, "present.json");
+        let absent = root.0.join(OTHER).join("absent.json");
+        assert!(present.exists());
+        assert!(!absent.exists());
+
+        let a = validate_path(present.to_str().unwrap(), &root.roots(), OWNER).unwrap_err();
+        let b = validate_path(absent.to_str().unwrap(), &root.roots(), OWNER).unwrap_err();
+        assert_eq!(
+            message(&a),
+            message(&b),
+            "import path leaks foreign existence"
+        );
+    }
+
+    /// Same requirement on the export side, where the leak would be of another
+    /// tenant's directory rather than its files.
+    #[test]
+    fn foreign_export_target_answers_the_same_whether_or_not_it_exists() {
+        let root = Root::new();
+        let present = root.file_for(OTHER, "present.json");
+        let absent = root.0.join(FOREIGN_UNSEEN).join("absent.json");
+
+        let a = validate_path_parent(present.to_str().unwrap(), &root.roots(), OWNER).unwrap_err();
+        let b = validate_path_parent(absent.to_str().unwrap(), &root.roots(), OWNER).unwrap_err();
+        assert_eq!(
+            message(&a),
+            message(&b),
+            "export path leaks foreign existence"
+        );
+    }
+
+    #[test]
+    fn account_scoped_roots_appends_one_component_per_root() {
+        let a = Arc::new(PathBuf::from("/srv/imports"));
+        let b = Arc::new(PathBuf::from("/mnt/data"));
+        let got = account_scoped_roots(&[a, b], OWNER).unwrap();
+        assert_eq!(
+            got,
+            vec![
+                PathBuf::from("/srv/imports/111122223333"),
+                PathBuf::from("/mnt/data/111122223333"),
+            ]
+        );
+    }
 }

--- a/crates/server/src/import_export_paths.rs
+++ b/crates/server/src/import_export_paths.rs
@@ -1,0 +1,386 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Resolution of the effective import/export path lists and their diagnostics.
+//!
+//! Two config surfaces feed one pair of path lists: the `[import]` / `[export]`
+//! sections, and the deprecated `import_export_root` key that supplies a single
+//! root for both. Which surface won determines what a diagnostic should tell the
+//! operator, so resolution records the source of each list rather than only its
+//! contents: advice to use separate directories is actionable for two
+//! independently configured roots and misleading for one deprecated key that
+//! makes them identical by construction.
+//!
+//! Kept out of `serve` and free of I/O so every branch is unit-testable.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+/// Where an effective path list came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PathSource {
+    /// The `[import]` or `[export]` section supplied it.
+    Section,
+    /// The deprecated `import_export_root` key supplied it.
+    LegacyRoot,
+    /// Neither: the operation is disabled. Bookkeeping only; no diagnostic
+    /// branches on it, since a list with no source produces no notice.
+    Unset,
+}
+
+/// The effective raw path lists, with the origin of each recorded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EffectivePaths {
+    pub(crate) import: Vec<String>,
+    pub(crate) export: Vec<String>,
+    pub(crate) import_source: PathSource,
+    pub(crate) export_source: PathSource,
+    /// The deprecated key as configured, retained so diagnostics read from the
+    /// same value the resolution used. Passing it back in would let a caller
+    /// silence a notice about a key that is in force.
+    legacy_root: Option<String>,
+}
+
+impl EffectivePaths {
+    /// Resolve the effective lists. A populated section always wins; the
+    /// deprecated key fills only a list a section left empty.
+    pub(crate) fn resolve(
+        import_section: &[String],
+        export_section: &[String],
+        legacy_root: Option<&str>,
+    ) -> Self {
+        let mut out = Self {
+            import: import_section.to_vec(),
+            export: export_section.to_vec(),
+            legacy_root: legacy_root.map(str::to_owned),
+            import_source: if import_section.is_empty() {
+                PathSource::Unset
+            } else {
+                PathSource::Section
+            },
+            export_source: if export_section.is_empty() {
+                PathSource::Unset
+            } else {
+                PathSource::Section
+            },
+        };
+
+        if let Some(legacy) = legacy_root {
+            if out.import.is_empty() {
+                out.import.push(legacy.to_owned());
+                out.import_source = PathSource::LegacyRoot;
+            }
+            if out.export.is_empty() {
+                out.export.push(legacy.to_owned());
+                out.export_source = PathSource::LegacyRoot;
+            }
+        }
+
+        out
+    }
+
+    /// Whether any overlap between the two lists is inherent rather than chosen.
+    /// True only when the deprecated key supplied both, in which case the roots
+    /// are the same path by construction and the remedy is migration.
+    pub(crate) fn overlap_is_inherent(&self) -> bool {
+        self.import_source == PathSource::LegacyRoot && self.export_source == PathSource::LegacyRoot
+    }
+
+    /// Diagnostics describing what the deprecated key actually did.
+    ///
+    /// Every case in which the key is set produces exactly one notice, including
+    /// the case where it silently supplies just one of the two lists. Reporting
+    /// only the fully-ignored case would leave an operator believing a key that
+    /// is in force is inert.
+    pub(crate) fn legacy_notices(&self) -> Vec<String> {
+        let Some(ref legacy) = self.legacy_root else {
+            return Vec::new();
+        };
+
+        let notice = match (self.import_source, self.export_source) {
+            (PathSource::LegacyRoot, PathSource::LegacyRoot) => format!(
+                "Deprecated import_export_root supplies both the import and export root ({legacy}), \
+                 so they are the same directory. Files are namespaced per account, so this is not a \
+                 cross-account exposure, but migrate to separate [import] and [export] paths to \
+                 keep the two apart."
+            ),
+            (PathSource::LegacyRoot, _) => format!(
+                "Deprecated import_export_root supplies the import root ({legacy}) because [import] \
+                 has no paths. Migrate to [import] paths; the key will be removed."
+            ),
+            (_, PathSource::LegacyRoot) => format!(
+                "Deprecated import_export_root supplies the export root ({legacy}) because [export] \
+                 has no paths. Migrate to [export] paths; the key will be removed."
+            ),
+            _ => format!(
+                "Deprecated import_export_root ({legacy}) is unused because both [import] and \
+                 [export] have paths. Remove it."
+            ),
+        };
+        vec![notice]
+    }
+}
+
+/// Diagnostics for roots that resolve to the same directory or nest.
+///
+/// With per-account namespacing an overlap is no longer a cross-account
+/// exposure, but it still means a tenant's own exports are re-importable and the
+/// two operations share a disk budget, so it is worth surfacing.
+///
+/// When `overlap_is_inherent` the identical-root case is left to the deprecation
+/// notice, which names the remedy that applies. Nesting is always reported: it
+/// cannot arise from a single legacy root.
+///
+/// The sources are decided on the raw config strings while this runs on the
+/// canonicalized roots, which is sound rather than a mismatch: inherent means
+/// both lists hold the identical legacy string, so canonicalization maps them to
+/// the same path and the suppressed case is always the one that matched.
+pub(crate) fn overlap_notices(
+    import: &[Arc<PathBuf>],
+    export: &[Arc<PathBuf>],
+    overlap_is_inherent: bool,
+) -> Vec<String> {
+    let mut notices = Vec::new();
+    for i in import {
+        for e in export {
+            if i == e {
+                if !overlap_is_inherent {
+                    notices.push(format!(
+                        "Import and export are configured with the same root ({}); files remain \
+                         namespaced per account, but consider separate directories.",
+                        i.display()
+                    ));
+                }
+            } else if i.starts_with(e.as_path()) || e.starts_with(i.as_path()) {
+                notices.push(format!(
+                    "Import root ({}) and export root ({}) are nested; files remain namespaced per \
+                     account, but consider separate directories.",
+                    i.display(),
+                    e.display()
+                ));
+            }
+        }
+    }
+    notices
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    fn roots(items: &[&str]) -> Vec<Arc<PathBuf>> {
+        items.iter().map(|s| Arc::new(PathBuf::from(s))).collect()
+    }
+
+    #[test]
+    fn sections_only() {
+        let p = EffectivePaths::resolve(&v(&["/in"]), &v(&["/out"]), None);
+        assert_eq!(p.import, v(&["/in"]));
+        assert_eq!(p.export, v(&["/out"]));
+        assert_eq!(p.import_source, PathSource::Section);
+        assert_eq!(p.export_source, PathSource::Section);
+        assert!(p.legacy_notices().is_empty());
+        assert!(!p.overlap_is_inherent());
+    }
+
+    #[test]
+    fn nothing_configured_leaves_both_unset() {
+        let p = EffectivePaths::resolve(&[], &[], None);
+        assert!(p.import.is_empty() && p.export.is_empty());
+        assert_eq!(p.import_source, PathSource::Unset);
+        assert_eq!(p.export_source, PathSource::Unset);
+        assert!(
+            !p.overlap_is_inherent(),
+            "disabled is not an inherent overlap"
+        );
+    }
+
+    /// One section on, one off, no legacy key: the Section/Unset split is the
+    /// only thing distinguishing "disabled" from "configured" downstream.
+    #[test]
+    fn one_section_only_without_a_legacy_key() {
+        let export_only = EffectivePaths::resolve(&[], &v(&["/out"]), None);
+        assert!(export_only.import.is_empty());
+        assert_eq!(export_only.import_source, PathSource::Unset);
+        assert_eq!(export_only.export_source, PathSource::Section);
+        assert!(export_only.legacy_notices().is_empty());
+
+        let import_only = EffectivePaths::resolve(&v(&["/in"]), &[], None);
+        assert!(import_only.export.is_empty());
+        assert_eq!(import_only.import_source, PathSource::Section);
+        assert_eq!(import_only.export_source, PathSource::Unset);
+        assert!(import_only.legacy_notices().is_empty());
+    }
+
+    /// Second guard on the reviewed defect, with a different root, so the
+    /// suppression is not pinned to one literal.
+    #[test]
+    fn identical_roots_from_legacy_key_are_suppressed_for_any_root() {
+        let p = EffectivePaths::resolve(&[], &[], Some("/srv/extenddb/data"));
+        assert!(p.overlap_is_inherent());
+        let n = overlap_notices(
+            &roots(&["/srv/extenddb/data"]),
+            &roots(&["/srv/extenddb/data"]),
+            p.overlap_is_inherent(),
+        );
+        assert!(n.is_empty(), "{n:?}");
+    }
+
+    #[test]
+    fn legacy_root_fills_both_when_no_sections() {
+        let p = EffectivePaths::resolve(&[], &[], Some("/legacy"));
+        assert_eq!(p.import, v(&["/legacy"]));
+        assert_eq!(p.export, v(&["/legacy"]));
+        assert_eq!(p.import_source, PathSource::LegacyRoot);
+        assert_eq!(p.export_source, PathSource::LegacyRoot);
+        assert!(p.overlap_is_inherent());
+
+        let n = p.legacy_notices();
+        assert_eq!(n.len(), 1);
+        assert!(n[0].contains("both the import and export root"), "{}", n[0]);
+        assert!(n[0].contains("migrate"), "must name the remedy: {}", n[0]);
+    }
+
+    /// The case that previously produced no diagnostic at all: the key is in
+    /// force for one operation while the operator is told nothing.
+    #[test]
+    fn legacy_root_filling_only_export_is_reported() {
+        let p = EffectivePaths::resolve(&v(&["/in"]), &[], Some("/legacy"));
+        assert_eq!(p.import, v(&["/in"]));
+        assert_eq!(p.export, v(&["/legacy"]));
+        assert_eq!(p.import_source, PathSource::Section);
+        assert_eq!(p.export_source, PathSource::LegacyRoot);
+        assert!(
+            !p.overlap_is_inherent(),
+            "only one list came from the legacy key, so an overlap here is chosen"
+        );
+
+        let n = p.legacy_notices();
+        assert_eq!(n.len(), 1, "must not be silent");
+        // "export root" alone is not discriminating: the both-legacy message
+        // contains it too ("both the import and export root").
+        assert!(
+            n[0].contains("because [export] has no paths"),
+            "must identify the branch, not just mention the export root: {}",
+            n[0]
+        );
+        assert!(!n[0].contains("both"), "wrong branch: {}", n[0]);
+        assert!(
+            !n[0].contains("unused"),
+            "the key is in force, not unused: {}",
+            n[0]
+        );
+    }
+
+    #[test]
+    fn legacy_root_filling_only_import_is_reported() {
+        let p = EffectivePaths::resolve(&[], &v(&["/out"]), Some("/legacy"));
+        assert_eq!(p.import, v(&["/legacy"]));
+        assert_eq!(p.import_source, PathSource::LegacyRoot);
+        assert_eq!(p.export_source, PathSource::Section);
+        let n = p.legacy_notices();
+        assert_eq!(n.len(), 1);
+        assert!(
+            n[0].contains("because [import] has no paths"),
+            "must identify the branch: {}",
+            n[0]
+        );
+        assert!(!n[0].contains("both"), "wrong branch: {}", n[0]);
+        assert!(!n[0].contains("unused"), "{}", n[0]);
+    }
+
+    #[test]
+    fn legacy_root_is_unused_when_both_sections_populated() {
+        let p = EffectivePaths::resolve(&v(&["/in"]), &v(&["/out"]), Some("/legacy"));
+        assert_eq!(p.import, v(&["/in"]));
+        assert_eq!(p.export, v(&["/out"]));
+        assert_eq!(p.import_source, PathSource::Section);
+        assert_eq!(p.export_source, PathSource::Section);
+        let n = p.legacy_notices();
+        assert_eq!(n.len(), 1);
+        assert!(n[0].contains("unused"), "{}", n[0]);
+    }
+
+    /// A notice about a key that is in force must not be silenceable from the
+    /// call site: the legacy value is captured at resolve time, not re-supplied.
+    #[test]
+    fn legacy_notice_reads_the_value_resolution_used() {
+        let applied = EffectivePaths::resolve(&[], &[], Some("/legacy"));
+        assert_eq!(applied.legacy_notices().len(), 1);
+
+        let absent = EffectivePaths::resolve(&[], &[], None);
+        assert!(absent.legacy_notices().is_empty());
+        assert_ne!(
+            applied.legacy_notices(),
+            absent.legacy_notices(),
+            "the notice must follow the resolved config, not a caller argument"
+        );
+    }
+
+    /// The reviewed defect: advising separate directories is not actionable when
+    /// the deprecated key is what made the roots identical.
+    #[test]
+    fn identical_roots_from_legacy_key_emit_no_overlap_advice() {
+        let p = EffectivePaths::resolve(&[], &[], Some("/legacy"));
+        let n = overlap_notices(
+            &roots(&["/legacy"]),
+            &roots(&["/legacy"]),
+            p.overlap_is_inherent(),
+        );
+        assert!(n.is_empty(), "deprecation notice owns this case: {n:?}");
+    }
+
+    /// Converse: two independently configured roots that happen to be identical
+    /// must still be reported, because changing one is the remedy.
+    #[test]
+    fn identical_roots_from_sections_are_reported() {
+        let p = EffectivePaths::resolve(&v(&["/same"]), &v(&["/same"]), None);
+        let n = overlap_notices(
+            &roots(&["/same"]),
+            &roots(&["/same"]),
+            p.overlap_is_inherent(),
+        );
+        assert_eq!(n.len(), 1);
+        assert!(n[0].contains("same root"), "{}", n[0]);
+    }
+
+    #[test]
+    fn nested_roots_are_reported_even_when_a_legacy_key_is_present() {
+        let p = EffectivePaths::resolve(&v(&["/data/in"]), &[], Some("/data"));
+        let n = overlap_notices(
+            &roots(&["/data/in"]),
+            &roots(&["/data"]),
+            p.overlap_is_inherent(),
+        );
+        assert_eq!(n.len(), 1, "nesting is never inherent");
+        assert!(n[0].contains("nested"), "{}", n[0]);
+    }
+
+    #[test]
+    fn disjoint_roots_are_silent() {
+        let n = overlap_notices(&roots(&["/in"]), &roots(&["/out"]), false);
+        assert!(n.is_empty(), "{n:?}");
+    }
+
+    /// A shared prefix that is not a path boundary must not count as nesting.
+    #[test]
+    fn sibling_roots_with_a_shared_string_prefix_are_silent() {
+        let n = overlap_notices(&roots(&["/data-in"]), &roots(&["/data"]), false);
+        assert!(n.is_empty(), "component-wise containment only: {n:?}");
+    }
+
+    #[test]
+    fn every_pair_is_checked_across_multiple_roots() {
+        let n = overlap_notices(
+            &roots(&["/a", "/shared"]),
+            &roots(&["/b", "/shared"]),
+            false,
+        );
+        assert_eq!(n.len(), 1, "{n:?}");
+        assert!(n[0].contains("/shared"), "{}", n[0]);
+    }
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -12,6 +12,7 @@ pub(crate) mod authorization;
 pub mod authz_cache;
 pub mod console;
 mod handler;
+mod import_export_paths;
 pub mod key_info_cache;
 pub mod management;
 mod metrics_endpoint;

--- a/crates/server/src/serve.rs
+++ b/crates/server/src/serve.rs
@@ -453,6 +453,29 @@ async fn serve_inner(params: ServeParams, port: u16) -> anyhow::Result<()> {
     let export_paths: Arc<[Arc<std::path::PathBuf>]> =
         Arc::from(resolve_paths(&export_paths_raw, "export")?);
 
+    // Import and export files are namespaced per account beneath each root, so a
+    // shared or nested root is no longer a cross-tenant exposure on its own.
+    // It is still worth surfacing, because it means one tenant's exports are
+    // re-importable by that same tenant and the two features share a disk quota.
+    for i in import_paths.iter() {
+        for e in export_paths.iter() {
+            if i == e {
+                tracing::warn!(
+                    "Import and export are configured with the same root ({}); files remain \
+                     namespaced per account, but consider separate directories",
+                    i.display()
+                );
+            } else if i.starts_with(e.as_path()) || e.starts_with(i.as_path()) {
+                tracing::warn!(
+                    "Import root ({}) and export root ({}) are nested; files remain namespaced \
+                     per account, but consider separate directories",
+                    i.display(),
+                    e.display()
+                );
+            }
+        }
+    }
+
     if import_paths.is_empty() {
         tracing::info!("Import disabled (no [import] paths configured)");
     } else {

--- a/crates/server/src/serve.rs
+++ b/crates/server/src/serve.rs
@@ -430,50 +430,29 @@ async fn serve_inner(params: ServeParams, port: u16) -> anyhow::Result<()> {
         Ok(resolved)
     };
 
-    // Build effective path lists: new config takes precedence over deprecated.
-    let mut import_paths_raw = app_config.import_config.paths.clone();
-    let mut export_paths_raw = app_config.export_config.paths.clone();
-    if let Some(ref legacy) = app_config.import_export_root {
-        if import_paths_raw.is_empty() {
-            import_paths_raw.push(legacy.clone());
-        }
-        if export_paths_raw.is_empty() {
-            export_paths_raw.push(legacy.clone());
-        }
-        if !app_config.import_config.paths.is_empty() && !app_config.export_config.paths.is_empty()
-        {
-            tracing::warn!(
-                "Both import_export_root and [import]/[export] sections configured; import_export_root is ignored"
-            );
-        }
+    // Build effective path lists: a populated section wins, and the deprecated
+    // import_export_root fills only a list a section left empty. Which surface
+    // won decides what the diagnostics should say, so it is recorded.
+    let effective = crate::import_export_paths::EffectivePaths::resolve(
+        &app_config.import_config.paths,
+        &app_config.export_config.paths,
+        app_config.import_export_root.as_deref(),
+    );
+    for notice in effective.legacy_notices() {
+        tracing::warn!("{notice}");
     }
 
     let import_paths: Arc<[Arc<std::path::PathBuf>]> =
-        Arc::from(resolve_paths(&import_paths_raw, "import")?);
+        Arc::from(resolve_paths(&effective.import, "import")?);
     let export_paths: Arc<[Arc<std::path::PathBuf>]> =
-        Arc::from(resolve_paths(&export_paths_raw, "export")?);
+        Arc::from(resolve_paths(&effective.export, "export")?);
 
-    // Import and export files are namespaced per account beneath each root, so a
-    // shared or nested root is no longer a cross-tenant exposure on its own.
-    // It is still worth surfacing, because it means one tenant's exports are
-    // re-importable by that same tenant and the two features share a disk quota.
-    for i in import_paths.iter() {
-        for e in export_paths.iter() {
-            if i == e {
-                tracing::warn!(
-                    "Import and export are configured with the same root ({}); files remain \
-                     namespaced per account, but consider separate directories",
-                    i.display()
-                );
-            } else if i.starts_with(e.as_path()) || e.starts_with(i.as_path()) {
-                tracing::warn!(
-                    "Import root ({}) and export root ({}) are nested; files remain namespaced \
-                     per account, but consider separate directories",
-                    i.display(),
-                    e.display()
-                );
-            }
-        }
+    for notice in crate::import_export_paths::overlap_notices(
+        &import_paths,
+        &export_paths,
+        effective.overlap_is_inherent(),
+    ) {
+        tracing::warn!("{notice}");
     }
 
     if import_paths.is_empty() {

--- a/docs/manuals/10-security-model.md
+++ b/docs/manuals/10-security-model.md
@@ -200,8 +200,19 @@ Input validation is layered:
 
 Import/export file paths are validated:
 - `..` components rejected
-- Paths canonicalized
-- Symlinks detected and rejected
+- Paths namespaced per account: a caller in account `A` may only resolve paths
+  under `<root>/A` for each configured root. Containment in the bare root is not
+  sufficient, so tenants sharing an instance cannot read or overwrite each
+  other's files. The account id comes from the authenticated identity, never
+  from the request
+- Containment is decided before any filesystem access, so a path belonging to
+  another account answers identically whether or not the file exists
+- Paths canonicalized, and containment re-checked afterwards so a symlinked
+  ancestor cannot redirect out of the subtree
+- Symlinks detected and rejected, including one planted at the export filename
+- Export refuses to overwrite an existing file, so it cannot truncate a file it
+  did not create
+- Both operations record the acting account, the operation and the resolved path
 - Error messages use generic text (no raw paths leaked)
 
 ## Error Message Security

--- a/docs/manuals/13-event-ticketing-demo.md
+++ b/docs/manuals/13-event-ticketing-demo.md
@@ -686,14 +686,20 @@ Export the Events table:
 aws dynamodb export-table-to-point-in-time \
     --table-arn "arn:aws:dynamodb:us-east-1:111122223333:table/Events" \
     --s3-bucket "local" \
-    --s3-prefix "/tmp/extenddb-exports/events.json" \
+    --s3-prefix "/tmp/extenddb-exports/111122223333/events.json" \
     --export-format DYNAMODB_JSON
 ```
+
+Export files are namespaced by account: the path sits under
+`<configured export root>/<account id>/`, which is why the account id appears in
+the prefix above. The server creates that directory on first use. Export also
+refuses to overwrite an existing file, so re-running this step needs a new
+filename (or the old file removed).
 
 Check the exported file:
 
 ```bash
-cat /tmp/extenddb-exports/events.json | python3 -m json.tool | head -40
+cat /tmp/extenddb-exports/111122223333/events.json | python3 -m json.tool | head -40
 ```
 
 ---

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -147,9 +147,24 @@ paths = ["/path/to/exports"]
 
 ### `Path must resolve under one of the configured allowed paths`
 
-**Cause:** An import or export file path resolves outside all configured allowed directories after canonicalization. This includes symlink escapes.
+**Cause:** An import or export file path does not resolve under the calling
+account's subtree of a configured allowed directory. Files are namespaced per
+account, so the path must be under `<root>/<account id>/`, not directly under
+`<root>`. This error also covers symlink escapes and paths outside every
+configured root; the wording is deliberately identical in all three cases so it
+cannot be used to probe for another account's files.
 
-**Fix:** Ensure the file path is within one of the configured `[import]` or `[export]` paths. Do not use symlinks that point outside the allowed directories.
+**Fix:** Place the file under `<root>/<account id>/`, using the account id the
+request is authenticated as. The export directory is created for you on first
+use. Do not use symlinks that point outside the allowed directories.
+
+### `Export file already exists; choose a different FilePath`
+
+**Cause:** Export refuses to overwrite. Something already exists at the
+requested `FilePath`, so the export stopped rather than truncating it. A symlink
+at that path produces the same error rather than being followed.
+
+**Fix:** Export to a new filename, or remove the existing file first.
 
 ### `Failed to daemonize: <error>`
 

--- a/extenddb.sample.toml
+++ b/extenddb.sample.toml
@@ -153,10 +153,16 @@
 #
 # max_import_bytes = 10737418240  # 10 GB default
 #
-# Deprecated: import_export_root sets a single root for both import and
-# export. If [import]/[export] sections are present, import_export_root
-# is ignored.
-# import_export_root = "/var/lib/extenddb/data"
+# Deprecated: import_export_root sets a single root for both import and export.
+# It fills only a list that the sections leave empty, so with both [import] and
+# [export] present it does nothing, and with neither present it makes the import
+# and export roots the same directory. The server logs which of those happened at
+# startup. Prefer the sections above; this key will be removed.
+#
+# It is a top-level key, so it has to appear before the first [section] header of
+# this file. Uncommenting it here would place it inside the preceding table and
+# the server would refuse to start with "unknown field import_export_root".
+#     import_export_root = "/var/lib/extenddb/data"
 
 # Runtime settings are managed via `extenddb settings set <key> <value>`, not this file.
 # See docs/getting-started.md for available runtime settings and their defaults.

--- a/extenddb.sample.toml
+++ b/extenddb.sample.toml
@@ -140,8 +140,13 @@
 # All file paths are canonicalized and must resolve under one of the
 # configured roots. Symlinks escaping a root are rejected.
 #
+# Files are namespaced per account beneath each root: a caller in account
+# 111122223333 may only read and write under <root>/111122223333. A path that
+# resolves elsewhere is rejected, so tenants sharing an instance cannot read or
+# overwrite each other's files. Export refuses to overwrite an existing file.
+#
 # [import]
-# paths = ["/var/lib/extenddb/imports", "/mnt/shared/data"]
+# paths = ["/var/lib/extenddb/imports"]
 #
 # [export]
 # paths = ["/var/lib/extenddb/exports"]

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -60,6 +60,57 @@ def extenddb_request(operation: str, body: dict) -> dict:
         error_msg = result.get("message", result.get("Message", ""))
         raise RuntimeError(f"{error_type}: {error_msg} (HTTP {resp.status_code})")
     return result
+
+
+# ---------------------------------------------------------------------------
+# Per-account path helpers
+#
+# Import and export files are namespaced by account: a caller in account A may
+# only read and write beneath <root>/A for each configured root. A path directly
+# under the bare root is rejected, which is what stops tenants sharing an
+# instance from reading or overwriting each other's files.
+#
+# devtools/run-tests points TMPDIR at the configured root, so
+# tempfile.gettempdir() is that root.
+# ---------------------------------------------------------------------------
+
+ACCOUNT_ID = os.environ.get("EXTENDDB_TEST_ACCOUNT_ID", "123456789012")
+FOREIGN_ACCOUNT = "999999999999"
+
+
+def account_dir(account: str = ACCOUNT_ID) -> str:
+    """Return (creating if needed) the per-account subtree of the root."""
+    path = os.path.join(tempfile.gettempdir(), account)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def export_target(suffix: str = ".json") -> str:
+    """A path for an export that does not yet exist.
+
+    Export refuses to overwrite, so the destination must not be pre-created.
+    This is why export destinations cannot use NamedTemporaryFile.
+    """
+    return os.path.join(account_dir(), f"exp-{uuid.uuid4().hex}{suffix}")
+
+
+def import_source(content: str, suffix: str = ".json", account: str = ACCOUNT_ID) -> str:
+    """Write an import fixture inside `account`'s subtree and return its path."""
+    path = os.path.join(account_dir(account), f"imp-{uuid.uuid4().hex}{suffix}")
+    with open(path, "w") as f:
+        f.write(content)
+    return path
+
+
+def discard(*paths: str) -> None:
+    """Remove files that may or may not exist."""
+    for path in paths:
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+
+
 @pytest.fixture()
 def unique_table_name():
     """Generate a unique table name."""
@@ -112,8 +163,7 @@ class TestExportTable:
         desc = dynamodb_client.describe_table(TableName=table_name)
         table_arn = desc["Table"]["TableArn"]
 
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
-            export_path = f.name
+        export_path = export_target()
 
         try:
             resp = extenddb_request("ExportTableToPointInTime", {
@@ -136,7 +186,7 @@ class TestExportTable:
                 assert "Item" in obj
                 assert "pk" in obj["Item"]
         finally:
-            os.unlink(export_path)
+            discard(export_path)
 
     def test_export_empty_table(self, dynamodb_client, unique_table_name, cleanup_table):
         """Export an empty table produces empty file."""
@@ -153,8 +203,7 @@ class TestExportTable:
         desc = dynamodb_client.describe_table(TableName=name)
         table_arn = desc["Table"]["TableArn"]
 
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
-            export_path = f.name
+        export_path = export_target()
 
         try:
             resp = extenddb_request("ExportTableToPointInTime", {
@@ -163,7 +212,7 @@ class TestExportTable:
             })
             assert resp["ExportDescription"]["ItemCount"] == 0
         finally:
-            os.unlink(export_path)
+            discard(export_path)
 # ---------------------------------------------------------------------------
 # ImportTable
 # ---------------------------------------------------------------------------
@@ -179,10 +228,7 @@ class TestImportTable:
             {"Item": {"pk": {"S": f"imp-{i}"}, "val": {"N": str(i)}}}
             for i in range(3)
         ]
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-            for item in items:
-                f.write(json.dumps(item) + "\n")
-            source_path = f.name
+        source_path = import_source("".join(json.dumps(i) + "\n" for i in items))
 
         try:
             resp = extenddb_request("ImportTable", {
@@ -210,7 +256,7 @@ class TestImportTable:
                 )
                 assert item["Item"]["val"]["N"] == str(i)
         finally:
-            os.unlink(source_path)
+            discard(source_path)
 
     def test_import_csv(self, dynamodb_client, unique_table_name, cleanup_table):
         """Import items from CSV file."""
@@ -218,9 +264,7 @@ class TestImportTable:
         cleanup_table(name)
 
         csv_content = "pk,name,age\ncsv-1,Alice,30\ncsv-2,Bob,25\n"
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
-            f.write(csv_content)
-            source_path = f.name
+        source_path = import_source(csv_content, suffix=".csv")
 
         try:
             resp = extenddb_request("ImportTable", {
@@ -247,7 +291,7 @@ class TestImportTable:
             assert item["Item"]["name"]["S"] == "Alice"
             assert item["Item"]["age"]["S"] == "30"
         finally:
-            os.unlink(source_path)
+            discard(source_path)
 
     def test_import_nonexistent_source(self, dynamodb_client, unique_table_name, cleanup_table):
         """Import from nonexistent path returns error."""
@@ -294,8 +338,7 @@ class TestImportTable:
         desc = dynamodb_client.describe_table(TableName=src_name)
         table_arn = desc["Table"]["TableArn"]
 
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
-            export_path = f.name
+        export_path = export_target()
 
         try:
             extenddb_request("ExportTableToPointInTime", {
@@ -329,4 +372,124 @@ class TestImportTable:
                 assert item["Item"]["n"]["N"] == expected["n"]
                 assert item["Item"]["s"]["S"] == expected["s"]
         finally:
-            os.unlink(export_path)
+            discard(export_path)
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant isolation
+# ---------------------------------------------------------------------------
+class TestCrossTenantIsolation:
+    """Import/export files are confined to the calling account's subtree.
+
+    A single instance may host several accounts, and the import/export roots are
+    server-wide. Without per-account namespacing, containment in a shared root
+    lets any tenant name another tenant's file: read it by importing it, or
+    destroy it by exporting over it. These tests drive a foreign account's path
+    directly rather than provisioning a second set of credentials, which is the
+    same approach `backup_arn_scoping` takes for ARNs.
+    """
+
+    TCP = {
+        "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+        "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+        "BillingMode": "PAY_PER_REQUEST",
+    }
+
+    def _import(self, path: str, table: str) -> dict:
+        return extenddb_request("ImportTable", {
+            "FileSource": {"Path": path},
+            "InputFormat": "DYNAMODB_JSON",
+            "TableCreationParameters": {"TableName": table, **self.TCP},
+        })
+
+    def test_import_from_another_accounts_subtree_is_denied(
+        self, unique_table_name, cleanup_table
+    ):
+        """The reported read primitive: importing a co-tenant's export file."""
+        cleanup_table(unique_table_name)
+        victim = import_source(
+            json.dumps({"Item": {"pk": {"S": "secret"}}}) + "\n",
+            account=FOREIGN_ACCOUNT,
+        )
+        try:
+            with pytest.raises(RuntimeError, match="ValidationException"):
+                self._import(victim, unique_table_name)
+        finally:
+            discard(victim)
+
+    def test_export_into_another_accounts_subtree_is_denied(
+        self, dynamodb_client, unique_table_name, cleanup_table
+    ):
+        """The reported destruction primitive: truncating a co-tenant's export.
+
+        The victim file must still hold its original bytes afterwards. Before the
+        fix it was truncated to zero length with no error to either party.
+        """
+        name = unique_table_name
+        cleanup_table(name)
+        dynamodb_client.create_table(TableName=name, **{
+            "AttributeDefinitions": self.TCP["AttributeDefinitions"],
+            "KeySchema": self.TCP["KeySchema"],
+            "BillingMode": self.TCP["BillingMode"],
+        })
+        wait_for_active(dynamodb_client, name)
+        table_arn = dynamodb_client.describe_table(TableName=name)["Table"]["TableArn"]
+
+        original = json.dumps({"Item": {"pk": {"S": "victim-data"}}}) + "\n"
+        victim = import_source(original, account=FOREIGN_ACCOUNT)
+        try:
+            with pytest.raises(RuntimeError, match="ValidationException"):
+                extenddb_request("ExportTableToPointInTime", {
+                    "TableArn": table_arn,
+                    "FilePath": victim,
+                    "ExportFormat": "DYNAMODB_JSON",
+                })
+            with open(victim) as f:
+                assert f.read() == original, "co-tenant's file was modified"
+        finally:
+            discard(victim)
+
+    def test_import_from_the_bare_root_is_denied(self, unique_table_name, cleanup_table):
+        """Containment in the shared root is not sufficient on its own."""
+        cleanup_table(unique_table_name)
+        stray = os.path.join(
+            tempfile.gettempdir(), f"unscoped-{uuid.uuid4().hex}.json"
+        )
+        with open(stray, "w") as f:
+            f.write(json.dumps({"Item": {"pk": {"S": "x"}}}) + "\n")
+        try:
+            with pytest.raises(RuntimeError, match="ValidationException"):
+                self._import(stray, unique_table_name)
+        finally:
+            discard(stray)
+
+    def test_export_refuses_to_overwrite_an_existing_file(
+        self, dynamodb_client, unique_table_name, cleanup_table
+    ):
+        """Export will not truncate a file that is already there, even its own."""
+        name = unique_table_name
+        cleanup_table(name)
+        dynamodb_client.create_table(TableName=name, **{
+            "AttributeDefinitions": self.TCP["AttributeDefinitions"],
+            "KeySchema": self.TCP["KeySchema"],
+            "BillingMode": self.TCP["BillingMode"],
+        })
+        wait_for_active(dynamodb_client, name)
+        table_arn = dynamodb_client.describe_table(TableName=name)["Table"]["TableArn"]
+
+        target = export_target()
+        try:
+            extenddb_request("ExportTableToPointInTime", {
+                "TableArn": table_arn,
+                "FilePath": target,
+                "ExportFormat": "DYNAMODB_JSON",
+            })
+            assert os.path.exists(target)
+            with pytest.raises(RuntimeError, match="already exists"):
+                extenddb_request("ExportTableToPointInTime", {
+                    "TableArn": table_arn,
+                    "FilePath": target,
+                    "ExportFormat": "DYNAMODB_JSON",
+                })
+        finally:
+            discard(target)

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import tempfile
 import time
 import uuid
@@ -389,6 +390,8 @@ class TestCrossTenantIsolation:
     same approach `backup_arn_scoping` takes for ARNs.
     """
 
+    JAIL_REFUSED = "Path must resolve under one of the configured allowed paths"
+
     TCP = {
         "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
         "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
@@ -403,7 +406,7 @@ class TestCrossTenantIsolation:
         })
 
     def test_import_from_another_accounts_subtree_is_denied(
-        self, unique_table_name, cleanup_table
+        self, dynamodb_client, unique_table_name, cleanup_table
     ):
         """The reported read primitive: importing a co-tenant's export file."""
         cleanup_table(unique_table_name)
@@ -412,8 +415,12 @@ class TestCrossTenantIsolation:
             account=FOREIGN_ACCOUNT,
         )
         try:
-            with pytest.raises(RuntimeError, match="ValidationException"):
+            with pytest.raises(RuntimeError, match=re.escape(self.JAIL_REFUSED)):
                 self._import(victim, unique_table_name)
+            # The source is validated before the destination is created, so a
+            # refused import must leave no table behind.
+            with pytest.raises(dynamodb_client.exceptions.ResourceNotFoundException):
+                dynamodb_client.describe_table(TableName=unique_table_name)
         finally:
             discard(victim)
 
@@ -438,7 +445,7 @@ class TestCrossTenantIsolation:
         original = json.dumps({"Item": {"pk": {"S": "victim-data"}}}) + "\n"
         victim = import_source(original, account=FOREIGN_ACCOUNT)
         try:
-            with pytest.raises(RuntimeError, match="ValidationException"):
+            with pytest.raises(RuntimeError, match=re.escape(self.JAIL_REFUSED)):
                 extenddb_request("ExportTableToPointInTime", {
                     "TableArn": table_arn,
                     "FilePath": victim,
@@ -458,7 +465,7 @@ class TestCrossTenantIsolation:
         with open(stray, "w") as f:
             f.write(json.dumps({"Item": {"pk": {"S": "x"}}}) + "\n")
         try:
-            with pytest.raises(RuntimeError, match="ValidationException"):
+            with pytest.raises(RuntimeError, match=re.escape(self.JAIL_REFUSED)):
                 self._import(stray, unique_table_name)
         finally:
             discard(stray)


### PR DESCRIPTION
## What this changes

Import and export file paths are now namespaced per account. A caller in account
`A` may only resolve paths beneath `<root>/A` for each configured `[import]` /
`[export]` root; anything else is refused. The account id comes from the
authenticated identity rather than the request.

Previously the allow-list was server-wide with no account dimension
(`ImportExportPathConfig` is a bare `Vec<String>`, resolved once at startup and
shared across request contexts), and `validate_path` / `validate_path_parent`
enforced containment in one of those roots and nothing else. On an instance
hosting more than one account, that meant a caller could name any path inside a
configured root regardless of who wrote it.

Four supporting changes on the same paths:

- **Containment is decided lexically, before any filesystem access.** Deciding it
  after canonicalization meant a path outside the caller's subtree answered
  "does not exist" when absent and the containment message when present, which
  distinguished the two. The post-canonicalization check is kept so a symlinked
  ancestor still cannot redirect out of the subtree.
- **Export refuses to overwrite.** The write is `create_new`, so an export cannot
  truncate a file it did not create, and an existing symlink at the destination
  is refused rather than followed. The final path component is symlink-checked
  explicitly, matching the import read path which already did this.
- **The import source is validated before the destination table is created**, so a
  refused import no longer leaves an empty orphaned table behind.
- **Both operations emit a record** carrying the acting account, the operation, the
  table and the resolved path. Neither was previously observable: they are
  synchronous and persist nothing.

## Behaviour changes for existing deployments

- A path directly under a configured root is no longer accepted.
- A file exported before this change cannot be imported after it without being
  moved into the account subtree.
- Re-exporting to an existing path now fails instead of truncating.

`import_export_root` continues to be honoured. It populates both lists from a
single value, which previously guaranteed the import and export roots
overlapped; with per-account namespacing a shared root is no longer a
cross-account concern, so startup warns rather than refusing. The shared example
path is dropped from the sample config.

## Tests

12 unit tests over the validators: own-subtree accept; foreign-subtree refuse
with the victim file present, so the refusal cannot come from absence;
bare-root refuse; identical answers for foreign-and-present versus
foreign-and-absent on both the import and export paths; symlink refusal;
relative paths in both directions; and the malformed-account-id guard.

4 integration tests drive the two primitives and the overwrite refusal over the
wire against a foreign account's path, following the approach
`backup_arn_scoping` takes for ARNs. They assert the exact containment message
rather than any `ValidationException`, the destruction test re-reads the victim's
bytes to prove they are intact, and the read-denial test asserts no table was
created.

Verified by building a server from the pre-change code and running the same four
integration tests against it: all four fail there (both primitives succeed, with
`DID NOT RAISE`), and all four pass after. Existing import/export tests move onto
the account subtree, and export destinations no longer pre-create the file.

Gates: `cargo fmt --all -- --check` exit 0, `cargo clippy --all-targets -- -D
warnings` exit 0, `cargo test --workspace` 810 passed with 0 filtered out, and
the 14 import/export integration tests green against a live server.

## Coverage note

This lives in `crates/engine` and touches no storage backend, so the behaviour is
identical on all three. Worth knowing that both the Postgres and SQLite
integration jobs run pytest with `--filter "not import_export"`, so
`test_import_export.py` executes only on the MongoDB job today. The unit tests run
everywhere via `cargo test`.

## Docs

`13-event-ticketing-demo.md` exported to a bare-root path, which this change
refuses, then `cat`ed a file that was never written; the demo was broken end to
end. `10-security-model.md` listed only `..`, canonicalization and symlinks under
path-traversal protection. `troubleshooting.md` explained the containment error
in terms that no longer cover a path inside a root but outside the account
subtree, and had no entry for the overwrite refusal.
