### PR TITLE
ci: check license notices freshness at PR time

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -1,0 +1,63 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# PR-time license notices freshness check.
+#
+# SOFTWARE-LICENSE-NOTICES.html embeds the version of every workspace crate,
+# so it goes stale on any version bump or dependency change. Until now the
+# only check lived in release-image's gate, so a PR could merge fully green
+# while leaving main unreleasable — exactly what happened with the 0.1.6
+# bump (#271, fixed by #272). This runs the SAME script with the SAME pinned
+# cargo-about (the script refuses any other version), so PR-time and
+# release-time can never disagree.
+#
+# Path-filtered to the generator's actual inputs; the release gate remains
+# the unconditional backstop.
+
+name: Licenses
+
+on:
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      - 'SOFTWARE-LICENSE-NOTICES.html'
+      - 'about.toml'
+      - 'about.hbs'
+      - 'devtools/generate-software-license-notices'
+      - '.github/workflows/licenses.yml'
+  merge_group:
+  push:
+    branches: [main]
+    paths:
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      - 'SOFTWARE-LICENSE-NOTICES.html'
+      - 'about.toml'
+      - 'about.hbs'
+      - 'devtools/generate-software-license-notices'
+      - '.github/workflows/licenses.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  notices-current:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: Cache cargo-about
+        id: cache-cargo-about
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-about
+          key: cargo-about-0.9.0-${{ runner.os }}
+      - name: Install cargo-about (same pin as the release gate)
+        if: steps.cache-cargo-about.outputs.cache-hit != 'true'
+        run: cargo install --locked --version 0.9.0 --features cli cargo-about
+      - name: Notices must be current
+        run: ./devtools/generate-software-license-notices --check


### PR DESCRIPTION
## What

A `Licenses` workflow that runs `devtools/generate-software-license-notices
--check` on pull requests, merge groups, and pushes to `main` — the exact
script and pinned `cargo-about 0.9.0` the `release-image` gate uses (the
script itself refuses any other version, so the PR-time and release-time
checks cannot drift apart). Path-filtered to the generator's inputs
(`Cargo.toml`/`Cargo.lock`, the notices file, about config, the script
itself); the binary is cached so the common case adds seconds, not a
compile. `contents: read` only.

## Why

Follow-up to the process gap called out in #272: the notices check ran only
inside `release-image`, so #271's version bump merged 32/32 green while
leaving `main` unable to produce a release candidate — discovered only when
the `v0.1.6` tag was dispatched. This moves the failure to the PR that
causes it, where the fix is one regeneration command instead of a burned
tag dispatch.

The release-gate check stays: it is the unconditional backstop for anything
the path filter cannot anticipate.

## Testing done

- `yaml.safe_load` passes on the workflow.
- The underlying script run locally on current `main` (post-#272):
  `SOFTWARE-LICENSE-NOTICES.html is current` — so this check goes green on
  merge, not red.
- Discriminating case: the same script at `75e1685` (pre-#272) fails with
  the exact CI message, per the verification table in #272 — this workflow
  would have blocked #271 at PR time.
- Path filter includes the workflow file itself, so future edits to the
  check re-trigger it.

## Checklist

- [ ] All tests pass (`cargo test --workspace`) — not applicable, workflow-only change
- [ ] Code is formatted (`cargo fmt --check`) — not applicable
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`) — not applicable
- [x] I have added or updated tests for new functionality — the check is itself the test; discriminating pass/fail cases cited above
- [x] I have updated documentation if behavior changed — header documents rationale and the #271/#272 incident
- [x] Breaking changes are noted below (if any)

ADR / RFC: n/a — CI tooling only.

## Breaking changes

None.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
