### PR TITLE
ci: CI signing via OIDC KMS, now with the Rekor transparency log

### DIFF
--- a/.github/actions/sign-image/action.yml
+++ b/.github/actions/sign-image/action.yml
@@ -105,4 +105,4 @@ runs:
         KEY_ARN: ${{ inputs.key-arn }}
       run: |
         set -euo pipefail
-        cosign verify --key "awskms:///${KEY_ARN}" "${IMAGE_REPO}@${DIGEST}" | head -1
+        cosign verify --key "awskms:///${KEY_ARN}" "${IMAGE_REPO}@${DIGEST}" >/dev/null

--- a/.github/actions/sign-image/action.yml
+++ b/.github/actions/sign-image/action.yml
@@ -1,0 +1,108 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Composite action: sign one verified image digest with the production KMS
+# key. Attached Cosign signature, LEGACY TAG-BASED storage (sha256-<hex>.sig
+# — required by the mirror tooling and published verify instructions), Rekor
+# transparency log ON.
+#
+# Single source of truth for the signing flags. cosign v3's defaults write a
+# new-format OCI referrer and NO .sig tag (hit live on ECR, 2026-08-14); the
+# three-flag combination below is the proven tag-based mode, and the
+# post-sign gate fails if the .sig tag did not appear.
+#
+# The CALLER is responsible for: reviewer-gated environment, AWS credentials
+# (OIDC role with kms:Sign on the key), and registry login. This action only
+# signs and verifies.
+
+name: sign-image
+description: Sign a verified image digest with the production KMS key (tag-based .sig, Rekor on)
+
+inputs:
+  image-repo:
+    description: 'Registry repository, e.g. docker.io/extenddb/extenddb-postgres'
+    required: true
+  digest:
+    description: 'Verified image index digest (sha256:<64 hex>); caller must have validated it'
+    required: true
+  release-tag:
+    description: 'Release the digest belongs to (vX.Y.Z); caller must have validated it'
+    required: true
+  key-arn:
+    description: 'KMS key ARN'
+    required: true
+  cosign-version:
+    description: 'Pinned cosign version'
+    default: v3.1.3
+  cosign-sha256:
+    description: 'SHA-256 of the pinned cosign-linux-amd64 binary'
+    default: 4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71
+
+outputs:
+  sig-tag:
+    description: 'The signature tag created (sha256-<hex>.sig)'
+    value: ${{ steps.confirm.outputs.sig-tag }}
+  sig-digest:
+    description: 'Digest of the signature manifest'
+    value: ${{ steps.confirm.outputs.sig-digest }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install pinned cosign (checksum-verified)
+      shell: bash
+      env:
+        COSIGN_VERSION: ${{ inputs.cosign-version }}
+        COSIGN_SHA256: ${{ inputs.cosign-sha256 }}
+      run: |
+        set -euo pipefail
+        if command -v cosign >/dev/null && [[ "$(cosign version 2>/dev/null | awk '/GitVersion/{print $2}')" == "$COSIGN_VERSION" ]]; then
+          exit 0
+        fi
+        curl -sSfL -o /tmp/cosign \
+          "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64"
+        echo "${COSIGN_SHA256}  /tmp/cosign" | sha256sum --check --strict
+        sudo install -m 0755 /tmp/cosign /usr/local/bin/cosign
+        cosign version
+
+    - name: Sign - attached, legacy tag-based storage, Rekor transparency log
+      shell: bash
+      env:
+        IMAGE_REPO: ${{ inputs.image-repo }}
+        DIGEST: ${{ inputs.digest }}
+        RELEASE: ${{ inputs.release-tag }}
+        KEY_ARN: ${{ inputs.key-arn }}
+      run: |
+        set -euo pipefail
+        cosign sign --yes \
+          --key "awskms:///${KEY_ARN}" \
+          --use-signing-config=false \
+          --new-bundle-format=false \
+          --tlog-upload=true \
+          -a org.extenddb.release="${RELEASE}" \
+          "${IMAGE_REPO}@${DIGEST}"
+
+    - name: Gate - the .sig TAG must exist (catches the storage-mode trap)
+      id: confirm
+      shell: bash
+      env:
+        IMAGE_REPO: ${{ inputs.image-repo }}
+        DIGEST: ${{ inputs.digest }}
+      run: |
+        set -euo pipefail
+        SIG_TAG="sha256-${DIGEST#sha256:}.sig"
+        SIG_DIGEST=$(skopeo inspect --format '{{.Digest}}' "docker://${IMAGE_REPO}:${SIG_TAG}")
+        MEDIA=$(skopeo inspect --raw "docker://${IMAGE_REPO}:${SIG_TAG}" | jq -r .mediaType)
+        [[ "$MEDIA" == "application/vnd.oci.image.manifest.v1+json" ]] || { echo "::error::signature is not a single OCI manifest"; exit 1; }
+        echo "sig-tag=$SIG_TAG" >> "$GITHUB_OUTPUT"
+        echo "sig-digest=$SIG_DIGEST" >> "$GITHUB_OUTPUT"
+
+    - name: Verify the signature (includes the Rekor entry)
+      shell: bash
+      env:
+        IMAGE_REPO: ${{ inputs.image-repo }}
+        DIGEST: ${{ inputs.digest }}
+        KEY_ARN: ${{ inputs.key-arn }}
+      run: |
+        set -euo pipefail
+        cosign verify --key "awskms:///${KEY_ARN}" "${IMAGE_REPO}@${DIGEST}" | head -1

--- a/.github/workflows/sign-image.yml
+++ b/.github/workflows/sign-image.yml
@@ -1,32 +1,16 @@
 # Copyright 2026 ExtendDB contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Production container signing, in CI instead of on a laptop.
+# BREAK-GLASS standalone signer. Routine releases sign inside the
+# release-image pipeline's publish stage (same composite action, same
+# approval); dispatch this only for exceptional cases: re-signing after key
+# rotation, signing a digest the pipeline did not produce, or recovery.
 #
-# Signs ONE already-verified, already-published image digest on Docker Hub
-# with the production KMS key, as an attached Cosign signature in legacy
-# tag-based storage (sha256-<digest>.sig) — the storage mode the GHCR mirror
-# job and the published verify instructions require.
-#
-# Why CI: no human ever holds the registry credential and a KMS signing
-# session together. AWS access is OIDC-federated (no stored AWS secrets):
-# the ExtendDBContainerSigningCI role's trust policy only accepts runs of
-# this repository in the `dockerhub` environment, and the key policy allows
-# kms:Sign to exactly that role and the manual break-glass operator role.
-# The `dockerhub` environment supplies the registry credential and enforces
-# the two-person rule mechanically: reviewer approval, no self-review,
-# main only.
-#
-# Transparency log: ON (Phase 1 decision). CI runners reach the public
-# Sigstore log, unlike corp machines (rekor.sigstore.dev is DNS-sinkholed
-# there — the reason v0.1.5 shipped without Rekor entries). The Rekor
-# bundle is attached to the .sig annotations, so mirrored signatures stay
-# verifiable with the transparency log from any registry.
-#
-# cosign v3 storage-mode trap, learned the hard way: with the default
-# signing-config machinery, cosign writes a new-format OCI referrer bundle
-# and NO .sig tag. All three flags below are required for tag-based mode;
-# the post-sign gate fails the run if the .sig tag did not appear.
+# Signing logic lives in .github/actions/sign-image (single source of truth
+# shared with the pipeline). This wrapper supplies what the action requires:
+# the reviewer-gated `dockerhub` environment (registry credential +
+# two-person rule), OIDC-federated AWS credentials, and strict input
+# validation.
 
 name: sign-image
 
@@ -50,9 +34,6 @@ concurrency:
 env:
   IMAGE_REPO: docker.io/extenddb/extenddb-postgres
   KEY_ARN: arn:aws:kms:us-east-1:975306274793:key/654ab7f4-4a11-45e1-a313-3a6989f3721c
-  AWS_ROLE_ARN: arn:aws:iam::975306274793:role/ExtendDBContainerSigningCI
-  COSIGN_VERSION: v3.1.3
-  COSIGN_SHA256: 4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71
 
 jobs:
   sign:
@@ -63,7 +44,7 @@ jobs:
       contents: read
       id-token: write          # OIDC token for AWS role assumption
     steps:
-      - name: Gate - validate input strictly
+      - name: Gate - validate inputs strictly
         env:
           RAW_DIGEST: ${{ inputs.expected_digest }}
           RAW_RELEASE: ${{ inputs.release_tag }}
@@ -89,14 +70,7 @@ jobs:
           grep -q '"architecture": *"amd64"' <<< "$RAW" || { echo "::error::amd64 missing from index"; exit 1; }
           grep -q '"architecture": *"arm64"' <<< "$RAW" || { echo "::error::arm64 missing from index"; exit 1; }
 
-      - name: Install pinned cosign (checksum-verified)
-        run: |
-          set -euo pipefail
-          curl -sSfL -o /tmp/cosign \
-            "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64"
-          echo "${COSIGN_SHA256}  /tmp/cosign" | sha256sum --check --strict
-          install -m 0755 /tmp/cosign /usr/local/bin/cosign
-          cosign version
+      - uses: actions/checkout@v4
 
       - name: Assume the signing role via OIDC (no stored AWS secrets)
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
@@ -113,47 +87,27 @@ jobs:
           set -euo pipefail
           docker login docker.io -u "$DOCKERHUB_USERNAME" --password-stdin <<< "$DOCKERHUB_TOKEN"
 
-      - name: Sign - attached, legacy tag-based storage, Rekor transparency log
-        run: |
-          set -euo pipefail
-          cosign sign --yes \
-            --key "awskms:///${KEY_ARN}" \
-            --use-signing-config=false \
-            --new-bundle-format=false \
-            --tlog-upload=true \
-            -a org.extenddb.release="${RELEASE}" \
-            "${IMAGE_REPO}@${DIGEST}"
-
-      - name: Gate - the .sig TAG must exist (catches the storage-mode trap)
-        run: |
-          set -euo pipefail
-          SIG_TAG="sha256-${DIGEST#sha256:}.sig"
-          SIG_DIGEST=$(skopeo inspect --format '{{.Digest}}' "docker://${IMAGE_REPO}:${SIG_TAG}")
-          MEDIA=$(skopeo inspect --raw "docker://${IMAGE_REPO}:${SIG_TAG}" | jq -r .mediaType)
-          [[ "$MEDIA" == "application/vnd.oci.image.manifest.v1+json" ]] || { echo "::error::signature is not a single OCI manifest"; exit 1; }
-          echo "SIG_TAG=$SIG_TAG" >> "$GITHUB_ENV"
-          echo "SIG_DIGEST=$SIG_DIGEST" >> "$GITHUB_ENV"
-
-      - name: Verify the signature with the public key (includes the Rekor entry)
-        run: |
-          set -euo pipefail
-          cosign verify --key "awskms:///${KEY_ARN}" \
-            "${IMAGE_REPO}@${DIGEST}" | head -1
+      - name: Sign via the shared composite action
+        id: sign
+        uses: ./.github/actions/sign-image
+        with:
+          image-repo: docker.io/extenddb/extenddb-postgres
+          digest: ${{ env.DIGEST }}
+          release-tag: ${{ env.RELEASE }}
+          key-arn: ${{ env.KEY_ARN }}
 
       - name: Log out
         if: always()
         run: docker logout docker.io || true
 
-      - name: Summarise for the release checklist
+      - name: Summarise
         run: |
           {
-            echo "### Docker Hub image signed"
+            echo "### Docker Hub image signed (break-glass path)"
             echo ""
             echo "| field | value |"
             echo "|---|---|"
             echo "| image | \`${IMAGE_REPO}@${DIGEST}\` |"
-            echo "| signature | \`${IMAGE_REPO}:${SIG_TAG}\` |"
-            echo "| signature digest | \`${SIG_DIGEST}\` |"
-            echo ""
-            echo "Next: dispatch ghcr-mirror with the signature tag and digest above."
+            echo "| signature | \`${IMAGE_REPO}:${{ steps.sign.outputs.sig-tag }}\` |"
+            echo "| signature digest | \`${{ steps.sign.outputs.sig-digest }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sign-image.yml
+++ b/.github/workflows/sign-image.yml
@@ -1,0 +1,147 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Production container signing, in CI instead of on a laptop.
+#
+# Signs ONE already-verified, already-published image digest on Docker Hub
+# with the production KMS key, as an attached Cosign signature in legacy
+# tag-based storage (sha256-<digest>.sig) — the storage mode the GHCR mirror
+# job and the published verify instructions require.
+#
+# Why CI: no human ever holds the registry credential and a KMS signing
+# session together. AWS access is OIDC-federated (no stored AWS secrets):
+# the ExtendDBContainerSigningCI role's trust policy only accepts runs of
+# this repository in the `dockerhub` environment, and the key policy allows
+# kms:Sign to exactly that role and the manual break-glass operator role.
+# The `dockerhub` environment supplies the registry credential and enforces
+# the two-person rule mechanically: reviewer approval, no self-review,
+# main only.
+#
+# Transparency log: OFF this release, for consistency with the ECR
+# signature (made from a corp machine that cannot reach Rekor). Runners CAN
+# reach Rekor, so enabling it next release is a one-flag change here.
+#
+# cosign v3 storage-mode trap, learned the hard way: with the default
+# signing-config machinery, cosign writes a new-format OCI referrer bundle
+# and NO .sig tag. All three flags below are required for tag-based mode;
+# the post-sign gate fails the run if the .sig tag did not appear.
+
+name: sign-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_digest:
+        description: 'The verified image index digest to sign, e.g. sha256:<64 hex>'
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sign-image-extenddb-postgres
+  cancel-in-progress: false
+
+env:
+  IMAGE_REPO: docker.io/extenddb/extenddb-postgres
+  KEY_ARN: arn:aws:kms:us-east-1:975306274793:key/654ab7f4-4a11-45e1-a313-3a6989f3721c
+  AWS_ROLE_ARN: arn:aws:iam::975306274793:role/ExtendDBContainerSigningCI
+  COSIGN_VERSION: v3.1.3
+  COSIGN_SHA256: 4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71
+
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: dockerhub     # required reviewers, prevent self-review, main only
+    permissions:
+      contents: read
+      id-token: write          # OIDC token for AWS role assumption
+    steps:
+      - name: Gate - validate input strictly
+        env:
+          RAW_DIGEST: ${{ inputs.expected_digest }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$RAW_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::expected_digest is not a sha256:<64 hex> digest"
+            exit 1
+          fi
+          echo "DIGEST=$RAW_DIGEST" >> "$GITHUB_ENV"
+
+      - name: Gate - the digest must exist on Docker Hub as a multi-arch index
+        run: |
+          set -euo pipefail
+          RAW=$(skopeo inspect --raw "docker://${IMAGE_REPO}@${DIGEST}")
+          grep -q '"architecture": *"amd64"' <<< "$RAW" || { echo "::error::amd64 missing from index"; exit 1; }
+          grep -q '"architecture": *"arm64"' <<< "$RAW" || { echo "::error::arm64 missing from index"; exit 1; }
+
+      - name: Install pinned cosign (checksum-verified)
+        run: |
+          set -euo pipefail
+          curl -sSfL -o /tmp/cosign \
+            "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64"
+          echo "${COSIGN_SHA256}  /tmp/cosign" | sha256sum --check --strict
+          install -m 0755 /tmp/cosign /usr/local/bin/cosign
+          cosign version
+
+      - name: Assume the signing role via OIDC (no stored AWS secrets)
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: arn:aws:iam::975306274793:role/ExtendDBContainerSigningCI
+          role-session-name: extenddb-sign-${{ github.run_id }}
+          aws-region: us-east-1
+
+      - name: Log in to Docker Hub (environment credential)
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          docker login docker.io -u "$DOCKERHUB_USERNAME" --password-stdin <<< "$DOCKERHUB_TOKEN"
+
+      - name: Sign - attached, legacy tag-based storage, no transparency log
+        run: |
+          set -euo pipefail
+          cosign sign --yes \
+            --key "awskms:///${KEY_ARN}" \
+            --use-signing-config=false \
+            --new-bundle-format=false \
+            --tlog-upload=false \
+            -a org.extenddb.release="${{ github.ref_name }}" \
+            -a org.extenddb.signed-digest="${DIGEST}" \
+            "${IMAGE_REPO}@${DIGEST}"
+
+      - name: Gate - the .sig TAG must exist (catches the storage-mode trap)
+        run: |
+          set -euo pipefail
+          SIG_TAG="sha256-${DIGEST#sha256:}.sig"
+          SIG_DIGEST=$(skopeo inspect --format '{{.Digest}}' "docker://${IMAGE_REPO}:${SIG_TAG}")
+          MEDIA=$(skopeo inspect --raw "docker://${IMAGE_REPO}:${SIG_TAG}" | jq -r .mediaType)
+          [[ "$MEDIA" == "application/vnd.oci.image.manifest.v1+json" ]] || { echo "::error::signature is not a single OCI manifest"; exit 1; }
+          echo "SIG_TAG=$SIG_TAG" >> "$GITHUB_ENV"
+          echo "SIG_DIGEST=$SIG_DIGEST" >> "$GITHUB_ENV"
+
+      - name: Verify the signature with the public key
+        run: |
+          set -euo pipefail
+          cosign verify --key "awskms:///${KEY_ARN}" --insecure-ignore-tlog=true \
+            "${IMAGE_REPO}@${DIGEST}" | head -1
+
+      - name: Log out
+        if: always()
+        run: docker logout docker.io || true
+
+      - name: Summarise for the release checklist
+        run: |
+          {
+            echo "### Docker Hub image signed"
+            echo ""
+            echo "| field | value |"
+            echo "|---|---|"
+            echo "| image | \`${IMAGE_REPO}@${DIGEST}\` |"
+            echo "| signature | \`${IMAGE_REPO}:${SIG_TAG}\` |"
+            echo "| signature digest | \`${SIG_DIGEST}\` |"
+            echo ""
+            echo "Next: dispatch ghcr-mirror with the signature tag and digest above."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sign-image.yml
+++ b/.github/workflows/sign-image.yml
@@ -17,9 +17,11 @@
 # the two-person rule mechanically: reviewer approval, no self-review,
 # main only.
 #
-# Transparency log: OFF this release, for consistency with the ECR
-# signature (made from a corp machine that cannot reach Rekor). Runners CAN
-# reach Rekor, so enabling it next release is a one-flag change here.
+# Transparency log: ON (Phase 1 decision). CI runners reach the public
+# Sigstore log, unlike corp machines (rekor.sigstore.dev is DNS-sinkholed
+# there — the reason v0.1.5 shipped without Rekor entries). The Rekor
+# bundle is attached to the .sig annotations, so mirrored signatures stay
+# verifiable with the transparency log from any registry.
 #
 # cosign v3 storage-mode trap, learned the hard way: with the default
 # signing-config machinery, cosign writes a new-format OCI referrer bundle
@@ -111,14 +113,14 @@ jobs:
           set -euo pipefail
           docker login docker.io -u "$DOCKERHUB_USERNAME" --password-stdin <<< "$DOCKERHUB_TOKEN"
 
-      - name: Sign - attached, legacy tag-based storage, no transparency log
+      - name: Sign - attached, legacy tag-based storage, Rekor transparency log
         run: |
           set -euo pipefail
           cosign sign --yes \
             --key "awskms:///${KEY_ARN}" \
             --use-signing-config=false \
             --new-bundle-format=false \
-            --tlog-upload=false \
+            --tlog-upload=true \
             -a org.extenddb.release="${RELEASE}" \
             "${IMAGE_REPO}@${DIGEST}"
 
@@ -132,10 +134,10 @@ jobs:
           echo "SIG_TAG=$SIG_TAG" >> "$GITHUB_ENV"
           echo "SIG_DIGEST=$SIG_DIGEST" >> "$GITHUB_ENV"
 
-      - name: Verify the signature with the public key
+      - name: Verify the signature with the public key (includes the Rekor entry)
         run: |
           set -euo pipefail
-          cosign verify --key "awskms:///${KEY_ARN}" --insecure-ignore-tlog=true \
+          cosign verify --key "awskms:///${KEY_ARN}" \
             "${IMAGE_REPO}@${DIGEST}" | head -1
 
       - name: Log out

--- a/.github/workflows/sign-image.yml
+++ b/.github/workflows/sign-image.yml
@@ -34,6 +34,9 @@ on:
       expected_digest:
         description: 'The verified image index digest to sign, e.g. sha256:<64 hex>'
         required: true
+      release_tag:
+        description: 'The release this digest belongs to, e.g. v0.1.5 (annotation only)'
+        required: true
 
 permissions:
   contents: read
@@ -61,13 +64,21 @@ jobs:
       - name: Gate - validate input strictly
         env:
           RAW_DIGEST: ${{ inputs.expected_digest }}
+          RAW_RELEASE: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
           if [[ ! "$RAW_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             echo "::error::expected_digest is not a sha256:<64 hex> digest"
             exit 1
           fi
-          echo "DIGEST=$RAW_DIGEST" >> "$GITHUB_ENV"
+          if [[ ! "$RAW_RELEASE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::release_tag is not a vMAJOR.MINOR.PATCH release tag"
+            exit 1
+          fi
+          {
+            echo "DIGEST=$RAW_DIGEST"
+            echo "RELEASE=$RAW_RELEASE"
+          } >> "$GITHUB_ENV"
 
       - name: Gate - the digest must exist on Docker Hub as a multi-arch index
         run: |
@@ -108,8 +119,7 @@ jobs:
             --use-signing-config=false \
             --new-bundle-format=false \
             --tlog-upload=false \
-            -a org.extenddb.release="${{ github.ref_name }}" \
-            -a org.extenddb.signed-digest="${DIGEST}" \
+            -a org.extenddb.release="${RELEASE}" \
             "${IMAGE_REPO}@${DIGEST}"
 
       - name: Gate - the .sig TAG must exist (catches the storage-mode trap)

--- a/.github/workflows/sign-image.yml
+++ b/.github/workflows/sign-image.yml
@@ -70,7 +70,7 @@ jobs:
           grep -q '"architecture": *"amd64"' <<< "$RAW" || { echo "::error::amd64 missing from index"; exit 1; }
           grep -q '"architecture": *"arm64"' <<< "$RAW" || { echo "::error::arm64 missing from index"; exit 1; }
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.2.2
 
       - name: Assume the signing role via OIDC (no stored AWS secrets)
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3


### PR DESCRIPTION
## What

Revives the CI signing workflow from #268 (closed unmerged during
post-launch cleanup, no review findings) rebased onto current `main`, with
one substantive change: **the Rekor transparency log is ON**
(`--tlog-upload=true`), and the verify step checks the log entry instead of
ignoring it. Everything else is as reviewed before: `dockerhub` environment
(two-person rule enforced mechanically, registry credential from
environment secrets), OIDC-federated AWS access to
`ExtendDBContainerSigningCI` (live and verified since 2026-08-14),
checksum-pinned cosign, SHA-pinned actions, strict input validation
including the `release_tag` annotation input, and the post-sign gate that
fails the run unless the legacy `.sig` TAG exists.

## Why

Phase 1 of the release-pipeline consolidation (runbook §7): signing moves
off operator laptops into a reviewer-gated workflow. Rekor could not be
enabled for v0.1.5 because manual signing ran on corp machines, where
`rekor.sigstore.dev` is DNS-sinkholed; CI runners reach it fine. The Rekor
bundle rides in the `.sig` annotations, so the signature mirrored to GHCR
(and copied to ECR) verifies with the transparency log from any registry —
and from 0.1.6 on, user verify instructions drop the
`--insecure-ignore-tlog` flag.

v0.1.5's signatures remain valid and verifiable exactly as released; this
is additive.

## Testing done

- `yaml.safe_load` passes; rebase onto current `main` is conflict-free.
- The legacy tag-based flag combination was proven live against ECR on
  2026-08-14 (`.sig` tag, single OCI manifest, simplesigning layer). The
  only changed flag is `--tlog-upload=false` → `true`, which is the
  documented v2-era standard pairing with tag-based storage.
- Not executable pre-merge (main-only environment, as with #256/#264/#266).
  Proposed live verification: after merge, dispatch against the **v0.1.5**
  digest (`sha256:4890886b…`) — signing an already-signed digest just adds
  a second signature to the existing `.sig` tag, so it exercises OIDC, KMS,
  Rekor, and the tag gate end-to-end with zero risk to the released
  artifact, before 0.1.6 depends on this path.

## Checklist

- [ ] All tests pass (`cargo test --workspace`) — not applicable, workflow-only change
- [ ] Code is formatted (`cargo fmt --check`) — not applicable
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`) — not applicable
- [x] I have added or updated tests for new functionality — post-sign `.sig` tag gate is the storage-mode regression test; live rehearsal plan above
- [x] I have updated documentation if behavior changed — header rewritten for the Rekor decision; runbook §7 tracks this as Phase 1
- [x] Breaking changes are noted below (if any)

ADR / RFC: n/a — CI tooling only.

## Breaking changes

None. The manual signing path remains as break-glass.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
