### PR TITLE
ci(ghcr-mirror): guarded forward-only latest moves

### DIFF
--- a/.github/workflows/ghcr-mirror.yml
+++ b/.github/workflows/ghcr-mirror.yml
@@ -24,10 +24,12 @@
 #   sha256-<64 hex>.sig       the Cosign signature artifact for an image digest
 #   X.Y.Z or latest           a release tag already promoted on Docker Hub
 #
-# Known limitation, deliberate: re-pointing `latest` at a NEW digest hits the
-# no-overwrite gate and fails closed. Fine for the first release (no `latest`
-# exists); the second release needs a guarded move-latest carve-out mirroring
-# promote-image's never-move-backwards rule, or the Track 2 pipeline.
+# `latest` is the one tag allowed to move, under a guard derived from
+# registry state: it may only move to the digest that the HIGHEST existing
+# X.Y.Z tag on GHCR already serves. Promote the version tag first, then
+# dispatch `latest`. Moving latest backwards, or to a digest no version tag
+# serves, fails closed. (First hit live on the 0.1.6 release, as predicted
+# by the previous revision of this header.)
 # A signature may only be mirrored after the image it signs is already in
 # GHCR, so a dangling signature cannot exist through this path.
 #
@@ -147,6 +149,27 @@ jobs:
             if [[ "$DST_DIGEST" == "$DIGEST" ]]; then
               echo "already-mirrored=true" >> "$GITHUB_ENV"
               echo "::notice::${DST_REPO}:${TAG} already exists with the exact verified digest; nothing to do"
+            elif [[ "$TAG" == "latest" ]]; then
+              # latest may move, but only forward: the target digest must be
+              # the one served by the HIGHEST version tag already on GHCR.
+              # (The version tag is mirrored before latest, so ordering is
+              # enforced structurally; promote-image applied the same rule
+              # on Docker Hub before anything reached this job.)
+              HIGHEST=$(skopeo list-tags "docker://${DST_REPO}" \
+                | jq -r '.Tags[]' \
+                | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+                | sort -V \
+                | tail -1 || true)
+              if [[ -z "$HIGHEST" ]]; then
+                echo "::error::no version tags exist on ${DST_REPO}; latest has nothing to follow"
+                exit 1
+              fi
+              HIGHEST_DIGEST=$(skopeo inspect --format '{{.Digest}}' "docker://${DST_REPO}:${HIGHEST}")
+              if [[ "$HIGHEST_DIGEST" != "$DIGEST" ]]; then
+                echo "::error::latest may only move to the digest of the highest version tag (${HIGHEST} -> ${HIGHEST_DIGEST}); mirror the version tag first"
+                exit 1
+              fi
+              echo "::notice::moving latest forward to the digest of ${HIGHEST}"
             else
               echo "::error::${DST_REPO}:${TAG} already exists with different digest ${DST_DIGEST}; refusing to overwrite"
               exit 1


### PR DESCRIPTION
## What

The documented `latest` carve-out for `ghcr-mirror`: when the dispatched tag
is exactly `latest` and it already exists with a different digest, the
overwrite gate now allows the move **iff** the target digest is the one
served by the highest `X.Y.Z` tag already on GHCR (`sort -V`, same
comparison promote-image uses). Anything else still fails closed: latest
moving backwards, latest pointing at a digest no version tag serves, or a
repository with no version tags. No new inputs — the guard is derived
entirely from registry state. All other tags keep strict no-overwrite.

## Why

Hit live on the 0.1.6 release, exactly as the header's known-limitation
note predicted: GHCR's `latest` points at the 0.1.5 digest, so the
no-overwrite gate refused the move (run 32180092481). `0.1.6` itself
mirrored fine; only `latest` is stuck one release behind.

Design choice: deriving the guard from registry state (rather than a
`move_latest` boolean) means the operator cannot assert anything the
registry does not confirm — the version tag must land first, and `latest`
can only follow it. Ordering is enforced structurally.

## Testing done

- `yaml.safe_load` passes.
- Guard logic traced against live GHCR state: current tags are `0.1.5`,
  `0.1.6`, `latest`→0.1.5-digest. `HIGHEST` resolves to `0.1.6`, whose
  digest equals the dispatch input → move allowed. Negative cases: version
  list empty → fail; dispatching latest with the 0.1.5 digest →
  `HIGHEST_DIGEST` ≠ input → fail (backwards move blocked).
- `sort -V` ordering: `0.1.10` > `0.1.9` handled correctly (same tooling as
  promote-image's guard).
- Not executable pre-merge (main-only environment). The immediate re-dispatch
  of `latest` for 0.1.6 after merge is the live verification, and fails
  closed if wrong.

## Checklist

- [ ] All tests pass (`cargo test --workspace`) — not applicable, workflow-only change
- [ ] Code is formatted (`cargo fmt --check`) — not applicable
- [ ] Clippy is clean (`cargo clippy -- -W clippy::pedantic`) — not applicable
- [x] I have added or updated tests for new functionality — guard traced above against live registry state; post-merge dispatch is the live test
- [x] I have updated documentation if behavior changed — header limitation note replaced with the carve-out semantics
- [x] Breaking changes are noted below (if any)

ADR / RFC: n/a — CI tooling only.

## Breaking changes

None. Existing dispatch shapes behave identically except the guarded latest move.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
