### PR TITLE
build: consolidate on a single crypto stack (aws-lc-rs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -2932,8 +2933,8 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
+ "aws-lc-rs",
  "pem",
- "ring",
  "rustls-pki-types",
  "time",
  "x509-parser",
@@ -2991,7 +2992,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3112,7 +3113,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4145,6 +4146,12 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -4688,12 +4695,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
  "asn1-rs",
+ "aws-lc-rs",
  "data-encoding",
  "der-parser",
  "lazy_static",
  "nom",
  "oid-registry",
- "ring",
  "rusticata-macros",
  "thiserror",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ urlencoding = { version = "2.1" }
 moka = { version = "0.12", features = ["future"] }
 
 # Database
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "json", "time", "uuid", "bigdecimal", "derive"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "tls-rustls-aws-lc-rs", "postgres", "json", "time", "uuid", "bigdecimal", "derive"] }
 mongodb = "3"
 bson = "2.13"
 dashmap = "6"
@@ -83,7 +83,7 @@ time = { version = "0.3", features = ["serde", "formatting", "parsing"] }
 # TLS
 axum-server = { version = "0.8", features = ["tls-rustls"] }
 rustls = { version = "0.23", features = ["aws_lc_rs"] }
-rcgen = "0.14"
+rcgen = { version = "0.14", default-features = false, features = ["crypto", "pem", "aws_lc_rs"] }
 
 # Process management
 daemonize = "0.5"


### PR DESCRIPTION
## What

Consolidates the workspace on a single crypto stack (aws-lc-rs) by removing two accidental `ring` entry points. Two-line `Cargo.toml` change plus lockfile.

## Why

`rustls` is already configured for `aws_lc_rs`, but `ring` was linked anyway, twice:

- `sqlx`'s `runtime-tokio-rustls` is an alias for `["runtime-tokio", "tls-rustls-ring"]` (sqlx 0.8.6 source), so Postgres TLS used ring while the server's own TLS used aws-lc.
- `rcgen`'s default features include `ring` (rcgen 0.14.8 source), so cert generation pulled it too.

Neither was a deliberate choice. Shipping two complete crypto stacks means two sets of crypto CVEs to track and ~1.6 MiB of dead-weight code in every binary.

## Change

- `sqlx`: `runtime-tokio-rustls` -> `["runtime-tokio", "tls-rustls-aws-lc-rs"]`
- `rcgen`: defaults -> explicit `["crypto", "pem", "aws_lc_rs"]`

`cargo tree -i ring` now prints nothing on both the `postgres` (default) and `sqlite,dev-mode` feature graphs.

## Verification

- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean on both feature sets
- `cargo test --lib --workspace`: 788 passed, 0 failed, 0 filtered
- `rcgen` cert generation exercised fresh (isolated HOME): new cert generated and served
- Live TLS handshake against the running server on the aws-lc-only stack (TLSv1.2, ECDHE-ECDSA-AES256-GCM-SHA384)
- SigV4-signed CreateTable / PutItem / GetItem end to end over that TLS session, with a bad-signature negative control (rejected)

## Notes for reviewers

- The changed crypto paths are Postgres connection TLS (sqlx) and self-signed cert generation + serving (rcgen/rustls); the verification above covers all three live.
- #221 touches the same `sqlx` line (adds `migrate`); whichever lands second has a one-line rebase.
