### PR TITLE
chore: regenerate licence notices after the ring drop (unblocks main)

### DIFF
--- a/SOFTWARE-LICENSE-NOTICES.html
+++ b/SOFTWARE-LICENSE-NOTICES.html
@@ -49,10 +49,10 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (212)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (211)</li>
             <li><a href="#MIT">MIT License</a> (53)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (19)</li>
-            <li><a href="#ISC">ISC License</a> (6)</li>
+            <li><a href="#ISC">ISC License</a> (5)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (4)</li>
             <li><a href="#CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</a> (2)</li>
             <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a> (1)</li>
@@ -4131,7 +4131,6 @@ limitations under the License.
                     <li><a href=" https://github.com/pest-parser/pest ">pest_meta 2.8.6</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.14</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.10</a></li>
-                    <li><a href=" https://github.com/briansmith/ring ">ring 0.17.14</a></li>
                     <li><a href=" https://github.com/ron-rs/ron ">ron 0.8.1</a></li>
                     <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.40</a></li>
                     <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
@@ -7138,27 +7137,6 @@ insights.
 // WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="ISC">ISC License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/briansmith/ring ">ring 0.17.14</a></li>
-                </ul>
-                <pre class="license-text">Copyright 2015-2025 Brian Smith.
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
-SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
-OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
-CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 </pre>
             </li>
             <li class="license">


### PR DESCRIPTION
## What this does

Regenerates `SOFTWARE-LICENSE-NOTICES.html`. **main is currently red and unreleasable**; this is the fix.

The file embeds the resolved dependency set, so it went stale when #285 consolidated on a single crypto stack and dropped `ring` from the graph. The shipped file still listed `ring 0.17.14` and carried the entire ISC licence section that existed only for it.

The regeneration removes exactly that and nothing else:

- Apache-2.0 count `212` to `211`
- ISC count `6` to `5`
- the `ring 0.17.14` entry and its ISC licence block deleted

Two insertions, twenty-four deletions. No other dependency is affected, and no Rust source is touched.

## Why main went red rather than the PR that caused it

#278 (which added the PR-time freshness check) and #285 (which changed the dependency graph) merged in the **same merge-queue batch**, twenty seconds apart:

```
ffb7ea4  12:50:14  ci: check license notices freshness at PR time   (#278)
0a3aaa0  12:50:34  build: consolidate on a single crypto stack ...   (#285)
1ae553d  12:50:54  fix: declare --sqlite-path on init ...            (#269)
```

Neither PR was red on its own. #285 predated the check existing, and #278's own PR was green because `ring` was still legitimately listed at that point. Only the combination is red.

Worth flagging separately: the queue *did* run `notices-current` on the batch head `1ae553d`, it *did* fail, and the batch merged anyway. So `notices-current` is not currently a required status check. Making it required would have caught this at the batch, and is probably worth a follow-up.

## Why this is release-blocking, not just a red mark

`release-image`'s gate runs the same freshness check, so main cannot be released while this file is stale. That is the failure mode #278's own header describes from the 0.1.6 bump (#271, fixed by #272).

There is also a queue-hygiene consequence: `merge_group:` in `licenses.yml` carries **no path filter**, so `notices-current` runs on every queued batch regardless of what the PR touches. Until this lands, every enqueue goes red, including PRs whose own checks are green because the path filter does not trigger on their `pull_request` event.

## Testing done

Reproduced and fixed with the pinned `cargo-about 0.9.0`, the same script and pin that both the CI job and the release gate invoke, so PR-time and release-time cannot disagree:

```
# on main @ 1ae553d
./devtools/generate-software-license-notices --check
error: SOFTWARE-LICENSE-NOTICES.html is stale
# exit 1

# with this change
./devtools/generate-software-license-notices --check
SOFTWARE-LICENSE-NOTICES.html is current
# exit 0
```

The diff was reviewed line by line rather than accepted as generated output: the only removals are the `ring` entry, the ISC block, and the two counts.

## Unrelated failure seen on main, for the record

`run-rust-integration` also failed on the merge_group run for `1ae553d`, but the **push** run on the same commit passed it. `integration` is not a second failure, it is that workflow's aggregator job. That looks like a flake and is not addressed here.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass — no Rust sources touched; the change is generated notices output
- [x] Code is formatted — n/a, no code
- [x] Clippy is clean — n/a, no code
- [x] I have added or updated tests for new functionality — n/a; the check that catches this already exists (#278)
- [x] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any)

ADR / RFC: n/a — no change to wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface.

## Breaking changes

None.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
