### PR TITLE
fix(sqlite): index GSI base-key columns for propagation deletes

### DIFF
--- a/crates/storage-sqlite/src/data/ddl.rs
+++ b/crates/storage-sqlite/src/data/ddl.rs
@@ -222,8 +222,14 @@ impl SqliteEngine {
     }
 
     /// Create a GSI/LSI data table. GSI keys are not unique, so the primary key
-    /// is `(pk, sk*, base_pk, base_sk*)` to keep one row per base item, and an
-    /// ordering index covers `(pk, sk*, base_pk, base_sk*)`.
+    /// is `(pk, base_pk, base_sk*)`: the base-table key is what makes a row
+    /// unique, keeping one row per base item per index partition.
+    ///
+    /// Two secondary indexes are created:
+    /// - `idx_order_*` on `(pk, sk*, base_pk, base_sk*)`, for sort-key ordering
+    ///   within an index partition. Only when the index declares a sort key.
+    /// - `idx_base_key_*` on `(base_pk, base_sk*)`, for the reverse lookup that
+    ///   index propagation uses to delete an item's old index row. Always.
     pub(crate) async fn create_index_data_table(
         tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
         index_id: &str,
@@ -279,6 +285,31 @@ impl SqliteEngine {
                 .await
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
         }
+
+        // Index on the base-table key columns, for `delete_index_row_multi`.
+        //
+        // GSI/LSI propagation deletes the old index row by base-table key:
+        // `DELETE FROM <idx> WHERE base_pk = ? AND base_sk* = ?`, with no `pk`
+        // predicate. Both the PRIMARY KEY and the ordering index above lead
+        // with `pk`, so neither can serve that filter and SQLite plans a full
+        // `SCAN` of the index table on every propagating write. Unconditional
+        // rather than gated on `idx_sks`, because the reverse lookup happens
+        // whether or not the index declares a sort key.
+        {
+            let mut base_key_cols = vec!["base_pk".to_owned()];
+            for (i, &(_, sk_type)) in base_sks.iter().enumerate() {
+                base_key_cols.push(format!("base_{}", sk_column_n(i, sk_type)));
+            }
+            let base_key_idx = format!(
+                "CREATE INDEX \"idx_base_key_{index_id}\" ON {idx_table} ({})",
+                base_key_cols.join(", ")
+            );
+            sqlx::query(&base_key_idx)
+                .execute(&mut **tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+        }
+
         Ok(())
     }
 
@@ -533,5 +564,187 @@ impl SqliteEngine {
             key_schema,
             projection,
         })
+    }
+}
+
+#[cfg(test)]
+mod index_data_table_tests {
+    use crate::store::SqliteEngine;
+    use extenddb_core::types::{
+        AttributeDefinition, KeySchemaElement, KeyType, ScalarAttributeType,
+    };
+    use sqlx::sqlite::SqlitePool;
+
+    fn hash(name: &str) -> KeySchemaElement {
+        KeySchemaElement {
+            attribute_name: name.to_owned(),
+            key_type: KeyType::Hash,
+        }
+    }
+
+    fn range(name: &str) -> KeySchemaElement {
+        KeySchemaElement {
+            attribute_name: name.to_owned(),
+            key_type: KeyType::Range,
+        }
+    }
+
+    fn attr(name: &str, t: ScalarAttributeType) -> AttributeDefinition {
+        AttributeDefinition {
+            attribute_name: name.to_owned(),
+            attribute_type: t,
+        }
+    }
+
+    /// Create an index data table through the real DDL path.
+    async fn make_index_table(
+        index_key_schema: &[KeySchemaElement],
+        attr_defs: &[AttributeDefinition],
+        base_key_schema: &[KeySchemaElement],
+        base_attr_defs: &[AttributeDefinition],
+    ) -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let mut tx = pool.begin().await.unwrap();
+        SqliteEngine::create_index_data_table(
+            &mut tx,
+            "probe",
+            index_key_schema,
+            attr_defs,
+            base_key_schema,
+            base_attr_defs,
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+        pool
+    }
+
+    /// The plan SQLite chooses for the reverse-lookup DELETE that index
+    /// propagation issues. `SEARCH` means an index is used, `SCAN` means a full
+    /// table scan.
+    async fn delete_plan(pool: &SqlitePool, where_clause: &str) -> String {
+        let rows: Vec<(i64, i64, i64, String)> = sqlx::query_as(&format!(
+            "EXPLAIN QUERY PLAN DELETE FROM \"_ddb_probe\" WHERE {where_clause}"
+        ))
+        .fetch_all(pool)
+        .await
+        .unwrap();
+        rows.into_iter()
+            .map(|r| r.3)
+            .collect::<Vec<_>>()
+            .join(" | ")
+    }
+
+    #[tokio::test]
+    async fn reverse_lookup_delete_uses_an_index_composite_base_key() {
+        let pool = make_index_table(
+            &[hash("gsi_pk"), range("gsi_sk")],
+            &[
+                attr("gsi_pk", ScalarAttributeType::S),
+                attr("gsi_sk", ScalarAttributeType::S),
+            ],
+            &[hash("id"), range("ts")],
+            &[
+                attr("id", ScalarAttributeType::S),
+                attr("ts", ScalarAttributeType::S),
+            ],
+        )
+        .await;
+
+        let plan = delete_plan(&pool, "base_pk = 'x' AND base_sk_s = 'y'").await;
+
+        assert!(
+            plan.contains("SEARCH"),
+            "reverse-lookup DELETE must use an index, got plan: {plan}"
+        );
+        assert!(
+            plan.contains("idx_base_key_probe"),
+            "must use the base-key index specifically, got plan: {plan}"
+        );
+        assert!(
+            !plan.contains("SCAN"),
+            "must not fall back to a table scan, got plan: {plan}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reverse_lookup_delete_uses_an_index_hash_only_base_key() {
+        let pool = make_index_table(
+            &[hash("gsi_pk"), range("gsi_sk")],
+            &[
+                attr("gsi_pk", ScalarAttributeType::S),
+                attr("gsi_sk", ScalarAttributeType::S),
+            ],
+            &[hash("id")],
+            &[attr("id", ScalarAttributeType::S)],
+        )
+        .await;
+
+        let plan = delete_plan(&pool, "base_pk = 'x'").await;
+
+        assert!(
+            plan.contains("SEARCH") && plan.contains("idx_base_key_probe"),
+            "hash-only base key must still index the reverse lookup, got plan: {plan}"
+        );
+        assert!(!plan.contains("SCAN"), "got plan: {plan}");
+    }
+
+    /// The ordering index is only created when the index declares a sort key, so
+    /// a sort-key-less index is the case where the base-key index is the *only*
+    /// secondary index. It must still be created, which is why that block is
+    /// unconditional.
+    #[tokio::test]
+    async fn reverse_lookup_delete_uses_an_index_when_index_has_no_sort_key() {
+        let pool = make_index_table(
+            &[hash("gsi_pk")],
+            &[attr("gsi_pk", ScalarAttributeType::S)],
+            &[hash("id"), range("ts")],
+            &[
+                attr("id", ScalarAttributeType::S),
+                attr("ts", ScalarAttributeType::S),
+            ],
+        )
+        .await;
+
+        let plan = delete_plan(&pool, "base_pk = 'x' AND base_sk_s = 'y'").await;
+
+        assert!(
+            plan.contains("SEARCH") && plan.contains("idx_base_key_probe"),
+            "an index with no sort key still needs the base-key index, got plan: {plan}"
+        );
+        assert!(!plan.contains("SCAN"), "got plan: {plan}");
+    }
+
+    /// Guards the column order. An index on `(base_sk_s, base_pk)` would also
+    /// satisfy the assertions above, but would not serve a `base_pk`-only
+    /// lookup, so pin that the index leads with `base_pk`.
+    #[tokio::test]
+    async fn base_key_index_leads_with_base_pk() {
+        let pool = make_index_table(
+            &[hash("gsi_pk"), range("gsi_sk")],
+            &[
+                attr("gsi_pk", ScalarAttributeType::S),
+                attr("gsi_sk", ScalarAttributeType::S),
+            ],
+            &[hash("id"), range("ts")],
+            &[
+                attr("id", ScalarAttributeType::S),
+                attr("ts", ScalarAttributeType::S),
+            ],
+        )
+        .await;
+
+        let cols: Vec<(i64, i64, Option<String>)> =
+            sqlx::query_as("PRAGMA index_info(\"idx_base_key_probe\")")
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        let names: Vec<String> = cols.into_iter().filter_map(|c| c.2).collect();
+
+        assert_eq!(
+            names,
+            vec!["base_pk".to_owned(), "base_sk_s".to_owned()],
+            "base-key index must lead with base_pk"
+        );
     }
 }


### PR DESCRIPTION
## What this does

Adds an index on `(base_pk, base_sk*)` to every GSI/LSI data table on the **SQLite** backend, at creation time.

This is the SQLite half of the defect diagnosed on PostgreSQL in #115 and #124. PR #127 fixes the PostgreSQL side; this is its counterpart. Neither closes the other's backend.

## Why

Index propagation deletes an item's old index row by base-table key:

```sql
DELETE FROM <idx_table> WHERE base_pk = ? AND base_sk_s = ?
```

There is no `pk` predicate, and both indexes on the table lead with `pk`:

| index | columns |
|---|---|
| `PRIMARY KEY` (autoindex) | `(pk, base_pk, base_sk*)` |
| `idx_order_*` | `(pk, sk*, base_pk, base_sk*)` |

So neither can serve the filter and SQLite plans a full `SCAN` of the index table on every propagating write. The cost grows with the size of the index rather than staying flat, which is the same asymptotic problem parsnips measured on PostgreSQL.

Measured on a faithful 66k-row replica of the generated schema, matching the row count in #115:

```
EXPLAIN QUERY PLAN DELETE FROM idx WHERE base_pk = ? AND base_sk_s = ?
  before -> SCAN idx                              6.621 ms mean
  after  -> SEARCH idx USING INDEX idx_base_key_* 0.003 ms mean
```

Same shape as the 12.76 ms to 0.021 ms that #115 measured on PostgreSQL.

## Two decisions worth reviewing

**Creation-time only, no migration.** There are no deployed SQLite databases carrying index tables, so nothing needs backfilling. This also avoids the implicit-rebuild-on-server-startup pattern that was objected to on the PostgreSQL side of this fix, where the reviewer asked for an operator-controlled migration instead. If a SQLite deployment ever does need retrofitting, the catalog-version path already exists.

**The index is unconditional**, not gated on the index declaring a sort key, unlike `idx_order_*` directly above it. The reverse lookup happens either way, and a sort-key-less index gets no ordering index at all, so for that shape this is the only secondary index on the table. There is a test for exactly that case.

## Testing done

Four new tests assert **the query plan SQLite actually chooses**, rather than merely that an index exists by name:

- composite base key
- hash-only base key
- an index with no sort key (the case where this is the only secondary index)
- column order: an index on `(base_sk_s, base_pk)` would satisfy the first three but would not serve a `base_pk`-only lookup, so the order is pinned via `PRAGMA index_info`

**Negative control.** Removing the `CREATE INDEX` execution fails all four with `got plan: SCAN _ddb_probe`, so they discriminate rather than pass vacuously. Re-proven after rebasing onto current `main`, since the vector merge changed this file by +165 lines.

**Live wiring check**, because the unit tests exercise the DDL function but not that it reaches it. Against a running dev-mode server on an isolated catalog, `CreateTable` with a GSI produced this in the real database file:

```
idx_base_key_<id> | CREATE INDEX "idx_base_key_<id>"
                    ON "_ddb_<id>" (base_pk, base_sk_s)

plan read back from that file:
  SEARCH _ddb_<id> USING INDEX idx_base_key_<id> (base_pk=? AND base_sk_s=?)
```

Gates:

```
cargo fmt --all -- --check                                                   # exit 0
cargo clippy --all-targets -- -D warnings                                    # exit 0
cargo clippy --all-targets --no-default-features --features sqlite -- -D warnings  # exit 0
cargo test --workspace     # 1019 passed; 0 failed; 0 filtered out
```

## Also in this diff

The doc comment on `create_index_data_table` stated the primary key as `(pk, sk*, base_pk, base_sk*)`. It does not include the index sort keys: `pk_cols` is `pk`, `base_pk`, then the base sort keys. The base-table key is what makes a row unique. Corrected, and both secondary indexes are now documented there.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`-D warnings` on both feature sets)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any)

ADR / RFC: n/a — no change to the wire protocol, `Storage` trait, auth model, or public CLI surface. The on-disk change is additive and applies only to newly created index tables.

## Breaking changes

None. New index tables gain an index; existing tables and all query results are unchanged.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
