### PR TITLE
docs(docker): publish a Docker Hub Overview, and a step to keep it current

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,0 +1,122 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Publish the Docker Hub repository Overview from a file in this repository.
+#
+# Neither `docker push` nor the `skopeo copy` that promote-image uses touches
+# repository metadata: the Overview lives on the Docker Hub repository object,
+# not on any image. GHCR derives its description from the OCI labels the
+# Dockerfile already sets, so the same image reads as documented there and blank
+# on Docker Hub. That is why this exists as its own step rather than falling out
+# of a push.
+#
+# Sourced from `docker/dockerhub-overview.md` so the published Overview is
+# reviewed like any other content and cannot drift from the repository.
+#
+# Dispatch-only and gated on the `dockerhub` environment, because it uses the
+# same credential that can push images. Deliberately NOT wired into
+# promote-image: the Overview is version-neutral, so a wording fix should not
+# require a release, and a release should not silently rewrite it.
+
+name: Docker Hub description
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dockerhub-description-extenddb-postgres
+  cancel-in-progress: false
+
+env:
+  HUB_NAMESPACE: extenddb
+  HUB_REPO: extenddb-postgres
+  OVERVIEW_FILE: docker/dockerhub-overview.md
+  # Docker Hub caps the short description at 100 characters.
+  SHORT_DESCRIPTION: DynamoDB-compatible API adapter backed by your own PostgreSQL 14+ database
+
+jobs:
+  publish-description:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: dockerhub
+    steps:
+      - name: Check out main
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: The Overview file must exist and be non-trivial
+        run: |
+          set -euo pipefail
+          if [[ ! -s "$OVERVIEW_FILE" ]]; then
+            echo "::error::$OVERVIEW_FILE is missing or empty"
+            exit 1
+          fi
+          BYTES=$(wc -c < "$OVERVIEW_FILE")
+          # Docker Hub caps full_description at 25000 characters.
+          if (( BYTES > 25000 )); then
+            echo "::error::$OVERVIEW_FILE is ${BYTES} bytes; Docker Hub caps the Overview at 25000"
+            exit 1
+          fi
+          if (( ${#SHORT_DESCRIPTION} > 100 )); then
+            echo "::error::SHORT_DESCRIPTION is ${#SHORT_DESCRIPTION} characters; Docker Hub caps it at 100"
+            exit 1
+          fi
+          echo "::notice::Overview is ${BYTES} bytes"
+
+      - name: Publish the Overview
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Hub API v2 wants a session token, then a PATCH on the repository.
+          TOKEN=$(jq -n --arg u "$DOCKERHUB_USERNAME" --arg p "$DOCKERHUB_TOKEN" \
+              '{username:$u, password:$p}' \
+            | curl -sS --fail-with-body -X POST \
+                -H 'Content-Type: application/json' \
+                --data @- \
+                https://hub.docker.com/v2/users/login/ \
+            | jq -r '.token')
+          if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
+            echo "::error::could not obtain a Docker Hub session token"
+            exit 1
+          fi
+
+          jq -n \
+              --rawfile full "$OVERVIEW_FILE" \
+              --arg short "$SHORT_DESCRIPTION" \
+              '{full_description:$full, description:$short}' \
+            | curl -sS --fail-with-body -X PATCH \
+                -H "Authorization: JWT ${TOKEN}" \
+                -H 'Content-Type: application/json' \
+                --data @- \
+                "https://hub.docker.com/v2/repositories/${HUB_NAMESPACE}/${HUB_REPO}/" \
+            > /dev/null
+
+      - name: Verify it took effect
+        run: |
+          set -euo pipefail
+          # Read back anonymously: proves the Overview is what an unauthenticated
+          # visitor now sees, rather than trusting the write's response.
+          GOT=$(curl -sS --fail-with-body \
+            "https://hub.docker.com/v2/repositories/${HUB_NAMESPACE}/${HUB_REPO}/")
+          GOT_FULL=$(jq -r '.full_description // ""' <<< "$GOT")
+          GOT_SHORT=$(jq -r '.description // ""' <<< "$GOT")
+
+          if [[ -z "$GOT_FULL" ]]; then
+            echo "::error::Overview is still empty after the PATCH"
+            exit 1
+          fi
+          if ! diff -q <(printf '%s' "$GOT_FULL") <(cat "$OVERVIEW_FILE") >/dev/null; then
+            echo "::error::published Overview does not match ${OVERVIEW_FILE}"
+            diff <(printf '%s' "$GOT_FULL") "$OVERVIEW_FILE" | head -20 || true
+            exit 1
+          fi
+          if [[ "$GOT_SHORT" != "$SHORT_DESCRIPTION" ]]; then
+            echo "::error::short description is '${GOT_SHORT}', expected '${SHORT_DESCRIPTION}'"
+            exit 1
+          fi
+          echo "::notice::Overview published and verified anonymously"

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -101,6 +101,32 @@ jobs:
           fi
           echo "::notice::Overview is ${BYTES} bytes, short description ${#SHORT} characters"
 
+      - name: Every link in the Overview must resolve
+        env:
+          FILE: ${{ steps.src.outputs.file }}
+        run: |
+          set -euo pipefail
+          # This page is a public front door, so a dead link is worse than a
+          # blank page. Loopback URLs are examples inside code blocks, not links.
+          FAILED=0
+          while read -r url; do
+            [[ -z "$url" ]] && continue
+            CODE=$(curl -sS -o /dev/null -w '%{http_code}' -L --max-time 20 "$url" || echo 000)
+            if [[ "$CODE" != "200" ]]; then
+              echo "::error::${CODE} ${url}"
+              FAILED=1
+            else
+              echo "  200 ${url}"
+            fi
+          done < <(grep -oE 'https://[^)"[:space:]]+' "$FILE" \
+                     | sed 's/[),.]*$//' \
+                     | grep -v '127\.0\.0\.1' \
+                     | sort -u)
+          if (( FAILED )); then
+            echo "::error::${FILE} contains links that do not resolve"
+            exit 1
+          fi
+
       - name: The Docker Hub repository must already exist
         env:
           IMAGE: ${{ inputs.image }}

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -13,10 +13,13 @@
 # Sourced from `docker/dockerhub-overview*.md` so the published Overview is
 # reviewed like any other content and cannot drift from the repository.
 #
-# Dispatch-only and gated on the `dockerhub` environment, because it uses the
-# same credential that can push images. Deliberately NOT wired into
-# promote-image: the Overview is version-neutral, so a wording fix should not
-# require a release, and a release should not silently rewrite it.
+# Two jobs: `validate` is credential-free and ungated, so a dead link, an
+# oversize file, or a missing Docker Hub repository is discovered on dispatch
+# without spending a reviewer approval. `publish` needs validate and carries
+# the `dockerhub` environment gate, because it uses the same credential that
+# can push images. Deliberately NOT wired into promote-image: the Overview is
+# version-neutral, so a wording fix should not require a release, and a
+# release should not silently rewrite it.
 #
 # One image per dispatch rather than a matrix over both, because a Docker Hub
 # repository that does not exist yet must fail loudly for that image alone
@@ -46,10 +49,14 @@ env:
   HUB_NAMESPACE: extenddb
 
 jobs:
-  publish-description:
+  # Credential-free, no environment gate: everything that can be proven
+  # without a secret is proven before a reviewer is asked to approve.
+  validate:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: dockerhub
+    outputs:
+      file: ${{ steps.src.outputs.file }}
+      short: ${{ steps.src.outputs.short }}
     steps:
       - name: Check out main
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -108,10 +115,12 @@ jobs:
           set -euo pipefail
           # This page is a public front door, so a dead link is worse than a
           # blank page. Loopback URLs are examples inside code blocks, not links.
+          # --retry so a transient blip does not fail the run.
           FAILED=0
           while read -r url; do
             [[ -z "$url" ]] && continue
-            CODE=$(curl -sS -o /dev/null -w '%{http_code}' -L --max-time 20 "$url" || echo 000)
+            CODE=$(curl -sS -o /dev/null -w '%{http_code}' -L --max-time 20 \
+                     --retry 2 --retry-delay 3 "$url" || echo 000)
             if [[ "$CODE" != "200" ]]; then
               echo "::error::${CODE} ${url}"
               FAILED=1
@@ -134,7 +143,7 @@ jobs:
           set -euo pipefail
           # A 404 here means the repository has not been created yet. Say so
           # plainly rather than letting the PATCH fail with an opaque error.
-          CODE=$(curl -sS -o /dev/null -w '%{http_code}' \
+          CODE=$(curl -sS -o /dev/null -w '%{http_code}' --retry 2 --retry-delay 3 \
             "https://hub.docker.com/v2/repositories/${HUB_NAMESPACE}/${IMAGE}/")
           if [[ "$CODE" == "404" ]]; then
             echo "::error::docker.io/${HUB_NAMESPACE}/${IMAGE} does not exist. Create the repository on Docker Hub first."
@@ -145,11 +154,23 @@ jobs:
             exit 1
           fi
 
+  # The only job with the credential, behind the dockerhub environment gate.
+  # By the time a reviewer approves, the content has already passed validation.
+  publish:
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: dockerhub
+    env:
+      FILE: ${{ needs.validate.outputs.file }}
+      SHORT: ${{ needs.validate.outputs.short }}
+    steps:
+      - name: Check out main
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
       - name: Publish the Overview
         env:
           IMAGE: ${{ inputs.image }}
-          FILE: ${{ steps.src.outputs.file }}
-          SHORT: ${{ steps.src.outputs.short }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
@@ -180,8 +201,6 @@ jobs:
       - name: Verify it took effect
         env:
           IMAGE: ${{ inputs.image }}
-          FILE: ${{ steps.src.outputs.file }}
-          SHORT: ${{ steps.src.outputs.short }}
         run: |
           set -euo pipefail
           # Read back anonymously: proves the Overview is what an unauthenticated
@@ -195,9 +214,13 @@ jobs:
             echo "::error::Overview is still empty after the PATCH"
             exit 1
           fi
-          if ! diff -q <(printf '%s' "$GOT_FULL") <(cat "$FILE") >/dev/null; then
+          # Both sides are command substitutions, so both have trailing
+          # newlines stripped: apples-to-apples. Comparing a stripped
+          # substitution against raw `cat` output false-fails on the
+          # trailing newline every .md file ends with.
+          if [[ "$GOT_FULL" != "$(cat "$FILE")" ]]; then
             echo "::error::published Overview does not match ${FILE}"
-            diff <(printf '%s' "$GOT_FULL") "$FILE" | head -20 || true
+            diff <(printf '%s\n' "$GOT_FULL") "$FILE" | head -20 || true
             exit 1
           fi
           if [[ "$GOT_SHORT" != "$SHORT" ]]; then

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,41 +1,49 @@
 # Copyright 2026 ExtendDB contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Publish the Docker Hub repository Overview from a file in this repository.
+# Publish a Docker Hub repository Overview from a file in this repository.
 #
 # Neither `docker push` nor the `skopeo copy` that promote-image uses touches
 # repository metadata: the Overview lives on the Docker Hub repository object,
 # not on any image. GHCR derives its description from the OCI labels the
-# Dockerfile already sets, so the same image reads as documented there and blank
+# Dockerfiles already set, so the same image reads as documented there and blank
 # on Docker Hub. That is why this exists as its own step rather than falling out
 # of a push.
 #
-# Sourced from `docker/dockerhub-overview.md` so the published Overview is
+# Sourced from `docker/dockerhub-overview*.md` so the published Overview is
 # reviewed like any other content and cannot drift from the repository.
 #
 # Dispatch-only and gated on the `dockerhub` environment, because it uses the
 # same credential that can push images. Deliberately NOT wired into
 # promote-image: the Overview is version-neutral, so a wording fix should not
 # require a release, and a release should not silently rewrite it.
+#
+# One image per dispatch rather than a matrix over both, because a Docker Hub
+# repository that does not exist yet must fail loudly for that image alone
+# instead of failing a run that also had work to do for the other.
 
 name: Docker Hub description
 
 on:
   workflow_dispatch:
+    inputs:
+      image:
+        description: 'Which Docker Hub repository to publish the Overview for'
+        required: true
+        type: choice
+        options:
+          - extenddb-postgres
+          - extenddb-dev
 
 permissions:
   contents: read
 
 concurrency:
-  group: dockerhub-description-extenddb-postgres
+  group: dockerhub-description-${{ inputs.image }}
   cancel-in-progress: false
 
 env:
   HUB_NAMESPACE: extenddb
-  HUB_REPO: extenddb-postgres
-  OVERVIEW_FILE: docker/dockerhub-overview.md
-  # Docker Hub caps the short description at 100 characters.
-  SHORT_DESCRIPTION: DynamoDB-compatible API adapter backed by your own PostgreSQL 14+ database
 
 jobs:
   publish-description:
@@ -46,27 +54,76 @@ jobs:
       - name: Check out main
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - name: The Overview file must exist and be non-trivial
+      - name: Resolve the Overview source for this image
+        id: src
+        env:
+          IMAGE: ${{ inputs.image }}
         run: |
           set -euo pipefail
-          if [[ ! -s "$OVERVIEW_FILE" ]]; then
-            echo "::error::$OVERVIEW_FILE is missing or empty"
+          # Docker Hub caps the short description at 100 characters; asserted below.
+          case "$IMAGE" in
+            extenddb-postgres)
+              FILE='docker/dockerhub-overview.md'
+              SHORT='DynamoDB-compatible API adapter backed by your own PostgreSQL 14+ database'
+              ;;
+            extenddb-dev)
+              FILE='docker/dockerhub-overview-dev.md'
+              SHORT='DynamoDB-compatible API over SQLite for local dev and CI. Plain HTTP, not for production.'
+              ;;
+            *)
+              echo "::error::unknown image '$IMAGE'"
+              exit 1
+              ;;
+          esac
+          echo "file=$FILE" >> "$GITHUB_OUTPUT"
+          echo "short=$SHORT" >> "$GITHUB_OUTPUT"
+          echo "::notice::publishing $FILE to ${IMAGE}"
+
+      - name: The Overview file must exist and be within Docker Hub's limits
+        env:
+          FILE: ${{ steps.src.outputs.file }}
+          SHORT: ${{ steps.src.outputs.short }}
+        run: |
+          set -euo pipefail
+          if [[ ! -s "$FILE" ]]; then
+            echo "::error::$FILE is missing or empty"
             exit 1
           fi
-          BYTES=$(wc -c < "$OVERVIEW_FILE")
+          BYTES=$(wc -c < "$FILE")
           # Docker Hub caps full_description at 25000 characters.
           if (( BYTES > 25000 )); then
-            echo "::error::$OVERVIEW_FILE is ${BYTES} bytes; Docker Hub caps the Overview at 25000"
+            echo "::error::$FILE is ${BYTES} bytes; Docker Hub caps the Overview at 25000"
             exit 1
           fi
-          if (( ${#SHORT_DESCRIPTION} > 100 )); then
-            echo "::error::SHORT_DESCRIPTION is ${#SHORT_DESCRIPTION} characters; Docker Hub caps it at 100"
+          if (( ${#SHORT} > 100 )); then
+            echo "::error::short description is ${#SHORT} characters; Docker Hub caps it at 100"
             exit 1
           fi
-          echo "::notice::Overview is ${BYTES} bytes"
+          echo "::notice::Overview is ${BYTES} bytes, short description ${#SHORT} characters"
+
+      - name: The Docker Hub repository must already exist
+        env:
+          IMAGE: ${{ inputs.image }}
+        run: |
+          set -euo pipefail
+          # A 404 here means the repository has not been created yet. Say so
+          # plainly rather than letting the PATCH fail with an opaque error.
+          CODE=$(curl -sS -o /dev/null -w '%{http_code}' \
+            "https://hub.docker.com/v2/repositories/${HUB_NAMESPACE}/${IMAGE}/")
+          if [[ "$CODE" == "404" ]]; then
+            echo "::error::docker.io/${HUB_NAMESPACE}/${IMAGE} does not exist. Create the repository on Docker Hub first."
+            exit 1
+          fi
+          if [[ "$CODE" != "200" ]]; then
+            echo "::error::unexpected HTTP ${CODE} querying docker.io/${HUB_NAMESPACE}/${IMAGE}"
+            exit 1
+          fi
 
       - name: Publish the Overview
         env:
+          IMAGE: ${{ inputs.image }}
+          FILE: ${{ steps.src.outputs.file }}
+          SHORT: ${{ steps.src.outputs.short }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
@@ -85,24 +142,26 @@ jobs:
             exit 1
           fi
 
-          jq -n \
-              --rawfile full "$OVERVIEW_FILE" \
-              --arg short "$SHORT_DESCRIPTION" \
+          jq -n --rawfile full "$FILE" --arg short "$SHORT" \
               '{full_description:$full, description:$short}' \
             | curl -sS --fail-with-body -X PATCH \
                 -H "Authorization: JWT ${TOKEN}" \
                 -H 'Content-Type: application/json' \
                 --data @- \
-                "https://hub.docker.com/v2/repositories/${HUB_NAMESPACE}/${HUB_REPO}/" \
+                "https://hub.docker.com/v2/repositories/${HUB_NAMESPACE}/${IMAGE}/" \
             > /dev/null
 
       - name: Verify it took effect
+        env:
+          IMAGE: ${{ inputs.image }}
+          FILE: ${{ steps.src.outputs.file }}
+          SHORT: ${{ steps.src.outputs.short }}
         run: |
           set -euo pipefail
           # Read back anonymously: proves the Overview is what an unauthenticated
-          # visitor now sees, rather than trusting the write's response.
+          # visitor now sees, rather than trusting the write's own response.
           GOT=$(curl -sS --fail-with-body \
-            "https://hub.docker.com/v2/repositories/${HUB_NAMESPACE}/${HUB_REPO}/")
+            "https://hub.docker.com/v2/repositories/${HUB_NAMESPACE}/${IMAGE}/")
           GOT_FULL=$(jq -r '.full_description // ""' <<< "$GOT")
           GOT_SHORT=$(jq -r '.description // ""' <<< "$GOT")
 
@@ -110,13 +169,13 @@ jobs:
             echo "::error::Overview is still empty after the PATCH"
             exit 1
           fi
-          if ! diff -q <(printf '%s' "$GOT_FULL") <(cat "$OVERVIEW_FILE") >/dev/null; then
-            echo "::error::published Overview does not match ${OVERVIEW_FILE}"
-            diff <(printf '%s' "$GOT_FULL") "$OVERVIEW_FILE" | head -20 || true
+          if ! diff -q <(printf '%s' "$GOT_FULL") <(cat "$FILE") >/dev/null; then
+            echo "::error::published Overview does not match ${FILE}"
+            diff <(printf '%s' "$GOT_FULL") "$FILE" | head -20 || true
             exit 1
           fi
-          if [[ "$GOT_SHORT" != "$SHORT_DESCRIPTION" ]]; then
-            echo "::error::short description is '${GOT_SHORT}', expected '${SHORT_DESCRIPTION}'"
+          if [[ "$GOT_SHORT" != "$SHORT" ]]; then
+            echo "::error::short description is '${GOT_SHORT}', expected '${SHORT}'"
             exit 1
           fi
-          echo "::notice::Overview published and verified anonymously"
+          echo "::notice::Overview for ${IMAGE} published and verified anonymously"

--- a/docker/dockerhub-overview-dev.md
+++ b/docker/dockerhub-overview-dev.md
@@ -1,89 +1,43 @@
-# ExtendDB dev (SQLite)
+# ExtendDB dev
 
-**The DynamoDB API, everywhere you run code.** — [extenddb.org](https://extenddb.org)
+ExtendDB dev is a single-container, DynamoDB-compatible endpoint that enables developers to develop and test applications against the DynamoDB API in their own development environment.
 
-> ExtendDB is an independent open source project managed by Amazon Web Services. It is not Amazon DynamoDB and does not contain any DynamoDB source code. "DynamoDB" is a trademark of Amazon.com, Inc. ExtendDB is a clean-room implementation that speaks the DynamoDB wire protocol. Behavioral differences from the real service are documented in [Differences from DynamoDB](https://github.com/ExtendDB/extenddb/blob/main/docs/differences-from-dynamodb.md).
+## Benefits of using ExtendDB dev
 
-A single container that speaks the DynamoDB wire protocol over SQLite, for **local development and CI**. No external database, no init step, no certificate to trust.
+The image has everything built in: the API, its storage, and a seeded credential. There is no external database to run, no init step, no bootstrap sidecar, and no certificate to trust, so it drops into a containerized build or a continuous integration suite as one service.
 
-> **Not for production, and not for shared networks.** This image serves plain HTTP with open authorization: whoever holds the credential can do everything. Always publish it to loopback only. For a durable, TLS-terminated deployment use [`extenddb/extenddb-postgres`](https://hub.docker.com/r/extenddb/extenddb-postgres).
+ExtendDB dev works with your existing DynamoDB API calls. Any AWS SDK, CLI, or tool that talks to DynamoDB talks to it unchanged, so you point your client at a different endpoint and nothing else about your code changes.
 
-## Quick start
+It needs no internet connection, and there are no provisioned throughput, data storage, or data transfer costs.
+
+Data is durable across restarts by default, or entirely in memory when you want a pristine database per test run.
+
+## Getting started with ExtendDB dev on Docker
+
+Run:
 
 ```bash
-docker run -d -p 127.0.0.1:18443:18443 -v extenddb:/var/lib/extenddb \
-  extenddb/extenddb-dev
+docker run -d -p 127.0.0.1:18443:18443 -v extenddb:/var/lib/extenddb extenddb/extenddb-dev
 ```
 
-Then point any AWS SDK, CLI, or tool at it, unchanged:
+Then use it like DynamoDB. The server seeds AWS's documented example credential and prints it at startup:
 
 ```bash
 AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE \
 AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
-aws dynamodb list-tables \
-  --region us-east-1 --endpoint-url http://127.0.0.1:18443
+aws dynamodb list-tables --region us-east-1 --endpoint-url http://127.0.0.1:18443
 ```
 
-That is AWS's documented example key pair. The server seeds it at startup and prints it in the logs. Secret scanners recognise it as an example credential, so it is safe in test fixtures. Pass `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to the container to use a different one.
+For an in-memory database that vanishes with the container, drop the volume and add `-e EXTENDDB__STORAGE__SQLITE__PATH=:memory:`.
 
-## Storage modes
+To learn how to configure ExtendDB dev, see [the `extenddb-dev` image](https://github.com/ExtendDB/extenddb/blob/main/docs/dev-image.md).
 
-One image, mode chosen at run time.
+For a durable, TLS-terminated deployment, use [`extenddb/extenddb-postgres`](https://hub.docker.com/r/extenddb/extenddb-postgres).
 
-**File-backed (default).** The database is `/var/lib/extenddb/extenddb.sqlite`. Mount a volume there and data survives restarts and upgrades:
+## Note
 
-```bash
-docker run -d -p 127.0.0.1:18443:18443 -v extenddb:/var/lib/extenddb \
-  extenddb/extenddb-dev
-```
+This image is built for local development and CI. It serves plain HTTP and its authorization is open, so whoever holds the credential can do anything. Publish it to loopback only, as the command above does, and do not keep real data in it.
 
-**In-memory.** Everything lives in process memory and vanishes when the container stops, which is what you want for a suite that needs a pristine database per run:
+ExtendDB is an independent open source project managed by Amazon Web Services. It is not Amazon DynamoDB and does not contain any DynamoDB source code. "DynamoDB" is a trademark of Amazon.com, Inc. ExtendDB is a clean-room implementation that speaks the DynamoDB wire protocol; behavioral differences from the service are documented in [Differences from DynamoDB](https://github.com/ExtendDB/extenddb/blob/main/docs/differences-from-dynamodb.md).
 
-```bash
-docker run -d -p 127.0.0.1:18443:18443 \
-  -e EXTENDDB__STORAGE__SQLITE__PATH=:memory: \
-  extenddb/extenddb-dev
-```
-
-## Why loopback matters
-
-The container binds `0.0.0.0` internally, which is required for port publishing to work at all. Containment is therefore the publish flag, not the bind address: keep the host side on `127.0.0.1`, as every example above does. Do not publish this port on a routable or shared interface, and do not put real data in it.
-
-## Tags
-
-| Tag | What it is |
-| --- | --- |
-| `X.Y.Z` | A released version. Immutable: a version tag is never overwritten. |
-| `latest` | The highest released version. Only ever moves forward. |
-
-Both `linux/amd64` and `linux/arm64` are published as a single multi-architecture index, so `docker pull` selects the right platform automatically.
-
-## Runtime contract
-
-| | |
-| --- | --- |
-| Endpoint | `http://127.0.0.1:18443` — plain HTTP, no TLS |
-| State volume | `/var/lib/extenddb` (file mode); omit it for a throwaway container |
-| User | `65532:65532`, non-root |
-| Healthcheck | built in, so `docker ps` and Compose `depends_on: condition: service_healthy` work with no extra wiring |
-
-The runtime base is distroless (`gcr.io/distroless/cc-debian12:nonroot`): no shell and no package manager, so `docker exec` into it is not possible by design. Licence notices for this image's exact dependency set ship at `/usr/share/doc/extenddb/SOFTWARE-LICENSE-NOTICES.html`.
-
-## Limitations
-
-- Single node, single process. Throughput settings are accepted and tracked but not enforced as capacity.
-- No TLS and no access control, as above.
-
-## Verifying the image
-
-Signed with the same ExtendDB release key as the production image, an ECDSA P-256 key held in AWS KMS. The public key is attached to each [GitHub release](https://github.com/ExtendDB/extenddb/releases) as `extenddb-signing.pub.pem`, and each release's notes carry the exact `cosign verify` invocation for that release.
-
-## Links
-
-- Project site: [extenddb.org](https://extenddb.org)
-- Source, issues and discussions: [github.com/ExtendDB/extenddb](https://github.com/ExtendDB/extenddb)
-- [The `extenddb-dev` image](https://github.com/ExtendDB/extenddb/blob/main/docs/dev-image.md)
-- [Getting started](https://github.com/ExtendDB/extenddb/blob/main/docs/getting-started.md)
-- [Differences from DynamoDB](https://github.com/ExtendDB/extenddb/blob/main/docs/differences-from-dynamodb.md)
-- Production image: [`extenddb/extenddb-postgres`](https://hub.docker.com/r/extenddb/extenddb-postgres)
-- Licensed under Apache-2.0
+More at [extenddb.org](https://extenddb.org) and [github.com/ExtendDB/extenddb](https://github.com/ExtendDB/extenddb). Licensed under Apache-2.0.

--- a/docker/dockerhub-overview-dev.md
+++ b/docker/dockerhub-overview-dev.md
@@ -17,7 +17,7 @@ Data is durable across restarts by default, or entirely in memory when you want 
 Run:
 
 ```bash
-docker run -d -p 127.0.0.1:18443:18443 -v extenddb:/var/lib/extenddb extenddb/extenddb-dev
+docker run -d -p 127.0.0.1:18080:18080 -v extenddb:/var/lib/extenddb extenddb/extenddb-dev
 ```
 
 Then use it like DynamoDB. The server seeds AWS's documented example credential and prints it at startup:
@@ -25,7 +25,7 @@ Then use it like DynamoDB. The server seeds AWS's documented example credential 
 ```bash
 AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE \
 AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
-aws dynamodb list-tables --region us-east-1 --endpoint-url http://127.0.0.1:18443
+aws dynamodb list-tables --region us-east-1 --endpoint-url http://127.0.0.1:18080
 ```
 
 For an in-memory database that vanishes with the container, drop the volume and add `-e EXTENDDB__STORAGE__SQLITE__PATH=:memory:`.

--- a/docker/dockerhub-overview-dev.md
+++ b/docker/dockerhub-overview-dev.md
@@ -1,0 +1,89 @@
+# ExtendDB dev (SQLite)
+
+**The DynamoDB API, everywhere you run code.** — [extenddb.org](https://extenddb.org)
+
+> ExtendDB is an independent open source project managed by Amazon Web Services. It is not Amazon DynamoDB and does not contain any DynamoDB source code. "DynamoDB" is a trademark of Amazon.com, Inc. ExtendDB is a clean-room implementation that speaks the DynamoDB wire protocol. Behavioral differences from the real service are documented in [Differences from DynamoDB](https://github.com/ExtendDB/extenddb/blob/main/docs/differences-from-dynamodb.md).
+
+A single container that speaks the DynamoDB wire protocol over SQLite, for **local development and CI**. No external database, no init step, no certificate to trust.
+
+> **Not for production, and not for shared networks.** This image serves plain HTTP with open authorization: whoever holds the credential can do everything. Always publish it to loopback only. For a durable, TLS-terminated deployment use [`extenddb/extenddb-postgres`](https://hub.docker.com/r/extenddb/extenddb-postgres).
+
+## Quick start
+
+```bash
+docker run -d -p 127.0.0.1:18443:18443 -v extenddb:/var/lib/extenddb \
+  extenddb/extenddb-dev
+```
+
+Then point any AWS SDK, CLI, or tool at it, unchanged:
+
+```bash
+AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE \
+AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
+aws dynamodb list-tables \
+  --region us-east-1 --endpoint-url http://127.0.0.1:18443
+```
+
+That is AWS's documented example key pair. The server seeds it at startup and prints it in the logs. Secret scanners recognise it as an example credential, so it is safe in test fixtures. Pass `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to the container to use a different one.
+
+## Storage modes
+
+One image, mode chosen at run time.
+
+**File-backed (default).** The database is `/var/lib/extenddb/extenddb.sqlite`. Mount a volume there and data survives restarts and upgrades:
+
+```bash
+docker run -d -p 127.0.0.1:18443:18443 -v extenddb:/var/lib/extenddb \
+  extenddb/extenddb-dev
+```
+
+**In-memory.** Everything lives in process memory and vanishes when the container stops, which is what you want for a suite that needs a pristine database per run:
+
+```bash
+docker run -d -p 127.0.0.1:18443:18443 \
+  -e EXTENDDB__STORAGE__SQLITE__PATH=:memory: \
+  extenddb/extenddb-dev
+```
+
+## Why loopback matters
+
+The container binds `0.0.0.0` internally, which is required for port publishing to work at all. Containment is therefore the publish flag, not the bind address: keep the host side on `127.0.0.1`, as every example above does. Do not publish this port on a routable or shared interface, and do not put real data in it.
+
+## Tags
+
+| Tag | What it is |
+| --- | --- |
+| `X.Y.Z` | A released version. Immutable: a version tag is never overwritten. |
+| `latest` | The highest released version. Only ever moves forward. |
+
+Both `linux/amd64` and `linux/arm64` are published as a single multi-architecture index, so `docker pull` selects the right platform automatically.
+
+## Runtime contract
+
+| | |
+| --- | --- |
+| Endpoint | `http://127.0.0.1:18443` — plain HTTP, no TLS |
+| State volume | `/var/lib/extenddb` (file mode); omit it for a throwaway container |
+| User | `65532:65532`, non-root |
+| Healthcheck | built in, so `docker ps` and Compose `depends_on: condition: service_healthy` work with no extra wiring |
+
+The runtime base is distroless (`gcr.io/distroless/cc-debian12:nonroot`): no shell and no package manager, so `docker exec` into it is not possible by design. Licence notices for this image's exact dependency set ship at `/usr/share/doc/extenddb/SOFTWARE-LICENSE-NOTICES.html`.
+
+## Limitations
+
+- Single node, single process. Throughput settings are accepted and tracked but not enforced as capacity.
+- No TLS and no access control, as above.
+
+## Verifying the image
+
+Signed with the same ExtendDB release key as the production image, an ECDSA P-256 key held in AWS KMS. The public key is attached to each [GitHub release](https://github.com/ExtendDB/extenddb/releases) as `extenddb-signing.pub.pem`, and each release's notes carry the exact `cosign verify` invocation for that release.
+
+## Links
+
+- Project site: [extenddb.org](https://extenddb.org)
+- Source, issues and discussions: [github.com/ExtendDB/extenddb](https://github.com/ExtendDB/extenddb)
+- [The `extenddb-dev` image](https://github.com/ExtendDB/extenddb/blob/main/docs/dev-image.md)
+- [Getting started](https://github.com/ExtendDB/extenddb/blob/main/docs/getting-started.md)
+- [Differences from DynamoDB](https://github.com/ExtendDB/extenddb/blob/main/docs/differences-from-dynamodb.md)
+- Production image: [`extenddb/extenddb-postgres`](https://hub.docker.com/r/extenddb/extenddb-postgres)
+- Licensed under Apache-2.0

--- a/docker/dockerhub-overview.md
+++ b/docker/dockerhub-overview.md
@@ -22,7 +22,7 @@ To learn how to configure and operate it, see [getting started](https://github.c
 
 Pin `X.Y.Z` or a digest for production; a version tag is never overwritten. `latest` tracks the highest release and only moves forward. Tags of the form `sha-<commit>` are unpromoted build candidates, not releases. Both `linux/amd64` and `linux/arm64` ship as one multi-architecture index.
 
-Every published image is signed with ExtendDB's release key, an ECDSA P-256 key held in AWS KMS. Each [release](https://github.com/ExtendDB/extenddb/releases) attaches the public key and gives the exact `cosign verify` command for that release. The same images are mirrored by digest to `ghcr.io/extenddb/extenddb-postgres`.
+Every published image is signed with ExtendDB's release key, an ECDSA P-256 key held in AWS KMS. The public key is committed in the repository as [`extenddb-signing.pub.pem`](https://github.com/ExtendDB/extenddb/blob/main/extenddb-signing.pub.pem), for use with `cosign verify --key`. The same images and their signatures are mirrored by digest to `ghcr.io/extenddb/extenddb-postgres` and `public.ecr.aws/extenddb/extenddb-postgres`.
 
 ## Note
 

--- a/docker/dockerhub-overview.md
+++ b/docker/dockerhub-overview.md
@@ -1,93 +1,31 @@
-# ExtendDB (PostgreSQL backend)
+# ExtendDB
 
-**The DynamoDB API, everywhere you run code.** — [extenddb.org](https://extenddb.org)
+ExtendDB is a DynamoDB-compatible API adapter that enables teams to run DynamoDB workloads on their own infrastructure, backed by a PostgreSQL database they operate.
 
-> ExtendDB is an independent open source project managed by Amazon Web Services. It is not Amazon DynamoDB and does not contain any DynamoDB source code. "DynamoDB" is a trademark of Amazon.com, Inc. ExtendDB is a clean-room implementation that speaks the DynamoDB wire protocol. Behavioral differences from the real service are documented in [Differences from DynamoDB](https://github.com/ExtendDB/extenddb/blob/main/docs/differences-from-dynamodb.md).
+## Benefits of using ExtendDB
 
-ExtendDB speaks the DynamoDB wire protocol, so any AWS SDK, CLI, or tool that works with DynamoDB works with ExtendDB unchanged. Point your client at the ExtendDB endpoint and nothing else about your code changes.
+ExtendDB works with your existing DynamoDB API calls. Any AWS SDK, CLI, or tool that talks to DynamoDB talks to ExtendDB unchanged, so you point your client at a different endpoint and nothing else about your code changes. The full surface is there: CRUD, Query, Scan, Batch, Transactions, Streams, TTL, Import and Export, plus SigV4 with IAM-compatible users, roles and policies.
 
-This image is an **adapter, not a database**. It contains the ExtendDB server compiled with the PostgreSQL backend. It does **not** contain a PostgreSQL server or data directory: bring your own PostgreSQL 14 or newer, whether that is RDS, Aurora PostgreSQL, or self-managed.
+It is an adapter, not a database. This image contains the ExtendDB server compiled with the PostgreSQL backend; you supply PostgreSQL 14 or newer, whether that is RDS, Aurora PostgreSQL, or self-managed. Your data therefore lives somewhere you already know how to back up, replicate, monitor and restore, using tools you already run.
 
-## Tags
+Because it runs on your infrastructure, ExtendDB needs no internet connection, and there are no provisioned throughput, data storage, or data transfer costs. That makes it a fit for self-hosted and air-gapped deployments, for DynamoDB semantics on any cloud that runs PostgreSQL, and for continuous integration against a durable backend rather than an ephemeral one.
 
-| Tag | What it is |
-| --- | --- |
-| `X.Y.Z` | A released version. Immutable: a version tag is never overwritten. |
-| `latest` | The highest released version. Only ever moves forward. |
-| `sha-<40-char-commit>` | A build candidate, published before promotion. Not a release; pin a version instead. |
+## Getting started with ExtendDB on Docker
 
-Both `linux/amd64` and `linux/arm64` are published as a single multi-architecture index, so `docker pull` selects the right platform automatically.
+For local development, the Compose stack in the repository starts PostgreSQL alongside ExtendDB and runs the one-time bootstrap for you. See [local development with Docker Compose](https://github.com/ExtendDB/extenddb/blob/main/docs/local-dev-docker-compose.md).
 
-For production, pin `X.Y.Z` or a digest rather than `latest`.
+For a real deployment the image serves three explicit operations: `extenddb init` once to bootstrap the database, `extenddb migrate` when upgrading, and `extenddb serve` in steady state, which is the default command. It listens on port 18443 over TLS, keeps configuration and certificates under `/var/lib/extenddb`, runs as a non-root user, and supports a read-only root filesystem.
 
-## Quick start
+To learn how to configure and operate it, see [getting started](https://github.com/ExtendDB/extenddb/blob/main/docs/getting-started.md) and the [container notes](https://github.com/ExtendDB/extenddb/blob/main/docker/README.md).
 
-For local development the fastest path is the Compose stack in the repository, which brings up PostgreSQL alongside ExtendDB and runs the one-time bootstrap for you. See [Local development with Docker Compose](https://github.com/ExtendDB/extenddb/blob/main/docs/local-dev-docker-compose.md).
+## Tags and verification
 
-Once running, use any DynamoDB client against the endpoint:
+Pin `X.Y.Z` or a digest for production; a version tag is never overwritten. `latest` tracks the highest release and only moves forward. Tags of the form `sha-<commit>` are unpromoted build candidates, not releases. Both `linux/amd64` and `linux/arm64` ship as one multi-architecture index.
 
-```bash
-aws dynamodb list-tables \
-  --endpoint-url https://127.0.0.1:18443 \
-  --region us-east-1
-```
+Every published image is signed with ExtendDB's release key, an ECDSA P-256 key held in AWS KMS. Each [release](https://github.com/ExtendDB/extenddb/releases) attaches the public key and gives the exact `cosign verify` command for that release. The same images are mirrored by digest to `ghcr.io/extenddb/extenddb-postgres`.
 
-## Running it yourself
+## Note
 
-The image serves three explicit operations. Do not use the Compose bootstrap behaviour as a production control plane.
+ExtendDB is an independent open source project managed by Amazon Web Services. It is not Amazon DynamoDB and does not contain any DynamoDB source code. "DynamoDB" is a trademark of Amazon.com, Inc. ExtendDB is a clean-room implementation that speaks the DynamoDB wire protocol; behavioral differences from the service are documented in [Differences from DynamoDB](https://github.com/ExtendDB/extenddb/blob/main/docs/differences-from-dynamodb.md).
 
-**1. Bootstrap once**, as a single Job holding the PostgreSQL bootstrap credential. Inject `EXTENDDB_PG_PASSWORD` and `EXTENDDB_APP_PASSWORD` from your orchestrator's secret store rather than passing them as arguments:
-
-```bash
-extenddb init \
-  --config /var/lib/extenddb/extenddb.toml \
-  --backend postgres \
-  --pg-host <postgres-host> --pg-port 5432 \
-  --pg-user <bootstrap-user> --extenddb-user <application-user> \
-  --bind-addr 0.0.0.0 --tls-san <service-dns-name>
-```
-
-**2. On upgrade**, back up PostgreSQL, scale down incompatible serving versions, then run one migration Job:
-
-```bash
-extenddb migrate --config /var/lib/extenddb/extenddb.toml --yes --pg-user <bootstrap-user>
-```
-
-The generated config stores the application connection but not the bootstrap password, so the migration Job receives that elevated credential separately. The serving container never gets it.
-
-**3. Steady state** is the image's default command:
-
-```bash
-extenddb serve --config /var/lib/extenddb/extenddb.toml --foreground
-```
-
-## Runtime contract
-
-| | |
-| --- | --- |
-| Port | `18443` (HTTPS) |
-| State volume | `/var/lib/extenddb` — must be writable; holds config and TLS material |
-| User | `10001:10001`, non-root |
-| Entrypoint | `tini`, so `SIGTERM` reaches the server and shutdown is graceful |
-| Healthcheck | `extenddb healthcheck` — liveness only, it does not probe PostgreSQL readiness |
-
-Supports a read-only root filesystem. Drop all capabilities, keep the runtime's default seccomp profile, and set CPU and memory limits in your orchestrator.
-
-TLS is on by default with a generated self-signed certificate, replaceable with a CA-signed one. The Compose stack's certificate and passwords are development defaults and must not be used anywhere shared.
-
-## Verifying the image
-
-Every published image is signed with ExtendDB's release key, an ECDSA P-256 key held in AWS KMS. The public key is attached to each [GitHub release](https://github.com/ExtendDB/extenddb/releases) as `extenddb-signing.pub.pem`, and each release's notes carry the exact `cosign verify` invocation for that release. Verify against the digest you are deploying.
-
-## Also available on GHCR
-
-The same images, by digest, are mirrored to `ghcr.io/extenddb/extenddb-postgres`.
-
-## Links
-
-- Project site: [extenddb.org](https://extenddb.org)
-- Source, issues and discussions: [github.com/ExtendDB/extenddb](https://github.com/ExtendDB/extenddb)
-- [Getting started](https://github.com/ExtendDB/extenddb/blob/main/docs/getting-started.md)
-- [Differences from DynamoDB](https://github.com/ExtendDB/extenddb/blob/main/docs/differences-from-dynamodb.md)
-- [Troubleshooting](https://github.com/ExtendDB/extenddb/blob/main/docs/troubleshooting.md)
-- Licensed under Apache-2.0
+More at [extenddb.org](https://extenddb.org) and [github.com/ExtendDB/extenddb](https://github.com/ExtendDB/extenddb). Licensed under Apache-2.0.

--- a/docker/dockerhub-overview.md
+++ b/docker/dockerhub-overview.md
@@ -1,0 +1,93 @@
+# ExtendDB (PostgreSQL backend)
+
+**The DynamoDB API, everywhere you run code.** — [extenddb.org](https://extenddb.org)
+
+> ExtendDB is an independent open source project managed by Amazon Web Services. It is not Amazon DynamoDB and does not contain any DynamoDB source code. "DynamoDB" is a trademark of Amazon.com, Inc. ExtendDB is a clean-room implementation that speaks the DynamoDB wire protocol. Behavioral differences from the real service are documented in [Differences from DynamoDB](https://github.com/ExtendDB/extenddb/blob/main/docs/differences-from-dynamodb.md).
+
+ExtendDB speaks the DynamoDB wire protocol, so any AWS SDK, CLI, or tool that works with DynamoDB works with ExtendDB unchanged. Point your client at the ExtendDB endpoint and nothing else about your code changes.
+
+This image is an **adapter, not a database**. It contains the ExtendDB server compiled with the PostgreSQL backend. It does **not** contain a PostgreSQL server or data directory: bring your own PostgreSQL 14 or newer, whether that is RDS, Aurora PostgreSQL, or self-managed.
+
+## Tags
+
+| Tag | What it is |
+| --- | --- |
+| `X.Y.Z` | A released version. Immutable: a version tag is never overwritten. |
+| `latest` | The highest released version. Only ever moves forward. |
+| `sha-<40-char-commit>` | A build candidate, published before promotion. Not a release; pin a version instead. |
+
+Both `linux/amd64` and `linux/arm64` are published as a single multi-architecture index, so `docker pull` selects the right platform automatically.
+
+For production, pin `X.Y.Z` or a digest rather than `latest`.
+
+## Quick start
+
+For local development the fastest path is the Compose stack in the repository, which brings up PostgreSQL alongside ExtendDB and runs the one-time bootstrap for you. See [Local development with Docker Compose](https://github.com/ExtendDB/extenddb/blob/main/docs/local-dev-docker-compose.md).
+
+Once running, use any DynamoDB client against the endpoint:
+
+```bash
+aws dynamodb list-tables \
+  --endpoint-url https://127.0.0.1:18443 \
+  --region us-east-1
+```
+
+## Running it yourself
+
+The image serves three explicit operations. Do not use the Compose bootstrap behaviour as a production control plane.
+
+**1. Bootstrap once**, as a single Job holding the PostgreSQL bootstrap credential. Inject `EXTENDDB_PG_PASSWORD` and `EXTENDDB_APP_PASSWORD` from your orchestrator's secret store rather than passing them as arguments:
+
+```bash
+extenddb init \
+  --config /var/lib/extenddb/extenddb.toml \
+  --backend postgres \
+  --pg-host <postgres-host> --pg-port 5432 \
+  --pg-user <bootstrap-user> --extenddb-user <application-user> \
+  --bind-addr 0.0.0.0 --tls-san <service-dns-name>
+```
+
+**2. On upgrade**, back up PostgreSQL, scale down incompatible serving versions, then run one migration Job:
+
+```bash
+extenddb migrate --config /var/lib/extenddb/extenddb.toml --yes --pg-user <bootstrap-user>
+```
+
+The generated config stores the application connection but not the bootstrap password, so the migration Job receives that elevated credential separately. The serving container never gets it.
+
+**3. Steady state** is the image's default command:
+
+```bash
+extenddb serve --config /var/lib/extenddb/extenddb.toml --foreground
+```
+
+## Runtime contract
+
+| | |
+| --- | --- |
+| Port | `18443` (HTTPS) |
+| State volume | `/var/lib/extenddb` — must be writable; holds config and TLS material |
+| User | `10001:10001`, non-root |
+| Entrypoint | `tini`, so `SIGTERM` reaches the server and shutdown is graceful |
+| Healthcheck | `extenddb healthcheck` — liveness only, it does not probe PostgreSQL readiness |
+
+Supports a read-only root filesystem. Drop all capabilities, keep the runtime's default seccomp profile, and set CPU and memory limits in your orchestrator.
+
+TLS is on by default with a generated self-signed certificate, replaceable with a CA-signed one. The Compose stack's certificate and passwords are development defaults and must not be used anywhere shared.
+
+## Verifying the image
+
+Every published image is signed with ExtendDB's release key, an ECDSA P-256 key held in AWS KMS. The public key is attached to each [GitHub release](https://github.com/ExtendDB/extenddb/releases) as `extenddb-signing.pub.pem`, and each release's notes carry the exact `cosign verify` invocation for that release. Verify against the digest you are deploying.
+
+## Also available on GHCR
+
+The same images, by digest, are mirrored to `ghcr.io/extenddb/extenddb-postgres`.
+
+## Links
+
+- Project site: [extenddb.org](https://extenddb.org)
+- Source, issues and discussions: [github.com/ExtendDB/extenddb](https://github.com/ExtendDB/extenddb)
+- [Getting started](https://github.com/ExtendDB/extenddb/blob/main/docs/getting-started.md)
+- [Differences from DynamoDB](https://github.com/ExtendDB/extenddb/blob/main/docs/differences-from-dynamodb.md)
+- [Troubleshooting](https://github.com/ExtendDB/extenddb/blob/main/docs/troubleshooting.md)
+- Licensed under Apache-2.0


### PR DESCRIPTION
## What this does

Publishes a Docker Hub **Overview** for `extenddb/extenddb-postgres`, and adds a step that keeps it in sync with the repository.

The Hub page currently has **446 pulls and a blank Overview**, plus a blank short description. A bare page reads as an abandoned image.

## Why it is blank, and why a push will never fix it

Neither `docker push` nor the `skopeo copy` that `promote-image` uses touches repository metadata. The Overview is `full_description` on the Docker Hub *repository* object, not on any image or manifest, and nothing in CI calls the Hub API.

The asymmetry worth knowing: **GHCR looks documented for the same image** because it derives its package description from the OCI labels the Dockerfile already sets at lines 47-48 (`org.opencontainers.image.title` and `.description`). Docker Hub ignores those labels for the Overview entirely. Same artifact, maintained on one registry and blank on the other.

## Why a new file rather than pointing at `docker/README.md`

`docker/README.md` is contributor-facing: generate notices, `docker build` with build args, the four-role Compose stack, run the smoke test. Someone pulling the image needs a different set of facts:

- the tag policy (`X.Y.Z` immutable, `latest` only moves forward, `sha-<commit>` are unpromoted candidates)
- that **PostgreSQL is not bundled** and 14+ must be supplied
- the runtime contract: port, state volume, non-root UID, `tini`, and that the healthcheck is liveness only
- how to verify the signature

So this adds `docker/dockerhub-overview.md` and leaves the existing doc for contributors.

It also carries the trademark notice from the README verbatim. The Hub page is a public front door and previously carried no notice at all, which matters more there than in a directory README. And it links to [extenddb.org](https://extenddb.org).

## Design of the sync step

**Sourced from a file in the repo**, so the published Overview is reviewed like any other content and cannot drift.

**Dispatch-only, gated on the `dockerhub` environment.** It uses the same credential that can push images, so it gets the same gate.

**Deliberately not wired into `promote-image`.** The Overview is version-neutral: a wording fix should not require a release, and a release should not silently rewrite the page. It also keeps this clear of #283, which is already changing that workflow.

**It verifies rather than assumes.** After the `PATCH` it re-reads the repository *anonymously* and diffs the published Overview against the file, so a silent no-op or a partial write fails the run instead of reporting green. That matters because the Hub API path cannot be exercised from a PR: the credential only exists inside the gated job. The first dispatch proves it end to end.

## Testing done

- Workflow YAML parses; the `jq` payload construction was exercised locally with no credentials involved.
- Size limits are asserted in the job and were checked here: the Overview is **4,945 characters** against Docker Hub's 25,000 cap, and the short description is **73** against its 100 cap.
- **Every link was fetched and returns 200**: extenddb.org, the repository, the releases page, and the four linked docs. A broken link on the front page would be worse than a blank one.
- Runtime facts were read out of the `Dockerfile` rather than restated from memory: `EXPOSE 18443`, state at `/var/lib/extenddb`, `USER 10001:10001`, `tini` entrypoint, and the healthcheck being liveness rather than backend readiness.
- Signature guidance points at the releases page rather than hardcoding a `cosign` invocation, because v0.1.6 needs `--insecure-ignore-tlog=true` and releases after #284 will not. Each release's notes already carry the right command and attach `extenddb-signing.pub.pem`.

## Follow-ups, not in scope

- `extenddb/extenddb-dev` now exists on Docker Hub (created with the 0.1.7 release), so both Overviews are publishable; the workflow is parameterised by `HUB_REPO` so it is a copy of the job rather than new machinery.
- Once #283 lands, folding this into the promote flow becomes an option, though the version-neutral argument above suggests leaving it separate.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass — no code changed
- [x] Code is formatted — n/a
- [x] Clippy is clean — n/a
- [x] I have added or updated tests for new functionality — the job asserts size caps and diffs the published result against the file
- [x] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any)

ADR / RFC: n/a — no change to the wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface.

## Breaking changes

None. No image, tag, or digest is affected.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
