### PR TITLE
fix(sqlite): restore must not report ACTIVE before the data copy completes

### DIFF
--- a/crates/storage-sqlite/src/backup.rs
+++ b/crates/storage-sqlite/src/backup.rs
@@ -15,8 +15,8 @@ use extenddb_core::types::{
     PointInTimeRecoveryDescription, ProvisionedThroughput, SourceTableDetails, TableDescription,
     TableKeyInfo,
 };
+use extenddb_storage::BackupEngine;
 use extenddb_storage::error::StorageError;
-use extenddb_storage::{BackupEngine, TableEngine};
 use futures::future::BoxFuture;
 
 use crate::data::{data_table_name, upsert_item_in_tx};
@@ -361,7 +361,13 @@ impl BackupEngine for SqliteEngine {
                 ..Default::default()
             };
 
-            let desc = self.create_table(&account_id, create_input).await?;
+            // `defer_active`: the target is written CREATING with no scheduled
+            // transition, so the control-plane worker cannot report it ACTIVE
+            // while the copy below is still running. The explicit ACTIVE update
+            // after the copy commits is the only flip.
+            let desc = self
+                .create_table_impl(&account_id, create_input, true)
+                .await?;
             let key_info = TableKeyInfo {
                 table_name: target_table_name.clone(),
                 account_id: account_id.clone(),

--- a/crates/storage-sqlite/src/create_table.rs
+++ b/crates/storage-sqlite/src/create_table.rs
@@ -8,6 +8,9 @@
 //! transaction afterward, with catalog cleanup if the data DDL fails. The
 //! control-plane delay (`control_plane_delay_seconds`) decides whether the
 //! table starts ACTIVE (delay 0) or CREATING with a scheduled transition.
+//!
+//! The restore path is the exception: see `defer_active` on
+//! [`SqliteEngine::create_table_impl`].
 
 use extenddb_core::types::{
     BillingMode, BillingModeSummary, CreateTableInput, GsiDescription, LsiDescription,
@@ -20,10 +23,17 @@ use crate::sqlite_util::{format_timestamp, is_unique_violation};
 use crate::store::SqliteEngine;
 
 impl SqliteEngine {
+    /// Create a table. When `defer_active` is set (the restore path), the row
+    /// is written `CREATING` with **no** scheduled transition, so the
+    /// background control-plane worker cannot flip it to `ACTIVE` while the
+    /// caller is still populating it; the caller sets `ACTIVE` itself once the
+    /// data copy completes. Normal `CreateTable` passes `false` and gets the
+    /// usual timed transition.
     pub(crate) async fn create_table_impl(
         &self,
         account_id: &str,
         input: CreateTableInput,
+        defer_active: bool,
     ) -> Result<TableDescription, StorageError> {
         Self::validate_account_id(account_id)?;
         // D1: every writer holds the engine write lock. This method runs two
@@ -82,7 +92,14 @@ impl SqliteEngine {
         let creation_ts = format_timestamp(now);
         #[allow(clippy::cast_precision_loss)]
         let creation_epoch = now.unix_timestamp() as f64;
-        let (initial_status, status_transition_at) = if delay_secs <= 0.0 {
+        let (initial_status, status_transition_at) = if defer_active {
+            // CREATING with no scheduled transition: the control-plane worker
+            // matches only rows with a non-NULL, matured `status_transition_at`
+            // (see `worker.rs`), so it can never flip this row mid-copy. The
+            // restore caller performs the single ACTIVE flip when the copy
+            // commits.
+            ("CREATING", None)
+        } else if delay_secs <= 0.0 {
             ("ACTIVE", None)
         } else {
             (

--- a/crates/storage-sqlite/src/store.rs
+++ b/crates/storage-sqlite/src/store.rs
@@ -574,7 +574,7 @@ mod d1_write_lock_tests {
         }))
         .expect("input");
         engine
-            .create_table_impl("000000000000", input)
+            .create_table_impl("000000000000", input, false)
             .await
             .expect("create table");
     }

--- a/crates/storage-sqlite/src/table_engine.rs
+++ b/crates/storage-sqlite/src/table_engine.rs
@@ -20,7 +20,7 @@ impl TableEngine for SqliteEngine {
         input: CreateTableInput,
     ) -> BoxFuture<'_, Result<TableDescription, StorageError>> {
         let account_id = account_id.to_owned();
-        Box::pin(async move { self.create_table_impl(&account_id, input).await })
+        Box::pin(async move { self.create_table_impl(&account_id, input, false).await })
     }
 
     fn delete_table(

--- a/crates/storage-sqlite/src/update_table.rs
+++ b/crates/storage-sqlite/src/update_table.rs
@@ -1250,7 +1250,7 @@ mod reconciler_tests {
         }))
         .expect("input");
         engine
-            .create_table_impl(account, input)
+            .create_table_impl(account, input, false)
             .await
             .expect("create table");
 
@@ -1330,7 +1330,7 @@ mod reconciler_tests {
         }))
         .expect("input");
         engine
-            .create_table_impl(account, input)
+            .create_table_impl(account, input, false)
             .await
             .expect("create table");
 
@@ -1445,7 +1445,7 @@ mod reconciler_tests {
         }))
         .expect("input");
         engine
-            .create_table_impl("000000000000", input)
+            .create_table_impl("000000000000", input, false)
             .await
             .expect("create table");
         let (table_id,): (String,) =
@@ -1571,7 +1571,7 @@ mod reconciler_tests {
         }))
         .expect("input");
         engine
-            .create_table_impl("000000000000", input)
+            .create_table_impl("000000000000", input, false)
             .await
             .expect("create table");
         let (table_id,): (String,) =
@@ -1658,7 +1658,7 @@ mod reconciler_tests {
         }))
         .expect("input");
         engine
-            .create_table_impl("000000000000", input)
+            .create_table_impl("000000000000", input, false)
             .await
             .expect("create table");
         let (table_id,): (String,) =
@@ -1743,7 +1743,7 @@ mod reconciler_tests {
         }))
         .expect("input");
         engine
-            .create_table_impl(account, input)
+            .create_table_impl(account, input, false)
             .await
             .expect("create table");
         let (table_id,): (String,) =
@@ -1844,7 +1844,7 @@ mod reconciler_tests {
         }))
         .expect("input");
         engine
-            .create_table_impl(account, input)
+            .create_table_impl(account, input, false)
             .await
             .expect("create table");
         let (table_id,): (String,) =
@@ -1995,7 +1995,7 @@ mod reconciler_tests {
         }))
         .expect("input");
         engine
-            .create_table_impl(account, input)
+            .create_table_impl(account, input, false)
             .await
             .expect("create table");
         let (table_id,): (String,) =

--- a/crates/storage-sqlite/src/vector_bench.rs
+++ b/crates/storage-sqlite/src/vector_bench.rs
@@ -118,7 +118,7 @@ mod tests {
         }))
         .expect("input");
         engine
-            .create_table_impl(account, input)
+            .create_table_impl(account, input, false)
             .await
             .expect("create table");
 

--- a/crates/storage-sqlite/src/workers.rs
+++ b/crates/storage-sqlite/src/workers.rs
@@ -855,7 +855,7 @@ mod vector_propagation_tests {
         }))
         .expect("input");
         engine
-            .create_table_impl("000000000000", input)
+            .create_table_impl("000000000000", input, false)
             .await
             .expect("create table");
         let (table_id,): (String,) =


### PR DESCRIPTION
## What

SQLite's `RestoreTableFromBackup` could report the restore target as `ACTIVE` before the data copy finished, so a client that waits-for-ACTIVE can read an empty or partial table.

The restore path created the target through the ordinary create-table flow, which either starts the table `ACTIVE` outright (creation delay 0) or schedules a `CREATING` -> `ACTIVE` transition on the creation-delay timer. The control-plane worker applies that transition without consulting the copy, and a row-by-row copy of a large backup outlasts the timer.

This is the **same defect already fixed for Postgres in `cf5d497` and covered for MongoDB in `f80dd9d`**. Both of those backends carry a `defer_active` flag; SQLite was never given it. Nothing exercised the gap until #244 added the `run-rust-integration-sqlite` job, which is why it surfaced today.

`RestoreTableToPointInTime` delegates to `RestoreTableFromBackup` on this backend, so it is covered by the same change.

## How

`create_table_impl` gains a `defer_active` flag. The restore path passes `true`, writing the row `CREATING` with **no** `status_transition_at`, so the worker's query can never match it:

```sql
WHERE table_status = 'CREATING' AND status_transition_at IS NOT NULL
  AND status_transition_at <= ?
```

The existing explicit ACTIVE update after the copy commits becomes the only flip. `TableEngine::create_table` passes `false` and is unchanged. The flag is checked **before** the `delay_secs <= 0.0` branch, so a deferred create holds `CREATING` even at a zero configured delay.

Five of the six changed files only thread `false` through existing test callers.

## Verification

The existing test is a race detector, and its own module doc warns that **passes are weak evidence**: on an idle server the copy finishes inside the transition window and the race goes unobserved. That is not a theoretical caveat, it is what happens here. On unfixed code at CI's delay of 0.05s:

| | result |
|---|---|
| unfixed, delay 0.05, 6 runs | **6/6 PASS** (race not observed) |

So a loop is not a control. Setting `control_plane_delay_seconds = 0` makes the defect deterministic rather than timing-dependent, because unfixed code then creates the target `ACTIVE` outright:

| | result |
|---|---|
| unfixed, delay 0 | **3/3 FAIL** - `restored table reported ACTIVE with 0/40000 items present` |
| fixed, delay 0 | **3/3 PASS** |
| fixed, delay 0.05 (CI setting) | **3/3 PASS** |

Run live against a release build with a real 40,000-item restore.

Gates: `cargo fmt --all --check` clean; `cargo clippy --all-targets -D warnings` clean on the `sqlite` and `postgres` feature sets; **1015 lib tests passed, 0 failed, 0 filtered** on both.

## Note for reviewers

This explains the intermittent `run-rust-integration-sqlite` failures appearing since #244 merged. It is a true positive, not a flake: the test cannot fail when the ordering is correct. Re-running turns it green without fixing anything.
