### PR TITLE
chore: bump workspace version to 0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "extenddb-app",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-app"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-auth"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-trait",
  "axum",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-cache"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "futures",
  "moka",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-config"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "config",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-engine"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "base64 0.22.1",
  "crc32fast",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-server"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-mongodb"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-postgres"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-sqlite"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SOFTWARE-LICENSE-NOTICES-DEV.html
+++ b/SOFTWARE-LICENSE-NOTICES-DEV.html
@@ -7085,16 +7085,16 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage-sqlite ">extenddb-storage-sqlite 0.1.6</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage-sqlite ">extenddb-storage-sqlite 0.1.7</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.103</a></li>
                     <li><a href=" https://github.com/andylokandy/arraydeque ">arraydeque 0.5.1</a></li>

--- a/SOFTWARE-LICENSE-NOTICES.html
+++ b/SOFTWARE-LICENSE-NOTICES.html
@@ -6665,16 +6665,16 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.6</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage-postgres ">extenddb-storage-postgres 0.1.6</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage-postgres ">extenddb-storage-postgres 0.1.7</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.103</a></li>
                     <li><a href=" https://github.com/andylokandy/arraydeque ">arraydeque 0.5.1</a></li>


### PR DESCRIPTION
## What

Workspace version 0.1.6 -> 0.1.7, with **both** licence notices files regenerated in the same commit. The notices embed every workspace crate version, so a bump without regeneration is the exact failure that made 0.1.6 unreleasable (#271, fixed by #272). `licenses.yml` gates both files at PR time now, and the release workflows gate them again at dispatch.

## Why 0.1.7

`v0.1.6` already exists and points 13+ commits behind current main, predating vector search entirely. The `release-dev-image` gate requires the dispatched tag to match `Cargo.toml` at the tagged commit, so shipping the dev image with vector search requires this bump, then a `v0.1.7` tag on the merged commit.

## Stacked on #281 — merge order matters

Base is `feat/dev-container`, deliberately: the DEV notices generator only exists on that branch, and regenerating the DEV notices against 0.1.7 requires it. **Merge #281 first.** GitHub retargets this PR to `main` automatically when #281 lands — then **verify the base actually shows `main` before merging this** (the #274 stranding lesson: merging within seconds of the parent can land the child on the dead parent branch).

## Verification

- `generate-software-license-notices --check` exit 0
- `generate-dev-license-notices --check` exit 0
- `cargo check` clean on `sqlite,dev-mode` and `postgres`
- the release gate comparison (tag `v0.1.7` vs workspace `Cargo.toml`) now matches

## Heads-up, not this PR's problem

`packaging/npm/package.json` on #258 still says 0.1.3; the npm publish gate will refuse that drift against a 0.1.7 workspace the moment #258 merges. #258 needs its manifest bumped before or at merge.