### PR TITLE
fix(sqlite): bind LIMIT as an integer, add BoundValue::Int, dedupe placeholder lists

### DIFF
--- a/crates/storage-sqlite/src/data/index.rs
+++ b/crates/storage-sqlite/src/data/index.rs
@@ -475,10 +475,10 @@ pub(crate) async fn insert_index_row_multi(
     cols.push("item_data".to_owned());
     values.push(BoundValue::Text(item_json));
 
-    let placeholders = vec!["?"; cols.len()].join(", ");
     let sql = format!(
-        "INSERT OR REPLACE INTO {idx_table} ({}) VALUES ({placeholders})",
-        cols.join(", ")
+        "INSERT OR REPLACE INTO {idx_table} ({}) VALUES ({binds})",
+        cols.join(", "),
+        binds = super::bind_list(cols.len())
     );
 
     let mut query = sqlx::query(&sql);

--- a/crates/storage-sqlite/src/data/mod.rs
+++ b/crates/storage-sqlite/src/data/mod.rs
@@ -114,9 +114,12 @@ pub(crate) fn json_to_item(v: serde_json::Value) -> Result<Item, StorageError> {
 /// A value bound into a positional `sqlx` query, already mapped to its SQLite
 /// storage representation.
 ///
-/// The `Text` and `Blob` cases carry sort-key values per D2. `Int` carries a
-/// query parameter that is a number in its own right rather than a key: before it
-/// existed, the only way an integer reached SQL in this crate was interpolation.
+/// The `Text` and `Blob` cases carry sort-key values per D2. `Int` carries a query
+/// parameter that is a number in its own right rather than a key. `BoundValue`
+/// previously had no integer case, so an integer travelling through a
+/// `BoundValue`-mediated bind list had to be interpolated instead, which is what the
+/// two `LIMIT` sites did. Integers bound directly, not through a `BoundValue`, were
+/// always possible and are used elsewhere.
 #[derive(Debug, Clone)]
 pub(crate) enum BoundValue {
     /// `TEXT` — used for `S` (raw string) and `N` (order-preserving encoding).
@@ -173,7 +176,8 @@ macro_rules! bind_bound {
 /// capture the identifier exists only inside the format string and **no
 /// expression appears in the macro arguments at all**, so a `syn`-based rule
 /// cannot see that a `VALUES (...)` interpolation is a placeholder list rather
-/// than a value. The named form puts the name and the call in one AST node.
+/// than a value. The named form puts the call in the macro's argument tokens,
+/// where a token-stream parser can find it.
 pub(crate) fn bind_list(n: usize) -> String {
     vec!["?"; n].join(", ")
 }
@@ -185,7 +189,10 @@ macro_rules! bind_sk_fetch_optional {
         let __q = match crate::data::sk_bound($sk) {
             crate::data::BoundValue::Text(s) => __q.bind(s),
             crate::data::BoundValue::Blob(b) => __q.bind(b),
-            crate::data::BoundValue::Int(i) => __q.bind(i),
+            crate::data::BoundValue::Int(_) => unreachable!(
+                "sk_bound never yields Int: N is encoded as TEXT so lexicographic \
+order equals numeric order"
+            ),
         };
         __q.fetch_optional($executor)
             .await
@@ -200,7 +207,10 @@ macro_rules! bind_sk_execute {
         let __q = match crate::data::sk_bound($sk) {
             crate::data::BoundValue::Text(s) => __q.bind(s),
             crate::data::BoundValue::Blob(b) => __q.bind(b),
-            crate::data::BoundValue::Int(i) => __q.bind(i),
+            crate::data::BoundValue::Int(_) => unreachable!(
+                "sk_bound never yields Int: N is encoded as TEXT so lexicographic \
+order equals numeric order"
+            ),
         };
         __q.bind($item_json)
             .execute($executor)
@@ -216,7 +226,10 @@ macro_rules! bind_sk_only_execute {
         let __q = match crate::data::sk_bound($sk) {
             crate::data::BoundValue::Text(s) => __q.bind(s),
             crate::data::BoundValue::Blob(b) => __q.bind(b),
-            crate::data::BoundValue::Int(i) => __q.bind(i),
+            crate::data::BoundValue::Int(_) => unreachable!(
+                "sk_bound never yields Int: N is encoded as TEXT so lexicographic \
+order equals numeric order"
+            ),
         };
         __q.execute($executor)
             .await

--- a/crates/storage-sqlite/src/data/mod.rs
+++ b/crates/storage-sqlite/src/data/mod.rs
@@ -176,8 +176,14 @@ macro_rules! bind_bound {
 /// capture the identifier exists only inside the format string and **no
 /// expression appears in the macro arguments at all**, so a `syn`-based rule
 /// cannot see that a `VALUES (...)` interpolation is a placeholder list rather
-/// than a value. The named form puts the call in the macro's argument tokens,
-/// where a token-stream parser can find it.
+/// than a value.
+///
+/// The named form fixes that in two steps. `syn` hands a macro's arguments over as an
+/// unparsed token stream, so there is no typed node until a rule parses them; **once
+/// parsed, the named form yields a single `Expr::Assign` binding the hole's name to the
+/// call.** That is what makes it better than a positional argument: the name and the
+/// call are associated structurally, so a rule does not have to map format-string holes
+/// to argument indices and cannot be off by one.
 pub(crate) fn bind_list(n: usize) -> String {
     vec!["?"; n].join(", ")
 }

--- a/crates/storage-sqlite/src/data/mod.rs
+++ b/crates/storage-sqlite/src/data/mod.rs
@@ -111,14 +111,22 @@ pub(crate) fn json_to_item(v: serde_json::Value) -> Result<Item, StorageError> {
     serde_json::from_value(v).map_err(|e| StorageError::Internal(e.to_string()))
 }
 
-/// A value bound to a sort-key column, already mapped to its SQLite storage
-/// representation per D2.
+/// A value bound into a positional `sqlx` query, already mapped to its SQLite
+/// storage representation.
+///
+/// The `Text` and `Blob` cases carry sort-key values per D2. `Int` carries a
+/// query parameter that is a number in its own right rather than a key: before it
+/// existed, the only way an integer reached SQL in this crate was interpolation.
 #[derive(Debug, Clone)]
 pub(crate) enum BoundValue {
     /// `TEXT` — used for `S` (raw string) and `N` (order-preserving encoding).
     Text(String),
     /// `BLOB` — used for `B`.
     Blob(Vec<u8>),
+    /// `INTEGER` — a numeric parameter, not a key. Distinct from `N`, which is
+    /// deliberately TEXT so that lexicographic order equals numeric order; this
+    /// is for values whose ordering is irrelevant, such as a `LIMIT`.
+    Int(i64),
 }
 
 /// Map a parsed sort-key value to its SQLite storage representation (D2):
@@ -137,8 +145,37 @@ macro_rules! bind_bound {
         match $bound {
             crate::data::BoundValue::Text(s) => $query.bind(s),
             crate::data::BoundValue::Blob(b) => $query.bind(b),
+            crate::data::BoundValue::Int(i) => $query.bind(i),
         }
     };
+}
+
+/// A positional placeholder list for `n` parameters: `?, ?, ?`.
+///
+/// Deduplicates two identical constructions on the index write paths.
+///
+/// # The call shape is load-bearing, so do not "simplify" it
+///
+/// Call sites pass this as a **named** `format!` argument:
+///
+/// ```ignore
+/// format!("INSERT INTO {t} ({}) VALUES ({binds})", cols, binds = bind_list(n))
+/// ```
+///
+/// Collapsing that to a local plus implicit capture, which reads as a tidy-up:
+///
+/// ```ignore
+/// let binds = bind_list(n);
+/// format!("INSERT INTO {t} ({}) VALUES ({binds})", cols)   // WRONG
+/// ```
+///
+/// changes nothing about the SQL and breaks a static check. With implicit
+/// capture the identifier exists only inside the format string and **no
+/// expression appears in the macro arguments at all**, so a `syn`-based rule
+/// cannot see that a `VALUES (...)` interpolation is a placeholder list rather
+/// than a value. The named form puts the name and the call in one AST node.
+pub(crate) fn bind_list(n: usize) -> String {
+    vec!["?"; n].join(", ")
 }
 
 /// Bind `pk` then a sort-key value, then `fetch_optional` a single JSON column.
@@ -148,6 +185,7 @@ macro_rules! bind_sk_fetch_optional {
         let __q = match crate::data::sk_bound($sk) {
             crate::data::BoundValue::Text(s) => __q.bind(s),
             crate::data::BoundValue::Blob(b) => __q.bind(b),
+            crate::data::BoundValue::Int(i) => __q.bind(i),
         };
         __q.fetch_optional($executor)
             .await
@@ -162,6 +200,7 @@ macro_rules! bind_sk_execute {
         let __q = match crate::data::sk_bound($sk) {
             crate::data::BoundValue::Text(s) => __q.bind(s),
             crate::data::BoundValue::Blob(b) => __q.bind(b),
+            crate::data::BoundValue::Int(i) => __q.bind(i),
         };
         __q.bind($item_json)
             .execute($executor)
@@ -177,6 +216,7 @@ macro_rules! bind_sk_only_execute {
         let __q = match crate::data::sk_bound($sk) {
             crate::data::BoundValue::Text(s) => __q.bind(s),
             crate::data::BoundValue::Blob(b) => __q.bind(b),
+            crate::data::BoundValue::Int(i) => __q.bind(i),
         };
         __q.execute($executor)
             .await

--- a/crates/storage-sqlite/src/data/mod.rs
+++ b/crates/storage-sqlite/src/data/mod.rs
@@ -182,8 +182,10 @@ macro_rules! bind_bound {
 /// unparsed token stream, so there is no typed node until a rule parses them; **once
 /// parsed, the named form yields a single `Expr::Assign` binding the hole's name to the
 /// call.** That is what makes it better than a positional argument: the name and the
-/// call are associated structurally, so a rule does not have to map format-string holes
-/// to argument indices and cannot be off by one.
+/// call are associated structurally, so a rule does not have to map *this* hole to an
+/// argument index and cannot be off by one for it. The same format string still holds a
+/// positional hole, the `({})` filled by `cols.join(", ")`, so a rule that wants to
+/// classify that one does need hole-to-index resolution.
 pub(crate) fn bind_list(n: usize) -> String {
     vec!["?"; n].join(", ")
 }

--- a/crates/storage-sqlite/src/data/query.rs
+++ b/crates/storage-sqlite/src/data/query.rs
@@ -164,6 +164,7 @@ pub(super) async fn execute_dynamic_query(
         query = match v {
             BoundValue::Text(s) => query.bind(s),
             BoundValue::Blob(b) => query.bind(b),
+            BoundValue::Int(i) => query.bind(i),
         };
     }
     let rows: Vec<(serde_json::Value,)> = query

--- a/crates/storage-sqlite/src/data/query_scan.rs
+++ b/crates/storage-sqlite/src/data/query_scan.rs
@@ -151,7 +151,8 @@ impl SqliteEngine {
         }
 
         let fetch_limit = limit.map_or(1_000_001, |l| l + 1);
-        let _ = write!(sql, " LIMIT {fetch_limit}");
+        sql.push_str(" LIMIT ?");
+        binds.push(BoundValue::Int(fetch_limit));
 
         let rows = execute_dynamic_query(&sql, binds, &self.pool).await?;
         finalize(rows, limit, &key_info.key_schema)
@@ -299,7 +300,8 @@ impl SqliteEngine {
         }
 
         let fetch_limit = limit.map_or(1_000_001, |l| l + 1);
-        let _ = write!(sql, " LIMIT {fetch_limit}");
+        sql.push_str(" LIMIT ?");
+        binds.push(BoundValue::Int(fetch_limit));
 
         let rows = execute_dynamic_query(&sql, binds, &self.pool).await?;
         finalize(rows, limit, &key_info.key_schema)

--- a/crates/storage-sqlite/src/data/vector_index.rs
+++ b/crates/storage-sqlite/src/data/vector_index.rs
@@ -468,10 +468,10 @@ pub(crate) async fn insert_vector_row(
         .chain(key_cols.iter().cloned())
         .chain(["vec".to_owned(), "nrm".to_owned(), "item_data".to_owned()])
         .collect::<Vec<_>>();
-    let placeholders = vec!["?"; cols.len()].join(", ");
     let sql = format!(
-        "INSERT INTO {vec_table} ({}) VALUES ({placeholders})",
-        cols.join(", ")
+        "INSERT INTO {vec_table} ({}) VALUES ({binds})",
+        cols.join(", "),
+        binds = super::bind_list(cols.len())
     );
     let key_binds = base_key_binds(item, base_key_schema, attr_defs)?;
     let mut q = sqlx::query(&sql).bind(part);


### PR DESCRIPTION
Three independent changes to the SQLite data plane. Each stands on its own merits; none depends on tooling that is not in the tree.

### 1. `BoundValue` gains `Int(i64)`

The type already models two of SQLite's storage classes, for sort keys: `S` and `N` to TEXT, `B` to BLOB. An integer that is a *parameter in its own right* rather than a key had no case, so an integer travelling through a `BoundValue`-mediated bind list had to be interpolated instead, which is what the two `LIMIT` sites did. Integers bound directly, not through a `BoundValue`, were always possible and are used elsewhere. That is the gap.

`Int` is deliberately distinct from `N`. `N` is TEXT on purpose, carrying an order-preserving encoding so lexicographic order equals numeric order; `Int` is for values whose ordering is irrelevant.

**Only `Int` is added, not `Real`.** Nothing needs `Real`, and the vector path stores `f32` as blobs, so the obvious future caller is not one. A variant with no producer is speculative API; adding it when something needs it is two lines and the need will be visible.

Every consumer matched `BoundValue` exhaustively, so the compiler enumerated all five sites that needed the new arm: `bind_bound!`, the three sort-key bind macros in `data/mod.rs` that inline the match rather than calling `bind_bound!`, and `execute_dynamic_query`. The three sort-key arms are `unreachable!`, because `sk_bound` never yields `Int`.

### 2. Query and Scan bind `LIMIT` rather than interpolating it

`data/query_scan.rs` was writing `" LIMIT {fetch_limit}"` at two sites. **The crate's own convention is already 14 `LIMIT ?` sites across six files**, so these two were the outliers, and binding a limit is better practice regardless of that. Both sites sit in `execute_dynamic_query` paths that already carry a bind vector, so the value appends to an existing list. The emitted SQL is otherwise unchanged.

### 3. `bind_list(n)` deduplicates two identical placeholder constructions

`vec!["?"; n].join(", ")` appeared identically on the two index write paths.

It lives in `data/mod.rs` rather than beside either caller because it is a generic SQL helper and `mod.rs` was already being touched for `BoundValue`. Putting it next to one of its two callers to keep the diff narrower would have been scope discipline standing in for a good home.

Its doc comment records that the **named-argument call shape is load-bearing** and names the wrong simplification, because collapsing it to a local plus implicit capture reads as a tidy-up and changes nothing about the SQL, while removing the only expression a static analysis can see.

### Not addressed here

`query_scan.rs:153` and `:301` compute `limit.map_or(1_000_001, |l| l + 1)`, and validation bounds `Limit` below only (`engine/src/query.rs:94`, `scan.rs:296`), so a large `Limit` overflows: debug builds panic, release builds wrap to `i64::MIN`, and a negative `LIMIT` in SQLite means no limit. **That is in the arithmetic before the value reaches SQL, so this change neither causes nor repairs it**, and bundling a fix would break the property that makes this PR reviewable. Filed separately.

Worth noting for whoever takes it: `ListTablesInput.limit` is `Option<i32>` (`crates/core/src/types/table.rs:769`) while `QueryInput` and `ScanInput` are `Option<i64>` (`crates/core/src/types/query.rs:78`, `:146`), and all three deserialize the same wire field. So there is a local consistency argument that does not depend on checking the real API. Narrowing the type alone moves the boundary rather than removing it, since `i32::MAX` stays reachable and `+ 1` still overflows; both the type and the arithmetic need attention.

### Verification

- `cargo build -p extenddb-storage-sqlite`, `cargo fmt --all -- --check`, `cargo clippy -p extenddb-storage-sqlite --all-targets`: clean.
- `cargo test -p extenddb-storage-sqlite --lib`: 60 passed, 0 failed.
- SQL text delta is exactly four lines: two `LIMIT` sites, and two `VALUES` interpolations renamed from `{placeholders}` to `{binds}` with the emitted SQL identical.
