### PR TITLE
chore(release): bump workspace version to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "extenddb-app",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-app"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-auth"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "axum",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-cache"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "futures",
  "moka",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-config"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "config",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-engine"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "base64 0.22.1",
  "crc32fast",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-server"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-mongodb"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-postgres"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-sqlite"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SOFTWARE-LICENSE-NOTICES-DEV.html
+++ b/SOFTWARE-LICENSE-NOTICES-DEV.html
@@ -7085,16 +7085,16 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage-sqlite ">extenddb-storage-sqlite 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage-sqlite ">extenddb-storage-sqlite 0.1.8</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.103</a></li>
                     <li><a href=" https://github.com/andylokandy/arraydeque ">arraydeque 0.5.1</a></li>

--- a/SOFTWARE-LICENSE-NOTICES.html
+++ b/SOFTWARE-LICENSE-NOTICES.html
@@ -6665,16 +6665,16 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.7</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage-postgres ">extenddb-storage-postgres 0.1.7</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.8</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage-postgres ">extenddb-storage-postgres 0.1.8</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.103</a></li>
                     <li><a href=" https://github.com/andylokandy/arraydeque ">arraydeque 0.5.1</a></li>


### PR DESCRIPTION
## What

Bumps the workspace version `0.1.7` → `0.1.8` (one line in the root
`Cargo.toml`), refreshes the twelve workspace-member entries in
`Cargo.lock`, and regenerates **both** license-notices files
(`SOFTWARE-LICENSE-NOTICES.html` and `SOFTWARE-LICENSE-NOTICES-DEV.html`)
for the crate version strings. No dependency or source change.

## Why

Requested by @LeeroyHannigan: opens the 0.1.8 release line for the fixes
accumulated on `main` since the `v0.1.7` tag. Does not affect v0.1.7
releases (the release gates read `Cargo.toml` at the tagged commit): the
pending dev-image mirror backfill and the postgres v0.1.7 release both
proceed from the existing tag regardless of this bump.

First version bump under the complete PR-time notices regime — both files
are now gated by `licenses.yml`, so the #271-style
merge-green-but-unreleasable failure cannot recur for either image.

## Testing done

- `cargo check --workspace --all-targets --locked` clean on current main.
- Both notices generators run and both `--check`s pass locally
  (`cargo-about 0.9.0`, same pin as the gates).
- `Cargo.lock` diff verified: exactly the twelve `extenddb*` workspace
  crates move `0.1.7` → `0.1.8`; the only version-string changes in the
  entire lockfile diff are that pair; no third-party entries changed.

## Checklist

- [ ] All tests pass (`cargo test --workspace`) — not re-run: no source or
      dependency change; merged code was tested by its own PRs' CI
- [ ] Code is formatted / clippy — not applicable, no Rust source changed
- [x] I have added or updated tests for new functionality — not applicable
- [x] I have updated documentation if behavior changed — not applicable
- [x] Breaking changes are noted below (if any)

ADR / RFC: n/a — version metadata only.

## Breaking changes

None.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
