### PR TITLE
chore(npm): bump launcher manifest to 0.1.8 with the workspace version

### DIFF
--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extenddb/dev",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "ExtendDB dev server launcher: a DynamoDB-compatible database for local development and CI. Spawns the extenddb dev binary (file-backed by default, in-memory with --memory) and hands back an endpoint plus credentials any AWS SDK accepts.",
   "license": "Apache-2.0",
   "repository": {
@@ -25,10 +25,10 @@
     "test": "node test/launcher.test.js"
   },
   "optionalDependencies": {
-    "@extenddb/linux-x64": "0.1.7",
-    "@extenddb/linux-arm64": "0.1.7",
-    "@extenddb/darwin-x64": "0.1.7",
-    "@extenddb/darwin-arm64": "0.1.7",
-    "@extenddb/win32-x64": "0.1.7"
+    "@extenddb/linux-x64": "0.1.8",
+    "@extenddb/linux-arm64": "0.1.8",
+    "@extenddb/darwin-x64": "0.1.8",
+    "@extenddb/darwin-arm64": "0.1.8",
+    "@extenddb/win32-x64": "0.1.8"
   }
 }


### PR DESCRIPTION
## What

One file: `packaging/npm/package.json` moves 0.1.7 -> 0.1.8 (`version` plus the five `optionalDependencies` pins, which move in lockstep).

## Why

The npm-publish gate refused the v0.1.8 dispatch:

```
packaging/npm/package.json at 60719ab says 0.1.7, expected 0.1.8 (bump it with the workspace version)
```

That refusal is correct: #298 bumped the workspace and cut v0.1.8, but the launcher manifest was not bumped with it. The publish step rewrites versions at publish time either way; the checked-in value exists so the manifest never misleads a reader, which is exactly the drift the gate exists to catch.

After this merges, re-dispatch `npm-publish` with `tag=v0.1.8`.