### PR TITLE
ci(actions): bounded settle window on post-copy assertions

### DIFF
--- a/.github/actions/copy-artifact/action.yml
+++ b/.github/actions/copy-artifact/action.yml
@@ -76,5 +76,16 @@ runs:
         else
           skopeo copy --preserve-digests "docker://${SRC}:${TAG}" "docker://${DST}:${TAG}"
         fi
-        GOT=$(probe "${DST}:${TAG}") || { echo "::error::${DST}:${TAG} missing after copy"; exit 1; }
-        [[ "$GOT" == "$WANT" ]] || { echo "::error::${DST}:${TAG} resolves to ${GOT}, expected ${WANT}"; exit 1; }
+        # Post-WRITE assertion with a bounded settle window: ECR Public shows
+        # read-after-write lag (a copy's own log confirms the write and the
+        # immediate read 404s — failed the v0.1.8 dev propagation live).
+        # Retry is only correct after our own write; the existence DECISION
+        # above stays a strict single probe.
+        for _ in 1 2 3 4 5 6; do
+          set +e; GOT=$(probe "${DST}:${TAG}"); rc=$?; set -e
+          [[ $rc == 0 && "$GOT" == "$WANT" ]] && exit 0
+          [[ $rc == 0 && "$GOT" != "$WANT" ]] && { echo "::error::${DST}:${TAG} resolves to ${GOT}, expected ${WANT}"; exit 1; }
+          sleep 5
+        done
+        echo "::error::${DST}:${TAG} not visible with expected digest after settle window"
+        exit 1

--- a/.github/actions/promote-registry/action.yml
+++ b/.github/actions/promote-registry/action.yml
@@ -98,6 +98,24 @@ runs:
           fi
         }
 
+        # settle(): post-WRITE assertion with a bounded settle window. ECR
+        # Public exhibits read-after-write lag (observed live: a copy's own
+        # log confirms the write, the immediate read 404s, and the tag is
+        # visible seconds later — this failed the v0.1.8 dev propagation).
+        # Retrying is ONLY correct after our own write; state DECISIONS
+        # (exists/absent/verify) stay strict single probes.
+        settle() {
+          local ref="$1" want="$2" got rc
+          for _ in 1 2 3 4 5 6; do
+            set +e; got=$(probe "$ref"); rc=$?; set -e
+            [[ $rc == 0 && "$got" == "$want" ]] && return 0
+            [[ $rc == 0 && "$got" != "$want" ]] && { echo "::error::${ref} resolves to ${got}, expected ${want}" >&2; return 1; }
+            sleep 5
+          done
+          echo "::error::${ref} not visible with expected digest after settle window" >&2
+          return 1
+        }
+
         # --- 1. signature first: verified before ANY tag is placed ---
         set +e; DST_SIG=$(probe "${DST}:${SIG_TAG}"); rc=$?; set -e
         [[ $rc == 0 || $rc == 9 ]] || exit 1
@@ -111,8 +129,7 @@ runs:
           skopeo copy --preserve-digests \
             "docker://${SRC}:${SIG_TAG}" \
             "docker://${DST}:${SIG_TAG}"
-          DST_SIG=$(probe "${DST}:${SIG_TAG}") || { echo "::error::signature missing after copy"; exit 1; }
-          [[ "$DST_SIG" == "$SRC_SIG" ]] || { echo "::error::signature copy digest mismatch (${DST_SIG} != ${SRC_SIG})"; exit 1; }
+          settle "${DST}:${SIG_TAG}" "$SRC_SIG" || { echo "::error::signature missing or mismatched after copy"; exit 1; }
         fi
         # The signature must actually VERIFY, not merely exist: an empty or
         # wrong-key manifest at the .sig tag name must not pass. Verified
@@ -165,7 +182,6 @@ runs:
         TAGS=("${VERSION}")
         [[ "$MOVE_LATEST" == "true" ]] && TAGS+=(latest)
         for t in "${TAGS[@]}"; do
-          GOT=$(probe "${DST}:${t}") || { echo "::error::${DST}:${t} missing after promotion"; exit 1; }
-          [[ "$GOT" == "$DIGEST" ]] || { echo "::error::${DST}:${t} resolves to ${GOT}, expected ${DIGEST}"; exit 1; }
+          settle "${DST}:${t}" "$DIGEST" || exit 1
         done
         echo "::notice::${DST}: promoted ${VERSION}$([[ "$MOVE_LATEST" == "true" ]] && echo ' + latest'), signature verified"


### PR DESCRIPTION
## What

Post-**write** assertions in `promote-registry` and `copy-artifact` now retry for up to ~30s (6 × 5s) before failing closed. State **decisions** — exists/absent classification, verify-before-tag — remain strict single probes; retrying those would reintroduce the fail-open class from the #283 review.

## Why

Live failure on the v0.1.8 dev propagation ([run 32514590435](https://github.com/ExtendDB/extenddb/actions/runs/32514590435)): the ECR signature copy's own log shows the manifest written, the immediate post-copy probe reported it missing, and the artifact was verifiably present minutes later (`crane digest` confirms it now) — ECR Public read-after-write lag, also observed manually during the v0.1.6 promotion. Because the action correctly signs-first, it died before copying the version tags, leaving ECR with a signature and no `0.1.8`/`latest`.

Urgency: the postgres v0.1.8 propagate job (pending behind its publish approval) asserts the same way against ECR and would likely hit the identical failure.

## Testing done

- `yaml.safe_load` passes on both actions.
- The recovery path after merge is itself the live verification: re-running the dev propagate takes the re-entry branches end to end (GHCR fully no-ops; ECR sees the existing signature, verifies it, and completes the version/latest copies under the settle window).

## Checklist

- [ ] Tests / fmt / clippy — not applicable, workflow-only change
- [x] Added or updated tests — the settle window is bounded and fails closed; decision probes deliberately unchanged
- [x] Breaking changes noted below

ADR / RFC: n/a — CI tooling only.

## Breaking changes

None.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.