### PR TITLE
ci(npm-publish): gate reads the launcher manifest from origin/main, not the tag tree

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -149,9 +149,13 @@ jobs:
           #    The publish step rewrites the version anyway, so a stale value
           #    would not break the release; it would quietly mislead anyone
           #    reading the manifest, which is worse.
-          PKG_VERSION=$(git show "${SHA}:packaging/npm/package.json" | jq -r .version)
+          # Read from origin/main, not the tag tree: packaging is release
+          # tooling and lives on main (same rule as the workflow definition
+          # itself). A tag cut before a manifest bump merged would otherwise
+          # fail here forever.
+          PKG_VERSION=$(git show "origin/main:packaging/npm/package.json" | jq -r .version)
           if [[ "$VERSION" != "$PKG_VERSION" ]]; then
-            echo "::error::packaging/npm/package.json at ${SHA} says ${PKG_VERSION}, expected ${VERSION} (bump it with the workspace version)"
+            echo "::error::packaging/npm/package.json on origin/main says ${PKG_VERSION}, expected ${VERSION} (bump it with the workspace version)"
             exit 1
           fi
 


### PR DESCRIPTION
## What

One line in the gate: check 5 reads `packaging/npm/package.json` from `origin/main` instead of the tag SHA (plus the matching error message).

## Why

The v0.1.8 dispatch failed **even after #299 merged**:

```
packaging/npm/package.json at 60719ab says 0.1.7, expected 0.1.8
```

`60719ab` is the v0.1.8 tag commit, cut before #299 landed, so the manifest at the tag tree says 0.1.7 permanently and no dispatch of this tag can ever pass. Packaging is release tooling and lives on main - the same rule this workflow's own header states for its definition. The version equality check is unchanged and still binds all three: main manifest == dispatched tag == Cargo.toml at the tag.

Two dispatch failures today prove both sides of the gate: the drift catch (#299's cause) was correct behavior; this tag-tree read is the defect.

After merge: dispatch `npm-publish` with `tag=v0.1.8` (**lowercase v** - the strict tag check rejects `V0.1.8`, which was tonight's first failure).