### PR TITLE
fix: compile on Windows — gate POSIX daemon/syslog/signal code behind cfg(unix)

### DIFF
--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -24,7 +24,6 @@ extenddb-server = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
-daemonize = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
@@ -33,6 +32,11 @@ toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 base64 = { workspace = true }
-libc = { workspace = true }
 rcgen = { workspace = true }
 rustls = { workspace = true }
+
+# Daemon mode (double-fork, PID files, SIGTERM) is POSIX-only; on Windows the
+# server runs with `serve --foreground` under an external supervisor.
+[target.'cfg(unix)'.dependencies]
+daemonize = { workspace = true }
+libc = { workspace = true }

--- a/crates/app/src/cmd_serve.rs
+++ b/crates/app/src/cmd_serve.rs
@@ -6,9 +6,12 @@
 use std::net::TcpListener;
 
 use clap::Args;
+#[cfg(unix)]
 use daemonize::Daemonize;
 
-use crate::serve_helpers::{check_config_permissions, verify_daemon_started};
+use crate::serve_helpers::check_config_permissions;
+#[cfg(unix)]
+use crate::serve_helpers::verify_daemon_started;
 use extenddb_config as config;
 use extenddb_config::pid_file_path;
 use extenddb_server::{BuildInfo, LogTarget, ServeParams};
@@ -202,43 +205,56 @@ pub fn run(args: &ServeArgs, build: BuildInfo) -> anyhow::Result<()> {
     // can be supervised by Docker, Kubernetes, systemd Type=simple, etc.
     // Graceful shutdown on SIGINT/SIGTERM still works.
     if !args.foreground {
-        let pid_file = pid_file
-            .as_ref()
-            .expect("daemon mode always has a PID file path");
-        // The listening socket bound successfully above, which proves no live
-        // server owns this port. Any existing PID file is therefore stale (a
-        // prior run that crashed or was killed without cleanup). Remove it
-        // before daemonizing so startup verification reads the new daemon's
-        // PID rather than a dead one from a previous run.
-        let _ = std::fs::remove_file(pid_file);
-        let daemon = Daemonize::new().pid_file(pid_file);
-        match daemon.execute() {
-            daemonize::Outcome::Parent(Ok(_)) => {
-                // Parent process: wait for the PID file to appear (written by
-                // the grandchild after the double-fork), then verify the daemon
-                // is still alive. This catches crashes during early startup
-                // (bad config, missing tables, TLS cert errors).
-                return verify_daemon_started(pid_file, &bind_addr);
-            }
-            daemonize::Outcome::Parent(Err(e)) => {
-                return Err(anyhow::anyhow!("Failed to daemonize: {e}"));
-            }
-            daemonize::Outcome::Child(Ok(_)) => {
-                // Child (daemon) process: continue to start the server.
-            }
-            daemonize::Outcome::Child(Err(e)) => {
-                return Err(anyhow::anyhow!("Failed to daemonize (child): {e}"));
-            }
-        }
+        // Daemon mode (double fork, PID file, syslog) is POSIX-only. On
+        // Windows the server must be run with `--foreground` under an
+        // external supervisor (a terminal, a service wrapper, or the npm
+        // launcher, which always passes `--foreground`).
+        #[cfg(not(unix))]
+        anyhow::bail!(
+            "daemon mode is not supported on this platform; \
+             run `extenddb serve --foreground`"
+        );
 
-        // P57 Bug 3 fix: After daemonize, stderr is /dev/null. Install a panic
-        // hook that writes to syslog so panics are visible. Without this, the
-        // child process silently disappears on panic. Reuses the server crate's
-        // raw syslog writer so there is one implementation of it — tracing is
-        // unusable here because the subscriber is only set up inside `serve`.
-        std::panic::set_hook(Box::new(|info| {
-            extenddb_server::log_to_syslog_raw(&format!("extenddb panic: {info}"));
-        }));
+        #[cfg(unix)]
+        {
+            let pid_file = pid_file
+                .as_ref()
+                .expect("daemon mode always has a PID file path");
+            // The listening socket bound successfully above, which proves no live
+            // server owns this port. Any existing PID file is therefore stale (a
+            // prior run that crashed or was killed without cleanup). Remove it
+            // before daemonizing so startup verification reads the new daemon's
+            // PID rather than a dead one from a previous run.
+            let _ = std::fs::remove_file(pid_file);
+            let daemon = Daemonize::new().pid_file(pid_file);
+            match daemon.execute() {
+                daemonize::Outcome::Parent(Ok(_)) => {
+                    // Parent process: wait for the PID file to appear (written by
+                    // the grandchild after the double-fork), then verify the daemon
+                    // is still alive. This catches crashes during early startup
+                    // (bad config, missing tables, TLS cert errors).
+                    return verify_daemon_started(pid_file, &bind_addr);
+                }
+                daemonize::Outcome::Parent(Err(e)) => {
+                    return Err(anyhow::anyhow!("Failed to daemonize: {e}"));
+                }
+                daemonize::Outcome::Child(Ok(_)) => {
+                    // Child (daemon) process: continue to start the server.
+                }
+                daemonize::Outcome::Child(Err(e)) => {
+                    return Err(anyhow::anyhow!("Failed to daemonize (child): {e}"));
+                }
+            }
+
+            // P57 Bug 3 fix: After daemonize, stderr is /dev/null. Install a panic
+            // hook that writes to syslog so panics are visible. Without this, the
+            // child process silently disappears on panic. Reuses the server crate's
+            // raw syslog writer so there is one implementation of it — tracing is
+            // unusable here because the subscriber is only set up inside `serve`.
+            std::panic::set_hook(Box::new(|info| {
+                extenddb_server::log_to_syslog_raw(&format!("extenddb panic: {info}"));
+            }));
+        }
     }
 
     tokio::runtime::Builder::new_multi_thread()

--- a/crates/app/src/cmd_stop.rs
+++ b/crates/app/src/cmd_stop.rs
@@ -6,18 +6,24 @@
 //! Reads the PID file, sends SIGTERM, polls until the process exits (or
 //! times out), and cleans up the stale PID file.
 
+#[cfg(unix)]
 use std::thread;
+#[cfg(unix)]
 use std::time::{Duration, Instant};
 
 use clap::Args;
 
+#[cfg(unix)]
 use crate::util::is_process_alive;
+#[cfg(unix)]
 use extenddb_config as config;
 
 /// Maximum time to wait for the process to exit after SIGTERM.
+#[cfg(unix)]
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Poll interval when waiting for process exit.
+#[cfg(unix)]
 const POLL_INTERVAL: Duration = Duration::from_millis(250);
 
 #[derive(Args)]
@@ -31,7 +37,22 @@ pub struct StopArgs {
     port: Option<u16>,
 }
 
+/// Non-unix: daemon mode does not exist, so there is never a PID file to
+/// read or a SIGTERM to send. The server always runs in the foreground
+/// here — stop it from whatever started it (Ctrl+C, the supervisor, or the
+/// npm launcher's `stop()`).
+#[cfg(not(unix))]
+pub fn run(_args: &StopArgs) {
+    eprintln!(
+        "`extenddb stop` is not supported on this platform: daemon mode is \
+         unix-only, so the server always runs in the foreground. Stop it from \
+         the terminal or supervisor that started it."
+    );
+    std::process::exit(1);
+}
+
 /// Stop the extenddb daemon by reading its PID file and sending SIGTERM.
+#[cfg(unix)]
 pub fn run(args: &StopArgs) {
     let app_config = config::load(&args.config).ok();
 

--- a/crates/app/src/serve_helpers.rs
+++ b/crates/app/src/serve_helpers.rs
@@ -4,9 +4,11 @@
 //! Helper functions for `extenddb serve`: daemonize health checks, PID file
 //! management, config permission checks, and syslog utilities.
 
+#[cfg(unix)]
 use std::path::PathBuf;
 
 /// Platform-appropriate hint for viewing syslog output.
+#[cfg(unix)]
 fn syslog_hint() -> &'static str {
     if cfg!(target_os = "macos") {
         "Check syslog: log show --predicate 'process == \"extenddb\"' --last 5m"
@@ -19,6 +21,7 @@ fn syslog_hint() -> &'static str {
 /// and then verifies the daemon process is still alive. This catches early
 /// startup failures (bad config, missing catalog tables, TLS cert errors)
 /// that would otherwise be invisible because stderr is /dev/null after fork.
+#[cfg(unix)]
 pub fn verify_daemon_started(pid_file: &PathBuf, bind_addr: &str) -> anyhow::Result<()> {
     let hint = syslog_hint();
 
@@ -72,35 +75,50 @@ pub fn verify_daemon_started(pid_file: &PathBuf, bind_addr: &str) -> anyhow::Res
 ///
 /// Returns an error if the file permissions are too open or cannot be read.
 pub fn check_config_permissions(config_path: &str) -> anyhow::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
 
-    let path = std::path::Path::new(config_path);
-    if !path.exists() {
-        // Config file is optional — `config::load` handles missing files.
-        return Ok(());
-    }
+        let path = std::path::Path::new(config_path);
+        if !path.exists() {
+            // Config file is optional — `config::load` handles missing files.
+            return Ok(());
+        }
 
-    let metadata = std::fs::metadata(path)
-        .map_err(|e| anyhow::anyhow!("Cannot read config file metadata for {config_path}: {e}"))?;
-    let mode = metadata.permissions().mode() & 0o777;
-
-    if mode & 0o077 != 0 {
-        // Auto-fix like SSH does: warn and tighten permissions rather than refusing
-        // to start. The config file may contain the encryption key for credential
-        // storage, so group/other access is a security risk.
-        tracing::warn!(
-            "Config file {} has permissions {:04o}, fixing to 0600. \
-             The config file may contain the encryption key for credential storage.",
-            config_path,
-            mode,
-        );
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|e| {
-            anyhow::anyhow!(
-                "Cannot fix config file permissions for {config_path}: {e}. \
-                 Fix manually with: chmod 600 {config_path}"
-            )
+        let metadata = std::fs::metadata(path).map_err(|e| {
+            anyhow::anyhow!("Cannot read config file metadata for {config_path}: {e}")
         })?;
-    }
+        let mode = metadata.permissions().mode() & 0o777;
 
-    Ok(())
+        if mode & 0o077 != 0 {
+            // Auto-fix like SSH does: warn and tighten permissions rather than refusing
+            // to start. The config file may contain the encryption key for credential
+            // storage, so group/other access is a security risk.
+            tracing::warn!(
+                "Config file {} has permissions {:04o}, fixing to 0600. \
+                 The config file may contain the encryption key for credential storage.",
+                config_path,
+                mode,
+            );
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(
+                |e| {
+                    anyhow::anyhow!(
+                        "Cannot fix config file permissions for {config_path}: {e}. \
+                         Fix manually with: chmod 600 {config_path}"
+                    )
+                },
+            )?;
+        }
+
+        Ok(())
+    }
+    // Windows has no POSIX permission bits; access control is via ACLs, which
+    // have no meaningful 0600 equivalent to enforce here. The dev/CI use case
+    // on Windows (the npm launcher) runs with an in-memory backend and no
+    // config file, so this check is a no-op rather than a porting project.
+    #[cfg(not(unix))]
+    {
+        let _ = config_path;
+        Ok(())
+    }
 }

--- a/crates/app/src/util.rs
+++ b/crates/app/src/util.rs
@@ -5,10 +5,21 @@
 
 /// Check whether a process is alive using `kill(pid, 0)` (POSIX signal 0).
 /// Works on both Linux and macOS (no `/proc` dependency).
+#[cfg(unix)]
 pub fn is_process_alive(pid: i32) -> bool {
     // SAFETY: kill with signal 0 performs error checking without sending a
     // signal. Returns 0 if the process exists and we have permission.
     unsafe { libc::kill(pid, 0) == 0 }
+}
+
+/// Non-unix fallback: there is no dependency-free liveness probe, so assume
+/// the process is alive. This is the conservative direction for every caller:
+/// guards that refuse to run alongside a live server keep refusing, and
+/// `status` at worst reports a stale PID. PID files only exist in daemon
+/// mode, which is unix-only, so this path is effectively unreachable.
+#[cfg(not(unix))]
+pub fn is_process_alive(_pid: i32) -> bool {
+    true
 }
 
 /// Append a secret to the backend argument vector when the corresponding CLI

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -36,6 +36,10 @@ rand = { workspace = true }
 axum-server = { workspace = true }
 rustls = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+# POSIX syslog is the daemon-mode log target; neither crate compiles on
+# Windows, where `serve --foreground` (stderr logging) is the only mode.
+[target.'cfg(unix)'.dependencies]
 syslog-tracing = { workspace = true }
 libc = { workspace = true }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -362,6 +362,7 @@ fn send_https_redirect(stream: &tokio::net::TcpStream, addr: std::net::SocketAdd
     let _ = stream.try_write(response.as_bytes());
 }
 
+#[cfg(unix)]
 async fn shutdown_signal() {
     let ctrl_c = tokio::signal::ctrl_c();
     let Ok(mut sigterm) = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
@@ -375,5 +376,13 @@ async fn shutdown_signal() {
         _ = ctrl_c => {},
         _ = sigterm.recv() => {},
     }
+    tracing::info!("Shutdown signal received, draining connections...");
+}
+
+/// Non-unix: there is no SIGTERM; Ctrl+C (which tokio maps to the console
+/// control handler on Windows) is the only shutdown signal.
+#[cfg(not(unix))]
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
     tracing::info!("Shutdown signal received, draining connections...");
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -380,7 +380,13 @@ async fn shutdown_signal() {
 }
 
 /// Non-unix: there is no SIGTERM; Ctrl+C (which tokio maps to the console
-/// control handler on Windows) is the only shutdown signal.
+/// control handler on Windows) is the only shutdown signal — and it only
+/// fires for an interactive console. Supervisors that terminate the process
+/// directly (including the npm launcher's `stop()`, which is
+/// `TerminateProcess` on Windows) hard-kill without reaching this path, so
+/// the worker drain is skipped. That is acceptable: drain only cancels and
+/// joins background workers — it flushes nothing, and storage commits
+/// per-transaction.
 #[cfg(not(unix))]
 async fn shutdown_signal() {
     let _ = tokio::signal::ctrl_c().await;

--- a/crates/server/src/serve.rs
+++ b/crates/server/src/serve.rs
@@ -19,6 +19,7 @@ use std::path::PathBuf;
 
 use extenddb_config as config;
 use extenddb_storage::CancellationToken;
+#[cfg(unix)]
 use syslog_tracing::{Facility, Options, Syslog};
 use tracing_subscriber::{
     EnvFilter, Layer, fmt, fmt::writer::BoxMakeWriter, layer::SubscriberExt, reload,
@@ -232,6 +233,7 @@ async fn serve_inner(params: ServeParams, port: u16) -> anyhow::Result<()> {
     // `.without_time()` only on the syslog path.
     let (writer, with_time): (BoxMakeWriter, bool) = match log_target {
         LogTarget::Stderr => (BoxMakeWriter::new(std::io::stderr), true),
+        #[cfg(unix)]
         LogTarget::Syslog => {
             let syslog = Syslog::new(
                 c"extenddb",
@@ -244,6 +246,16 @@ async fn serve_inner(params: ServeParams, port: u16) -> anyhow::Result<()> {
                 )
             })?;
             (BoxMakeWriter::new(syslog), false)
+        }
+        // POSIX syslog does not exist on this platform; daemon mode (the only
+        // caller that selects Syslog) is unix-only, so this is unreachable in
+        // practice but must still be handled for the type to be total.
+        #[cfg(not(unix))]
+        LogTarget::Syslog => {
+            anyhow::bail!(
+                "syslog logging is not supported on this platform; \
+                 run `extenddb serve --foreground` (logs to stderr)"
+            )
         }
     };
 
@@ -645,6 +657,7 @@ async fn drain_workers(shutdown: &CancellationToken, handles: Vec<tokio::task::J
 /// startup before syslog tracing is configured, and from the caller's panic
 /// hook after daemonizing (stderr is `/dev/null` there, so a panic would
 /// otherwise be invisible).
+#[cfg(unix)]
 pub fn log_to_syslog_raw(msg: &str) {
     // SAFETY: openlog/syslog are POSIX-standard C functions. The ident
     // string is a static C string literal with 'static lifetime.
@@ -658,6 +671,13 @@ pub fn log_to_syslog_raw(msg: &str) {
             libc::syslog(libc::LOG_CRIT, c"%s".as_ptr(), cmsg.as_ptr());
         }
     }
+}
+
+/// Non-unix fallback: there is no POSIX syslog and no daemonized deployment
+/// (daemon mode is unix-only), so stderr is always attached — write there.
+#[cfg(not(unix))]
+pub fn log_to_syslog_raw(msg: &str) {
+    eprintln!("{msg}");
 }
 
 /// Seed (or refresh) the developer-mode credential and return its access key id.


### PR DESCRIPTION
## Why

npm-publish run [32528088299](https://github.com/ExtendDB/extenddb/actions/runs/32528088299) is the first run to ever pass the gate (thanks to #299 + #301), which means the `win32-x64` build job is the first thing to ever compile ExtendDB for Windows — and it can't. `extenddb-server` fails with 9 errors (`syslog_tracing`, `tokio::signal::unix`, raw `libc::syslog`), and behind it `daemonize` and `libc::kill` in `extenddb-app` fail the same way.

## What

The POSIX daemon subsystem is gated `cfg(unix)` rather than ported — the npm launcher (the only consumer of a Windows binary) always runs `serve --foreground`, which never touches any of it:

- **server**: `syslog-tracing`/`libc` → `[target.'cfg(unix)'.dependencies]`. Syslog writer arm and `log_to_syslog_raw` get unix impls; non-unix `log_to_syslog_raw` falls back to stderr (always attached without daemonize). `shutdown_signal` is cfg-split: Ctrl+C only on non-unix.
- **app**: `daemonize`/`libc` → unix-only deps. `serve` without `--foreground` bails on non-unix with a clear message; `stop` prints an honest unsupported message; `check_config_permissions` is a documented no-op (Windows ACLs, not mode bits); `is_process_alive` conservatively returns `true` on non-unix (guards keep refusing, PID files only exist in unix daemon mode).

## Verification

- `cargo check --target x86_64-pc-windows-msvc --no-default-features --features sqlite,dev-mode -p extenddb`: **clean** (C build scripts stubbed locally; the CI run already proved libsqlite3-sys/aws-lc-sys compile on the real Windows runner — the failures were all in our Rust source).
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, server+app test suites (52 tests): all pass on Linux.

## Release consequence

The build jobs compile from the **tag tree**, so no v0.1.8 dispatch can ever pass — the tag predates this fix. After this merges, npm publishing needs a 0.1.9 bump (both `Cargo.toml` **and** `packaging/npm/package.json`) and a fresh tag.