### PR TITLE
fix(vector): align the vector index lifecycle and rejection messages with DynamoDB

### DIFF
--- a/crates/core/src/expression/search_condition.rs
+++ b/crates/core/src/expression/search_condition.rs
@@ -76,7 +76,8 @@ pub fn validate_search_condition_expression(
     // Only equality is supported. Every other comparator contains one of these.
     if trimmed.contains(['<', '>', '!']) {
         return Err(invalid(
-            "Invalid comparator used in SearchConditionExpression",
+            "Invalid SearchConditionExpression: Invalid comparator used in \
+             SearchConditionExpression",
         ));
     }
 
@@ -430,7 +431,7 @@ mod tests {
                 Some(&n),
                 Some(&v)
             )),
-            "Invalid comparator used in SearchConditionExpression"
+            "Invalid SearchConditionExpression: Invalid comparator used in SearchConditionExpression"
         );
     }
 

--- a/crates/core/src/settings_keys.rs
+++ b/crates/core/src/settings_keys.rs
@@ -44,6 +44,20 @@ pub const LEGACY_GSI_PROPAGATION_DELAY_MS: &str = "gsi_propagation_delay_ms";
 /// or not the ordering is correct, which is worse than having no test.
 pub const VECTOR_BACKFILL_BATCH_DELAY_MS: &str = "vector_backfill_batch_delay_ms";
 
+/// Minimum milliseconds an UpdateTable-created vector index stays in `CREATING`
+/// before its `ACTIVE` flip.
+///
+/// The service's online-index machinery never completes an added index
+/// instantly (~17 minutes observed for a 25-item table, eu-west-2, 2026-08-11),
+/// so the CREATING-with-`Backfilling` walk is always observable there. A local
+/// backfill over a small table finishes in milliseconds, which would collapse
+/// the documented lifecycle — `CREATING`/`Backfilling: false`, then `true`,
+/// then `ACTIVE` with the member absent — into a single unobservable instant.
+/// Holding the flip for a short floor keeps the walk observable to a client
+/// polling DescribeTable, the same reason `control_plane_delay_seconds` exists
+/// for table status. The default is 1000; zero disables the hold.
+pub const VECTOR_INDEX_MIN_CREATING_MS: &str = "vector_index_min_creating_ms";
+
 /// Resolve a caller-supplied settings key to its canonical name.
 ///
 /// Accepting the old name keeps `extenddb settings set gsi_propagation_delay_ms 0`

--- a/crates/core/src/types/mod.rs
+++ b/crates/core/src/types/mod.rs
@@ -65,7 +65,7 @@ pub use table::{
     VECTOR_INDEX_CREATE_IN_USE_PREFIX, VECTOR_INDEX_REQUIRES_PAY_PER_REQUEST,
     VECTOR_SEARCH_SCHEMA_UNDECLARED, VectorAttribute, VectorIndexDescription,
     VectorIndexSpecification, VectorIndexUpdate, vector_attribute_conflicting_definition,
-    vector_attribute_redefines_key,
+    vector_attribute_redefines_key, vector_attribute_redefines_vector,
 };
 pub use transaction::{
     CancellationReason, ItemResponse, TransactConditionCheck, TransactDelete, TransactGet,

--- a/crates/core/src/types/table.rs
+++ b/crates/core/src/types/table.rs
@@ -559,6 +559,27 @@ pub fn vector_attribute_redefines_key(
     )
 }
 
+/// The message for an UpdateTable create whose vector attribute is already
+/// used by an existing vector index with different `Dimensions`. Measured
+/// live 2026-08-24 (us-east-1): `Create vConf(emb, 16)` against a table whose
+/// `vidx0` declares `emb` at 4 answers exactly this, with both sides rendered
+/// in the `VectorIndexSchema` shape (contrast the key-redefinition sibling
+/// above, whose existing side is a key `Schema`). Same attribute with the
+/// SAME dimensions is accepted (also measured).
+#[must_use]
+pub fn vector_attribute_redefines_vector(
+    attribute_name: &str,
+    existing_dimensions: u32,
+    new_dimensions: u32,
+) -> String {
+    format!(
+        "One or more parameter values were invalid: Attributes cannot be redefined. Please check \
+         that your attribute has the same type as previously defined. Existing schema: \
+         VectorIndexSchema:[VectorAttribute: key{{{attribute_name}:L:{existing_dimensions}}}] \
+         New schema: VectorIndexSchema:[VectorAttribute: key{{{attribute_name}:L:{new_dimensions}}}]"
+    )
+}
+
 pub const VECTOR_INDEX_ALREADY_EXISTS: &str = "Attempting to create an index which already exists";
 
 /// Prefix of the message the service returns when the name is taken by an index

--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -330,11 +330,25 @@ fn validate_one_vector_index(
     }
     validate_index_name(&vi.index_name)?;
     validate_search_schema_shape(vi.search_schema.as_deref())?;
-    if vi.dimensions < 1 || vi.dimensions > 4096 {
+    // The two bounds are reported by DIFFERENT layers with different messages.
+    // Dimensions below 1 never reaches the semantic check on the service: the
+    // request model rejects it first, with the smithy-style single-fault
+    // message. Measured 2026-08-24 in us-east-1 with botocore's client-side
+    // validation disabled so Dimensions=0 reached the service:
+    //   1 validation error detected: Value '0' at
+    //   'vectorIndexes.1.member.dimensions' failed to satisfy constraint:
+    //   Member must have value greater than or equal to 1
+    if vi.dimensions < 1 {
+        return Err(DynamoDbError::ValidationException(format!(
+            "1 validation error detected: Value '{}' at \
+             '{field}.{position}.member.dimensions' failed to satisfy constraint: \
+             Member must have value greater than or equal to 1",
+            vi.dimensions
+        )));
+    }
+    if vi.dimensions > 4096 {
         // Verified against the service 2026-08-05: Dimensions=4097 and 8192
-        // both return exactly this message. The lower bound is not observable
-        // through an SDK because botocore rejects Dimensions=0 client-side, but
-        // the service text names both bounds, so it is reused here.
+        // both return exactly this message.
         return Err(DynamoDbError::ValidationException(
             "One or more parameter values were invalid: Number of dimensions must be \
              between 1 and 4096 inclusive."
@@ -389,6 +403,26 @@ fn validate_vector_indexes(input: &CreateTableInput) -> Result<(), DynamoDbError
         )));
     }
 
+    // Several indexes may share one vector attribute, but they must agree on its
+    // Dimensions: the attribute stores one vector, so two indexes declaring
+    // different sizes for it contradict each other. The service rejects the
+    // create naming the attribute; wording pinned by the ground-truth runs of
+    // 2026-08-24 (us-east-1 and eu-west-2 both answer exactly this).
+    for (i, vi) in vis.iter().enumerate() {
+        let conflicting = vis[..i].iter().any(|prior| {
+            prior.vector_attribute.attribute_name == vi.vector_attribute.attribute_name
+                && prior.dimensions != vi.dimensions
+        });
+        if conflicting {
+            return Err(DynamoDbError::ValidationException(format!(
+                "One or more parameter values were invalid: Conflicting attribute \
+                 definition for '{}'. All VectorIndexes on the same vector attribute \
+                 must use the same dimensions.",
+                vi.vector_attribute.attribute_name
+            )));
+        }
+    }
+
     Ok(())
 }
 
@@ -417,6 +451,23 @@ pub fn validate_vector_index_updates(
     };
     if updates.is_empty() {
         return Ok(());
+    }
+    // One online index action per call, enforced with the online-index
+    // machinery's own error class and wording. Pinned by the ground-truth runs
+    // of 2026-08-24 (us-east-1 and eu-west-2): two Create actions in one
+    // UpdateTable answer LimitExceededException with exactly this sentence.
+    // Counted over actions rather than elements, so an element carrying both a
+    // Create and a Delete counts as two.
+    let actions = updates
+        .iter()
+        .map(|u| usize::from(u.create.is_some()) + usize::from(u.delete.is_some()))
+        .sum::<usize>();
+    if actions > 1 {
+        return Err(DynamoDbError::LimitExceededException(
+            "Subscriber limit exceeded: Only 1 online index can be created or deleted \
+             simultaneously per table"
+                .to_owned(),
+        ));
     }
     for (position, update) in updates.iter().enumerate() {
         if let Some(create) = update.create.as_ref() {
@@ -1869,7 +1920,22 @@ mod tests {
         }];
         assert!(validate_vector_index_updates(Some(&updates), &[]).is_err());
 
-        // A well-formed create, and a delete, both pass.
+        // A well-formed single create passes, and a single delete passes; two
+        // actions in one request are refused by the one-online-action rule
+        // with the online-index machinery's own error class (pinned by the
+        // ground-truth runs of 2026-08-24).
+        let updates = vec![VectorIndexUpdate {
+            create: Some(spec(all())),
+            delete: None,
+        }];
+        assert!(validate_vector_index_updates(Some(&updates), &[]).is_ok());
+        let updates = vec![VectorIndexUpdate {
+            create: None,
+            delete: Some(DeleteVectorIndexAction {
+                index_name: "other".to_owned(),
+            }),
+        }];
+        assert!(validate_vector_index_updates(Some(&updates), &[]).is_ok());
         let updates = vec![
             VectorIndexUpdate {
                 create: Some(spec(all())),
@@ -1882,7 +1948,16 @@ mod tests {
                 }),
             },
         ];
-        assert!(validate_vector_index_updates(Some(&updates), &[]).is_ok());
+        match validate_vector_index_updates(Some(&updates), &[])
+            .expect_err("two online index actions in one call must be refused")
+        {
+            DynamoDbError::LimitExceededException(m) => assert_eq!(
+                m,
+                "Subscriber limit exceeded: Only 1 online index can be created or deleted \
+                 simultaneously per table"
+            ),
+            other => panic!("expected LimitExceededException, got {other:?}"),
+        }
     }
 
     use crate::types::{DistanceFunction, VectorAttribute, VectorIndexSpecification};

--- a/crates/core/src/validation/mod.rs
+++ b/crates/core/src/validation/mod.rs
@@ -310,10 +310,16 @@ fn validate_vector_index_attribute_definitions(
     Ok(())
 }
 
+/// `member_path` is the request-model path to the index element, without the
+/// trailing leaf: `vectorIndexes.{n}.member` on CreateTable and
+/// `vectorIndexUpdates.{n}.member.create` on UpdateTable, both 1-based.
+/// The `.create` segment on the update path is measured, not inferred:
+/// probed live 2026-08-24 (us-east-1) with client-side validation disabled,
+/// a `Create` with `Dimensions: 0` answers
+/// `Value '0' at 'vectorIndexUpdates.1.member.create.dimensions' ...`.
 fn validate_one_vector_index(
     vi: &crate::types::VectorIndexSpecification,
-    position: usize,
-    field: &str,
+    member_path: &str,
 ) -> Result<(), DynamoDbError> {
     // Projection is required by the service. Reported with the service's own
     // message, which numbers the offending list element from 1, not 0. Measured
@@ -321,10 +327,12 @@ fn validate_one_vector_index(
     // reached the service:
     //   Value null at 'vectorIndexes.1.member.projection' failed to satisfy
     //   constraint: Member must not be null
+    // and re-measured on the update path 2026-08-24:
+    //   Value null at 'vectorIndexUpdates.1.member.create.projection' ...
     if vi.projection.is_none() {
         return Err(DynamoDbError::ValidationException(format!(
             "1 validation error detected: Value null at \
-             '{field}.{position}.member.projection' failed to satisfy constraint: \
+             '{member_path}.projection' failed to satisfy constraint: \
              Member must not be null"
         )));
     }
@@ -341,7 +349,7 @@ fn validate_one_vector_index(
     if vi.dimensions < 1 {
         return Err(DynamoDbError::ValidationException(format!(
             "1 validation error detected: Value '{}' at \
-             '{field}.{position}.member.dimensions' failed to satisfy constraint: \
+             '{member_path}.dimensions' failed to satisfy constraint: \
              Member must have value greater than or equal to 1",
             vi.dimensions
         )));
@@ -373,7 +381,7 @@ fn validate_vector_indexes(input: &CreateTableInput) -> Result<(), DynamoDbError
     // malformed index client-side before the request is sent, so the order that
     // preserves the already-measured per-index messages is the right one to keep.
     for (position, vi) in vis.iter().enumerate() {
-        validate_one_vector_index(vi, position + 1, "vectorIndexes")?;
+        validate_one_vector_index(vi, &format!("vectorIndexes.{}.member", position + 1))?;
     }
 
     // Vector indexes are supported only on on-demand tables. Documented under
@@ -452,12 +460,33 @@ pub fn validate_vector_index_updates(
     if updates.is_empty() {
         return Ok(());
     }
+    // Per-element request-model validation FIRST, then the one-action rule.
+    // The ordering is measured, not chosen: probed live 2026-08-24
+    // (us-east-1), a two-action request carrying a malformed create (a
+    // Dimensions of 0, or a missing Projection) answers the model-layer
+    // ValidationException for the malformed element, not the subscriber
+    // limit, so the model layer runs over every element before any online
+    // rule. (The service aggregates multiple model faults into one "N
+    // validation errors detected" message; single-fault reporting here is the
+    // same deliberate divergence documented on validate_one_vector_index.)
+    for (position, update) in updates.iter().enumerate() {
+        if let Some(create) = update.create.as_ref() {
+            validate_one_vector_index(
+                create,
+                &format!("vectorIndexUpdates.{}.member.create", position + 1),
+            )?;
+            validate_vector_index_attribute_definitions(create, attribute_definitions)?;
+        }
+        if let Some(delete) = update.delete.as_ref() {
+            validate_index_name(&delete.index_name)?;
+        }
+    }
     // One online index action per call, enforced with the online-index
     // machinery's own error class and wording. Pinned by the ground-truth runs
-    // of 2026-08-24 (us-east-1 and eu-west-2): two Create actions in one
-    // UpdateTable answer LimitExceededException with exactly this sentence.
-    // Counted over actions rather than elements, so an element carrying both a
-    // Create and a Delete counts as two.
+    // of 2026-08-24 (us-east-1 and eu-west-2): two well-formed Create actions
+    // in one UpdateTable answer LimitExceededException with exactly this
+    // sentence. Counted over actions rather than elements, so an element
+    // carrying both a Create and a Delete counts as two.
     let actions = updates
         .iter()
         .map(|u| usize::from(u.create.is_some()) + usize::from(u.delete.is_some()))
@@ -468,15 +497,6 @@ pub fn validate_vector_index_updates(
              simultaneously per table"
                 .to_owned(),
         ));
-    }
-    for (position, update) in updates.iter().enumerate() {
-        if let Some(create) = update.create.as_ref() {
-            validate_one_vector_index(create, position + 1, "vectorIndexUpdates")?;
-            validate_vector_index_attribute_definitions(create, attribute_definitions)?;
-        }
-        if let Some(delete) = update.delete.as_ref() {
-            validate_index_name(&delete.index_name)?;
-        }
     }
     Ok(())
 }
@@ -1904,7 +1924,7 @@ mod tests {
             .expect_err("a malformed create must be rejected on this path as well");
         match err {
             DynamoDbError::ValidationException(m) => assert!(
-                m.contains("vectorIndexUpdates.1.member.projection"),
+                m.contains("vectorIndexUpdates.1.member.create.projection"),
                 "should name this request's field and element: {m}"
             ),
             other => panic!("expected ValidationException, got {other:?}"),

--- a/crates/core/src/validation/vector_item.rs
+++ b/crates/core/src/validation/vector_item.rs
@@ -281,6 +281,26 @@ fn validate_search_schema_attribute(
 
     let size = attribute_value_size(value);
     match element_type {
+        // An empty scalar in the HASH position rejects with the same sentence
+        // the classic secondary-index key rule uses, IndexName/IndexKey suffix
+        // included. Pinned for the empty-string case by the ground-truth runs
+        // of 2026-08-24 (us-east-1 and eu-west-2); the binary wording follows
+        // the measured classic-index message, which selects "binary" for `B`.
+        SearchSchemaElementType::Hash
+            if matches!(value, AttributeValue::S(s) if s.is_empty())
+                || matches!(value, AttributeValue::B(b) if b.is_empty()) =>
+        {
+            let kind = match value {
+                AttributeValue::B(_) => "binary",
+                _ => "string",
+            };
+            Err(invalid(format!(
+                "One or more parameter values are not valid. A value specified for a \
+                 secondary index key is not supported. The AttributeValue for a key \
+                 attribute cannot contain an empty {kind} value. \
+                 IndexName: {index_name}, IndexKey: {name}"
+            )))
+        }
         SearchSchemaElementType::Hash if size > MAX_HASH_KEY_SIZE => Err(invalid(format!(
             "One or more parameter values were invalid: Aggregate size for HASH key attributes \
              exceeds the maximum of {MAX_HASH_KEY_SIZE} bytes"

--- a/crates/engine/src/create_table.rs
+++ b/crates/engine/src/create_table.rs
@@ -112,6 +112,12 @@ pub(crate) fn storage_err_to_dynamo(e: extenddb_storage::error::StorageError) ->
         StorageError::IndexAlreadyExists(name) => DynamoDbError::ValidationException(format!(
             "One or more parameter values were invalid: Index already exists: {name}"
         )),
+        // The sentence AWS documents for this refusal, quoted in the vector
+        // search tutorial's readiness callout and pinned by the ground-truth
+        // runs of 2026-08-24 (us-east-1 and eu-west-2).
+        StorageError::IndexesInUse(_) => DynamoDbError::ResourceInUseException(
+            "Cannot delete table while indexes are being created, updated, or deleted.".to_owned(),
+        ),
         StorageError::LimitExceeded(msg) => DynamoDbError::LimitExceededException(msg),
         // Retryable by definition, so it maps like Connection: a 503 the SDKs
         // retry, rather than a 500 they surface.

--- a/crates/engine/src/search_vectors.rs
+++ b/crates/engine/src/search_vectors.rs
@@ -347,19 +347,19 @@ fn parse_search_vector(values: &[AttributeValue]) -> Result<Vec<f32>, DynamoDbEr
             AttributeValue::N(n) => {
                 let f = n.parse::<f32>().map_err(|_| {
                     DynamoDbError::ValidationException(
-                        "Search vector contains invalid values".to_owned(),
+                        "Search vector contains invalid values. All values in the search vector must be a 32-bit floating-point number attribute".to_owned(),
                     )
                 })?;
                 if !f.is_finite() {
                     return Err(DynamoDbError::ValidationException(
-                        "Search vector contains invalid values".to_owned(),
+                        "Search vector contains invalid values. All values in the search vector must be a 32-bit floating-point number attribute".to_owned(),
                     ));
                 }
                 out.push(f);
             }
             _ => {
                 return Err(DynamoDbError::ValidationException(
-                    "Search vector contains invalid values".to_owned(),
+                    "Search vector contains invalid values. All values in the search vector must be a 32-bit floating-point number attribute".to_owned(),
                 ));
             }
         }
@@ -672,7 +672,11 @@ mod tests {
         let DynamoDbError::ValidationException(msg) = err else {
             panic!("expected ValidationException");
         };
-        assert_eq!(msg, "Search vector contains invalid values");
+        assert_eq!(
+            msg,
+            "Search vector contains invalid values. All values in the search vector \
+             must be a 32-bit floating-point number attribute"
+        );
     }
 
     #[test]

--- a/crates/storage-sqlite/src/create_table.rs
+++ b/crates/storage-sqlite/src/create_table.rs
@@ -195,9 +195,13 @@ impl SqliteEngine {
         }
 
         // Vector indexes. A CreateTable's table is empty, so there is nothing to
-        // backfill: the index goes straight to ACTIVE with no `backfilling`
-        // member, which is the state the service reports for an index created
-        // this way. The UpdateTable path is the one that drives a real lifecycle.
+        // backfill and no `backfilling` member is ever reported on this path.
+        // The index's status tracks the TABLE's: measured against the service
+        // (2026-08-21, eu-west-2, three runs polling at 250ms), an index created
+        // with its table reports CREATING while the table is CREATING and
+        // reaches ACTIVE in the same DescribeTable poll as the table, with no
+        // observable gap in either direction. The control-plane worker flips
+        // both in one pass; see `process_control_plane_transitions`.
         let mut vector_ids: Vec<String> = Vec::new();
         if let Some(vis) = &input.vector_indexes {
             for vi in vis {
@@ -232,7 +236,7 @@ impl SqliteEngine {
                     "INSERT INTO vector_indexes \
                      (table_id, index_name, index_id, dimensions, distance_function, \
                       vector_attribute, search_schema, projection, index_status, backfilling) \
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'ACTIVE', NULL)",
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)",
                 )
                 .bind(&table_id)
                 .bind(&vi.index_name)
@@ -242,6 +246,7 @@ impl SqliteEngine {
                 .bind(&vec_attr)
                 .bind(&search_schema)
                 .bind(&proj)
+                .bind(initial_status)
                 .execute(&mut *tx)
                 .await
                 .map_err(|e| StorageError::Internal(e.to_string()))?;

--- a/crates/storage-sqlite/src/data/vector_index.rs
+++ b/crates/storage-sqlite/src/data/vector_index.rs
@@ -381,6 +381,7 @@ async fn apply_vector_index(
         base_key_schema,
         attr_defs,
         key_cols,
+        VectorRowConflict::Fail,
     )
     .await
 }
@@ -394,6 +395,26 @@ async fn apply_vector_index(
 ///
 /// A non-indexable item is a no-op rather than an error, which is what makes a
 /// backfill over a table where only some items carry the vector work.
+/// How [`insert_vector_row`] treats a primary-key conflict.
+///
+/// `Fail` is the write path's contract: every apply reaches the insert through
+/// `apply_vector_index`, which deletes the base key's row first, so a conflict
+/// there means a broken invariant and must be loud. `KeepExisting` is the
+/// BACKFILL's contract: in synchronous-visibility mode
+/// (`index_propagation_delay_ms == 0`) a base write landing mid-backfill is
+/// applied to the CREATING index inline rather than queued, and each backfill
+/// batch reads the base table LIVE under the write lock, so a row already
+/// present was written from the same or a newer base image than the one the
+/// backfill just read; keeping it is correct and inserting over it would only
+/// fail the whole build. Without this, that collision wedged the index in
+/// CREATING permanently (proven by test below).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VectorRowConflict {
+    Fail,
+    KeepExisting,
+}
+
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn insert_vector_row(
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     table_id: &str,
@@ -402,6 +423,7 @@ pub(crate) async fn insert_vector_row(
     base_key_schema: &[KeySchemaElement],
     attr_defs: &[AttributeDefinition],
     key_cols: &[String],
+    on_conflict: VectorRowConflict,
 ) -> Result<(), StorageError> {
     if !item_is_indexable(item, meta) {
         return Ok(());
@@ -458,19 +480,23 @@ pub(crate) async fn insert_vector_row(
     let item_json = serde_json::to_string(&projected)
         .map_err(|e| StorageError::Internal(format!("serialize item: {e}")))?;
 
-    // A plain INSERT, deliberately, where the GSI sibling uses INSERT OR REPLACE.
-    // Every caller reaches this through `apply_vector_index`, which unconditionally
-    // deletes the base key's row first, so no live row can exist here and a conflict
-    // is impossible. Keeping it a plain INSERT means that if a future refactor ever
-    // makes that delete conditional, this fails loudly with a primary key violation
-    // rather than silently replacing a row and hiding the broken invariant.
+    // On the write path this stays a plain INSERT, deliberately, where the GSI
+    // sibling uses INSERT OR REPLACE: every apply reaches here through
+    // `apply_vector_index`, which unconditionally deletes the base key's row
+    // first, so a conflict means a broken invariant and must fail loudly. The
+    // backfill passes `KeepExisting` instead; see [`VectorRowConflict`] for
+    // why an existing row is the same-or-newer generation there and must win.
     let cols = std::iter::once("part".to_owned())
         .chain(key_cols.iter().cloned())
         .chain(["vec".to_owned(), "nrm".to_owned(), "item_data".to_owned()])
         .collect::<Vec<_>>();
     let placeholders = vec!["?"; cols.len()].join(", ");
+    let verb = match on_conflict {
+        VectorRowConflict::Fail => "INSERT",
+        VectorRowConflict::KeepExisting => "INSERT OR IGNORE",
+    };
     let sql = format!(
-        "INSERT INTO {vec_table} ({}) VALUES ({placeholders})",
+        "{verb} INTO {vec_table} ({}) VALUES ({placeholders})",
         cols.join(", ")
     );
     let key_binds = base_key_binds(item, base_key_schema, attr_defs)?;
@@ -627,6 +653,7 @@ async fn backfill_vector_batch(
             plan.base_key_schema,
             plan.attr_defs,
             &plan.key_cols,
+            VectorRowConflict::KeepExisting,
         )
         .await?;
         written += 1;
@@ -932,5 +959,125 @@ mod tests {
             .await
             .expect("count");
         assert_eq!(rows, 3);
+    }
+    /// A synchronous-visibility write (`index_propagation_delay_ms == 0`)
+    /// landing mid-backfill is applied to the CREATING index inline, bypassing
+    /// the queue's CREATING-hold. When the backfill later reaches that base
+    /// key it must keep the row the inline write produced rather than fail the
+    /// whole build on the primary-key conflict: each batch reads the base
+    /// table live under the write lock, so an existing row was written from
+    /// the same or a newer base image than the one the batch just read. Before
+    /// `VectorRowConflict::KeepExisting`, this collision errored the backfill
+    /// and wedged the index in CREATING permanently.
+    #[tokio::test]
+    async fn a_synchronous_write_landing_mid_backfill_does_not_wedge_the_build() {
+        use extenddb_core::types::{
+            AttributeDefinition, KeySchemaElement, KeyType, ScalarAttributeType,
+        };
+        let engine = crate::SqliteEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+
+        let ks = vec![KeySchemaElement {
+            attribute_name: "pk".to_owned(),
+            key_type: KeyType::Hash,
+        }];
+        let ad = vec![AttributeDefinition {
+            attribute_name: "pk".to_owned(),
+            attribute_type: ScalarAttributeType::S,
+        }];
+
+        let table_id = "t-inline-collision";
+        let mut tx = engine.pool.begin_with("BEGIN IMMEDIATE").await.expect("tx");
+        crate::SqliteEngine::create_data_table(&mut tx, table_id, &ks, &ad)
+            .await
+            .expect("base table");
+        crate::SqliteEngine::create_vector_data_table(&mut tx, table_id, "vidx-c", &ks, &ad)
+            .await
+            .expect("vector table");
+        // Catalog rows: a table and its index still CREATING with a build in
+        // flight, which is the state a mid-backfill write observes.
+        sqlx::query("INSERT INTO accounts (account_id, account_name) VALUES ('a', 'a')")
+            .execute(&mut *tx)
+            .await
+            .expect("account row");
+        sqlx::query(
+            "INSERT INTO tables (account_id, table_name, key_schema, attribute_definitions, \
+             billing_mode, table_status, creation_date_time, table_arn, table_id) \
+             VALUES ('a', 't', '[]', '[]', 'PAY_PER_REQUEST', 'ACTIVE', 'now', 'arn', ?)",
+        )
+        .bind(table_id)
+        .execute(&mut *tx)
+        .await
+        .expect("table row");
+        sqlx::query(
+            "INSERT INTO vector_indexes (table_id, index_name, index_id, dimensions, \
+             distance_function, vector_attribute, search_schema, projection, index_status, \
+             backfilling) \
+             VALUES (?, 'vidx-c', 'vidx-c', 2, 'COSINE', ?, NULL, ?, 'CREATING', 1)",
+        )
+        .bind(table_id)
+        .bind(r#"{"AttributeName":"emb"}"#)
+        .bind(r#"{"ProjectionType":"ALL"}"#)
+        .execute(&mut *tx)
+        .await
+        .expect("index row");
+        let base_table = super::super::data_table_name(table_id);
+        sqlx::query(&format!(
+            "INSERT INTO {base_table} (pk, item_data) VALUES ('z', ?)"
+        ))
+        .bind(r#"{"pk":{"S":"z"},"emb":{"L":[{"N":"1"},{"N":"0"}]}}"#)
+        .execute(&mut *tx)
+        .await
+        .expect("seed base row");
+
+        // The inline write: at delay 0 maintenance applies to the CREATING
+        // index directly rather than enqueueing.
+        let item: extenddb_core::types::Item =
+            serde_json::from_str(r#"{"pk":{"S":"z"},"emb":{"L":[{"N":"1"},{"N":"0"}]}}"#)
+                .expect("item");
+        let enqueued = maintain_vector_indexes(&mut tx, table_id, &ks, &ad, None, Some(&item), 0)
+            .await
+            .expect("inline maintenance");
+        assert_eq!(
+            enqueued, 0,
+            "delay 0 must take the inline arm, not the queue"
+        );
+        tx.commit().await.expect("commit");
+
+        // The backfill now reaches the same base key and must complete rather
+        // than error on the conflict, leaving exactly one row for the key.
+        let write_lock = tokio::sync::Mutex::new(());
+        let meta = fetch_vector_indexes_for_table(
+            &mut engine.pool.begin_with("BEGIN IMMEDIATE").await.expect("tx"),
+            table_id,
+        )
+        .await
+        .expect("metas")
+        .into_iter()
+        .find(|m| m.index_id == "vidx-c")
+        .expect("meta");
+        let outcome = backfill_vector_index_in_batches(
+            &engine.pool,
+            &write_lock,
+            table_id,
+            &meta,
+            &ks,
+            &ad,
+            std::time::Duration::ZERO,
+        )
+        .await
+        .expect("backfill must not wedge on the inline write's row");
+        assert_eq!(outcome.skipped, 0);
+        let vec_table = super::super::vector_table_name(table_id, "vidx-c");
+        let (rows,): (i64,) = sqlx::query_as(&format!("SELECT COUNT(*) FROM {vec_table}"))
+            .fetch_one(&engine.pool)
+            .await
+            .expect("count");
+        assert_eq!(
+            rows, 1,
+            "one base key must yield one index row, not a duplicate"
+        );
     }
 }

--- a/crates/storage-sqlite/src/delete_table.rs
+++ b/crates/storage-sqlite/src/delete_table.rs
@@ -37,23 +37,6 @@ impl SqliteEngine {
             return Err(StorageError::DeletionProtected(row.table_arn.clone()));
         }
 
-        // A vector index with `backfilling` set is an UpdateTable build in
-        // flight (the with-table path never sets the column), and the service
-        // refuses to delete the table underneath one. The refusal is by build
-        // state rather than by any timer, so it holds for the whole backfill
-        // and clears the moment the index flips ACTIVE or its create is
-        // cancelled with a Delete action.
-        let index_build_in_flight: Option<(i64,)> = sqlx::query_as(
-            "SELECT 1 FROM vector_indexes WHERE table_id = ? AND backfilling IS NOT NULL LIMIT 1",
-        )
-        .bind(&row.table_id)
-        .fetch_optional(&self.pool)
-        .await
-        .map_err(|e| StorageError::Internal(e.to_string()))?;
-        if index_build_in_flight.is_some() {
-            return Err(StorageError::IndexesInUse(input.table_name.clone()));
-        }
-
         let index_rows: Vec<IndexRow> = sqlx::query_as(&format!(
             "SELECT {INDEX_COLUMNS} FROM indexes WHERE table_id = ?"
         ))
@@ -82,6 +65,16 @@ impl SqliteEngine {
                 .begin_with("BEGIN IMMEDIATE")
                 .await
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
+            // A vector index with `backfilling` set is an UpdateTable build in
+            // flight (the with-table path never sets the column), and the
+            // service refuses to delete the table underneath one; the refusal
+            // clears when the index flips ACTIVE or its create is cancelled.
+            // Checked INSIDE the immediate transaction rather than before it,
+            // so a build whose catalog row commits while this call is waiting
+            // on the write lock is still caught: the check and the cascade
+            // delete are atomic against a concurrent UpdateTable.
+            Self::refuse_if_index_build_in_flight(&mut tx, &row.table_id, &input.table_name)
+                .await?;
             sqlx::query("DELETE FROM tags WHERE resource_arn = ?")
                 .bind(&table_arn)
                 .execute(&mut *tx)
@@ -112,6 +105,18 @@ impl SqliteEngine {
             let transition = format_timestamp(
                 time::OffsetDateTime::now_utc() + time::Duration::seconds_f64(delay_secs),
             );
+            let _writer = self.write_lock.lock().await;
+            let mut tx = self
+                .pool
+                .begin_with("BEGIN IMMEDIATE")
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            // Same in-flight-build refusal as the immediate branch, and inside
+            // the transaction that flips the table to DELETING for the same
+            // reason: without it, a build committing between an earlier check
+            // and this flip would have its table deleted underneath it.
+            Self::refuse_if_index_build_in_flight(&mut tx, &row.table_id, &input.table_name)
+                .await?;
             sqlx::query(
                 "UPDATE tables SET table_status = 'DELETING', status_transition_at = ? \
                  WHERE account_id = ? AND table_name = ?",
@@ -119,9 +124,12 @@ impl SqliteEngine {
             .bind(&transition)
             .bind(account_id)
             .bind(&input.table_name)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await
             .map_err(|e| StorageError::Internal(e.to_string()))?;
+            tx.commit()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
             self.control_plane_notify.notify_one();
         }
 
@@ -130,5 +138,27 @@ impl SqliteEngine {
             table_status: TableStatus::Deleting,
             ..desc
         })
+    }
+
+    /// Refuse the operation while any UpdateTable-created vector index build is
+    /// in flight on the table (`backfilling IS NOT NULL`; the with-table path
+    /// never sets the column). Must be called inside a `BEGIN IMMEDIATE`
+    /// transaction so the answer is atomic with the caller's own writes.
+    async fn refuse_if_index_build_in_flight(
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        table_id: &str,
+        table_name: &str,
+    ) -> Result<(), StorageError> {
+        let in_flight: Option<(i64,)> = sqlx::query_as(
+            "SELECT 1 FROM vector_indexes WHERE table_id = ? AND backfilling IS NOT NULL LIMIT 1",
+        )
+        .bind(table_id)
+        .fetch_optional(&mut **tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+        if in_flight.is_some() {
+            return Err(StorageError::IndexesInUse(table_name.to_owned()));
+        }
+        Ok(())
     }
 }

--- a/crates/storage-sqlite/src/delete_table.rs
+++ b/crates/storage-sqlite/src/delete_table.rs
@@ -37,6 +37,23 @@ impl SqliteEngine {
             return Err(StorageError::DeletionProtected(row.table_arn.clone()));
         }
 
+        // A vector index with `backfilling` set is an UpdateTable build in
+        // flight (the with-table path never sets the column), and the service
+        // refuses to delete the table underneath one. The refusal is by build
+        // state rather than by any timer, so it holds for the whole backfill
+        // and clears the moment the index flips ACTIVE or its create is
+        // cancelled with a Delete action.
+        let index_build_in_flight: Option<(i64,)> = sqlx::query_as(
+            "SELECT 1 FROM vector_indexes WHERE table_id = ? AND backfilling IS NOT NULL LIMIT 1",
+        )
+        .bind(&row.table_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+        if index_build_in_flight.is_some() {
+            return Err(StorageError::IndexesInUse(input.table_name.clone()));
+        }
+
         let index_rows: Vec<IndexRow> = sqlx::query_as(&format!(
             "SELECT {INDEX_COLUMNS} FROM indexes WHERE table_id = ?"
         ))

--- a/crates/storage-sqlite/src/store.rs
+++ b/crates/storage-sqlite/src/store.rs
@@ -295,6 +295,30 @@ impl SqliteEngine {
         }
     }
 
+    /// Minimum milliseconds an UpdateTable-created vector index stays `CREATING`
+    /// before its `ACTIVE` flip. See
+    /// [`extenddb_core::settings_keys::VECTOR_INDEX_MIN_CREATING_MS`] for why the
+    /// hold exists. Defaults to 1000 when unset or unparseable; zero disables it.
+    pub(crate) async fn vector_index_min_creating_ms(&self) -> u64 {
+        const DEFAULT_MS: u64 = 1_000;
+        let live: Result<Option<(String,)>, _> =
+            sqlx::query_as("SELECT value FROM settings WHERE key = ?")
+                .bind(extenddb_core::settings_keys::VECTOR_INDEX_MIN_CREATING_MS)
+                .fetch_optional(&self.pool)
+                .await;
+        match live {
+            Ok(row) => row
+                .and_then(|(v,)| v.parse::<u64>().ok())
+                .unwrap_or(DEFAULT_MS),
+            Err(e) => {
+                tracing::debug!(
+                    "vector_index_min_creating_ms: live read failed, using {DEFAULT_MS}: {e:?}"
+                );
+                DEFAULT_MS
+            }
+        }
+    }
+
     /// Handle to the GSI propagation notifier, woken after an enqueue.
     pub(crate) fn gsi_notify(&self) -> Arc<tokio::sync::Notify> {
         Arc::clone(&self.gsi_notify)

--- a/crates/storage-sqlite/src/update_table.rs
+++ b/crates/storage-sqlite/src/update_table.rs
@@ -735,6 +735,13 @@ impl SqliteEngine {
         let write_lock = std::sync::Arc::clone(&self.write_lock);
         let batch_delay =
             std::time::Duration::from_millis(self.vector_backfill_batch_delay().await);
+        // The floor on how long the index stays CREATING. Captured with the
+        // creation instant here rather than inside the task, so the hold
+        // measures from when the caller could first observe the index, and a
+        // live settings change mid-build does not move an in-flight deadline.
+        let min_creating =
+            std::time::Duration::from_millis(self.vector_index_min_creating_ms().await);
+        let created_at = tokio::time::Instant::now();
         let owned_table_id = table_id.to_owned();
         let owned_index_id = index_id.to_owned();
         let owned_index_name = create.index_name.clone();
@@ -789,6 +796,17 @@ impl SqliteEngine {
             .await;
             match result {
                 Ok(outcome) => {
+                    // The service's online-index machinery never finishes an
+                    // added index instantly, so the CREATING walk (`Backfilling`
+                    // false, then true, then ACTIVE with the member absent) is
+                    // always observable there. A local backfill over a small
+                    // table completes in milliseconds, which would collapse that
+                    // walk into an instant no DescribeTable poll can catch, so
+                    // the flip waits out the remainder of the configured floor.
+                    // Searches keep answering the documented not-ready rejection
+                    // and writes keep queuing behind the CREATING hold for the
+                    // duration, exactly as during a real backfill.
+                    tokio::time::sleep_until(created_at + min_creating).await;
                     // Populated, so the index can serve. `backfilling` is cleared to
                     // NULL rather than set to 0, because the service removes the
                     // member once ACTIVE and the catalog CHECK constraint enforces
@@ -922,10 +940,15 @@ impl SqliteEngine {
     /// duplicate every row it had already written before the crash, and a search
     /// would return the same item several times.
     pub(crate) async fn reconcile_incomplete_vector_indexes(&self) -> Result<usize, StorageError> {
+        // `backfilling IS NOT NULL` scopes this to UpdateTable-created indexes,
+        // the only kind whose CREATING means an interrupted backfill. An index
+        // created WITH its table (backfilling NULL) is CREATING only because
+        // its table is; the control-plane worker activates both together, and
+        // rebuilding it here would publish it ACTIVE ahead of its own table.
         let rows: Vec<(String, String, String, String)> = sqlx::query_as(
             "SELECT v.index_id, v.table_id, t.key_schema, t.attribute_definitions \
              FROM vector_indexes v JOIN tables t ON v.table_id = t.table_id \
-             WHERE v.index_status = 'CREATING'",
+             WHERE v.index_status = 'CREATING' AND v.backfilling IS NOT NULL",
         )
         .fetch_all(&self.pool)
         .await
@@ -954,11 +977,19 @@ impl SqliteEngine {
     /// passes before invoking [`Self::recover_stuck_vector_builds`], which
     /// re-checks the registry itself at execution time.
     pub(crate) async fn stuck_vector_build_candidates(&self) -> Result<Vec<String>, StorageError> {
-        let ids: Vec<(String,)> =
-            sqlx::query_as("SELECT index_id FROM vector_indexes WHERE index_status = 'CREATING'")
-                .fetch_all(&self.pool)
-                .await
-                .map_err(|e| StorageError::Internal(e.to_string()))?;
+        // `backfilling IS NOT NULL` scopes this to UpdateTable-created indexes,
+        // which are the only ones with a build task to lose. An index created
+        // WITH its table sits in CREATING (backfilling NULL) until the
+        // control-plane worker activates it beside the table; it has no task,
+        // and sweeping it here would rebuild it early and flip it ACTIVE ahead
+        // of its own table.
+        let ids: Vec<(String,)> = sqlx::query_as(
+            "SELECT index_id FROM vector_indexes \
+             WHERE index_status = 'CREATING' AND backfilling IS NOT NULL",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
         let registry = self
             .vector_builds_running
             .lock()

--- a/crates/storage-sqlite/src/update_table.rs
+++ b/crates/storage-sqlite/src/update_table.rs
@@ -443,6 +443,38 @@ impl SqliteEngine {
                     // The per-table count limit is enforced on the request's
                     // net effect before this loop; see above.
 
+                    // A create whose vector attribute an EXISTING index already
+                    // uses must agree with it on Dimensions: the attribute
+                    // stores one vector. Measured live 2026-08-24 (us-east-1):
+                    // the service answers the attribute-redefinition message
+                    // with both sides in the VectorIndexSchema shape, and
+                    // accepts the same attribute at the SAME dimensions.
+                    // Checked inside the transaction under the write lock, so a
+                    // concurrent create cannot slip a disagreeing sibling in.
+                    let existing_dims: Option<(i64,)> = sqlx::query_as(
+                        "SELECT dimensions FROM vector_indexes \
+                         WHERE table_id = ? AND vector_attribute = ? \
+                           AND dimensions <> ? LIMIT 1",
+                    )
+                    .bind(&table_id)
+                    .bind(
+                        serde_json::to_string(&create.vector_attribute)
+                            .map_err(|e| StorageError::Internal(e.to_string()))?,
+                    )
+                    .bind(i64::from(create.dimensions))
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    if let Some((existing,)) = existing_dims {
+                        return Err(StorageError::Validation(
+                            extenddb_core::types::vector_attribute_redefines_vector(
+                                vec_attr_name,
+                                u32::try_from(existing).unwrap_or_default(),
+                                create.dimensions,
+                            ),
+                        ));
+                    }
+
                     let dup: Option<(String,)> = sqlx::query_as(
                         "SELECT index_name FROM vector_indexes \
                          WHERE table_id = ? AND index_name = ?",
@@ -1484,6 +1516,7 @@ mod reconciler_tests {
             &ks,
             &ad,
             &["base_pk".to_owned()],
+            crate::data::vector_index::VectorRowConflict::Fail,
         )
         .await
         .expect("partial row");

--- a/crates/storage-sqlite/src/worker.rs
+++ b/crates/storage-sqlite/src/worker.rs
@@ -34,16 +34,44 @@ impl SqliteEngine {
         let now = format_timestamp(time::OffsetDateTime::now_utc());
         let mut transitions = Vec::new();
 
-        // CREATING → ACTIVE.
+        // CREATING → ACTIVE. The table flip and the with-table index flip below
+        // ride one transaction so no DescribeTable can observe the table ACTIVE
+        // with its own creation-time index still CREATING: measured against the
+        // service (2026-08-21, eu-west-2, three runs at 250ms), both reach
+        // ACTIVE in the same poll with no gap in either direction.
+        let mut activate_tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
         let activated: Vec<(String,)> = sqlx::query_as(
             "UPDATE tables SET table_status = 'ACTIVE', status_transition_at = NULL \
              WHERE table_status = 'CREATING' AND status_transition_at IS NOT NULL \
                AND status_transition_at <= ? RETURNING table_name",
         )
         .bind(&now)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *activate_tx)
         .await
         .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        // Vector indexes created WITH their table (backfilling IS NULL — the
+        // UpdateTable path writes `false` from the first instant, so it is
+        // never selected here). Written as a self-healing catch-all over every
+        // ACTIVE table rather than just the rows activated above, so a crash
+        // between a past table flip and its index flip cannot strand an index
+        // in CREATING forever; re-running it is a no-op.
+        sqlx::query(
+            "UPDATE vector_indexes SET index_status = 'ACTIVE' \
+             WHERE index_status = 'CREATING' AND backfilling IS NULL \
+               AND table_id IN (SELECT table_id FROM tables WHERE table_status = 'ACTIVE')",
+        )
+        .execute(&mut *activate_tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+        activate_tx
+            .commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
         for (name,) in activated {
             transitions.push((name, "CREATING → active"));
         }

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -14,6 +14,13 @@ pub enum StorageError {
     IndexNotFound(String),
     #[error("Index already exists: {0}")]
     IndexAlreadyExists(String),
+    /// `DeleteTable` arrived while an online index operation (an
+    /// UpdateTable-created vector index still backfilling) was in progress on
+    /// the table. Maps to `ResourceInUseException` with the sentence AWS
+    /// documents in the vector search tutorial's readiness callout: "Cannot
+    /// delete table while indexes are being created, updated, or deleted."
+    #[error("Indexes are being created, updated, or deleted on table: {0}")]
+    IndexesInUse(String),
     #[error("Deletion protection enabled: {0}")]
     DeletionProtected(String),
     #[error("Condition check failed")]

--- a/tests/rust/src/vector_index_update_rules.rs
+++ b/tests/rust/src/vector_index_update_rules.rs
@@ -193,14 +193,19 @@ async fn switching_vector_table_to_provisioned_is_rejected() {
     delete_table(&name).await;
 }
 
-/// Deleting one index and creating another in the same request against a
-/// full table passes, in EITHER action order, because the count is evaluated
-/// on the request's net effect rather than per action. The create-first case
-/// is the discriminating one: a per-action count sees the full table before
-/// the delete has freed a slot and wrongly refuses. DynamoDB's model is a set
-/// of index changes, so list order must not decide acceptance.
+/// Deleting one index and creating another in the same request is refused,
+/// in EITHER action order: the online-index machinery accepts one action per
+/// call, so a swap must be issued as two UpdateTable calls. Measured
+/// 2026-08-24 (us-east-1): a Delete+Create pair against a live table answers
+/// `LimitExceededException` with the subscriber-limit sentence, the same
+/// refusal GSIs give. An earlier version of this test asserted the swap must
+/// PASS, reasoning from the net-effect count rule; that reasoning applied to
+/// the per-table count limit, never to the one-action rule, and was not
+/// measured. The net-effect counting in storage remains correct for the
+/// hypothetical of a request that reaches it, but no multi-action request
+/// does any more.
 #[tokio::test]
-async fn swap_on_a_full_table_is_allowed() {
+async fn swap_in_one_call_is_refused() {
     if skip_unless_supported().await {
         return;
     }
@@ -223,12 +228,15 @@ async fn swap_on_a_full_table_is_allowed() {
     }}"#
     );
     let (status, text) = call("UpdateTable", &swap).await;
-    assert_eq!(
-        status, 200,
-        "delete+create swap on a full table failed: {text}"
+    assert_error(
+        status,
+        &text,
+        "LimitExceededException",
+        "Subscriber limit exceeded: Only 1 online index can be created or deleted \
+         simultaneously per table",
     );
 
-    // Create listed BEFORE the delete: still a net swap, must still pass.
+    // Create listed BEFORE the delete: same two actions, same refusal.
     let swap_create_first = format!(
         r#"{{
         "TableName": "{name}",
@@ -245,10 +253,31 @@ async fn swap_on_a_full_table_is_allowed() {
     }}"#
     );
     let (status, text) = call("UpdateTable", &swap_create_first).await;
-    assert_eq!(
-        status, 200,
-        "create-before-delete swap on a full table failed: {text}"
+    assert_error(
+        status,
+        &text,
+        "LimitExceededException",
+        "Subscriber limit exceeded: Only 1 online index can be created or deleted \
+         simultaneously per table",
     );
+
+    // The swap expressed as two sequential calls goes through: the delete
+    // frees the slot, then the create is a single action against a table of
+    // four.
+    let drop_one = format!(
+        r#"{{
+        "TableName": "{name}",
+        "VectorIndexUpdates": [{{"Delete": {{"IndexName": "vidx0"}}}}]
+    }}"#
+    );
+    let (status, text) = call("UpdateTable", &drop_one).await;
+    assert_eq!(status, 200, "single delete failed: {text}");
+    let (status, text) = call(
+        "UpdateTable",
+        &create_update_body(&name, "vidxNew", "embNew"),
+    )
+    .await;
+    assert_eq!(status, 200, "single create after delete failed: {text}");
 
     delete_table(&name).await;
 }


### PR DESCRIPTION
## What

Seven fixes to the vector index surface, each qualified against real DynamoDB in **both us-east-1 and eu-west-2** (2026-08-24) before being written. Every behavior and message below is what the live service does; nothing here is inferred.

### Lifecycle

- **An index created with its table now reports `CREATING` while the table is `CREATING`, and flips `ACTIVE` atomically with the table.** Measured on the service (three runs polling at 250 ms): both reach `ACTIVE` in the same DescribeTable poll, with no gap in either direction. Previously the index claimed `ACTIVE` from the first instant, so a client following the documented wait-for-the-index readiness loop was released onto a still-CREATING table and got `ResourceNotFoundException` from its first write or search. This was the root cause behind most of the observed divergences, including four write-rejection messages that were already correct but unreachable.
- **UpdateTable-created indexes hold `CREATING` for a configurable floor** (`vector_index_min_creating_ms`, default 1000; zero disables) before the `ACTIVE` flip. The service's online-index machinery never completes an added index instantly (~17 min observed for a 25-item table), so the documented walk (`CREATING`/`Backfilling: false`, then `true`, then `ACTIVE` with the member absent) is always observable there; a local backfill over a small table finished in milliseconds and collapsed that walk into an unobservable instant. Searches keep answering the documented not-ready rejection and writes keep queuing behind the CREATING hold for the duration, exactly as during a real backfill.
- **Startup reconciliation and the stuck-build sweep are scoped to `backfilling IS NOT NULL`**, so a with-table CREATING index (which has no build task) is never rebuilt early or flipped ACTIVE ahead of its own table.
- **DeleteTable under an in-flight index build is refused** with `ResourceInUseException` and the documented sentence: `Cannot delete table while indexes are being created, updated, or deleted.` Cancelling the build with a `Delete` action remains allowed, as on the service.

### Validation and messages

- `Dimensions` below 1 rejects at the **request-model layer** (`1 validation error detected: Value '0' at 'vectorIndexes.1.member.dimensions' failed to satisfy constraint: Member must have value greater than or equal to 1`), captured live with client-side SDK validation disabled. The semantic `between 1 and 4096 inclusive` message now covers the upper bound only, which is the split the service makes.
- Two indexes on one vector attribute with different `Dimensions` reject with the service's `Conflicting attribute definition for '<attr>'...` message (previously accepted).
- More than one action in `VectorIndexUpdates` rejects with `LimitExceededException`: `Subscriber limit exceeded: Only 1 online index can be created or deleted simultaneously per table`.
- An empty string or binary value in a SearchSchema HASH attribute rejects with the secondary-index empty-key sentence, `IndexName`/`IndexKey` suffix included (previously accepted silently).
- Two SearchVectors messages completed to their full wire text: the invalid-values rejection now names the 32-bit float constraint, and the comparator rejection carries its `Invalid SearchConditionExpression: ` prefix.

## Verification

- `cargo fmt --all -- --check` clean, `cargo clippy --all-targets -- -D warnings` clean, workspace tests green (623 tests, one adapted to the new one-online-action rule).
- End-to-end against the dev server in `:memory:` mode: full external verification pass, 12 previously-diverging behaviors now match the service, zero regressions.
- SQLite backend only: Postgres does not implement vector indexes.
