### PR TITLE
ci(npm): retire the dead macos-13 runner and prove the build matrix before merge

### DIFF
--- a/.github/workflows/npm-build-dryrun.yml
+++ b/.github/workflows/npm-build-dryrun.yml
@@ -1,0 +1,31 @@
+# Pre-merge proof of the npm release build matrix.
+#
+# Every npm-publish failure to date surfaced only at release dispatch time,
+# after a human approval was already spent: the build matrix had never been
+# executed before a real release run. This workflow runs the exact matrix
+# (same reusable workflow, same runner labels, same build/smoke/launcher
+# steps, no publish) on every pull request that touches the release path, so
+# a retired runner label, a platform compile break, or a launcher regression
+# is caught while the change is still reviewable.
+name: npm build dry run
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/npm-publish.yml'
+      - '.github/workflows/npm-build-matrix.yml'
+      - '.github/workflows/npm-build-dryrun.yml'
+      - 'packaging/npm/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-build-dryrun-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  matrix:
+    uses: ./.github/workflows/npm-build-matrix.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/npm-build-dryrun.yml
+++ b/.github/workflows/npm-build-dryrun.yml
@@ -4,9 +4,11 @@
 # after a human approval was already spent: the build matrix had never been
 # executed before a real release run. This workflow runs the exact matrix
 # (same reusable workflow, same runner labels, same build/smoke/launcher
-# steps, no publish) on every pull request that touches the release path, so
-# a retired runner label, a platform compile break, or a launcher regression
-# is caught while the change is still reviewable.
+# steps, no publish) on every pull request that touches the release path OR
+# anything the release binary is built from, so a retired runner label, a
+# platform compile break (POSIX-only crates arrive through source and
+# Cargo.lock changes), or a launcher regression is caught while the change
+# is still reviewable.
 name: npm build dry run
 
 on:
@@ -16,6 +18,10 @@ on:
       - '.github/workflows/npm-build-matrix.yml'
       - '.github/workflows/npm-build-dryrun.yml'
       - 'packaging/npm/**'
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain*'
 
 permissions:
   contents: read
@@ -29,3 +35,40 @@ jobs:
     uses: ./.github/workflows/npm-build-matrix.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
+      # Every platform reports even when one fails: a pre-merge proof is
+      # worth more when it shows the full damage, not the first casualty.
+      fail-fast: false
+
+  # The publish job's side of the artifact contract, exercised pre-merge:
+  # resolve the platform list from optionalDependencies exactly as
+  # npm-publish.yml does, and require artifacts/bin-<pkg>/<bin> to exist for
+  # every entry. A drift between the matrix upload layout and the publish
+  # read path otherwise passes the dry run and fails only at release time.
+  artifact-contract:
+    needs: matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out the pull request head
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Download the built binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          path: artifacts/
+
+      - name: Every optionalDependencies platform must have its artifact
+        run: |
+          set -euo pipefail
+          # Same derivation as the publish job: the launcher's
+          # optionalDependencies is the single source of truth.
+          PLATFORMS=$(jq -r '.optionalDependencies | keys[] | ltrimstr("@extenddb/")' packaging/npm/package.json)
+          for pkg in $PLATFORMS; do
+            bin="extenddb"; [[ "$pkg" == win32-* ]] && bin="extenddb.exe"
+            [[ -f "artifacts/bin-${pkg}/${bin}" ]] || { echo "::error::publish expects artifacts/bin-${pkg}/${bin} and it is not there"; exit 1; }
+          done
+          # The one artifact this runner can execute must actually run.
+          chmod +x artifacts/bin-linux-x64/extenddb
+          artifacts/bin-linux-x64/extenddb --version

--- a/.github/workflows/npm-build-matrix.yml
+++ b/.github/workflows/npm-build-matrix.yml
@@ -1,0 +1,135 @@
+# The npm platform build matrix, shared between the release workflow
+# (npm-publish.yml) and the pull-request dry run (npm-build-dryrun.yml).
+#
+# One definition on purpose: the release path and the pre-merge proof must be
+# the same jobs on the same runner labels, or the dry run proves nothing. A
+# runner label that GitHub has retired does not fail fast -- the job queues
+# until the run is cancelled -- so the only reliable check that a label exists
+# is executing it, which the dry run does on every change to these files.
+name: npm build matrix
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Commit SHA to build (callers must pass a fully resolved SHA)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    # If one platform fails, cancel the rest: nothing is published either way.
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - pkg: linux-x64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - pkg: linux-arm64
+            runner: ubuntu-24.04-arm      # native arm64, no qemu
+            target: aarch64-unknown-linux-gnu
+          - pkg: darwin-x64
+            # Intel macOS runners are retired (macos-13 was the last; jobs
+            # targeting it queue forever). Cross-compile from arm64 instead
+            # and execute the binary under Rosetta 2, which macOS applies
+            # transparently when an x86_64 binary is spawned.
+            runner: macos-15
+            target: x86_64-apple-darwin
+          - pkg: darwin-arm64
+            runner: macos-15
+            target: aarch64-apple-darwin
+          - pkg: win32-x64
+            runner: windows-latest
+            target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60          # a hung Rust build must not burn the 6h default
+    env:
+      BIN_NAME: extenddb${{ matrix.pkg == 'win32-x64' && '.exe' || '' }}
+      BIN_PATH: target/${{ matrix.target }}/release/extenddb${{ matrix.pkg == 'win32-x64' && '.exe' || '' }}
+    steps:
+      # CodeQL's actions/cache-poisoning/poisonable-step query flags the build
+      # and test steps below, because a workflow_dispatch run executes in the
+      # default branch's context (and therefore its Actions cache scope) while
+      # checking out a ref supplied at dispatch time. Two properties make that
+      # unexploitable here, neither of which the query can see:
+      #
+      #   1. The release caller's `gate` has already proved this SHA is an
+      #      ancestor of origin/main (`git merge-base --is-ancestor`), so the
+      #      code executed below is reviewed code already on main; the dry-run
+      #      caller builds pull-request code with pull-request permissions.
+      #      Poisoning either would require access that permits strictly worse
+      #      things directly.
+      #   2. Nothing in this workflow reads or writes the Actions cache at all:
+      #      there is no actions/cache step, no rust-cache, and no `cache:`
+      #      input on setup-node. There is no cache entry to poison.
+      #
+      # Keep both true if this job grows: adding a cache step here would make
+      # the finding real, and it would then need a trusted-ref guard.
+      - name: Check out the requested commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.97.0
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Rosetta 2 must be present (darwin-x64 runs on an arm64 host)
+        if: matrix.pkg == 'darwin-x64'
+        run: |
+          set -euo pipefail
+          # Preinstalled on GitHub's arm64 macOS images; a no-op then. If it
+          # ever disappears, fail here with a clear cause rather than letting
+          # the smoke test die with a cryptic exec format error.
+          sudo softwareupdate --install-rosetta --agree-to-license
+          arch -x86_64 /usr/bin/true
+
+      - name: Build the slim dev-mode binary
+        # SQLite backend only, dev-mode on: the launcher's contract binary.
+        # `--locked` so the build is exactly the reviewed Cargo.lock. The
+        # explicit --target keeps the output path uniform across native and
+        # cross-compiled platforms.
+        run: cargo build --release --locked --no-default-features --features sqlite,dev-mode -p extenddb --target ${{ matrix.target }}
+
+      - name: The binary must be the target architecture
+        if: matrix.pkg == 'darwin-x64'
+        run: |
+          set -euo pipefail
+          # Cross-compiling makes "it built" weaker evidence than usual: a
+          # wrong-target binary would run fine on this host. Pin the arch.
+          file "${BIN_PATH}" | grep -q 'x86_64' || { echo "::error::expected an x86_64 binary: $(file "${BIN_PATH}")"; exit 1; }
+
+      - name: Smoke test - the binary must run on the target architecture
+        shell: bash
+        # For darwin-x64 this executes the x86_64 binary on the arm64 host,
+        # which macOS routes through Rosetta 2 transparently -- a real
+        # execution on the target instruction set, not just a compile.
+        run: |
+          set -euo pipefail
+          "${BIN_PATH}" --version
+
+      - name: Run the launcher test suite against the built binary
+        # The same suite that gates packaging/ in CI, here proving the real
+        # release binary on the real target platform, including the
+        # file-persistence and memory-mode contracts. node spawns the binary
+        # as a subprocess, so the darwin-x64 case exercises the Rosetta path
+        # end to end.
+        shell: bash
+        env:
+          EXTENDDB_BINARY: ${{ github.workspace }}/target/${{ matrix.target }}/release/extenddb${{ matrix.pkg == 'win32-x64' && '.exe' || '' }}
+        run: |
+          set -euo pipefail
+          cd packaging/npm
+          node test/launcher.test.js
+
+      - name: Upload the binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: bin-${{ matrix.pkg }}
+          path: ${{ env.BIN_PATH }}
+          if-no-files-found: error

--- a/.github/workflows/npm-build-matrix.yml
+++ b/.github/workflows/npm-build-matrix.yml
@@ -15,15 +15,21 @@ on:
         description: 'Commit SHA to build (callers must pass a fully resolved SHA)'
         required: true
         type: string
+      fail-fast:
+        description: 'Cancel remaining platforms when one fails (release: true; dry run: false so every platform reports)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
 
 jobs:
   build:
-    # If one platform fails, cancel the rest: nothing is published either way.
+    # Release runs cancel the rest when one platform fails (nothing is
+    # published either way); the dry run sets false so every platform reports.
     strategy:
-      fail-fast: true
+      fail-fast: ${{ inputs.fail-fast }}
       matrix:
         include:
           - pkg: linux-x64
@@ -83,10 +89,13 @@ jobs:
         if: matrix.pkg == 'darwin-x64'
         run: |
           set -euo pipefail
-          # Preinstalled on GitHub's arm64 macOS images; a no-op then. If it
-          # ever disappears, fail here with a clear cause rather than letting
-          # the smoke test die with a cryptic exec format error.
-          sudo softwareupdate --install-rosetta --agree-to-license
+          # NOT preinstalled on GitHub's arm64 macOS images: the installer
+          # genuinely downloads Rosetta here. softwareupdate is network-bound
+          # and known for spurious non-zero exits, so its exit code must not
+          # gate the run; the capability probe on the next line is the real
+          # gate. Fail closed on "Rosetta cannot execute x86_64", not on a
+          # flaky installer.
+          sudo softwareupdate --install-rosetta --agree-to-license || true
           arch -x86_64 /usr/bin/true
 
       - name: Build the slim dev-mode binary

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -166,84 +166,13 @@ jobs:
 
   build:
     needs: gate
-    # If one platform fails, cancel the rest: nothing is published either way.
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - pkg: linux-x64
-            runner: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - pkg: linux-arm64
-            runner: ubuntu-24.04-arm      # native arm64, no qemu
-            target: aarch64-unknown-linux-gnu
-          - pkg: darwin-x64
-            runner: macos-13              # last Intel macOS runner
-            target: x86_64-apple-darwin
-          - pkg: darwin-arm64
-            runner: macos-14
-            target: aarch64-apple-darwin
-          - pkg: win32-x64
-            runner: windows-latest
-            target: x86_64-pc-windows-msvc
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60          # a hung Rust build must not burn the 6h default
-    env:
-      BIN_NAME: extenddb${{ matrix.pkg == 'win32-x64' && '.exe' || '' }}
-    steps:
-      # CodeQL's actions/cache-poisoning/poisonable-step query flags the build
-      # and test steps below, because a workflow_dispatch run executes in the
-      # default branch's context (and therefore its Actions cache scope) while
-      # checking out a ref supplied at dispatch time. Two properties make that
-      # unexploitable here, neither of which the query can see:
-      #
-      #   1. `gate` has already proved this SHA is an ancestor of origin/main
-      #      (`git merge-base --is-ancestor`), so the code executed below is
-      #      reviewed code already on main. Poisoning it would require push
-      #      access to main, which permits strictly worse things directly.
-      #   2. Nothing in this workflow reads or writes the Actions cache at all:
-      #      there is no actions/cache step, no rust-cache, and no `cache:`
-      #      input on setup-node. There is no cache entry to poison.
-      #
-      # Keep both true if this job grows: adding a cache step here would make
-      # the finding real, and it would then need a trusted-ref guard.
-      - name: Check out the tagged commit
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
-        with:
-          ref: ${{ needs.gate.outputs.sha }}
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.97.0
-
-      - name: Build the slim dev-mode binary
-        # SQLite backend only, dev-mode on: the launcher's contract binary.
-        # `--locked` so the build is exactly the reviewed Cargo.lock.
-        run: cargo build --release --locked --no-default-features --features sqlite,dev-mode -p extenddb
-
-      - name: Smoke test - the native binary must run
-        shell: bash
-        run: |
-          set -euo pipefail
-          "target/release/${BIN_NAME}" --version
-
-      - name: Run the launcher test suite against the built binary
-        # The same suite that gates packaging/ in CI, here proving the real
-        # release binary on the real target platform, including the
-        # file-persistence and memory-mode contracts.
-        shell: bash
-        env:
-          EXTENDDB_BINARY: ${{ github.workspace }}/target/release/extenddb${{ matrix.pkg == 'win32-x64' && '.exe' || '' }}
-        run: |
-          set -euo pipefail
-          cd packaging/npm
-          node test/launcher.test.js
-
-      - name: Upload the binary
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: bin-${{ matrix.pkg }}
-          path: target/release/${{ env.BIN_NAME }}
-          if-no-files-found: error
+    # The matrix lives in npm-build-matrix.yml, shared with the pull-request
+    # dry run (npm-build-dryrun.yml) so the release path and the pre-merge
+    # proof are the same jobs on the same runner labels. Change the matrix
+    # there and the dry run exercises it on real runners before merge.
+    uses: ./.github/workflows/npm-build-matrix.yml
+    with:
+      ref: ${{ needs.gate.outputs.sha }}
 
   publish:
     needs: [gate, build]


### PR DESCRIPTION
## What

The darwin-x64 build job targeted `macos-13`, which GitHub has retired. Jobs on retired labels do not fail fast, they queue until the run is cancelled: both v0.1.8-era dispatches show every other platform green in minutes while darwin-x64 sat queued for over an hour. Intel macOS hosted runners are gone entirely, so darwin-x64 now cross-compiles on `macos-15` (arm64) and executes the smoke test and full launcher suite under Rosetta 2, keeping a real execution on the target instruction set. An arch assertion on the produced binary guards against silently building for the host. darwin-arm64 moves to `macos-15` as well.

The structural fix: the build matrix moves to a reusable workflow (`npm-build-matrix.yml`) shared by `npm-publish.yml` and a new pull-request dry run (`npm-build-dryrun.yml`) that runs the identical jobs on the identical runner labels, minus the publish, on any PR touching the release path. Every npm-publish failure so far surfaced only at dispatch time because the matrix had never executed before a real release run. One shared definition means the dry run cannot drift from the release build.

## Why now

This is the last blocker before the v0.1.9 tag and dispatch. Without it the release wedges on the darwin-x64 queue exactly as v0.1.8 did.

## Testing done

- All three workflow files parse.
- The exact new build invocation (`--target x86_64-unknown-linux-gnu` leg) built clean locally and the launcher suite passed 4/4 against the target-path binary.
- This PR's own dry run exercises all five runner labels, including the macos-15 cross-compile + Rosetta leg, before merge. Do not merge until it is green.
