### PR TITLE
fix(npm): static musl linux binaries with an old-libc execution gate; bump 0.1.10

### DIFF
--- a/.github/workflows/npm-build-matrix.yml
+++ b/.github/workflows/npm-build-matrix.yml
@@ -32,12 +32,18 @@ jobs:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:
         include:
+          # Linux is musl-static on purpose: a glibc-linked binary inherits
+          # the build runner's glibc floor (ubuntu-latest today means
+          # GLIBC_2.38+, which excludes Amazon Linux 2023, Ubuntu 22.04 and
+          # Debian 12 - the exact CI hosts this launcher exists for). Static
+          # musl has no floor, and the container gate below proves it by
+          # executing the binary on the oldest-libc image we care about.
           - pkg: linux-x64
             runner: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
           - pkg: linux-arm64
             runner: ubuntu-24.04-arm      # native arm64, no qemu
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
           - pkg: darwin-x64
             # Intel macOS runners are retired (macos-13 was the last; jobs
             # targeting it queue forever). Cross-compile from arm64 instead
@@ -84,6 +90,21 @@ jobs:
         uses: dtolnay/rust-toolchain@1.97.0
         with:
           targets: ${{ matrix.target }}
+
+      - name: Install the musl toolchain (linux legs build static binaries)
+        if: contains(matrix.target, 'musl')
+        run: |
+          set -euo pipefail
+          sudo apt-get update -q
+          sudo apt-get install -y -q musl-tools
+          # cc-rs (bundled SQLite) and the linker both go through musl-gcc.
+          {
+            echo "CC_${TARGET_ENV}=musl-gcc"
+            echo "CARGO_TARGET_${TARGET_UPPER}_LINKER=musl-gcc"
+          } >> "$GITHUB_ENV"
+        env:
+          TARGET_ENV: ${{ matrix.target == 'x86_64-unknown-linux-musl' && 'x86_64_unknown_linux_musl' || 'aarch64_unknown_linux_musl' }}
+          TARGET_UPPER: ${{ matrix.target == 'x86_64-unknown-linux-musl' && 'X86_64_UNKNOWN_LINUX_MUSL' || 'AARCH64_UNKNOWN_LINUX_MUSL' }}
 
       - name: Rosetta 2 must be present (darwin-x64 runs on an arm64 host)
         if: matrix.pkg == 'darwin-x64'
@@ -135,6 +156,17 @@ jobs:
           set -euo pipefail
           cd packaging/npm
           node test/launcher.test.js
+
+      - name: Portability gate - the binary must run on the oldest libc we support
+        if: contains(matrix.target, 'musl')
+        run: |
+          set -euo pipefail
+          # The build host can always execute its own binary, so nothing above
+          # proves portability. amazonlinux:2 (glibc 2.26) is the oldest libc
+          # among the CI hosts this launcher targets; a static binary must run
+          # there unmodified. This gate is what failed silently in 0.1.9.
+          file "${BIN_PATH}" | grep -Eq 'static(-pie|ally)' || { echo "::error::binary is not statically linked: $(file "${BIN_PATH}")"; exit 1; }
+          docker run --rm -v "$(pwd)/${BIN_PATH}:/extenddb:ro" amazonlinux:2 /extenddb --version
 
       - name: Upload the binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "extenddb-app",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-app"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-auth"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "async-trait",
  "axum",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-cache"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "futures",
  "moka",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-config"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "config",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-core"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-engine"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "base64 0.22.1",
  "crc32fast",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-server"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-mongodb"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-postgres"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-sqlite"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SOFTWARE-LICENSE-NOTICES-DEV.html
+++ b/SOFTWARE-LICENSE-NOTICES-DEV.html
@@ -7085,16 +7085,16 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage-sqlite ">extenddb-storage-sqlite 0.1.9</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage-sqlite ">extenddb-storage-sqlite 0.1.10</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.103</a></li>
                     <li><a href=" https://github.com/andylokandy/arraydeque ">arraydeque 0.5.1</a></li>

--- a/SOFTWARE-LICENSE-NOTICES.html
+++ b/SOFTWARE-LICENSE-NOTICES.html
@@ -6665,16 +6665,16 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.9</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage-postgres ">extenddb-storage-postgres 0.1.9</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage-postgres ">extenddb-storage-postgres 0.1.10</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.103</a></li>
                     <li><a href=" https://github.com/andylokandy/arraydeque ">arraydeque 0.5.1</a></li>

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extenddb/dev",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "ExtendDB dev server launcher: a DynamoDB-compatible database for local development and CI. Spawns the extenddb dev binary (file-backed by default, in-memory with --memory) and hands back an endpoint plus credentials any AWS SDK accepts.",
   "license": "Apache-2.0",
   "repository": {
@@ -25,10 +25,10 @@
     "test": "node test/launcher.test.js"
   },
   "optionalDependencies": {
-    "@extenddb/linux-x64": "0.1.9",
-    "@extenddb/linux-arm64": "0.1.9",
-    "@extenddb/darwin-x64": "0.1.9",
-    "@extenddb/darwin-arm64": "0.1.9",
-    "@extenddb/win32-x64": "0.1.9"
+    "@extenddb/linux-x64": "0.1.10",
+    "@extenddb/linux-arm64": "0.1.10",
+    "@extenddb/darwin-x64": "0.1.10",
+    "@extenddb/darwin-arm64": "0.1.10",
+    "@extenddb/win32-x64": "0.1.10"
   }
 }


### PR DESCRIPTION
## What

The 0.1.9 linux npm binaries were glibc-linked and built on ubuntu-latest, inheriting the runner's GLIBC_2.38+ floor. They fail to start on Amazon Linux 2023, Ubuntu 22.04 and Debian 12, a large share of the CI hosts the launcher targets. CI could not see this: the build host can always execute its own binary, so every green smoke and launcher run proved only that the binary runs where it was built. Caught by installing the published candidate on an older host before dist-tag promotion; 0.1.9 stays on the candidate tag and never reaches latest.

Both linux legs now build musl-static (no libc floor), and a new portability gate makes the property load-bearing: the binary must be statically linked per file(1) and must execute inside an amazonlinux:2 container (glibc 2.26). The gate runs in the PR dry run and the release build via the shared matrix.

Version bumps to 0.1.10 (npm versions are immutable); Cargo.lock and both license notices regenerated, --check clean.

## Testing done

- Workspace check + fmt clean on the bumped tree; both notices generators --check clean.
- This PR's dry run builds all five platforms, runs the launcher suite on each, and executes both linux binaries in amazonlinux:2. Do not merge until green.
