### PR TITLE
Amazon bought a database. We put it in the database.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -126,6 +126,62 @@ jobs:
           EXTENDDB_ADMIN_PASSWORD: ${{ steps.init.outputs.admin_password }}
         run: devtools/run-tests --extenddb --pytest --comprehensive --parallel --filter "not import_export"
 
+  run-integration-duckdb:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Build release (DuckDB backend)
+        run: cargo build --release -p extenddb --no-default-features --features duckdb
+
+      - name: Initialize ExtendDB
+        id: init
+        run: |
+          output=$(./target/release/extenddb init --backend duckdb --config extenddb.toml 2>&1)
+          echo "$output"
+          password=$(echo "$output" | grep -oP 'Password: \K\S+')
+          echo "admin_password=$password" >> "$GITHUB_OUTPUT"
+
+      - name: Start ExtendDB
+        run: |
+          # --write-pid-file so devtools/run-tests can restart the server with
+          # 'extenddb stop' when it needs to apply a config change.
+          ./target/release/extenddb serve --config extenddb.toml --foreground --write-pid-file &
+          for i in $(seq 1 30); do
+            if curl -sk https://127.0.0.1:18443/health | grep -q healthy; then
+              echo "Server ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server failed to start"
+          exit 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run integration tests
+        env:
+          EXTENDDB_TEST_ENDPOINT: https://127.0.0.1:18443
+          EXTENDDB_ADMIN_USER: admin
+          EXTENDDB_ADMIN_PASSWORD: ${{ steps.init.outputs.admin_password }}
+        # test_gsi_async drives the server out-of-band with `extenddb settings
+        # set` from a second process. DuckDB holds a process-exclusive lock on
+        # the database file, so a second process cannot open it while the
+        # server is running; the propagation paths it exercises are covered by
+        # the crate's unit tests instead.
+        run: devtools/run-tests --extenddb --pytest --comprehensive --parallel --filter "not import_export and not test_gsi_async"
+
   run-integration-dev-mode:
     # dev-mode was shipped with no CI coverage at all, which is how the batch and
     # transaction authorization regression reached main: the build compiled, so
@@ -321,6 +377,7 @@ jobs:
       [
         run-integration,
         run-integration-sqlite,
+        run-integration-duckdb,
         run-integration-dev-mode,
         run-rust-integration,
         run-rust-integration-sqlite,
@@ -330,6 +387,7 @@ jobs:
       - run: |
           if [ "${{ needs.run-integration.result }}" != "success" ] || \
              [ "${{ needs.run-integration-sqlite.result }}" != "success" ] || \
+             [ "${{ needs.run-integration-duckdb.result }}" != "success" ] || \
              [ "${{ needs.run-integration-dev-mode.result }}" != "success" ] || \
              [ "${{ needs.run-rust-integration.result }}" != "success" ] || \
              [ "${{ needs.run-rust-integration-sqlite.result }}" != "success" ]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -70,6 +71,15 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anstream"
@@ -128,6 +138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +160,169 @@ name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "arrow"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cfdd0833e32a9874d2b55089333ad310c0be208aafa277385ce2461dec90be3"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514ba0ef0d4c5896202dae736251ce415abb43a950bed570fb7981b8716c0e4c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "arrow-select"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
 
 [[package]]
 name = "asn1-rs"
@@ -358,6 +540,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +693,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +725,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
 ]
 
 [[package]]
@@ -612,6 +817,17 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "comfy-table"
+version = "7.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -798,6 +1014,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix 0.38.44",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +1200,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1282,23 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "duckdb"
+version = "1.10505.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "970e05eedd3f55c435194d9104f90a9b4a79a80d6e73251bc9ff43e178130c4e"
+dependencies = [
+ "arrow",
+ "cast",
+ "comfy-table",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.10.0",
+ "libduckdb-sys",
+ "num-integer",
+ "strum",
+]
 
 [[package]]
 name = "dunce"
@@ -1113,6 +1379,7 @@ dependencies = [
  "extenddb-app",
  "extenddb-config",
  "extenddb-storage",
+ "extenddb-storage-duckdb",
  "extenddb-storage-mongodb",
  "extenddb-storage-postgres",
  "extenddb-storage-sqlite",
@@ -1283,6 +1550,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "extenddb-storage-duckdb"
+version = "0.1.10"
+dependencies = [
+ "aes-gcm",
+ "async-trait",
+ "base64 0.22.1",
+ "bcrypt",
+ "bigdecimal",
+ "crc32fast",
+ "duckdb",
+ "extenddb-auth",
+ "extenddb-core",
+ "extenddb-storage",
+ "futures",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "toml",
+ "tracing",
+ "uuid",
+ "zeroize",
+]
+
+[[package]]
 name = "extenddb-storage-mongodb"
 version = "0.1.10"
 dependencies = [
@@ -1366,10 +1659,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1385,6 +1700,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1618,6 +1934,18 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1871,6 +2199,30 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2141,10 +2493,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libduckdb-sys"
+version = "1.10505.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb514dab5e271e849235c1cb98bd65a2ae107fbd619a6740219319c54a71d95"
+dependencies = [
+ "cc",
+ "flate2",
+ "pkg-config",
+ "serde",
+ "serde_json",
+ "tar",
+ "ureq",
+ "vcpkg",
+ "zip",
+]
 
 [[package]]
 name = "libm"
@@ -2174,6 +2600,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2479,6 +2911,15 @@ dependencies = [
  "rand 0.8.6",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2960,6 +3401,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3068,6 +3521,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3075,7 +3541,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3640,6 +4106,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3724,6 +4211,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3732,7 +4230,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4129,6 +4627,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4157,6 +4661,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+dependencies = [
+ "base64 0.23.1",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+dependencies = [
+ "base64 0.23.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4173,6 +4705,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -4379,12 +4917,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4707,6 +5302,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "yaml-rust2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4845,7 +5450,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/storage-postgres",
     "crates/storage-mongodb",
     "crates/storage-sqlite",
+    "crates/storage-duckdb",
     "crates/auth",
     "crates/server",
     "crates/app",
@@ -33,6 +34,7 @@ extenddb-config = { path = "crates/config" }
 extenddb-storage-postgres = { path = "crates/storage-postgres" }
 extenddb-storage-mongodb = { path = "crates/storage-mongodb" }
 extenddb-storage-sqlite = { path = "crates/storage-sqlite" }
+extenddb-storage-duckdb = { path = "crates/storage-duckdb" }
 extenddb-auth = { path = "crates/auth" }
 extenddb-server = { path = "crates/server" }
 extenddb-app = { path = "crates/app" }

--- a/crates/app/src/cmd_init.rs
+++ b/crates/app/src/cmd_init.rs
@@ -35,6 +35,12 @@ pub struct InitArgs {
     #[arg(long)]
     sqlite_path: Option<String>,
 
+    /// DuckDB database file path (default: extenddb.duckdb). The chosen path
+    /// is written to the generated config file, so `serve` finds it without
+    /// further flags. DuckDB backend only.
+    #[arg(long)]
+    duckdb_path: Option<String>,
+
     /// PostgreSQL host (hostname, IP address, or absolute Unix socket directory path)
     #[arg(long)]
     pg_host: Option<String>,
@@ -380,5 +386,15 @@ mod tests {
     #[test]
     fn init_rejects_unknown_flags() {
         assert!(parse(&["--sqlite-pathological", "/data/x.sqlite"]).is_err());
+    }
+
+    /// `--duckdb-path` is the DuckDB backend's analogue of `--sqlite-path` and
+    /// is read by that backend's bootstrapper from the raw argv, so it must be
+    /// declared here or clap rejects it before the bootstrapper ever sees it.
+    #[test]
+    fn init_accepts_duckdb_path() {
+        let args =
+            parse(&["--backend", "duckdb", "--duckdb-path", "/data/x.duckdb"]).expect("parse");
+        assert_eq!(args.duckdb_path.as_deref(), Some("/data/x.duckdb"));
     }
 }

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -17,10 +17,13 @@ postgres = ["extenddb-storage-postgres"]
 sqlite = ["extenddb-storage-sqlite"]
 # Build the SQLite backend in its zero-config, ephemeral in-memory mode.
 sqlite-memory = ["sqlite", "extenddb-storage-sqlite/memory"]
+duckdb = ["extenddb-storage-duckdb"]
+# Build the DuckDB backend in its zero-config, ephemeral in-memory mode.
+duckdb-memory = ["duckdb", "extenddb-storage-duckdb/memory"]
 mongodb = ["extenddb-storage-mongodb"]
 # Developer mode: plain HTTP on loopback, open authorization (SigV4 still
 # enforced), seeded dev credential. A build-time profile for local/CI only; it
-# requires a dev backend (`sqlite`/`sqlite-memory`) and fails to build with a
+# requires a dev backend (`sqlite`/`sqlite-memory`, `duckdb`/`duckdb-memory`) and fails to build with a
 # production backend like `postgres` (enforced at compile time in `main.rs`).
 dev-mode = ["extenddb-app/dev-mode"]
 
@@ -30,5 +33,6 @@ extenddb-storage = { workspace = true }
 extenddb-storage-postgres = { workspace = true, optional = true }
 extenddb-storage-mongodb = { workspace = true, optional = true }
 extenddb-storage-sqlite = { workspace = true, optional = true }
+extenddb-storage-duckdb = { workspace = true, optional = true }
 anyhow = { workspace = true }
 extenddb-config = { workspace = true }

--- a/crates/bin/src/main.rs
+++ b/crates/bin/src/main.rs
@@ -11,8 +11,9 @@
 //!
 //! In-tree backends are selected by mutually exclusive Cargo features:
 //! `postgres` (the default production backend), `mongodb` (production, built with
-//! `--no-default-features --features mongodb`), and `sqlite`/`sqlite-memory` (the
-//! dev/CI backend). Exactly one must be enabled: [`set_backend`] installs one
+//! `--no-default-features --features mongodb`), `sqlite`/`sqlite-memory` (the
+//! dev/CI backend), and `duckdb`/`duckdb-memory` (embedded, columnar). Exactly
+//! one must be enabled: [`set_backend`] installs one
 //! backend per process, so a build with more than one would be ambiguous and is
 //! rejected at compile time.
 
@@ -20,16 +21,24 @@
 #[cfg(any(
     all(feature = "postgres", feature = "sqlite"),
     all(feature = "postgres", feature = "mongodb"),
+    all(feature = "postgres", feature = "duckdb"),
     all(feature = "sqlite", feature = "mongodb"),
+    all(feature = "sqlite", feature = "duckdb"),
+    all(feature = "mongodb", feature = "duckdb"),
 ))]
 compile_error!(
-    "the `postgres`, `mongodb`, and `sqlite` features are mutually exclusive: a \
+    "the `postgres`, `mongodb`, `sqlite`, and `duckdb` features are mutually exclusive: a \
      thin bin installs exactly one backend (e.g. build the MongoDB binary with \
      `--no-default-features --features mongodb`)"
 );
-#[cfg(not(any(feature = "postgres", feature = "mongodb", feature = "sqlite")))]
+#[cfg(not(any(
+    feature = "postgres",
+    feature = "mongodb",
+    feature = "sqlite",
+    feature = "duckdb"
+)))]
 compile_error!(
-    "no backend selected: enable the `postgres` (default), `mongodb`, or `sqlite` feature"
+    "no backend selected: enable the `postgres` (default), `mongodb`, `sqlite`, or `duckdb` feature"
 );
 
 // Developer mode relaxes the security posture (plain HTTP on loopback, open
@@ -37,14 +46,16 @@ compile_error!(
 // dev/CI-suitable backend. Rather than denying each production backend by name
 // (every backend is a production backend unless proven otherwise, so a deny-list
 // would have to grow with each new one), require a known dev backend: dev-mode
-// compiles only when `sqlite` is enabled. `sqlite-memory` enables `sqlite`, so it
-// is covered too; postgres, mongodb — or any future production backend — fail the
-// build, so there is no path by which a production deployment can serve in dev mode.
-#[cfg(all(feature = "dev-mode", not(feature = "sqlite")))]
+// compiles only when `sqlite` or `duckdb` is enabled (both embedded, both with an
+// in-memory mode). `sqlite-memory` / `duckdb-memory` enable their base feature,
+// so they are covered too; postgres, mongodb — or any future production backend —
+// fail the build, so there is no path by which a production deployment can serve
+// in dev mode.
+#[cfg(all(feature = "dev-mode", not(any(feature = "sqlite", feature = "duckdb"))))]
 compile_error!(
-    "the `dev-mode` feature requires a dev/CI backend such as `sqlite`; it must \
-     not be built with a production backend like `postgres` or `mongodb` (build \
-     with `--no-default-features --features sqlite-memory,dev-mode`)"
+    "the `dev-mode` feature requires a dev/CI backend such as `sqlite` or `duckdb`; \
+     it must not be built with a production backend like `postgres` or `mongodb` \
+     (build with `--no-default-features --features sqlite-memory,dev-mode`)"
 );
 
 fn main() -> anyhow::Result<()> {
@@ -57,6 +68,8 @@ fn main() -> anyhow::Result<()> {
     extenddb_storage::set_backend(extenddb_storage_sqlite::backend())?;
     #[cfg(feature = "mongodb")]
     extenddb_storage::set_backend(extenddb_storage_mongodb::backend())?;
+    #[cfg(feature = "duckdb")]
+    extenddb_storage::set_backend(extenddb_storage_duckdb::backend())?;
 
     extenddb_app::run(extenddb_app::BuildInfo {
         // Read from the bin crate so the reported version is the deployed
@@ -77,6 +90,8 @@ mod tests {
         let _ = extenddb_storage::set_backend(extenddb_storage_sqlite::backend());
         #[cfg(feature = "mongodb")]
         let _ = extenddb_storage::set_backend(extenddb_storage_mongodb::backend());
+        #[cfg(feature = "duckdb")]
+        let _ = extenddb_storage::set_backend(extenddb_storage_duckdb::backend());
     }
 
     /// Zero-config serve contract: with the SQLite backend installed,
@@ -100,6 +115,28 @@ mod tests {
             assert!(
                 path.ends_with("extenddb.sqlite"),
                 "default file path should be extenddb.sqlite, got: {path}"
+            );
+        }
+    }
+
+    /// Zero-config serve contract for the DuckDB backend, mirroring the SQLite
+    /// one: built-in defaults load with no config file, bind to loopback, and
+    /// select the backend's default database path.
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn builtin_defaults_load_for_duckdb_and_bind_loopback() {
+        install_backend();
+        let cfg = extenddb_config::load_builtin_defaults()
+            .expect("duckdb storage config has no required fields");
+        assert_eq!(cfg.server.bind_addr, "127.0.0.1");
+        assert_eq!(cfg.server.port, 18443);
+        let path = cfg.storage.connection_config();
+        if cfg!(feature = "duckdb-memory") {
+            assert_eq!(path, ":memory:");
+        } else {
+            assert!(
+                path.ends_with("extenddb.duckdb"),
+                "default file path should be extenddb.duckdb, got: {path}"
             );
         }
     }

--- a/crates/storage-duckdb/.gitignore
+++ b/crates/storage-duckdb/.gitignore
@@ -1,0 +1,4 @@
+/target
+Cargo.lock
+*.duckdb
+*.duckdb.wal

--- a/crates/storage-duckdb/Cargo.toml
+++ b/crates/storage-duckdb/Cargo.toml
@@ -1,0 +1,37 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+[package]
+name = "extenddb-storage-duckdb"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[features]
+# Compile the in-memory (`:memory:`) database in as the default storage path,
+# yielding a zero-config, ephemeral, bootstrap-on-serve deployment (no `init`,
+# no file on disk). Without this feature the backend is file-backed and the path
+# must be configured as usual.
+memory = []
+
+[dependencies]
+extenddb-core = { workspace = true }
+extenddb-storage = { workspace = true }
+extenddb-auth = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+duckdb = { version = "1.10505.0", features = ["bundled", "json"] }
+tokio = { workspace = true, features = ["sync"] }
+toml = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true }
+time = { workspace = true }
+base64 = { workspace = true }
+bcrypt = { workspace = true }
+aes-gcm = { workspace = true }
+rand = { workspace = true }
+bigdecimal = { workspace = true }
+crc32fast = { workspace = true }
+zeroize = { workspace = true }

--- a/crates/storage-duckdb/README.md
+++ b/crates/storage-duckdb/README.md
@@ -1,0 +1,124 @@
+# extenddb-storage-duckdb
+
+DuckDB storage backend for [ExtendDB](https://github.com/ExtendDB/extenddb), an
+in-tree workspace crate selected by Cargo feature.
+
+## Design
+
+Single-file (or in-memory) storage using the embedded [DuckDB](https://duckdb.org)
+engine via the `duckdb` crate (statically linked; no server, no external
+dependency at runtime). Targets:
+
+- Local development without PostgreSQL
+- CI / integration tests (especially the ephemeral in-memory mode)
+- Single-node, embedded, and edge deployments
+- Anyone who has ever wanted to run `SELECT ... GROUP BY` directly against the
+  file their DynamoDB-compatible database lives in
+
+The crate is a port of `extenddb-storage-sqlite` — same catalog schema, same
+per-table data layout, same order-preserving `N` sort-key encoding, same
+persistent `gsi_pending` queue — with the storage engine swapped. The differences
+that matter:
+
+- **No `sqlx` driver exists for DuckDB**, so `src/db.rs` provides a small
+  `sqlx`-shaped async facade over the synchronous `duckdb` crate: a connection
+  pool, positional `query` / `query_as` / `query_scalar` builders, and an
+  explicit-commit / rollback-on-drop `Transaction`. Every statement runs on a
+  `spawn_blocking` thread; the connection is moved there and back.
+- **In-memory databases are shared across the pool.** All connections are
+  `try_clone()`s of one root connection onto the same database instance, so
+  `:memory:` gets a real read pool instead of SQLite's single pinned connection.
+- **No foreign keys.** DuckDB cannot cascade deletes, so the catalog declares
+  none; `src/referential.rs` removes children explicitly inside the parent's
+  delete transaction and checks parents exist before child inserts.
+- **MVCC inside the process.** Readers never block on the writer. Writers are
+  still serialized in-process by the engine's `write_lock`, which is what makes
+  condition-check-then-write atomic; DuckDB's optimistic conflict detection is a
+  backstop, not the mechanism. Across processes there is no sharing at all (see
+  Known limits).
+- **64-bit integers everywhere.** DuckDB's `INTEGER` is 32-bit, so every catalog
+  integer column is `BIGINT`, and `REAL` (32-bit in DuckDB) is `DOUBLE`.
+
+## Building
+
+The backend is compiled into the `extenddb` binary via feature flags (Postgres
+remains the default):
+
+```bash
+# DuckDB only, no Postgres compiled in
+cargo build -p extenddb --no-default-features --features duckdb
+
+# DuckDB in zero-config, ephemeral in-memory mode
+cargo build -p extenddb --no-default-features --features duckdb-memory
+```
+
+The first build compiles DuckDB from source (`libduckdb-sys` with the `bundled`
+feature). Budget several minutes and a cup of something; it is cached afterwards.
+
+## Configuration
+
+```toml
+[storage]
+backend = "duckdb"
+
+[storage.duckdb]
+# Database file path, or ":memory:" for an ephemeral in-memory database.
+path = "extenddb.duckdb"
+# Connection pool size (writes are serialized regardless).
+pool_size = 10
+```
+
+`extenddb init --backend duckdb --duckdb-path <path>` writes the path into the
+generated config file.
+
+### In-memory mode
+
+`path = ":memory:"` selects an ephemeral database that bootstraps on `serve`
+(no `init`, no file on disk). The `memory` crate feature (exposed by the binary
+as `duckdb-memory`) makes `:memory:` the compiled-in default path.
+
+## Developer mode
+
+`dev-mode` (plain HTTP on loopback, open authorization, seeded credential, SigV4
+still verified) builds with this backend exactly as it does with SQLite:
+
+```bash
+cargo build -p extenddb --no-default-features --features duckdb-memory,dev-mode
+extenddb serve --config extenddb.toml   # bootstraps on serve; no init
+```
+
+## Conformance
+
+Per [RFC-0002](https://github.com/ExtendDB/extenddb/blob/main/docs/rfcs), this
+backend implements the full storage trait surface.
+
+Mandatory traits:
+
+- `TableEngine`, `DataEngine`
+- `ManagementStore`, `AdminStore`, `Bootstrapper`
+
+Optional traits (all implemented):
+
+- `MetadataEngine`, `StreamEngine`, `WorkerStore`
+- `SettingsStore`, `MetricsStore`, `RateLimitStore`, `AuthorizationStore`,
+  `BackupEngine`
+
+Conformance is validated by the shared ExtendDB integration suite run against a
+DuckDB-served instance (`run-integration-duckdb` in CI).
+
+## Known limits
+
+- **One process at a time.** DuckDB takes a process-exclusive lock on the database
+  file. While `extenddb serve` is running, no second process can open the same
+  file, so out-of-band tooling that connects directly (`extenddb settings get|set`,
+  `catalog-check`, `verify`) must run while the server is stopped or against an
+  `:memory:` server not at all. Everything that goes through the server's own
+  API is unaffected.
+- **No TTL expression index.** DuckDB does not allow indexes over extension
+  functions, so the TTL sweep is a filtered scan of `item_data` rather than an
+  indexed lookup.
+- **Cold builds are slow.** DuckDB is compiled from source the first time.
+
+## License
+
+Apache License 2.0 — see the workspace [LICENSE](../../LICENSE).

--- a/crates/storage-duckdb/docs/design-decisions.md
+++ b/crates/storage-duckdb/docs/design-decisions.md
@@ -1,0 +1,154 @@
+<!--
+Copyright 2026 ExtendDB contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+# extenddb-storage-duckdb — Design Decisions
+
+This memo records the DuckDB-specific decisions taken to reach behavioural
+parity with the SQLite backend (`crates/storage-sqlite`), from which this crate
+was ported, and through it with the reference PostgreSQL backend. Decisions the
+SQLite backend already made and that carry over unchanged (the order-preserving
+`N` sort-key TEXT encoding, the single logical database, the persistent
+`gsi_pending` queue, synchronous LSI maintenance, `rowid`-based parallel scan
+segments) are not repeated here; see that crate's `docs/design-decisions.md`.
+
+---
+
+## D1 — Async execution model
+
+### Problem
+`duckdb::Connection` is synchronous, `Send` but not `Sync`, and there is no
+`sqlx` driver. The rest of the crate is async and written against `sqlx`'s
+builder API (`query(...).bind(...).fetch_all(&pool)`), with ~600 call sites.
+
+### Options
+- **(A) Call DuckDB inline on the async thread.** Simplest; blocks a tokio
+  worker for the duration of every statement. Point lookups are sub-millisecond
+  but a `Scan` or a backfill batch is not, and blocking the executor stalls
+  unrelated requests.
+- **(B) `block_in_place`.** Panics on a current-thread runtime, which every
+  `#[tokio::test]` in the crate uses.
+- **(C) Move the connection onto a `spawn_blocking` thread per statement.**
+  Each pooled connection lives in a `tokio::sync::Mutex<Option<Connection>>`
+  slot; a statement takes the connection out, runs on the blocking pool, and
+  puts it back. A transaction holds its slot for its whole lifetime so every
+  statement in it runs on the same connection. If the blocking task panics the
+  slot is left empty and re-cloned from the root connection on next use.
+
+### Decision
+**(C)**, wrapped in `src/db.rs` as a facade that reproduces the subset of the
+`sqlx` API the crate uses (`query`, `query_as`, `query_scalar`, `raw_sql`,
+`Pool::begin`, `Transaction::commit`, rollback on drop, `rows_affected`). Rows
+are materialised into `Vec<duckdb::types::Value>` on the blocking side and
+decoded into tuples or structs on the async side, so nothing borrowed from
+DuckDB crosses a thread boundary. The port of the storage code is then mostly
+`sqlx::` → `db::`.
+
+---
+
+## D2 — One database instance per process, per file
+
+### Problem
+DuckDB permits a single database instance per file per process and takes a
+file lock. The SQLite backend opens *two* independent pools over the same file
+at serve time (engine + catalog) and a third in the bootstrapper; a naive port
+fails on the second `Connection::open`.
+
+### Decision
+`db::Pool` keeps a process-wide registry of root connections keyed by canonical
+path. Every pool over a path is a set of `try_clone()`s of that path's root, so
+they share one instance; the catalog pool is opened as a `sibling` of the engine
+pool. `drop_databases` forgets the registry entry before deleting the file so
+the lock is released. In-memory databases are **not** registered: each
+`Pool::open(":memory:")` is a private database (what the unit tests expect), and
+connections cloned from it all see the same data — which is why the ephemeral
+mode can run a real read pool where SQLite had to pin one connection.
+
+---
+
+## D3 — Referential integrity without foreign keys
+
+### Problem
+DuckDB accepts `FOREIGN KEY` clauses but does not implement `ON DELETE CASCADE`,
+and it rejects updates to rows that a foreign key references. The SQLite catalog
+relies on cascades in eleven parent-delete paths (tables → indexes /
+vector_indexes / stream_shards / stream_records; accounts → every IAM table;
+users → tags / access keys / memberships; groups → memberships; roles → tags /
+sessions; backups → items) and on FK violations to report `NotFound` in seven
+child-insert paths.
+
+### Options
+- **(A) Keep the constraints, drop `ON DELETE CASCADE`.** Parent deletes then
+  fail while children exist, and every update to `tables` (status flips, item
+  counts) risks the referenced-row restriction. Rejected.
+- **(B) Declare no foreign keys; enforce in code.** `src/referential.rs` holds
+  one function per parent that deletes its children, called inside the parent's
+  delete transaction, plus `ensure_*_exists` checks that produce the same
+  `NotFound` errors the constraints did.
+
+### Decision
+**(B)**. The pool-based deletes (`delete_user`, `delete_group`, `delete_role`,
+`delete_account`) become single transactions via `delete_with_children`. The
+existence checks in autocommit paths are not atomic with the insert that follows;
+a lost race surfaces as `NotFound` from a later read instead of from a
+constraint, which is the same outcome the callers already handle.
+
+---
+
+## D4 — Type widths and dialect
+
+- `INTEGER` → `BIGINT` throughout (DuckDB `INTEGER` is 32-bit; SQLite's is
+  64-bit, and `table_size_bytes` alone would overflow it). `REAL` → `DOUBLE` for
+  the same reason (DuckDB `REAL` is `FLOAT`).
+- Booleans stay 0/1 integers in the catalog; a Rust `bool` parameter binds as
+  `BIGINT` so `col = ?` compares integer to integer.
+- `INTEGER PRIMARY KEY AUTOINCREMENT` → `BIGINT PRIMARY KEY DEFAULT
+  nextval('gsi_pending_seq')`.
+- Timestamps: `strftime('%Y-%m-%dT%H:%M:%fZ','now')` →
+  `strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ')`. Without the ICU
+  extension a `TIMESTAMPTZ` casts to `TIMESTAMP` as UTC, which is the stored
+  format. `strftime('%s','now')` → `epoch(now())`.
+- `sqlite_master` → `duckdb_tables()`; `GLOB` is supported natively.
+- Partial indexes (`CREATE INDEX ... WHERE`) are not supported; the two the
+  SQLite schema used become full indexes.
+- `BEGIN IMMEDIATE` → `BEGIN TRANSACTION`. There is no reserved-lock concept;
+  the engine `write_lock` already serializes writers, and DuckDB's optimistic
+  `Conflict on update` error is classified `Transient` by `map_db_err` as a
+  backstop.
+- The TTL sweep's `json_extract` → `json_extract_string` + `TRY_CAST` (DuckDB's
+  `json_extract` returns a quoted JSON scalar, and the sweep must not error on a
+  non-numeric TTL attribute).
+- `rowid` starts at 0 in DuckDB (1 in SQLite); the vector-backfill cursor
+  starts at `-1`.
+- Numbered parameters are `$1`, not `?1`.
+
+---
+
+## D5 — Error classification
+
+`is_unique_violation` matches DuckDB's `Duplicate key ... violates primary key
+constraint` / `violates unique constraint` messages. A failed statement aborts
+a DuckDB transaction (unlike SQLite, where the transaction stays usable); every
+path in the crate that catches a constraint error inside a transaction already
+returns the error and lets the transaction drop, so the rollback-on-drop in
+`db::Transaction` is what keeps pooled connections clean.
+
+---
+
+## D6 — Out-of-process tooling and the file lock
+
+DuckDB takes a process-exclusive lock on a read-write database file. The
+SQLite backend lets `extenddb settings`, `catalog-check`, and `verify` open the
+file alongside a running server; here they must run while the server is stopped.
+No workaround was attempted: a read-only open conflicts with a writer too, and
+routing the CLI through the server's management API is a cross-backend change
+outside this crate. Documented in the README; the integration module that
+depends on it (`test_gsi_async`) is excluded from the DuckDB CI job.
+
+## D7 — TTL sweep without an expression index
+
+DuckDB rejects `CREATE INDEX ... (json_extract_string(...))` ("Cannot use
+json_extract_string in this context"). Left as an error, the engine retries the
+index forever and never marks `ttl_index_ready`, so nothing ever expires. The
+backend therefore skips the index and flips the flag; the sweep is a filtered
+scan bounded by `LIMIT`, which at the batch sizes the worker uses is acceptable.

--- a/crates/storage-duckdb/src/admin_store.rs
+++ b/crates/storage-duckdb/src/admin_store.rs
@@ -1,0 +1,126 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `AdminStore` implementation: admin-user management, separate from IAM users.
+
+use crate::db;
+use extenddb_storage::management_store::{AdminEntry, AdminStore, OpError, OpResult};
+use futures::future::BoxFuture;
+
+use crate::catalog_store::DuckDbCatalogStore;
+use crate::duckdb_util::{is_unique_violation, parse_timestamp};
+
+impl AdminStore for DuckDbCatalogStore {
+    fn create_admin(&self, admin_name: &str, password_hash: &str) -> BoxFuture<'_, OpResult<()>> {
+        let admin_name = admin_name.to_owned();
+        let password_hash = password_hash.to_owned();
+        Box::pin(async move {
+            db::query("INSERT INTO admin_users (admin_name, password_hash) VALUES (?, ?)")
+                .bind(&admin_name)
+                .bind(&password_hash)
+                .execute(self.pool())
+                .await
+                .map_err(|e| {
+                    if is_unique_violation(&e) {
+                        OpError::AlreadyExists("Admin user already exists".to_owned())
+                    } else {
+                        tracing::error!("create_admin: {e}");
+                        OpError::Internal("Database error".to_owned())
+                    }
+                })?;
+            Ok(())
+        })
+    }
+
+    fn list_admins(&self) -> BoxFuture<'_, OpResult<Vec<AdminEntry>>> {
+        Box::pin(async move {
+            let rows: Vec<(String, String)> =
+                db::query_as("SELECT admin_name, created_at FROM admin_users ORDER BY admin_name")
+                    .fetch_all(self.pool())
+                    .await
+                    .map_err(|e| {
+                        tracing::error!("list_admins: {e}");
+                        OpError::Internal("Database error".to_owned())
+                    })?;
+            rows.into_iter()
+                .map(|(admin_name, created)| {
+                    Ok(AdminEntry {
+                        admin_name,
+                        created_at: parse_timestamp(&created)
+                            .map_err(|e| OpError::Internal(format!("parse created_at: {e}")))?,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn delete_admin(&self, admin_name: &str) -> BoxFuture<'_, OpResult<()>> {
+        let admin_name = admin_name.to_owned();
+        Box::pin(async move {
+            let result = db::query("DELETE FROM admin_users WHERE admin_name = ?")
+                .bind(&admin_name)
+                .execute(self.pool())
+                .await
+                .map_err(|e| {
+                    tracing::error!("delete_admin: {e}");
+                    OpError::Internal("Database error".to_owned())
+                })?;
+            if result.rows_affected() == 0 {
+                return Err(OpError::NotFound("Admin user not found".to_owned()));
+            }
+            Ok(())
+        })
+    }
+
+    fn change_admin_password(
+        &self,
+        admin_name: &str,
+        password_hash: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let admin_name = admin_name.to_owned();
+        let password_hash = password_hash.to_owned();
+        Box::pin(async move {
+            let result = db::query("UPDATE admin_users SET password_hash = ? WHERE admin_name = ?")
+                .bind(&password_hash)
+                .bind(&admin_name)
+                .execute(self.pool())
+                .await
+                .map_err(|e| {
+                    tracing::error!("change_admin_password: {e}");
+                    OpError::Internal("Database error".to_owned())
+                })?;
+            if result.rows_affected() == 0 {
+                return Err(OpError::NotFound("Admin user not found".to_owned()));
+            }
+            Ok(())
+        })
+    }
+
+    fn verify_admin_password(
+        &self,
+        admin_name: &str,
+        password: &str,
+    ) -> BoxFuture<'_, OpResult<Option<bool>>> {
+        let admin_name = admin_name.to_owned();
+        let password = password.to_owned();
+        Box::pin(async move {
+            let row: Option<(String,)> =
+                db::query_as("SELECT password_hash FROM admin_users WHERE admin_name = ?")
+                    .bind(&admin_name)
+                    .fetch_optional(self.pool())
+                    .await
+                    .map_err(|e| {
+                        tracing::error!("verify_admin_password: {e}");
+                        OpError::Internal("Database error".to_owned())
+                    })?;
+            let Some((hash,)) = row else {
+                return Ok(None);
+            };
+            let verified = tokio::task::spawn_blocking(move || bcrypt::verify(&password, &hash))
+                .await
+                .map_err(|e| OpError::Internal(format!("bcrypt task: {e}")))?
+                .unwrap_or(false);
+            Ok(Some(verified))
+        })
+    }
+}

--- a/crates/storage-duckdb/src/authorization_store.rs
+++ b/crates/storage-duckdb/src/authorization_store.rs
@@ -1,0 +1,253 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `AuthorizationStore` implementation: read-only IAM policy, boundary,
+//! session, and tag lookups used by the policy evaluator on every authorized
+//! request. Policy documents are stored as JSON text and returned verbatim.
+
+use crate::db;
+use extenddb_storage::authorization_store::{AuthorizationStore, SessionData};
+use extenddb_storage::management_store::{OpError, OpResult};
+use futures::future::BoxFuture;
+
+use crate::catalog_store::DuckDbCatalogStore;
+use crate::duckdb_util::parse_timestamp;
+
+/// Map any query error to a sanitized internal error, logging the detail.
+fn db_err(ctx: &str, e: db::Error) -> OpError {
+    tracing::error!("{ctx}: {e}");
+    OpError::Internal("Database error".to_owned())
+}
+
+impl AuthorizationStore for DuckDbCatalogStore {
+    fn fetch_user_policies(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<String>>> {
+        let account_id = account_id.to_owned();
+        let user_name = user_name.to_owned();
+        Box::pin(async move {
+            let rows: Vec<(String,)> = db::query_as(
+                "SELECT policy_document FROM iam_policies \
+                 WHERE account_id = ? AND principal_type = 'user' AND principal_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&user_name)
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_user_policies", e))?;
+            Ok(rows.into_iter().map(|(d,)| d).collect())
+        })
+    }
+
+    fn fetch_user_group_policies(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<String>>> {
+        let account_id = account_id.to_owned();
+        let user_name = user_name.to_owned();
+        Box::pin(async move {
+            let rows: Vec<(String,)> = db::query_as(
+                "SELECT p.policy_document FROM iam_policies p \
+                 JOIN iam_group_members m \
+                   ON m.account_id = p.account_id AND m.group_name = p.principal_name \
+                 WHERE p.account_id = ? AND p.principal_type = 'group' AND m.user_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&user_name)
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_user_group_policies", e))?;
+            Ok(rows.into_iter().map(|(d,)| d).collect())
+        })
+    }
+
+    fn fetch_user_boundary(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<String>>> {
+        let account_id = account_id.to_owned();
+        let user_name = user_name.to_owned();
+        Box::pin(async move {
+            let row: Option<(String,)> = db::query_as(
+                "SELECT policy_document FROM iam_permissions_boundaries \
+                 WHERE account_id = ? AND principal_type = 'user' AND principal_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&user_name)
+            .fetch_optional(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_user_boundary", e))?;
+            Ok(row.map(|(d,)| d))
+        })
+    }
+
+    fn fetch_role_policies(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<String>>> {
+        let account_id = account_id.to_owned();
+        let role_name = role_name.to_owned();
+        Box::pin(async move {
+            let rows: Vec<(String,)> = db::query_as(
+                "SELECT policy_document FROM iam_policies \
+                 WHERE account_id = ? AND principal_type = 'role' AND principal_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&role_name)
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_role_policies", e))?;
+            Ok(rows.into_iter().map(|(d,)| d).collect())
+        })
+    }
+
+    fn fetch_role_boundary(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<String>>> {
+        let account_id = account_id.to_owned();
+        let role_name = role_name.to_owned();
+        Box::pin(async move {
+            let row: Option<(String,)> = db::query_as(
+                "SELECT policy_document FROM iam_permissions_boundaries \
+                 WHERE account_id = ? AND principal_type = 'role' AND principal_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&role_name)
+            .fetch_optional(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_role_boundary", e))?;
+            Ok(row.map(|(d,)| d))
+        })
+    }
+
+    fn fetch_session_data(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        session_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<SessionData>>> {
+        let account_id = account_id.to_owned();
+        let role_name = role_name.to_owned();
+        let session_name = session_name.to_owned();
+        Box::pin(async move {
+            let row: Option<(Option<String>, Option<String>, String)> = db::query_as(
+                "SELECT session_policy, session_tags, expires_at FROM iam_sessions \
+                 WHERE account_id = ? AND role_name = ? AND session_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&role_name)
+            .bind(&session_name)
+            .fetch_optional(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_session_data", e))?;
+
+            let Some((session_policy, tags_json, expires_at)) = row else {
+                return Ok(None);
+            };
+
+            // Treat an expired session as absent (parity with the Postgres
+            // expiry filter). Authentication already rejects expired sessions,
+            // so this is defense-in-depth; evaluate it with the same parser
+            // lookup_session uses rather than a format-fragile SQL comparison.
+            if let Ok(expires) = parse_timestamp(&expires_at)
+                && expires < time::OffsetDateTime::now_utc()
+            {
+                return Ok(None);
+            }
+
+            // session_tags is stored as JSON: either an object {key: value} or
+            // an array [{"Key": ..., "Value": ...}] (the form AWS SDKs send).
+            // Handle both, matching the Postgres backend.
+            let session_tags: Vec<(String, String)> = tags_json
+                .as_deref()
+                .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+                .map(|v| {
+                    if let Some(arr) = v.as_array() {
+                        arr.iter()
+                            .filter_map(|tag| {
+                                match (
+                                    tag.get("Key").and_then(|k| k.as_str()),
+                                    tag.get("Value").and_then(|x| x.as_str()),
+                                ) {
+                                    (Some(k), Some(val)) => Some((k.to_owned(), val.to_owned())),
+                                    _ => None,
+                                }
+                            })
+                            .collect()
+                    } else if let Some(obj) = v.as_object() {
+                        obj.iter()
+                            .filter_map(|(k, val)| val.as_str().map(|s| (k.clone(), s.to_owned())))
+                            .collect()
+                    } else {
+                        Vec::new()
+                    }
+                })
+                .unwrap_or_default();
+
+            Ok(Some(SessionData {
+                session_policy,
+                session_tags,
+            }))
+        })
+    }
+
+    fn fetch_user_tags(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        let account_id = account_id.to_owned();
+        let user_name = user_name.to_owned();
+        Box::pin(async move {
+            db::query_as(
+                "SELECT tag_key, tag_value FROM iam_user_tags \
+                 WHERE account_id = ? AND user_name = ? ORDER BY tag_key",
+            )
+            .bind(&account_id)
+            .bind(&user_name)
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_user_tags", e))
+        })
+    }
+
+    fn fetch_role_tags(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        let account_id = account_id.to_owned();
+        let role_name = role_name.to_owned();
+        Box::pin(async move {
+            db::query_as(
+                "SELECT tag_key, tag_value FROM iam_role_tags \
+                 WHERE account_id = ? AND role_name = ? ORDER BY tag_key",
+            )
+            .bind(&account_id)
+            .bind(&role_name)
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_role_tags", e))
+        })
+    }
+
+    fn fetch_resource_tags(&self, arn: &str) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        let arn = arn.to_owned();
+        Box::pin(async move {
+            db::query_as(
+                "SELECT tag_key, tag_value FROM tags WHERE resource_arn = ? ORDER BY tag_key",
+            )
+            .bind(&arn)
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| db_err("fetch_resource_tags", e))
+        })
+    }
+}

--- a/crates/storage-duckdb/src/backup.rs
+++ b/crates/storage-duckdb/src/backup.rs
@@ -1,0 +1,527 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `BackupEngine` for the DuckDB backend.
+//!
+//! A backup snapshots every item's `item_data` into `backup_items`. Restore
+//! recreates the table via `create_table` and upserts the snapshot under the
+//! engine write lock. `RestoreTableToPointInTime` is implemented as a
+//! snapshot-then-restore (then discard the temporary backup), matching the
+//! PostgreSQL backend's behaviour.
+
+use crate::db;
+use extenddb_core::types::{
+    AttributeDefinition, BackupDescription, BackupDetails, BackupSummary, BillingMode,
+    ContinuousBackupsDescription, CreateTableInput, KeySchemaElement,
+    PointInTimeRecoveryDescription, ProvisionedThroughput, SourceTableDetails, TableDescription,
+    TableKeyInfo,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::{BackupEngine, TableEngine};
+use futures::future::BoxFuture;
+
+use crate::data::{data_table_name, upsert_item_in_tx};
+use crate::duckdb_util::parse_timestamp;
+use crate::store::DuckDbEngine;
+
+fn epoch_millis() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+/// Backup id: creation timestamp plus an 8-hex random suffix, matching the
+/// PostgreSQL backend. The suffix makes ARNs non-guessable and prevents two
+/// backups created in the same millisecond from colliding.
+fn backup_id() -> String {
+    use rand::Rng;
+    let suffix: u32 = rand::rng().random();
+    format!("{ts}-{suffix:08x}", ts = epoch_millis())
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn ts_to_epoch(s: &str) -> f64 {
+    parse_timestamp(s)
+        .map(|dt| dt.unix_timestamp() as f64)
+        .unwrap_or(0.0)
+}
+
+impl BackupEngine for DuckDbEngine {
+    fn create_backup(
+        &self,
+        account_id: &str,
+        table_name: &str,
+        backup_name: &str,
+    ) -> BoxFuture<'_, Result<BackupDetails, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        let backup_name = backup_name.to_owned();
+        Box::pin(async move {
+            let row: Option<(String, String, String, String, i64)> = db::query_as(
+                "SELECT table_id, key_schema, attribute_definitions, billing_mode, table_size_bytes \
+                 FROM tables WHERE account_id = ? AND table_name = ? AND table_status = 'ACTIVE'",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let (table_id, key_schema, attr_defs, billing_mode, size_bytes) =
+                row.ok_or_else(|| StorageError::TableNotFound(table_name.clone()))?;
+
+            let backup_arn = format!(
+                "arn:aws:dynamodb:{region}:{account_id}:table/{table_name}/backup/{id}",
+                region = self.region,
+                id = backup_id()
+            );
+
+            let ddb_table = data_table_name(&table_id);
+            let items: Vec<(String,)> = db::query_as(&format!("SELECT item_data FROM {ddb_table}"))
+                .fetch_all(&self.pool)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let item_count = i64::try_from(items.len()).unwrap_or(i64::MAX);
+
+            let _writer = self.write_lock.lock().await;
+            let mut tx = self
+                .pool
+                .begin()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            db::query(
+                "INSERT INTO backups (backup_arn, backup_name, table_id, table_name, account_id, \
+                 backup_status, backup_size_bytes, item_count, key_schema, attribute_definitions, \
+                 billing_mode) VALUES (?, ?, ?, ?, ?, 'AVAILABLE', ?, ?, ?, ?, ?)",
+            )
+            .bind(&backup_arn)
+            .bind(&backup_name)
+            .bind(&table_id)
+            .bind(&table_name)
+            .bind(&account_id)
+            .bind(size_bytes)
+            .bind(item_count)
+            .bind(&key_schema)
+            .bind(&attr_defs)
+            .bind(&billing_mode)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            for (item_data,) in &items {
+                db::query(
+                    "INSERT INTO backup_items (backup_arn, pk, sk, item_data) VALUES (?, '', NULL, ?)",
+                )
+                .bind(&backup_arn)
+                .bind(item_data)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            }
+
+            let created_at: (String,) =
+                db::query_as("SELECT created_at FROM backups WHERE backup_arn = ?")
+                    .bind(&backup_arn)
+                    .fetch_one(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            tx.commit()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            Ok(BackupDetails {
+                backup_arn,
+                backup_name,
+                backup_status: "AVAILABLE".to_owned(),
+                backup_type: "USER".to_owned(),
+                backup_size_bytes: size_bytes,
+                backup_creation_date_time: ts_to_epoch(&created_at.0),
+            })
+        })
+    }
+
+    fn describe_backup(
+        &self,
+        account_id: &str,
+        backup_arn: &str,
+    ) -> BoxFuture<'_, Result<BackupDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        let backup_arn = backup_arn.to_owned();
+        Box::pin(async move {
+            #[allow(clippy::type_complexity)]
+            let row: Option<(String, String, String, String, i64, i64, String, String, String, String)> =
+                db::query_as(
+                    "SELECT b.backup_name, b.backup_status, b.table_id, b.table_name, \
+                     b.backup_size_bytes, b.item_count, b.key_schema, b.billing_mode, \
+                     COALESCE(t.table_arn, \
+                       'arn:aws:dynamodb:' || ? || ':' || b.account_id || ':table/' || b.table_name), \
+                     b.created_at \
+                     FROM backups b LEFT JOIN tables t ON t.table_id = b.table_id \
+                     WHERE b.backup_arn = ? AND b.account_id = ? \
+                     AND b.backup_status != 'DELETED'",
+                )
+                .bind(&self.region)
+                .bind(&backup_arn)
+                .bind(&account_id)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let (name, status, table_id, table_name, size, count, ks, billing, table_arn, created) =
+                row.ok_or_else(|| {
+                    StorageError::Validation(format!("Backup not found: {backup_arn}"))
+                })?;
+
+            let key_schema: Vec<KeySchemaElement> =
+                serde_json::from_str(&ks).map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            Ok(BackupDescription {
+                backup_details: BackupDetails {
+                    backup_arn: backup_arn.clone(),
+                    backup_name: name,
+                    backup_status: status,
+                    backup_type: "USER".to_owned(),
+                    backup_size_bytes: size,
+                    backup_creation_date_time: ts_to_epoch(&created),
+                },
+                source_table_details: SourceTableDetails {
+                    table_name,
+                    table_id,
+                    table_arn,
+                    key_schema,
+                    item_count: count,
+                    table_size_bytes: size,
+                    billing_mode: Some(billing),
+                    table_creation_date_time: ts_to_epoch(&created),
+                },
+            })
+        })
+    }
+
+    fn list_backups(
+        &self,
+        account_id: &str,
+        table_name: Option<&str>,
+    ) -> BoxFuture<'_, Result<Vec<BackupSummary>, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.map(str::to_owned);
+        Box::pin(async move {
+            let rows: Vec<(String, String, String, String, i64, String, String)> =
+                if let Some(tn) = table_name {
+                    db::query_as(
+                        "SELECT b.backup_arn, b.backup_name, b.table_name, b.backup_status, \
+                         b.backup_size_bytes, \
+                         COALESCE(t.table_arn, 'arn:aws:dynamodb:' || ? || ':' || b.account_id || ':table/' || b.table_name), \
+                         b.created_at FROM backups b LEFT JOIN tables t ON t.table_id = b.table_id \
+                         WHERE b.account_id = ? AND b.table_name = ? AND b.backup_status != 'DELETED' \
+                         ORDER BY b.created_at DESC",
+                    )
+                    .bind(&self.region)
+                    .bind(&account_id)
+                    .bind(tn)
+                    .fetch_all(&self.pool)
+                    .await
+                } else {
+                    db::query_as(
+                        "SELECT b.backup_arn, b.backup_name, b.table_name, b.backup_status, \
+                         b.backup_size_bytes, \
+                         COALESCE(t.table_arn, 'arn:aws:dynamodb:' || ? || ':' || b.account_id || ':table/' || b.table_name), \
+                         b.created_at FROM backups b LEFT JOIN tables t ON t.table_id = b.table_id \
+                         WHERE b.account_id = ? AND b.backup_status != 'DELETED' \
+                         ORDER BY b.created_at DESC",
+                    )
+                    .bind(&self.region)
+                    .bind(&account_id)
+                    .fetch_all(&self.pool)
+                    .await
+                }
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            Ok(rows
+                .into_iter()
+                .map(
+                    |(arn, name, tn, status, size, table_arn, created)| BackupSummary {
+                        backup_arn: arn,
+                        backup_name: name,
+                        table_name: tn,
+                        table_arn,
+                        backup_status: status,
+                        backup_type: "USER".to_owned(),
+                        backup_size_bytes: size,
+                        backup_creation_date_time: ts_to_epoch(&created),
+                    },
+                )
+                .collect())
+        })
+    }
+
+    fn delete_backup(
+        &self,
+        account_id: &str,
+        backup_arn: &str,
+    ) -> BoxFuture<'_, Result<BackupDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        let backup_arn = backup_arn.to_owned();
+        Box::pin(async move {
+            // Resolves account-scoped, so a backup owned by another account is
+            // reported missing here and the writes below never run.
+            let desc = self.describe_backup(&account_id, &backup_arn).await?;
+
+            // The account predicate is repeated on both writes rather than
+            // relying on the lookup above, so the statements are correct on
+            // their own terms.
+            db::query(
+                "DELETE FROM backup_items WHERE backup_arn = $1 AND EXISTS (\
+                 SELECT 1 FROM backups b WHERE b.backup_arn = $1 AND b.account_id = $2)",
+            )
+            .bind(&backup_arn)
+            .bind(&account_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            db::query(
+                "UPDATE backups SET backup_status = 'DELETED' \
+                 WHERE backup_arn = ? AND account_id = ?",
+            )
+            .bind(&backup_arn)
+            .bind(&account_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(BackupDescription {
+                backup_details: BackupDetails {
+                    backup_status: "DELETED".to_owned(),
+                    ..desc.backup_details
+                },
+                source_table_details: desc.source_table_details,
+            })
+        })
+    }
+
+    fn restore_table_from_backup(
+        &self,
+        account_id: &str,
+        target_table_name: &str,
+        backup_arn: &str,
+    ) -> BoxFuture<'_, Result<TableDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        let target_table_name = target_table_name.to_owned();
+        let backup_arn = backup_arn.to_owned();
+        Box::pin(async move {
+            let row: Option<(String, String, String)> = db::query_as(
+                "SELECT key_schema, attribute_definitions, billing_mode \
+                 FROM backups WHERE backup_arn = ? AND account_id = ? \
+                 AND backup_status = 'AVAILABLE'",
+            )
+            .bind(&backup_arn)
+            .bind(&account_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let (ks, ad, billing) = row.ok_or_else(|| {
+                StorageError::Validation(format!("Backup not found: {backup_arn}"))
+            })?;
+            let key_schema: Vec<KeySchemaElement> =
+                serde_json::from_str(&ks).map_err(|e| StorageError::Internal(e.to_string()))?;
+            let attr_defs: Vec<AttributeDefinition> =
+                serde_json::from_str(&ad).map_err(|e| StorageError::Internal(e.to_string()))?;
+            let billing_mode = Some(if billing == "PAY_PER_REQUEST" {
+                BillingMode::PayPerRequest
+            } else {
+                BillingMode::Provisioned
+            });
+
+            let create_input = CreateTableInput {
+                table_name: target_table_name.clone(),
+                key_schema: key_schema.clone(),
+                attribute_definitions: attr_defs.clone(),
+                billing_mode,
+                provisioned_throughput: Some(ProvisionedThroughput {
+                    read_capacity_units: 5,
+                    write_capacity_units: 5,
+                }),
+                global_secondary_indexes: None,
+                local_secondary_indexes: None,
+                stream_specification: None,
+                tags: None,
+                deletion_protection_enabled: None,
+                sse_specification: None,
+                table_class: None,
+                on_demand_throughput: None,
+                ..Default::default()
+            };
+
+            let desc = self.create_table(&account_id, create_input).await?;
+            let key_info = TableKeyInfo {
+                table_name: target_table_name.clone(),
+                account_id: account_id.clone(),
+                table_id: desc.table_id.clone(),
+                base_key_schema: key_schema.clone(),
+                key_schema,
+                attribute_definitions: attr_defs,
+                has_lsi: false,
+                // The restored table is created above without secondary
+                // indexes, so there is no index metadata to carry.
+                global_secondary_indexes: Vec::new(),
+                local_secondary_indexes: Vec::new(),
+                stream_specification: None,
+                ..Default::default()
+            };
+
+            let items: Vec<(String,)> =
+                db::query_as("SELECT item_data FROM backup_items WHERE backup_arn = ?")
+                    .bind(&backup_arn)
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let item_count = i64::try_from(items.len()).unwrap_or(i64::MAX);
+
+            let _writer = self.write_lock.lock().await;
+            let mut tx = self
+                .pool
+                .begin()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            for (item_json,) in &items {
+                let item: extenddb_core::types::Item = serde_json::from_str(item_json)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                upsert_item_in_tx(&mut tx, &key_info, &item).await?;
+            }
+            db::query("UPDATE tables SET item_count = ? WHERE account_id = ? AND table_name = ?")
+                .bind(item_count)
+                .bind(&account_id)
+                .bind(&target_table_name)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            // Mark the restored table ACTIVE immediately: the data is fully
+            // populated and ready to serve. This matches the Postgres backend
+            // and real DynamoDB, where a restored table becomes ACTIVE once the
+            // restore completes (the CREATING status is transient) rather than
+            // waiting for the control-plane transition poller.
+            db::query(
+                "UPDATE tables SET table_status = 'ACTIVE', status_transition_at = NULL \
+                 WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&target_table_name)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            tx.commit()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            Ok(desc)
+        })
+    }
+
+    fn describe_continuous_backups(
+        &self,
+        account_id: &str,
+        table_name: &str,
+    ) -> BoxFuture<'_, Result<ContinuousBackupsDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        Box::pin(async move {
+            let exists: bool = db::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM tables WHERE account_id = ? AND table_name = ?)",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if !exists {
+                return Err(StorageError::TableNotFound(table_name));
+            }
+
+            let pitr: Option<(bool,)> = db::query_as(
+                "SELECT pitr_enabled FROM continuous_backups WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let enabled = pitr.is_some_and(|r| r.0);
+
+            #[allow(clippy::cast_precision_loss)]
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as f64;
+
+            Ok(ContinuousBackupsDescription {
+                continuous_backups_status: "ENABLED".to_owned(),
+                point_in_time_recovery_description: Some(PointInTimeRecoveryDescription {
+                    point_in_time_recovery_status: if enabled { "ENABLED" } else { "DISABLED" }
+                        .to_owned(),
+                    earliest_restorable_date_time: enabled.then_some(now - 35.0 * 24.0 * 3600.0),
+                    latest_restorable_date_time: enabled.then_some(now),
+                }),
+            })
+        })
+    }
+
+    fn update_continuous_backups(
+        &self,
+        account_id: &str,
+        table_name: &str,
+        pitr_enabled: bool,
+    ) -> BoxFuture<'_, Result<ContinuousBackupsDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        Box::pin(async move {
+            let exists: bool = db::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM tables WHERE account_id = ? AND table_name = ?)",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if !exists {
+                return Err(StorageError::TableNotFound(table_name));
+            }
+            db::query(
+                "INSERT INTO continuous_backups (account_id, table_name, pitr_enabled) \
+                 VALUES (?, ?, ?) \
+                 ON CONFLICT (account_id, table_name) DO UPDATE SET pitr_enabled = excluded.pitr_enabled",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .bind(pitr_enabled)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            self.describe_continuous_backups(&account_id, &table_name)
+                .await
+        })
+    }
+
+    fn restore_table_to_point_in_time(
+        &self,
+        account_id: &str,
+        source_table_name: &str,
+        target_table_name: &str,
+    ) -> BoxFuture<'_, Result<TableDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        let source_table_name = source_table_name.to_owned();
+        let target_table_name = target_table_name.to_owned();
+        Box::pin(async move {
+            let backup = self
+                .create_backup(&account_id, &source_table_name, "__pitr_restore__")
+                .await?;
+            let desc = self
+                .restore_table_from_backup(&account_id, &target_table_name, &backup.backup_arn)
+                .await?;
+            let _ = self.delete_backup(&account_id, &backup.backup_arn).await;
+            Ok(desc)
+        })
+    }
+}

--- a/crates/storage-duckdb/src/bootstrapper.rs
+++ b/crates/storage-duckdb/src/bootstrapper.rs
@@ -1,0 +1,502 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `Bootstrapper` implementation for the DuckDB backend.
+//!
+//! DuckDB has no server, users, or roles, and catalog and data live in one
+//! file. Initialization therefore reduces to: create the file, apply the
+//! catalog schema, and seed the encryption key, default account, and admin
+//! user. Destruction removes the database file and its WAL/SHM sidecars.
+
+use crate::db;
+use async_trait::async_trait;
+use extenddb_core::types::{AttributeDefinition, KeySchemaElement, KeyType};
+use extenddb_storage::bootstrapper::{
+    AdminBootstrapResult, Bootstrapper, KeyDefinitionRepair, helpers,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::management_store::{OpError, OpResult};
+use extenddb_storage::util::recover_sort_key_definitions;
+
+use crate::duckdb_util::duckdb_path;
+use crate::schema::{self, CATALOG_VERSION};
+
+/// DuckDB backend bootstrapper.
+///
+/// Holds the database file path. Each operation opens a short-lived
+/// single-connection pool, since `init`/`destroy`/`migrate` are one-shot CLI
+/// paths, not the hot serving path.
+pub struct DuckDbBootstrapper {
+    path: String,
+}
+
+impl DuckDbBootstrapper {
+    pub fn new(path: impl Into<String>) -> Self {
+        Self { path: path.into() }
+    }
+
+    /// Build a `DuckDbBootstrapper` from the config file and CLI args.
+    ///
+    /// Resolution order for the database path (bootstrapper commands: init,
+    /// destroy, migrate): the `--duckdb-path <p>` CLI flag (declared on
+    /// `InitArgs`), then `[storage.duckdb].path` in the config file, then the
+    /// default `extenddb.duckdb`. `serve` does not use this path; it reads
+    /// the config (with `EXTENDDB__STORAGE__SQLITE__PATH` overriding).
+    pub async fn from_config(config_path: &str, cli_args: &[String]) -> Result<Self, StorageError> {
+        if let Some(p) = helpers::extract_arg(cli_args, "--duckdb-path") {
+            return Ok(Self::new(p));
+        }
+
+        let path = if std::path::Path::new(config_path).exists() {
+            let content = std::fs::read_to_string(config_path)
+                .map_err(|e| StorageError::Internal(format!("read config {config_path}: {e}")))?;
+            let parsed: toml::Value = toml::from_str(&content)
+                .map_err(|e| StorageError::Internal(format!("parse config {config_path}: {e}")))?;
+            parsed
+                .get("storage")
+                .and_then(|s| s.get("duckdb"))
+                .and_then(|s| s.get("path"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("extenddb.duckdb")
+                .to_owned()
+        } else {
+            "extenddb.duckdb".to_owned()
+        };
+
+        Ok(Self::new(path))
+    }
+
+    fn is_memory(&self) -> bool {
+        self.path == ":memory:" || self.path.starts_with("file::memory:")
+    }
+
+    /// Open a short-lived single-connection pool with the standard PRAGMAs.
+    /// For a real filesystem path, the parent directory is created first:
+    /// `init --duckdb-path` may point into a directory that does not exist
+    /// yet, and bootstrapping it is exactly init's job.
+    async fn pool(&self) -> OpResult<db::Pool> {
+        if self.path != ":memory:"
+            && let Some(parent) = std::path::Path::new(&self.path).parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                OpError::Internal(format!(
+                    "create parent directory for DuckDB database '{}': {e}",
+                    self.path
+                ))
+            })?;
+        }
+        let pool = db::Pool::open(&duckdb_path(&self.path), 1)
+            .await
+            .map_err(|e| OpError::Internal(format!("open DuckDB database '{}': {e}", self.path)))?;
+        // The database stores the encryption key next to the secrets it
+        // protects; keep the file and its WAL owner-only from the moment they
+        // exist rather than waiting for the first `serve`.
+        #[cfg(unix)]
+        if !self.is_memory() {
+            use std::os::unix::fs::PermissionsExt;
+            for suffix in ["", ".wal"] {
+                let f = format!("{}{suffix}", self.path);
+                if std::path::Path::new(&f).exists() {
+                    let _ = std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o600));
+                }
+            }
+        }
+        Ok(pool)
+    }
+}
+
+#[async_trait]
+impl Bootstrapper for DuckDbBootstrapper {
+    async fn ensure_app_user(&self) -> OpResult<()> {
+        Ok(()) // DuckDB has no user concept.
+    }
+
+    async fn grant_app_role_to_admin(&self) -> OpResult<()> {
+        Ok(()) // DuckDB has no role concept.
+    }
+
+    async fn create_catalog_db(&self) -> OpResult<()> {
+        // Connecting with mode=rwc creates the file; refuse to clobber an
+        // existing database so `init` is not silently destructive.
+        if !self.is_memory() && std::path::Path::new(&self.path).exists() {
+            return Err(OpError::AlreadyExists(format!(
+                "DuckDB database '{}' already exists. Run 'destroy' first, then 'init'.",
+                self.path
+            )));
+        }
+        Ok(())
+    }
+
+    async fn create_data_db(&self) -> OpResult<()> {
+        Ok(()) // Catalog and data share one file.
+    }
+
+    async fn run_catalog_migrations(&self) -> OpResult<()> {
+        let pool = self.pool().await?;
+        schema::apply(&pool).await
+    }
+
+    async fn run_data_migrations(&self) -> OpResult<()> {
+        Ok(()) // Single file — schema applied in run_catalog_migrations.
+    }
+
+    async fn pending_data_migrations(&self) -> OpResult<Vec<String>> {
+        // DuckDB applies its complete schema in run_catalog_migrations (a single
+        // file), so there are no separately-tracked data migrations that can be
+        // pending.
+        Ok(Vec::new())
+    }
+
+    async fn record_data_connection(&self) -> OpResult<()> {
+        let pool = self.pool().await?;
+        db::query(
+            "INSERT INTO settings (key, value) VALUES ('data_database_name', ?) \
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        )
+        .bind(&self.path)
+        .execute(&pool)
+        .await
+        .map_err(|e| OpError::Internal(format!("record data db name: {e}")))?;
+        Ok(())
+    }
+
+    async fn bootstrap_encryption_key(&self) -> OpResult<()> {
+        let pool = self.pool().await?;
+        let exists: bool =
+            db::query_scalar("SELECT EXISTS(SELECT 1 FROM settings WHERE key = 'encryption_key')")
+                .fetch_one(&pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("check encryption key: {e}")))?;
+        if exists {
+            return Ok(());
+        }
+        let key = helpers::generate_encryption_key();
+        db::query("INSERT OR IGNORE INTO settings (key, value) VALUES ('encryption_key', ?)")
+            .bind(&key)
+            .execute(&pool)
+            .await
+            .map_err(|e| OpError::Internal(format!("store encryption key: {e}")))?;
+        Ok(())
+    }
+
+    async fn bootstrap_default_account(&self) -> OpResult<()> {
+        let pool = self.pool().await?;
+        // Reuse the existing account when already bootstrapped, otherwise create
+        // the single default account. Either way, record its id as the canonical
+        // default account so callers never infer it from list ordering. The
+        // settings write is idempotent (INSERT OR IGNORE), so it also backfills
+        // the marker for catalogs bootstrapped before it existed.
+        let account_id: String = match db::query_scalar(
+            "SELECT account_id FROM accounts ORDER BY account_id LIMIT 1",
+        )
+        .fetch_optional(&pool)
+        .await
+        .map_err(|e| OpError::Internal(format!("check accounts: {e}")))?
+        {
+            Some(id) => id,
+            None => {
+                let id = helpers::generate_account_id();
+                db::query(
+                    "INSERT OR IGNORE INTO accounts (account_id, account_name) VALUES (?, 'default')",
+                )
+                .bind(&id)
+                .execute(&pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("create default account: {e}")))?;
+                id
+            }
+        };
+        db::query("INSERT OR IGNORE INTO settings (key, value) VALUES ('default_account_id', ?)")
+            .bind(&account_id)
+            .execute(&pool)
+            .await
+            .map_err(|e| OpError::Internal(format!("record default account id: {e}")))?;
+        Ok(())
+    }
+
+    async fn bootstrap_admin_user(
+        &self,
+        env_user: Option<&str>,
+        env_password: Option<&str>,
+    ) -> OpResult<AdminBootstrapResult> {
+        let pool = self.pool().await?;
+        let username = env_user
+            .filter(|s| !s.is_empty())
+            .unwrap_or("admin")
+            .to_owned();
+
+        let exists: bool =
+            db::query_scalar("SELECT EXISTS(SELECT 1 FROM admin_users WHERE admin_name = ?)")
+                .bind(&username)
+                .fetch_one(&pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("check admin user: {e}")))?;
+        if exists {
+            return Ok(AdminBootstrapResult {
+                username,
+                generated_password: None,
+                already_existed: true,
+                from_env: env_user.is_some(),
+            });
+        }
+
+        let (password, from_env) = match env_password.filter(|s| !s.is_empty()) {
+            Some(p) => (p.to_owned(), true),
+            None => (helpers::generate_random_password(), false),
+        };
+        let password_hash = helpers::hash_password_async(password.clone()).await?;
+
+        db::query("INSERT INTO admin_users (admin_name, password_hash) VALUES (?, ?)")
+            .bind(&username)
+            .bind(&password_hash)
+            .execute(&pool)
+            .await
+            .map_err(|e| OpError::Internal(format!("create admin user: {e}")))?;
+
+        Ok(AdminBootstrapResult {
+            username,
+            generated_password: if from_env { None } else { Some(password) },
+            already_existed: false,
+            from_env,
+        })
+    }
+
+    async fn is_catalog_initialized(&self) -> OpResult<bool> {
+        if !self.is_memory() && !std::path::Path::new(&self.path).exists() {
+            return Ok(false);
+        }
+        let Ok(pool) = self.pool().await else {
+            return Ok(false);
+        };
+        schema::table_exists(&pool, "settings").await
+    }
+
+    /// Repair table metadata damaged by the pre-fix `UpdateTable` (#259).
+    ///
+    /// DuckDB keeps the catalog and the data tables in one file, so the physical
+    /// sort key columns are read with `PRAGMA table_info`. Otherwise identical to
+    /// the PostgreSQL implementation: for any base sort key with no attribute
+    /// definition, recover the type from its column name.
+    async fn repair_lost_sort_key_definitions(&self, apply: bool) -> OpResult<KeyDefinitionRepair> {
+        let mut report = KeyDefinitionRepair::default();
+        let Ok(pool) = self.pool().await else {
+            return Ok(report);
+        };
+        // A never-initialised catalog has no `tables` table, and `pool()` opens
+        // with mode=rwc, which silently creates an empty database file, so the
+        // SELECT below would hard-error rather than find nothing. PostgreSQL
+        // degrades gracefully through its get_data_db_name() guard; this is the
+        // DuckDB equivalent.
+        if !schema::table_exists(&pool, "tables").await? {
+            return Ok(report);
+        }
+
+        let rows: Vec<(String, String, String, String, String)> = db::query_as(
+            "SELECT account_id, table_name, table_id, key_schema, attribute_definitions \
+             FROM tables ORDER BY table_name",
+        )
+        .fetch_all(&pool)
+        .await
+        .map_err(|e| OpError::Internal(format!("Cannot read tables: {e}")))?;
+
+        for (account_id, table_name, table_id, ks_json, ad_json) in rows {
+            let key_schema: Vec<KeySchemaElement> = match serde_json::from_str(&ks_json) {
+                Ok(v) => v,
+                Err(e) => {
+                    report
+                        .needs_attention
+                        .push(format!("{table_name}: unreadable key_schema ({e})"));
+                    continue;
+                }
+            };
+            let attr_defs: Vec<AttributeDefinition> =
+                serde_json::from_str(&ad_json).unwrap_or_default();
+
+            // Reported for every table on every run, not only when a sort key is
+            // repaired: the partition key definition is dropped by the same write and
+            // is not recoverable from the schema, because the pk column is always TEXT.
+            // It is not needed for correctness either, since partition key values are
+            // encoded from the key schema alone, so it is reported rather than guessed
+            // and keeps being reported until a human restores it.
+            let pk_missing: Vec<&str> = key_schema
+                .iter()
+                .filter(|ks| ks.key_type == KeyType::Hash)
+                .filter(|ks| {
+                    !attr_defs
+                        .iter()
+                        .any(|ad| ad.attribute_name == ks.attribute_name)
+                })
+                .map(|ks| ks.attribute_name.as_str())
+                .collect();
+            if !pk_missing.is_empty() {
+                report.needs_attention.push(format!(
+                    "{table_name}: partition key definition(s) [{}] are absent; reads and \
+                     writes are unaffected, but index key type validation cannot check them",
+                    pk_missing.join(", ")
+                ));
+            }
+
+            let missing: Vec<&KeySchemaElement> = key_schema
+                .iter()
+                .filter(|ks| ks.key_type == KeyType::Range)
+                .filter(|ks| {
+                    !attr_defs
+                        .iter()
+                        .any(|ad| ad.attribute_name == ks.attribute_name)
+                })
+                .collect();
+            if missing.is_empty() {
+                continue;
+            }
+
+            // PRIMARY KEY columns only, in key order. Every data table carries all
+            // three typed columns for each sort key position (sk_s, sk_n, sk_b), so
+            // column existence says nothing about the declared type: only the pk
+            // position reported by table_info does. `table_id` is interpolated
+            // because PRAGMA takes no bind parameters; it is checked as a UUID first
+            // so a malformed catalog row cannot reach the statement.
+            if uuid::Uuid::parse_str(&table_id).is_err() {
+                report
+                    .needs_attention
+                    .push(format!("{table_name}: table_id {table_id:?} is not a UUID"));
+                continue;
+            }
+            let mut key_columns: Vec<(i64, String)> =
+                db::query_as::<(i64, String, String, i64, Option<String>, i64)>(&format!(
+                    "PRAGMA table_info(\"_ddb_{table_id}\")"
+                ))
+                .fetch_all(&pool)
+                .await
+                .map_err(|e| {
+                    OpError::Internal(format!("Cannot read columns of {table_name}: {e}"))
+                })?
+                .into_iter()
+                .filter(|(.., pk_pos)| *pk_pos > 0)
+                .map(|(_, name, _, _, _, pk_pos)| (pk_pos, name))
+                .collect();
+            key_columns.sort_unstable();
+            let columns: Vec<String> = key_columns.into_iter().map(|(_, name)| name).collect();
+
+            let recovered = recover_sort_key_definitions(&key_schema, &attr_defs, &columns);
+            if recovered.is_empty() {
+                report.needs_attention.push(format!(
+                    "{table_name}: sort key(s) [{}] have no attribute definition and no \
+                     matching PRIMARY KEY column was found to recover the type from",
+                    missing
+                        .iter()
+                        .map(|ks| ks.attribute_name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+                continue;
+            }
+
+            let mut merged = attr_defs;
+            merged.extend(recovered.iter().cloned());
+            let merged_json = serde_json::to_string(&merged)
+                .map_err(|e| OpError::Internal(format!("Cannot serialize definitions: {e}")))?;
+            if apply {
+                db::query(
+                    "UPDATE tables SET attribute_definitions = $1 \
+                     WHERE account_id = $2 AND table_name = $3",
+                )
+                .bind(&merged_json)
+                .bind(&account_id)
+                .bind(&table_name)
+                .execute(&pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("Cannot repair {table_name}: {e}")))?;
+            }
+
+            for def in &recovered {
+                report.repaired.push(format!(
+                    "{table_name}: {} ({:?})",
+                    def.attribute_name, def.attribute_type
+                ));
+            }
+        }
+
+        Ok(report)
+    }
+
+    async fn list_table_names(&self) -> OpResult<Vec<String>> {
+        let Ok(pool) = self.pool().await else {
+            return Ok(Vec::new());
+        };
+        let rows: Vec<(String,)> =
+            db::query_as("SELECT table_name FROM tables ORDER BY table_name")
+                .fetch_all(&pool)
+                .await
+                .unwrap_or_default();
+        Ok(rows.into_iter().map(|(n,)| n).collect())
+    }
+
+    async fn get_data_db_name(&self) -> OpResult<Option<String>> {
+        let Ok(pool) = self.pool().await else {
+            return Ok(None);
+        };
+        let row: Option<(String,)> =
+            db::query_as("SELECT value FROM settings WHERE key = 'data_database_name'")
+                .fetch_optional(&pool)
+                .await
+                .unwrap_or(None);
+        Ok(row.map(|(v,)| v))
+    }
+
+    async fn drop_databases(&self, _data_db: &str) -> OpResult<()> {
+        if self.is_memory() {
+            return Ok(());
+        }
+        // Release this process's handle on the database first: DuckDB holds a
+        // file lock for as long as an instance is open.
+        db::forget_path(&self.path);
+        if std::path::Path::new(&self.path).exists() {
+            std::fs::remove_file(&self.path)
+                .map_err(|e| OpError::Internal(format!("remove database file: {e}")))?;
+        }
+        // Remove the write-ahead log sidecar if present.
+        let _ = std::fs::remove_file(format!("{}.wal", self.path));
+        Ok(())
+    }
+
+    async fn read_catalog_version(&self) -> OpResult<Option<String>> {
+        let Ok(pool) = self.pool().await else {
+            return Ok(None);
+        };
+        if !schema::table_exists(&pool, "settings").await? {
+            return Ok(None);
+        }
+        let row: Option<(String,)> =
+            db::query_as("SELECT value FROM settings WHERE key = 'catalog_version'")
+                .fetch_optional(&pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("read catalog version: {e}")))?;
+        Ok(row.map(|(v,)| v))
+    }
+
+    fn expected_catalog_version(&self) -> String {
+        CATALOG_VERSION.to_string()
+    }
+
+    fn catalog_database_name(&self) -> String {
+        self.path.clone()
+    }
+
+    fn endpoint_info(&self) -> String {
+        format!("duckdb:{}", self.path)
+    }
+
+    fn catalog_connection_url(&self) -> String {
+        duckdb_path(&self.path)
+    }
+
+    fn generate_backend_config_section(&self) -> String {
+        format!(
+            "[storage.duckdb]\n\
+             path = \"{}\"\n\
+             # pool_size = 10",
+            self.path
+        )
+    }
+}

--- a/crates/storage-duckdb/src/catalog_store.rs
+++ b/crates/storage-duckdb/src/catalog_store.rs
@@ -1,0 +1,367 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `DuckDbCatalogStore`: the catalog/management store backing the management
+//! API and authorization. Implements `SettingsStore`, `MetricsStore`,
+//! `RateLimitStore`, `DiagnosticsStore`, `AdminStore` (in `admin_store`),
+//! `AuthorizationStore` (in `authorization_store`), `ManagementStore` (in the
+//! `management_store` module), and the `CatalogStore` supertrait.
+
+use crate::db;
+use std::sync::Arc;
+
+use extenddb_storage::CatalogStore;
+use extenddb_storage::diagnostics::{DiagError, DiagResult, DiagnosticsStore};
+use extenddb_storage::management_store::{
+    MetricsRow, MetricsStore, OpError, OpResult, RateLimitStore, SettingsStore,
+};
+use futures::future::BoxFuture;
+
+use time::OffsetDateTime;
+
+use crate::duckdb_util::{format_timestamp, parse_timestamp};
+
+/// Catalog store over the shared DuckDB pool.
+///
+/// The encryption key is cached at construction (from the `settings` table) so
+/// access-key creation/import can encrypt secrets without an extra query.
+pub struct DuckDbCatalogStore {
+    pool: db::Pool,
+    encryption_key: Option<Arc<str>>,
+}
+
+impl DuckDbCatalogStore {
+    /// Construct without a cached encryption key (settings/diagnostics-only use).
+    pub fn new(pool: db::Pool) -> Self {
+        Self {
+            pool,
+            encryption_key: None,
+        }
+    }
+
+    /// Construct with the cached AES-256-GCM encryption key (base64).
+    pub fn with_encryption_key(pool: db::Pool, encryption_key: String) -> Self {
+        Self {
+            pool,
+            encryption_key: Some(Arc::from(encryption_key.as_str())),
+        }
+    }
+
+    pub(crate) fn pool(&self) -> &db::Pool {
+        &self.pool
+    }
+
+    pub(crate) fn encryption_key(&self) -> Option<&Arc<str>> {
+        self.encryption_key.as_ref()
+    }
+}
+
+// ── SettingsStore ──────────────────────────────────────────────────────
+
+impl SettingsStore for DuckDbCatalogStore {
+    fn get_setting(&self, key: &str) -> BoxFuture<'_, OpResult<Option<String>>> {
+        let key = key.to_owned();
+        Box::pin(async move {
+            let row: Option<(String,)> = db::query_as("SELECT value FROM settings WHERE key = ?")
+                .bind(&key)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("get_setting: {e}")))?;
+            Ok(row.map(|(v,)| v))
+        })
+    }
+
+    fn set_setting(&self, key: &str, value: &str) -> BoxFuture<'_, OpResult<()>> {
+        let key = key.to_owned();
+        let value = value.to_owned();
+        Box::pin(async move {
+            db::query(
+                "INSERT INTO settings (key, value) VALUES (?, ?) \
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            )
+            .bind(&key)
+            .bind(&value)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| OpError::Internal(format!("set_setting: {e}")))?;
+            Ok(())
+        })
+    }
+
+    fn list_settings(&self) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        Box::pin(async move {
+            db::query_as("SELECT key, value FROM settings ORDER BY key")
+                .fetch_all(&self.pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("list_settings: {e}")))
+        })
+    }
+
+    fn cached_encryption_key(&self) -> Option<String> {
+        self.encryption_key.as_ref().map(|k| k.to_string())
+    }
+}
+
+// ── MetricsStore ───────────────────────────────────────────────────────
+
+struct DbMetricsRow {
+    bucket: String,
+    metric: String,
+    table_name: String,
+    index_name: String,
+    operation: String,
+    sum: f64,
+    count: i64,
+    min: f64,
+    max: f64,
+}
+
+crate::impl_from_row!(DbMetricsRow {
+    bucket,
+    metric,
+    table_name,
+    index_name,
+    operation,
+    sum,
+    count,
+    min,
+    max
+});
+
+impl MetricsStore for DuckDbCatalogStore {
+    fn insert_metrics(&self, rows: &[MetricsRow]) -> BoxFuture<'_, OpResult<()>> {
+        let rows = rows.to_vec();
+        Box::pin(async move {
+            for row in &rows {
+                let bucket = format_timestamp(row.bucket);
+                let result = db::query(
+                    "INSERT INTO metrics \
+                     (bucket, metric, table_name, index_name, operation, sum, count, min, max) \
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) \
+                     ON CONFLICT(bucket, metric, table_name, index_name, operation) DO UPDATE SET \
+                       sum = metrics.sum + excluded.sum, \
+                       count = metrics.count + excluded.count, \
+                       min = LEAST(metrics.min, excluded.min), \
+                       max = GREATEST(metrics.max, excluded.max)",
+                )
+                .bind(&bucket)
+                .bind(&row.metric)
+                .bind(row.table_name.as_deref().unwrap_or(""))
+                .bind(row.index_name.as_deref().unwrap_or(""))
+                .bind(row.operation.as_deref().unwrap_or(""))
+                .bind(row.sum)
+                .bind(row.count)
+                .bind(row.min)
+                .bind(row.max)
+                .execute(&self.pool)
+                .await;
+                if let Err(e) = result {
+                    tracing::warn!("insert_metrics row failed: {e}");
+                }
+            }
+            Ok(())
+        })
+    }
+
+    fn query_metrics(
+        &self,
+        start: OffsetDateTime,
+        end: OffsetDateTime,
+        table_name: Option<&str>,
+        metric: Option<&str>,
+    ) -> BoxFuture<'_, OpResult<Vec<MetricsRow>>> {
+        let table_name = table_name.map(str::to_owned);
+        let metric = metric.map(str::to_owned);
+        let start_str = format_timestamp(start);
+        let end_str = format_timestamp(end);
+        Box::pin(async move {
+            let mut sql = String::from(
+                "SELECT bucket, metric, table_name, index_name, operation, sum, count, min, max \
+                 FROM metrics WHERE bucket >= ? AND bucket <= ?",
+            );
+            let table_filter = table_name.as_deref().filter(|s| !s.is_empty());
+            if table_filter.is_some() {
+                sql.push_str(" AND table_name = ?");
+            }
+            if metric.is_some() {
+                sql.push_str(" AND metric = ?");
+            }
+            sql.push_str(" ORDER BY bucket");
+
+            let mut q = db::query_as::<DbMetricsRow>(&sql)
+                .bind(&start_str)
+                .bind(&end_str);
+            if let Some(tn) = table_filter {
+                q = q.bind(tn.to_owned());
+            }
+            if let Some(m) = metric.as_deref() {
+                q = q.bind(m.to_owned());
+            }
+
+            let rows = q
+                .fetch_all(&self.pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("query_metrics: {e}")))?;
+
+            Ok(rows
+                .into_iter()
+                .filter_map(|r| {
+                    Some(MetricsRow {
+                        bucket: parse_timestamp(&r.bucket).ok()?,
+                        metric: r.metric,
+                        table_name: (!r.table_name.is_empty()).then_some(r.table_name),
+                        index_name: (!r.index_name.is_empty()).then_some(r.index_name),
+                        operation: (!r.operation.is_empty()).then_some(r.operation),
+                        sum: r.sum,
+                        count: r.count,
+                        min: r.min,
+                        max: r.max,
+                    })
+                })
+                .collect())
+        })
+    }
+
+    fn prune_metrics(&self, retention: std::time::Duration) -> BoxFuture<'_, OpResult<()>> {
+        Box::pin(async move {
+            let cutoff = OffsetDateTime::now_utc()
+                - time::Duration::seconds(i64::try_from(retention.as_secs()).unwrap_or(i64::MAX));
+            let cutoff_str = format_timestamp(cutoff);
+            db::query("DELETE FROM metrics WHERE bucket < ?")
+                .bind(&cutoff_str)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| OpError::Internal(format!("prune_metrics: {e}")))?;
+            Ok(())
+        })
+    }
+}
+
+// ── RateLimitStore ─────────────────────────────────────────────────────
+
+impl RateLimitStore for DuckDbCatalogStore {
+    fn count_principal_failures(
+        &self,
+        principal: &str,
+        window_seconds: i64,
+    ) -> BoxFuture<'_, OpResult<i64>> {
+        let principal = principal.to_owned();
+        Box::pin(async move {
+            let cutoff = format_timestamp(
+                OffsetDateTime::now_utc() - time::Duration::seconds(window_seconds),
+            );
+            let row: (i64,) = db::query_as(
+                "SELECT COUNT(*) FROM login_attempts \
+                 WHERE principal = ? AND success = 0 AND attempted_at > ?",
+            )
+            .bind(&principal)
+            .bind(&cutoff)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| OpError::Internal(format!("count_principal_failures: {e}")))?;
+            Ok(row.0)
+        })
+    }
+
+    fn count_ip_failures(
+        &self,
+        source_ip: &str,
+        window_seconds: i64,
+    ) -> BoxFuture<'_, OpResult<i64>> {
+        let source_ip = source_ip.to_owned();
+        Box::pin(async move {
+            let cutoff = format_timestamp(
+                OffsetDateTime::now_utc() - time::Duration::seconds(window_seconds),
+            );
+            let row: (i64,) = db::query_as(
+                "SELECT COUNT(*) FROM login_attempts \
+                 WHERE source_ip = ? AND success = 0 AND attempted_at > ?",
+            )
+            .bind(&source_ip)
+            .bind(&cutoff)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| OpError::Internal(format!("count_ip_failures: {e}")))?;
+            Ok(row.0)
+        })
+    }
+
+    fn record_failed_login(&self, principal: &str, source_ip: Option<&str>) -> BoxFuture<'_, ()> {
+        let principal = principal.to_owned();
+        let source_ip = source_ip.map(str::to_owned);
+        Box::pin(async move {
+            let now = format_timestamp(OffsetDateTime::now_utc());
+            let result = db::query(
+                "INSERT INTO login_attempts (principal, attempted_at, success, source_ip) \
+                 VALUES (?, ?, 0, ?)",
+            )
+            .bind(&principal)
+            .bind(&now)
+            .bind(source_ip.as_deref())
+            .execute(&self.pool)
+            .await;
+            if let Err(e) = result {
+                tracing::error!("record_failed_login: {e}");
+            }
+        })
+    }
+
+    fn cleanup_old_attempts(&self, max_age_seconds: i64) -> BoxFuture<'_, ()> {
+        Box::pin(async move {
+            let cutoff = format_timestamp(
+                OffsetDateTime::now_utc() - time::Duration::seconds(max_age_seconds),
+            );
+            if let Err(e) = db::query("DELETE FROM login_attempts WHERE attempted_at < ?")
+                .bind(&cutoff)
+                .execute(&self.pool)
+                .await
+            {
+                tracing::error!("cleanup_old_attempts: {e}");
+            }
+        })
+    }
+}
+
+// ── DiagnosticsStore ───────────────────────────────────────────────────
+
+impl DiagnosticsStore for DuckDbCatalogStore {
+    fn count_tables(&self) -> BoxFuture<'_, DiagResult<i64>> {
+        Box::pin(async move {
+            let (count,): (i64,) = db::query_as("SELECT COUNT(*) FROM tables")
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|e| DiagError::QueryFailed(e.to_string()))?;
+            Ok(count)
+        })
+    }
+
+    fn count_indexes(&self) -> BoxFuture<'_, DiagResult<i64>> {
+        Box::pin(async move {
+            let (count,): (i64,) = db::query_as("SELECT COUNT(*) FROM indexes")
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|e| DiagError::QueryFailed(e.to_string()))?;
+            Ok(count)
+        })
+    }
+
+    fn test_data_database_connection(&self) -> BoxFuture<'_, DiagResult<String>> {
+        Box::pin(async move {
+            // Catalog and data share one DuckDB file; report its recorded name.
+            let row: Option<(String,)> =
+                db::query_as("SELECT value FROM settings WHERE key = 'data_database_name'")
+                    .fetch_optional(&self.pool)
+                    .await
+                    .map_err(|e| DiagError::QueryFailed(e.to_string()))?;
+            Ok(row.map_or_else(|| "duckdb (embedded)".to_owned(), |(n,)| n))
+        })
+    }
+}
+
+// ── CatalogStore supertrait ────────────────────────────────────────────
+
+impl CatalogStore for DuckDbCatalogStore {
+    fn cached_encryption_key(&self) -> Option<String> {
+        self.encryption_key.as_ref().map(|k| k.to_string())
+    }
+}

--- a/crates/storage-duckdb/src/config.rs
+++ b/crates/storage-duckdb/src/config.rs
@@ -1,0 +1,144 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Storage configuration for the DuckDB backend (`[storage.duckdb]`).
+
+use std::any::Any;
+
+use extenddb_storage::config::StorageConfig;
+use serde::Deserialize;
+
+/// DuckDB backend configuration.
+///
+/// `path` is the database file location; `:memory:` selects an ephemeral
+/// in-memory database. `pool_size` bounds the read connection pool (writes are
+/// serialized by the engine regardless).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DuckDbConfig {
+    #[serde(default = "default_path")]
+    pub path: String,
+    #[serde(default = "default_pool_size")]
+    pub pool_size: u32,
+}
+
+impl Default for DuckDbConfig {
+    fn default() -> Self {
+        Self {
+            path: default_path(),
+            pool_size: default_pool_size(),
+        }
+    }
+}
+
+/// The compiled-in default database location.
+///
+/// With the `memory` feature the default is `:memory:`, producing an ephemeral,
+/// bootstrap-on-serve deployment with no file on disk. Otherwise the default is
+/// a file in the working directory.
+fn default_path() -> String {
+    if cfg!(feature = "memory") {
+        ":memory:".to_owned()
+    } else {
+        "extenddb.duckdb".to_owned()
+    }
+}
+
+fn default_pool_size() -> u32 {
+    10
+}
+
+impl StorageConfig for DuckDbConfig {
+    fn connection_config(&self) -> &str {
+        &self.path
+    }
+
+    fn max_connections(&self) -> u32 {
+        self.pool_size
+    }
+
+    fn max_catalog_connections(&self) -> u32 {
+        // Single DuckDB file — catalog and data share one connection pool.
+        self.pool_size
+    }
+
+    fn clone_box(&self) -> Box<dyn StorageConfig> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Deserialize a `[storage.duckdb]` TOML table into a boxed `StorageConfig`.
+pub fn deserialize_config(table: &toml::Table) -> Result<Box<dyn StorageConfig>, String> {
+    let mut config: DuckDbConfig = table
+        .clone()
+        .try_into()
+        .map_err(|e: toml::de::Error| format!("Failed to parse duckdb config: {e}"))?;
+    config.path = resolve_path(config.path);
+    Ok(Box::new(config))
+}
+
+/// Resolve a relative database file path to absolute, against the current
+/// working directory.
+///
+/// This runs at config load — before `serve` daemonizes. Daemonization changes
+/// the process working directory, so a relative `path` would otherwise resolve
+/// differently (or fail to open) in the daemonized child. In-memory and URI
+/// paths are left untouched.
+fn resolve_path(path: String) -> String {
+    if path.contains(":memory:") || path.starts_with("file:") || path.starts_with("duckdb:") {
+        return path;
+    }
+    let p = std::path::Path::new(&path);
+    if p.is_absolute() {
+        return path;
+    }
+    match std::env::current_dir() {
+        Ok(cwd) => cwd.join(p).to_string_lossy().into_owned(),
+        Err(_) => path,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults() {
+        let c = DuckDbConfig::default();
+        #[cfg(not(feature = "memory"))]
+        assert_eq!(c.path, "extenddb.duckdb");
+        #[cfg(feature = "memory")]
+        assert_eq!(c.path, ":memory:");
+        assert_eq!(c.pool_size, 10);
+        assert_eq!(c.max_connections(), 10);
+        assert_eq!(c.max_catalog_connections(), 10);
+    }
+
+    #[cfg(feature = "memory")]
+    #[test]
+    fn memory_feature_defaults_to_in_memory() {
+        assert_eq!(DuckDbConfig::default().path, ":memory:");
+        assert_eq!(default_path(), ":memory:");
+    }
+
+    #[test]
+    fn deserialize_full() {
+        let mut t = toml::Table::new();
+        t.insert("path".into(), toml::Value::String(":memory:".into()));
+        t.insert("pool_size".into(), toml::Value::Integer(4));
+        let boxed = deserialize_config(&t).expect("parse");
+        assert_eq!(boxed.connection_config(), ":memory:");
+        assert_eq!(boxed.max_connections(), 4);
+    }
+
+    #[test]
+    fn deserialize_rejects_unknown_field() {
+        let mut t = toml::Table::new();
+        t.insert("bogus".into(), toml::Value::Integer(1));
+        assert!(deserialize_config(&t).is_err());
+    }
+}

--- a/crates/storage-duckdb/src/create_table.rs
+++ b/crates/storage-duckdb/src/create_table.rs
@@ -1,0 +1,518 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `create_table` implementation for `DuckDbEngine`.
+//!
+//! Catalog metadata (table row, indexes, tags, stream shards) is written in one
+//! transaction; the per-table/index data tables are created in a second
+//! transaction afterward, with catalog cleanup if the data DDL fails. The
+//! control-plane delay (`control_plane_delay_seconds`) decides whether the
+//! table starts ACTIVE (delay 0) or CREATING with a scheduled transition.
+
+use crate::db;
+use extenddb_core::types::{
+    BillingMode, BillingModeSummary, CreateTableInput, GsiDescription, LsiDescription,
+    ProvisionedThroughputDescription, SseDescription, SseType, TableDescription, TableStatus,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::{index_arn, stream_arn, table_arn};
+
+use crate::duckdb_util::{format_timestamp, is_unique_violation};
+use crate::store::DuckDbEngine;
+
+impl DuckDbEngine {
+    pub(crate) async fn create_table_impl(
+        &self,
+        account_id: &str,
+        input: CreateTableInput,
+    ) -> Result<TableDescription, StorageError> {
+        Self::validate_account_id(account_id)?;
+        let table_id = uuid::Uuid::new_v4().to_string();
+        let table_arn = table_arn(&self.region, account_id, &input.table_name);
+        let billing_mode = input.billing_mode.unwrap_or(BillingMode::Provisioned);
+        let billing_str = match billing_mode {
+            BillingMode::Provisioned => "PROVISIONED",
+            BillingMode::PayPerRequest => "PAY_PER_REQUEST",
+        };
+
+        let to_str = |v: &serde_json::Value| -> Result<String, StorageError> {
+            serde_json::to_string(v).map_err(|e| StorageError::Internal(e.to_string()))
+        };
+        let key_schema_json = serde_json::to_string(&input.key_schema)
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let attr_defs_json = serde_json::to_string(&input.attribute_definitions)
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let pt_json = input
+            .provisioned_throughput
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let stream_json = input
+            .stream_specification
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let sse_json = input.sse_specification.as_ref().map(to_str).transpose()?;
+        let on_demand_json = input
+            .on_demand_throughput
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let deletion_protection = input.deletion_protection_enabled.unwrap_or(false);
+
+        // Control-plane delay decides initial status and scheduled transition.
+        let delay_secs: f64 = db::query_scalar::<String>(
+            "SELECT value FROM settings WHERE key = 'control_plane_delay_seconds'",
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?
+        .and_then(|v| v.parse::<f64>().ok())
+        .unwrap_or(0.25);
+
+        let now = time::OffsetDateTime::now_utc();
+        let creation_ts = format_timestamp(now);
+        #[allow(clippy::cast_precision_loss)]
+        let creation_epoch = now.unix_timestamp() as f64;
+        let (initial_status, status_transition_at) = if delay_secs <= 0.0 {
+            ("ACTIVE", None)
+        } else {
+            (
+                "CREATING",
+                Some(format_timestamp(
+                    now + time::Duration::seconds_f64(delay_secs),
+                )),
+            )
+        };
+
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        db::query(
+            "INSERT INTO tables \
+             (account_id, table_name, key_schema, attribute_definitions, billing_mode, \
+              provisioned_throughput, stream_specification, table_status, creation_date_time, \
+              table_arn, table_id, deletion_protection_enabled, status_transition_at, \
+              table_class, sse_specification, on_demand_throughput) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(account_id)
+        .bind(&input.table_name)
+        .bind(&key_schema_json)
+        .bind(&attr_defs_json)
+        .bind(billing_str)
+        .bind(&pt_json)
+        .bind(&stream_json)
+        .bind(initial_status)
+        .bind(&creation_ts)
+        .bind(&table_arn)
+        .bind(&table_id)
+        .bind(deletion_protection)
+        .bind(&status_transition_at)
+        .bind(&input.table_class)
+        .bind(&sse_json)
+        .bind(&on_demand_json)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| {
+            if is_unique_violation(&e) {
+                StorageError::TableAlreadyExists(input.table_name.clone())
+            } else {
+                StorageError::Internal(e.to_string())
+            }
+        })?;
+
+        // GSI / LSI metadata.
+        let mut gsi_ids: Vec<String> = Vec::new();
+        if let Some(gsis) = &input.global_secondary_indexes {
+            for gsi in gsis {
+                let ks = serde_json::to_string(&gsi.key_schema)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                let proj = serde_json::to_string(&gsi.projection)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                let pt = gsi
+                    .provisioned_throughput
+                    .as_ref()
+                    .map(|pt| {
+                        serde_json::to_string(&ProvisionedThroughputDescription {
+                            read_capacity_units: pt.read_capacity_units,
+                            write_capacity_units: pt.write_capacity_units,
+                            number_of_decreases_today: 0,
+                            last_increase_date_time: None,
+                            last_decrease_date_time: None,
+                        })
+                    })
+                    .transpose()
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                let index_id = uuid::Uuid::new_v4().to_string();
+                db::query(
+                    "INSERT INTO indexes \
+                     (table_id, index_name, index_id, index_type, key_schema, projection, \
+                      index_status, provisioned_throughput) \
+                     VALUES (?, ?, ?, 'GSI', ?, ?, 'ACTIVE', ?)",
+                )
+                .bind(&table_id)
+                .bind(&gsi.index_name)
+                .bind(&index_id)
+                .bind(&ks)
+                .bind(&proj)
+                .bind(&pt)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+                gsi_ids.push(index_id);
+            }
+        }
+        let mut lsi_ids: Vec<String> = Vec::new();
+        if let Some(lsis) = &input.local_secondary_indexes {
+            for lsi in lsis {
+                let ks = serde_json::to_string(&lsi.key_schema)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                let proj = serde_json::to_string(&lsi.projection)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                let index_id = uuid::Uuid::new_v4().to_string();
+                db::query(
+                    "INSERT INTO indexes \
+                     (table_id, index_name, index_id, index_type, key_schema, projection, \
+                      index_status, provisioned_throughput) \
+                     VALUES (?, ?, ?, 'LSI', ?, ?, 'ACTIVE', NULL)",
+                )
+                .bind(&table_id)
+                .bind(&lsi.index_name)
+                .bind(&index_id)
+                .bind(&ks)
+                .bind(&proj)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+                lsi_ids.push(index_id);
+            }
+        }
+
+        // Vector indexes. A CreateTable's table is empty, so there is nothing to
+        // backfill and no `backfilling` member is ever reported on this path.
+        // The index's status tracks the TABLE's: measured against the service
+        // (2026-08-21, eu-west-2, three runs polling at 250ms), an index created
+        // with its table reports CREATING while the table is CREATING and
+        // reaches ACTIVE in the same DescribeTable poll as the table, with no
+        // observable gap in either direction. The control-plane worker flips
+        // both in one pass; see `process_control_plane_transitions`.
+        let mut vector_ids: Vec<String> = Vec::new();
+        if let Some(vis) = &input.vector_indexes {
+            for vi in vis {
+                let vec_attr = serde_json::to_string(&vi.vector_attribute)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                let search_schema = vi
+                    .search_schema
+                    .as_ref()
+                    .map(serde_json::to_string)
+                    .transpose()
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                let proj = vi
+                    .projection
+                    .as_ref()
+                    .map(serde_json::to_string)
+                    .transpose()
+                    .map_err(|e| StorageError::Internal(e.to_string()))?
+                    .ok_or_else(|| {
+                        // Core validation requires Projection, so reaching here
+                        // means the request bypassed validation rather than that
+                        // the caller omitted it.
+                        StorageError::Internal(
+                            "vector index reached storage without a projection".to_owned(),
+                        )
+                    })?;
+                let distance = serde_json::to_string(&vi.distance_function)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?
+                    .trim_matches('"')
+                    .to_owned();
+                let index_id = uuid::Uuid::new_v4().to_string();
+                db::query(
+                    "INSERT INTO vector_indexes \
+                     (table_id, index_name, index_id, dimensions, distance_function, \
+                      vector_attribute, search_schema, projection, index_status, backfilling) \
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)",
+                )
+                .bind(&table_id)
+                .bind(&vi.index_name)
+                .bind(&index_id)
+                .bind(i64::from(vi.dimensions))
+                .bind(&distance)
+                .bind(&vec_attr)
+                .bind(&search_schema)
+                .bind(&proj)
+                .bind(initial_status)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+                vector_ids.push(index_id);
+            }
+        }
+
+        // Tags.
+        if let Some(tags) = &input.tags {
+            for tag in tags {
+                db::query("INSERT INTO tags (resource_arn, tag_key, tag_value) VALUES (?, ?, ?)")
+                    .bind(&table_arn)
+                    .bind(&tag.key)
+                    .bind(&tag.value)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            }
+        }
+
+        // Stream shards (same transaction — single file).
+        let stream_label = if input
+            .stream_specification
+            .as_ref()
+            .is_some_and(|s| s.stream_enabled)
+        {
+            Some(Self::init_stream_shards(&mut tx, account_id, &input.table_name, &table_id).await?)
+        } else {
+            None
+        };
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        // Data tables in a second transaction; clean up catalog on failure.
+        let data_result = async {
+            let mut data_tx = self
+                .pool
+                .begin()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Self::create_data_table(
+                &mut data_tx,
+                &table_id,
+                &input.key_schema,
+                &input.attribute_definitions,
+            )
+            .await?;
+            if let Some(gsis) = &input.global_secondary_indexes {
+                for (i, gsi) in gsis.iter().enumerate() {
+                    Self::create_index_data_table(
+                        &mut data_tx,
+                        &gsi_ids[i],
+                        &gsi.key_schema,
+                        &input.attribute_definitions,
+                        &input.key_schema,
+                        &input.attribute_definitions,
+                    )
+                    .await?;
+                }
+            }
+            if let Some(lsis) = &input.local_secondary_indexes {
+                for (i, lsi) in lsis.iter().enumerate() {
+                    Self::create_index_data_table(
+                        &mut data_tx,
+                        &lsi_ids[i],
+                        &lsi.key_schema,
+                        &input.attribute_definitions,
+                        &input.key_schema,
+                        &input.attribute_definitions,
+                    )
+                    .await?;
+                }
+            }
+            if input.vector_indexes.is_some() {
+                for index_id in &vector_ids {
+                    Self::create_vector_data_table(
+                        &mut data_tx,
+                        &table_id,
+                        index_id,
+                        &input.key_schema,
+                        &input.attribute_definitions,
+                    )
+                    .await?;
+                }
+            }
+            data_tx
+                .commit()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok::<(), StorageError>(())
+        }
+        .await;
+
+        if let Err(e) = data_result {
+            tracing::error!(
+                "Failed to create data tables for '{}', cleaning up catalog: {e}",
+                input.table_name
+            );
+            if let Ok(mut cleanup) = self.pool.begin().await {
+                let _ = crate::referential::delete_table_children(&mut cleanup, &table_id).await;
+                let _ = db::query("DELETE FROM tables WHERE account_id = ? AND table_name = ?")
+                    .bind(account_id)
+                    .bind(&input.table_name)
+                    .execute(&mut *cleanup)
+                    .await;
+                let _ = cleanup.commit().await;
+            }
+            return Err(e);
+        }
+
+        self.control_plane_notify.notify_one();
+
+        // Build the response from in-scope data (avoids a post-commit read race).
+        let (rcu, wcu) = input.provisioned_throughput.as_ref().map_or((0, 0), |pt| {
+            (pt.read_capacity_units, pt.write_capacity_units)
+        });
+
+        let gsis = input.global_secondary_indexes.as_ref().map(|gs| {
+            gs.iter()
+                .map(|g| GsiDescription {
+                    index_name: g.index_name.clone(),
+                    key_schema: g.key_schema.clone(),
+                    projection: g.projection.clone(),
+                    index_status: "ACTIVE".to_owned(),
+                    provisioned_throughput: Some(ProvisionedThroughputDescription {
+                        read_capacity_units: g
+                            .provisioned_throughput
+                            .as_ref()
+                            .map_or(0, |pt| pt.read_capacity_units),
+                        write_capacity_units: g
+                            .provisioned_throughput
+                            .as_ref()
+                            .map_or(0, |pt| pt.write_capacity_units),
+                        number_of_decreases_today: 0,
+                        last_increase_date_time: None,
+                        last_decrease_date_time: None,
+                    }),
+                    index_size_bytes: 0,
+                    item_count: 0,
+                    index_arn: index_arn(
+                        &self.region,
+                        account_id,
+                        &input.table_name,
+                        &g.index_name,
+                    ),
+                })
+                .collect()
+        });
+        let lsis = input.local_secondary_indexes.as_ref().map(|ls| {
+            ls.iter()
+                .map(|l| LsiDescription {
+                    index_name: l.index_name.clone(),
+                    key_schema: l.key_schema.clone(),
+                    projection: l.projection.clone(),
+                    index_size_bytes: 0,
+                    item_count: 0,
+                    index_arn: index_arn(
+                        &self.region,
+                        account_id,
+                        &input.table_name,
+                        &l.index_name,
+                    ),
+                })
+                .collect()
+        });
+
+        let billing_mode_summary = (billing_mode == BillingMode::PayPerRequest).then_some({
+            BillingModeSummary {
+                billing_mode: BillingMode::PayPerRequest,
+                last_update_to_pay_per_request_date_time: Some(creation_epoch),
+            }
+        });
+        let latest_stream_arn = stream_label
+            .as_ref()
+            .map(|label| stream_arn(&self.region, account_id, &input.table_name, label));
+        let response_status = if initial_status == "ACTIVE" {
+            TableStatus::Active
+        } else {
+            TableStatus::Creating
+        };
+        let sse_description = input.sse_specification.as_ref().and_then(|spec| {
+            let enabled = spec
+                .get("Enabled")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+            enabled.then(|| SseDescription {
+                status: "ENABLED".to_owned(),
+                sse_type: Some(SseType::KMS),
+                kms_master_key_arn: Some(format!(
+                    "arn:aws:kms:{}:{}:key/default",
+                    self.region, account_id
+                )),
+            })
+        });
+
+        // Echo the vector indexes we just created. Built from the request plus the
+        // ids assigned above rather than re-read from the catalog, which would add
+        // a round trip to say something already known. A CreateTable's table is
+        // empty, so each index is ACTIVE with no `backfilling` member.
+        let vector_index_descs: Option<Vec<extenddb_core::types::VectorIndexDescription>> = input
+            .vector_indexes
+            .as_ref()
+            .map(|vis| {
+                vis.iter()
+                    .map(|vi| extenddb_core::types::VectorIndexDescription {
+                        index_name: vi.index_name.clone(),
+                        vector_attribute: vi.vector_attribute.clone(),
+                        dimensions: vi.dimensions,
+                        search_schema: vi.search_schema.clone(),
+                        distance_function: vi.distance_function,
+                        index_status: extenddb_core::types::IndexStatus::Active,
+                        backfilling: None,
+                        index_size_bytes: 0,
+                        item_count: 0,
+                        index_arn: extenddb_storage::util::index_arn(
+                            &self.region,
+                            account_id,
+                            &input.table_name,
+                            &vi.index_name,
+                        ),
+                        projection: vi.projection.clone(),
+                    })
+                    .collect()
+            })
+            .filter(|v: &Vec<_>| !v.is_empty());
+
+        Ok(TableDescription {
+            restore_summary: None,
+            table_name: input.table_name,
+            key_schema: input.key_schema,
+            attribute_definitions: input.attribute_definitions,
+            table_status: response_status,
+            creation_date_time: creation_epoch,
+            table_size_bytes: 0,
+            item_count: 0,
+            table_arn,
+            table_id,
+            provisioned_throughput: ProvisionedThroughputDescription {
+                read_capacity_units: rcu,
+                write_capacity_units: wcu,
+                number_of_decreases_today: 0,
+                last_increase_date_time: None,
+                last_decrease_date_time: None,
+            },
+            billing_mode_summary,
+            global_secondary_indexes: gsis,
+            local_secondary_indexes: lsis,
+            stream_specification: input.stream_specification,
+            latest_stream_arn,
+            latest_stream_label: stream_label,
+            deletion_protection_enabled: deletion_protection,
+            sse_description,
+            table_class_summary: input
+                .table_class
+                .as_ref()
+                .map(|tc| serde_json::json!({ "TableClass": tc })),
+            on_demand_throughput: input.on_demand_throughput,
+            // Every field is populated deliberately, with no `..Default::default()`
+            // spread. This response is the complete description of what was just
+            // created, so a new core field should break this site and force a
+            // decision about whether create must report it, rather than silently
+            // defaulting. Sites that legitimately opt out still use the spread.
+            vector_indexes: vector_index_descs,
+        })
+    }
+}

--- a/crates/storage-duckdb/src/credential_store.rs
+++ b/crates/storage-duckdb/src/credential_store.rs
@@ -1,0 +1,173 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! DuckDB-backed `CredentialStore` for SigV4 verification.
+//!
+//! `AKIA…` keys resolve to long-lived IAM user access keys; `ASIA…` keys
+//! resolve to temporary `AssumeRole` sessions (with expiry enforcement).
+//! Secrets are decrypted with AES-256-GCM; the `access_key_id` is the AAD, with
+//! a no-AAD fallback for any legacy ciphertext.
+
+use crate::db;
+use aes_gcm::aead::{Aead, Payload};
+use aes_gcm::{Aes256Gcm, Key, KeyInit, Nonce};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use extenddb_auth::{CredentialStore, StoredCredential};
+use extenddb_core::error::DynamoDbError;
+
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use crate::duckdb_util::parse_timestamp;
+
+/// Decrypt a `nonce(12) || ciphertext` secret with AES-256-GCM.
+fn decrypt_secret(encrypted: &[u8], key_b64: &str, aad: &str) -> Result<String, String> {
+    if encrypted.len() < 28 {
+        return Err("ciphertext too short (need 12-byte nonce + 16-byte tag)".to_owned());
+    }
+    let key_bytes = BASE64
+        .decode(key_b64)
+        .map_err(|e| format!("decode encryption key: {e}"))?;
+    if key_bytes.len() != 32 {
+        return Err("encryption key must be 32 bytes".to_owned());
+    }
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key_bytes));
+    let nonce = Nonce::from_slice(&encrypted[..12]);
+
+    if let Ok(plaintext) = cipher.decrypt(
+        nonce,
+        Payload {
+            msg: &encrypted[12..],
+            aad: aad.as_bytes(),
+        },
+    ) {
+        return String::from_utf8(plaintext).map_err(|e| format!("secret not UTF-8: {e}"));
+    }
+    // Fallback: ciphertext written without AAD.
+    let plaintext = cipher
+        .decrypt(nonce, &encrypted[12..])
+        .map_err(|e| format!("decrypt: {e}"))?;
+    String::from_utf8(plaintext).map_err(|e| format!("secret not UTF-8: {e}"))
+}
+
+/// Credential store over the catalog DuckDB pool.
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct DuckDbCredentialStore {
+    #[zeroize(skip)]
+    pool: db::Pool,
+    encryption_key: String,
+}
+
+impl DuckDbCredentialStore {
+    pub fn new(pool: db::Pool, encryption_key: String) -> Self {
+        Self {
+            pool,
+            encryption_key,
+        }
+    }
+
+    async fn lookup_user(
+        &self,
+        access_key_id: &str,
+    ) -> Result<Option<StoredCredential>, DynamoDbError> {
+        let row: Option<(Vec<u8>, String, String, bool)> = db::query_as(
+            "SELECT secret_key_encrypted, account_id, user_name, is_active \
+             FROM access_keys WHERE access_key_id = ?",
+        )
+        .bind(access_key_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!("credential lookup failed for {access_key_id}: {e}");
+            DynamoDbError::InternalServerError("Internal error during authentication".to_owned())
+        })?;
+
+        let Some((encrypted, account_id, user_name, is_active)) = row else {
+            return Ok(None);
+        };
+        let secret_key =
+            decrypt_secret(&encrypted, &self.encryption_key, access_key_id).map_err(|e| {
+                tracing::error!("secret decryption failed for {access_key_id}: {e}");
+                DynamoDbError::InternalServerError(
+                    "Internal error during authentication".to_owned(),
+                )
+            })?;
+        Ok(Some(StoredCredential {
+            secret_key,
+            account_id,
+            principal_name: user_name,
+            session_name: None,
+            is_session: false,
+            session_token: None,
+            is_active,
+            expires_at: None,
+        }))
+    }
+
+    async fn lookup_session(
+        &self,
+        access_key_id: &str,
+    ) -> Result<Option<StoredCredential>, DynamoDbError> {
+        let row: Option<(Vec<u8>, String, String, String, String, String)> = db::query_as(
+            "SELECT secret_key_encrypted, account_id, role_name, session_name, \
+                    session_token, expires_at \
+             FROM iam_sessions WHERE access_key_id = ?",
+        )
+        .bind(access_key_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!("session lookup failed for {access_key_id}: {e}");
+            DynamoDbError::InternalServerError("Internal error during authentication".to_owned())
+        })?;
+
+        let Some((encrypted, account_id, role_name, session_name, session_token, expires_at)) = row
+        else {
+            return Ok(None);
+        };
+
+        let expires = parse_timestamp(&expires_at).map_err(|e| {
+            tracing::error!("session expiry parse error: {e}");
+            DynamoDbError::InternalServerError("Internal error during authentication".to_owned())
+        })?;
+        if expires < time::OffsetDateTime::now_utc() {
+            return Err(DynamoDbError::ExpiredTokenException(
+                "The security token included in the request is expired".to_owned(),
+            ));
+        }
+
+        let secret_key =
+            decrypt_secret(&encrypted, &self.encryption_key, access_key_id).map_err(|e| {
+                tracing::error!("session secret decryption failed for {access_key_id}: {e}");
+                DynamoDbError::InternalServerError(
+                    "Internal error during authentication".to_owned(),
+                )
+            })?;
+        Ok(Some(StoredCredential {
+            secret_key,
+            account_id,
+            principal_name: role_name,
+            session_name: Some(session_name),
+            is_session: true,
+            session_token: Some(session_token),
+            is_active: true,
+            expires_at: Some(expires),
+        }))
+    }
+}
+
+#[async_trait::async_trait]
+impl CredentialStore for DuckDbCredentialStore {
+    async fn lookup_credential(
+        &self,
+        access_key_id: &str,
+    ) -> Result<Option<StoredCredential>, DynamoDbError> {
+        if access_key_id.starts_with("ASIA") {
+            self.lookup_session(access_key_id).await
+        } else if access_key_id.starts_with("AKIA") {
+            self.lookup_user(access_key_id).await
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/crates/storage-duckdb/src/data/data_engine.rs
+++ b/crates/storage-duckdb/src/data/data_engine.rs
@@ -1,0 +1,398 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `DataEngine` trait implementation for `DuckDbEngine`.
+//!
+//! Each method clones its borrowed arguments into owned values and delegates to
+//! the corresponding `*_impl` method inside a boxed future. The transact-write
+//! path rebuilds borrowed `TransactWriteOp`s from owned components inside the
+//! future, since the trait's borrowed ops cannot outlive the call.
+
+use extenddb_core::expression::{Expr, ExpressionMaps, KeyCondition, UpdateAction};
+use extenddb_core::types::{Item, ReturnValuesOnConditionCheckFailure, TableKeyInfo};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::{DataEngine, IdempotencyKey, StreamCapture, TransactGetOp, TransactWriteOp};
+use futures::future::BoxFuture;
+
+use crate::store::DuckDbEngine;
+
+impl DataEngine for DuckDbEngine {
+    /// Declares vector support by handing over the implementation. `Some(self)`
+    /// only compiles because `DuckDbEngine` implements `VectorSearchEngine`, so
+    /// this cannot claim a capability the backend does not have.
+    fn as_vector_search(&self) -> Option<&dyn extenddb_storage::VectorSearchEngine> {
+        Some(self)
+    }
+
+    fn put_item(
+        &self,
+        key_info: &TableKeyInfo,
+        item: Item,
+        return_old: bool,
+        condition: Option<&Expr>,
+        maps: &ExpressionMaps,
+        stream: Option<&StreamCapture>,
+    ) -> BoxFuture<'_, Result<Option<Item>, StorageError>> {
+        let key_info = key_info.clone();
+        let condition = condition.cloned();
+        let maps = maps.clone();
+        let stream = stream.cloned();
+        Box::pin(async move {
+            self.put_item_impl(
+                &key_info,
+                item,
+                return_old,
+                condition.as_ref(),
+                &maps,
+                stream.as_ref(),
+            )
+            .await
+        })
+    }
+
+    fn get_item(
+        &self,
+        key_info: &TableKeyInfo,
+        key: &Item,
+    ) -> BoxFuture<'_, Result<Option<Item>, StorageError>> {
+        let key_info = key_info.clone();
+        let key = key.clone();
+        Box::pin(async move { self.get_item_impl(&key_info, &key).await })
+    }
+
+    fn delete_item(
+        &self,
+        key_info: &TableKeyInfo,
+        key: &Item,
+        return_old: bool,
+        condition: Option<&Expr>,
+        maps: &ExpressionMaps,
+        stream: Option<&StreamCapture>,
+    ) -> BoxFuture<'_, Result<Option<Item>, StorageError>> {
+        let key_info = key_info.clone();
+        let key = key.clone();
+        let condition = condition.cloned();
+        let maps = maps.clone();
+        let stream = stream.cloned();
+        Box::pin(async move {
+            self.delete_item_impl(
+                &key_info,
+                &key,
+                return_old,
+                condition.as_ref(),
+                &maps,
+                stream.as_ref(),
+            )
+            .await
+        })
+    }
+
+    fn update_item(
+        &self,
+        key_info: &TableKeyInfo,
+        key: &Item,
+        actions: &[UpdateAction],
+        return_old: bool,
+        return_new: bool,
+        condition: Option<&Expr>,
+        maps: &ExpressionMaps,
+        stream: Option<&StreamCapture>,
+    ) -> BoxFuture<'_, Result<(Option<Item>, Option<Item>), StorageError>> {
+        let key_info = key_info.clone();
+        let key = key.clone();
+        let actions = actions.to_vec();
+        let condition = condition.cloned();
+        let maps = maps.clone();
+        let stream = stream.cloned();
+        Box::pin(async move {
+            self.update_item_impl(
+                &key_info,
+                &key,
+                &actions,
+                return_old,
+                return_new,
+                condition.as_ref(),
+                &maps,
+                stream.as_ref(),
+            )
+            .await
+        })
+    }
+
+    fn query(
+        &self,
+        key_info: &TableKeyInfo,
+        key_condition: &KeyCondition,
+        maps: &ExpressionMaps,
+        forward: bool,
+        limit: Option<i64>,
+        exclusive_start_key: Option<&Item>,
+        index_name: Option<&str>,
+    ) -> BoxFuture<'_, Result<(Vec<Item>, Option<Item>), StorageError>> {
+        let key_info = key_info.clone();
+        let key_condition = key_condition.clone();
+        let maps = maps.clone();
+        let exclusive_start_key = exclusive_start_key.cloned();
+        let index_name = index_name.map(str::to_owned);
+        Box::pin(async move {
+            self.query_impl(
+                &key_info,
+                &key_condition,
+                &maps,
+                forward,
+                limit,
+                exclusive_start_key.as_ref(),
+                index_name.as_deref(),
+            )
+            .await
+        })
+    }
+
+    fn scan(
+        &self,
+        key_info: &TableKeyInfo,
+        limit: Option<i64>,
+        exclusive_start_key: Option<&Item>,
+        segment: Option<i64>,
+        total_segments: Option<i64>,
+        index_name: Option<&str>,
+    ) -> BoxFuture<'_, Result<(Vec<Item>, Option<Item>), StorageError>> {
+        let key_info = key_info.clone();
+        let exclusive_start_key = exclusive_start_key.cloned();
+        let index_name = index_name.map(str::to_owned);
+        Box::pin(async move {
+            self.scan_impl(
+                &key_info,
+                limit,
+                exclusive_start_key.as_ref(),
+                segment,
+                total_segments,
+                index_name.as_deref(),
+            )
+            .await
+        })
+    }
+
+    fn transact_get_items(
+        &self,
+        ops: &[TransactGetOp<'_>],
+    ) -> BoxFuture<'_, Result<Vec<Option<Item>>, StorageError>> {
+        let owned: Vec<(TableKeyInfo, Item)> = ops
+            .iter()
+            .map(|op| (op.key_info.clone(), op.key.clone()))
+            .collect();
+        Box::pin(async move {
+            let borrowed: Vec<TransactGetOp> = owned
+                .iter()
+                .map(|(key_info, key)| TransactGetOp { key_info, key })
+                .collect();
+            self.transact_get_items_impl(&borrowed).await
+        })
+    }
+
+    fn transact_write_items(
+        &self,
+        ops: &[TransactWriteOp<'_>],
+        idempotency: Option<IdempotencyKey<'_>>,
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let owned: Vec<OwnedWriteOp> = ops.iter().map(OwnedWriteOp::from_op).collect();
+        let idempotency = idempotency.map(|k| {
+            (
+                k.account_id.to_owned(),
+                k.token.to_owned(),
+                k.fingerprint.to_owned(),
+            )
+        });
+        Box::pin(async move {
+            let borrowed: Vec<TransactWriteOp> = owned.iter().map(OwnedWriteOp::as_op).collect();
+            self.transact_write_items_impl(
+                &borrowed,
+                idempotency.as_ref().map(|(a, t, f)| IdempotencyKey {
+                    account_id: a,
+                    token: t,
+                    fingerprint: f,
+                }),
+            )
+            .await
+        })
+    }
+
+    fn cleanup_expired_idempotency_tokens(
+        &self,
+        max_age_seconds: i64,
+    ) -> BoxFuture<'_, Result<u64, StorageError>> {
+        Box::pin(async move {
+            self.cleanup_expired_idempotency_tokens_impl(max_age_seconds)
+                .await
+        })
+    }
+}
+
+/// Owned form of a `TransactWriteOp`, so the borrowed ops can be reconstructed
+/// inside the `'static` future.
+enum OwnedWriteOp {
+    Put {
+        key_info: TableKeyInfo,
+        item: Item,
+        condition: Option<Expr>,
+        maps: ExpressionMaps,
+        rv: ReturnValuesOnConditionCheckFailure,
+        stream: Option<StreamCapture>,
+    },
+    Delete {
+        key_info: TableKeyInfo,
+        key: Item,
+        condition: Option<Expr>,
+        maps: ExpressionMaps,
+        rv: ReturnValuesOnConditionCheckFailure,
+        stream: Option<StreamCapture>,
+    },
+    Update {
+        key_info: TableKeyInfo,
+        key: Item,
+        actions: Vec<UpdateAction>,
+        condition: Option<Expr>,
+        maps: ExpressionMaps,
+        rv: ReturnValuesOnConditionCheckFailure,
+        stream: Option<StreamCapture>,
+    },
+    ConditionCheck {
+        key_info: TableKeyInfo,
+        key: Item,
+        condition: Expr,
+        maps: ExpressionMaps,
+        rv: ReturnValuesOnConditionCheckFailure,
+    },
+}
+
+impl OwnedWriteOp {
+    fn from_op(op: &TransactWriteOp<'_>) -> Self {
+        match op {
+            TransactWriteOp::Put {
+                key_info,
+                item,
+                condition,
+                maps,
+                return_values_on_ccf,
+                stream,
+            } => Self::Put {
+                key_info: (*key_info).clone(),
+                item: (*item).clone(),
+                condition: condition.cloned(),
+                maps: (*maps).clone(),
+                rv: *return_values_on_ccf,
+                stream: stream.clone(),
+            },
+            TransactWriteOp::Delete {
+                key_info,
+                key,
+                condition,
+                maps,
+                return_values_on_ccf,
+                stream,
+            } => Self::Delete {
+                key_info: (*key_info).clone(),
+                key: (*key).clone(),
+                condition: condition.cloned(),
+                maps: (*maps).clone(),
+                rv: *return_values_on_ccf,
+                stream: stream.clone(),
+            },
+            TransactWriteOp::Update {
+                key_info,
+                key,
+                actions,
+                condition,
+                maps,
+                return_values_on_ccf,
+                stream,
+            } => Self::Update {
+                key_info: (*key_info).clone(),
+                key: (*key).clone(),
+                actions: actions.to_vec(),
+                condition: condition.cloned(),
+                maps: (*maps).clone(),
+                rv: *return_values_on_ccf,
+                stream: stream.clone(),
+            },
+            TransactWriteOp::ConditionCheck {
+                key_info,
+                key,
+                condition,
+                maps,
+                return_values_on_ccf,
+            } => Self::ConditionCheck {
+                key_info: (*key_info).clone(),
+                key: (*key).clone(),
+                condition: (*condition).clone(),
+                maps: (*maps).clone(),
+                rv: *return_values_on_ccf,
+            },
+        }
+    }
+
+    fn as_op(&self) -> TransactWriteOp<'_> {
+        match self {
+            Self::Put {
+                key_info,
+                item,
+                condition,
+                maps,
+                rv,
+                stream,
+            } => TransactWriteOp::Put {
+                key_info,
+                item,
+                condition: condition.as_ref(),
+                maps,
+                return_values_on_ccf: *rv,
+                stream: stream.clone(),
+            },
+            Self::Delete {
+                key_info,
+                key,
+                condition,
+                maps,
+                rv,
+                stream,
+            } => TransactWriteOp::Delete {
+                key_info,
+                key,
+                condition: condition.as_ref(),
+                maps,
+                return_values_on_ccf: *rv,
+                stream: stream.clone(),
+            },
+            Self::Update {
+                key_info,
+                key,
+                actions,
+                condition,
+                maps,
+                rv,
+                stream,
+            } => TransactWriteOp::Update {
+                key_info,
+                key,
+                actions,
+                condition: condition.as_ref(),
+                maps,
+                return_values_on_ccf: *rv,
+                stream: stream.clone(),
+            },
+            Self::ConditionCheck {
+                key_info,
+                key,
+                condition,
+                maps,
+                rv,
+            } => TransactWriteOp::ConditionCheck {
+                key_info,
+                key,
+                condition,
+                maps,
+                return_values_on_ccf: *rv,
+            },
+        }
+    }
+}

--- a/crates/storage-duckdb/src/data/ddl.rs
+++ b/crates/storage-duckdb/src/data/ddl.rs
@@ -1,0 +1,744 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! DDL for per-DynamoDB-table and per-index data tables, plus catalog fetches
+//! of `TableKeyInfo` / `IndexInfo`.
+//!
+//! Sort-key columns follow design decision D2: `sk_s`/`base_sk_s` are `TEXT`,
+//! `sk_n`/`base_sk_n` are `TEXT` (order-preserving numeric encoding, never
+//! `DOUBLE`), `sk_b`/`base_sk_b` are `BLOB`.
+
+use crate::db;
+use extenddb_core::types::{
+    AttributeDefinition, IndexInfo, IndexType, KeySchemaElement, Projection, StreamSpecification,
+    TableKeyInfo,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::sk_column_n;
+
+use super::{
+    all_sort_key_info, data_table_name, index_table_name, vector_table_glob_pattern,
+    vector_table_name,
+};
+use crate::store::DuckDbEngine;
+
+/// DuckDB column type for the Nth sort-key position and scalar type (D2).
+fn sk_col_defs(index: usize) -> [String; 3] {
+    if index == 0 {
+        [
+            "sk_s TEXT".to_owned(),
+            "sk_n TEXT".to_owned(),
+            "sk_b BLOB".to_owned(),
+        ]
+    } else {
+        let n = index + 1;
+        [
+            format!("sk{n}_s TEXT"),
+            format!("sk{n}_n TEXT"),
+            format!("sk{n}_b BLOB"),
+        ]
+    }
+}
+
+/// DuckDB column type for the Nth base-table sort-key position (D2).
+fn base_sk_col_defs(index: usize) -> [String; 3] {
+    if index == 0 {
+        [
+            "base_sk_s TEXT".to_owned(),
+            "base_sk_n TEXT".to_owned(),
+            "base_sk_b BLOB".to_owned(),
+        ]
+    } else {
+        let n = index + 1;
+        [
+            format!("base_sk{n}_s TEXT"),
+            format!("base_sk{n}_n TEXT"),
+            format!("base_sk{n}_b BLOB"),
+        ]
+    }
+}
+
+impl DuckDbEngine {
+    /// Create the per-DynamoDB-table data table.
+    ///
+    /// # Safety (SQL injection)
+    /// `table_id` is a server-generated UUID; column names are constants. No
+    /// user input is interpolated into the DDL.
+    pub(crate) async fn create_data_table(
+        tx: &mut db::Transaction,
+        table_id: &str,
+        key_schema: &[KeySchemaElement],
+        attr_defs: &[AttributeDefinition],
+    ) -> Result<(), StorageError> {
+        let ddb_table = data_table_name(table_id);
+        let sk_infos = all_sort_key_info(key_schema, attr_defs);
+
+        let ddl = if sk_infos.is_empty() {
+            format!(
+                "CREATE TABLE {ddb_table} (pk TEXT NOT NULL PRIMARY KEY, item_data TEXT NOT NULL)"
+            )
+        } else {
+            let mut col_defs = vec!["pk TEXT NOT NULL".to_owned()];
+            let mut pk_cols = vec!["pk".to_owned()];
+            for (i, &(_, sk_type)) in sk_infos.iter().enumerate() {
+                col_defs.extend(sk_col_defs(i));
+                pk_cols.push(sk_column_n(i, sk_type));
+            }
+            col_defs.push("item_data TEXT NOT NULL".to_owned());
+            format!(
+                "CREATE TABLE {ddb_table} (\n    {},\n    PRIMARY KEY ({})\n)",
+                col_defs.join(",\n    "),
+                pk_cols.join(", ")
+            )
+        };
+
+        db::query(&ddl)
+            .execute(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Create a vector-index data table: one row per indexed vector.
+    ///
+    /// `part` is the search-schema HASH value when one is declared, and a single
+    /// constant otherwise, so an unscoped index is one partition rather than a
+    /// separate code path. `nrm` is the vector's precomputed L2 norm, so cosine
+    /// costs one dot product at query time instead of two passes.
+    ///
+    /// # Safety (SQL injection)
+    /// `index_id` is a server-generated UUID and column names are constants, so
+    /// no user input reaches the DDL. Vector attribute names are stored as data,
+    /// never as identifiers.
+    pub(crate) async fn create_vector_data_table(
+        tx: &mut db::Transaction,
+        table_id: &str,
+        index_id: &str,
+        base_key_schema: &[KeySchemaElement],
+        base_attr_defs: &[AttributeDefinition],
+    ) -> Result<(), StorageError> {
+        let vec_table = vector_table_name(table_id, index_id);
+        let base_sks = all_sort_key_info(base_key_schema, base_attr_defs);
+
+        let mut col_defs = vec![
+            "part TEXT NOT NULL".to_owned(),
+            "base_pk TEXT NOT NULL".to_owned(),
+        ];
+        for i in 0..base_sks.len() {
+            col_defs.extend(base_sk_col_defs(i));
+        }
+        col_defs.push("vec BLOB NOT NULL".to_owned());
+        col_defs.push("nrm DOUBLE NOT NULL".to_owned());
+        col_defs.push("item_data TEXT NOT NULL".to_owned());
+
+        // Keyed by the base item, not by the partition, so one base item yields
+        // at most one vector row and a re-put replaces rather than duplicates.
+        let mut pk_cols = vec!["base_pk".to_owned()];
+        for (i, &(_, sk_type)) in base_sks.iter().enumerate() {
+            pk_cols.push(format!("base_{}", sk_column_n(i, sk_type)));
+        }
+
+        let ddl = format!(
+            "CREATE TABLE {vec_table} (\n    {},\n    PRIMARY KEY ({})\n)",
+            col_defs.join(",\n    "),
+            pk_cols.join(", ")
+        );
+        db::query(&ddl)
+            .execute(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        // The scan is always partition-scoped, so this index is what keeps a
+        // search off the full table when a HASH element is declared.
+        let part_idx =
+            format!("CREATE INDEX \"_vidx_part_{table_id}_{index_id}\" ON {vec_table} (part)");
+        db::query(&part_idx)
+            .execute(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Drop every vector-index data table belonging to one DynamoDB table.
+    ///
+    /// Discovered from `duckdb_tables()` rather than from the catalog, because the
+    /// caller runs this after the catalog rows have been cascade-deleted in the
+    /// same transaction, so `vector_indexes` is already empty for this table.
+    /// Without this, dropping a table would leave its vector data tables behind
+    /// forever with nothing left pointing at them.
+    /// Drop one vector index's data table.
+    ///
+    /// The table-drop path sweeps `duckdb_tables()` instead, because by the time it
+    /// runs the catalog rows have already cascade-deleted and the index ids are
+    /// unreadable. Here the id is known, so the name is derived directly rather
+    /// than matched by pattern.
+    pub(crate) async fn drop_vector_data_table_by_id(
+        pool: &db::Pool,
+        table_id: &str,
+        index_id: &str,
+    ) -> Result<(), StorageError> {
+        let vec_table = vector_table_name(table_id, index_id);
+        db::query(&format!("DROP TABLE IF EXISTS {vec_table}"))
+            .execute(pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn drop_all_vector_data_tables(
+        tx: &mut db::Transaction,
+        table_id: &str,
+    ) -> Result<(), StorageError> {
+        let names: Vec<String> =
+            db::query_scalar("SELECT table_name FROM duckdb_tables() WHERE table_name GLOB ?")
+                .bind(vector_table_glob_pattern(table_id))
+                .fetch_all(&mut **tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+        for name in names {
+            // Names come from duckdb_tables(), not from user input, and are quoted.
+            db::query(&format!("DROP TABLE IF EXISTS \"{name}\""))
+                .execute(&mut **tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    /// Drop the per-DynamoDB-table data table.
+    pub(crate) async fn drop_data_table(
+        tx: &mut db::Transaction,
+        table_id: &str,
+    ) -> Result<(), StorageError> {
+        let ddb_table = data_table_name(table_id);
+        db::query(&format!("DROP TABLE IF EXISTS {ddb_table}"))
+            .execute(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        // Vector data tables are keyed by index, not by table, so they are not
+        // reached by dropping the item table or by the catalog cascade.
+        Self::drop_all_vector_data_tables(tx, table_id).await?;
+        Ok(())
+    }
+
+    /// Create a GSI/LSI data table. GSI keys are not unique, so the primary key
+    /// is `(pk, base_pk, base_sk*)`: the base-table key is what makes a row
+    /// unique, keeping one row per base item per index partition.
+    ///
+    /// Two secondary indexes are created:
+    /// - `idx_order_*` on `(pk, sk*, base_pk, base_sk*)`, for sort-key ordering
+    ///   within an index partition. Only when the index declares a sort key.
+    /// - `idx_base_key_*` on `(base_pk, base_sk*)`, for the reverse lookup that
+    ///   index propagation uses to delete an item's old index row. Always.
+    pub(crate) async fn create_index_data_table(
+        tx: &mut db::Transaction,
+        index_id: &str,
+        index_key_schema: &[KeySchemaElement],
+        attr_defs: &[AttributeDefinition],
+        base_key_schema: &[KeySchemaElement],
+        base_attr_defs: &[AttributeDefinition],
+    ) -> Result<(), StorageError> {
+        let idx_table = index_table_name(index_id);
+        let idx_sks = all_sort_key_info(index_key_schema, attr_defs);
+        let base_sks = all_sort_key_info(base_key_schema, base_attr_defs);
+
+        let mut col_defs = vec!["pk TEXT NOT NULL".to_owned()];
+        for i in 0..idx_sks.len() {
+            col_defs.extend(sk_col_defs(i));
+        }
+        col_defs.push("base_pk TEXT NOT NULL".to_owned());
+        for i in 0..base_sks.len() {
+            col_defs.extend(base_sk_col_defs(i));
+        }
+        col_defs.push("item_data TEXT NOT NULL".to_owned());
+
+        let mut pk_cols = vec!["pk".to_owned(), "base_pk".to_owned()];
+        for (i, &(_, sk_type)) in base_sks.iter().enumerate() {
+            pk_cols.push(format!("base_{}", sk_column_n(i, sk_type)));
+        }
+
+        let ddl = format!(
+            "CREATE TABLE {idx_table} (\n    {},\n    PRIMARY KEY ({})\n)",
+            col_defs.join(",\n    "),
+            pk_cols.join(", ")
+        );
+        db::query(&ddl)
+            .execute(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        if !idx_sks.is_empty() {
+            let mut order_cols = vec!["pk".to_owned()];
+            for (i, &(_, sk_type)) in idx_sks.iter().enumerate() {
+                order_cols.push(sk_column_n(i, sk_type));
+            }
+            order_cols.push("base_pk".to_owned());
+            for (i, &(_, sk_type)) in base_sks.iter().enumerate() {
+                order_cols.push(format!("base_{}", sk_column_n(i, sk_type)));
+            }
+            let order_idx = format!(
+                "CREATE INDEX \"idx_order_{index_id}\" ON {idx_table} ({})",
+                order_cols.join(", ")
+            );
+            db::query(&order_idx)
+                .execute(&mut **tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+        }
+
+        // Index on the base-table key columns, for `delete_index_row_multi`.
+        //
+        // GSI/LSI propagation deletes the old index row by base-table key:
+        // `DELETE FROM <idx> WHERE base_pk = ? AND base_sk* = ?`, with no `pk`
+        // predicate. Both the PRIMARY KEY and the ordering index above lead
+        // with `pk`, so neither can serve that filter and DuckDB plans a full
+        // `SCAN` of the index table on every propagating write. Unconditional
+        // rather than gated on `idx_sks`, because the reverse lookup happens
+        // whether or not the index declares a sort key.
+        {
+            let mut base_key_cols = vec!["base_pk".to_owned()];
+            for (i, &(_, sk_type)) in base_sks.iter().enumerate() {
+                base_key_cols.push(format!("base_{}", sk_column_n(i, sk_type)));
+            }
+            let base_key_idx = format!(
+                "CREATE INDEX \"idx_base_key_{index_id}\" ON {idx_table} ({})",
+                base_key_cols.join(", ")
+            );
+            db::query(&base_key_idx)
+                .execute(&mut **tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+        }
+
+        Ok(())
+    }
+
+    /// Drop a GSI/LSI data table.
+    pub(crate) async fn drop_index_data_table(
+        tx: &mut db::Transaction,
+        index_id: &str,
+    ) -> Result<(), StorageError> {
+        let idx_table = index_table_name(index_id);
+        db::query(&format!("DROP TABLE IF EXISTS {idx_table}"))
+            .execute(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Fetch `TableKeyInfo` for an ACTIVE table from the catalog.
+    pub(crate) async fn fetch_table_key_info(
+        &self,
+        account_id: &str,
+        table_name: &str,
+    ) -> Result<TableKeyInfo, StorageError> {
+        let row: Option<(String, String, String, String, Option<String>)> = db::query_as(
+            "SELECT key_schema, attribute_definitions, table_status, table_id, \
+             stream_specification \
+             FROM tables WHERE account_id = ? AND table_name = ?",
+        )
+        .bind(account_id)
+        .bind(table_name)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let (ks_str, ad_str, status, table_id, stream_spec_str) =
+            row.ok_or_else(|| StorageError::TableNotFound(table_name.to_owned()))?;
+
+        match status.as_str() {
+            "ACTIVE" => {}
+            // A table still being created, or being deleted, is not usable for
+            // data-plane operations; DynamoDB reports it as not found (not
+            // in-use). UPDATING keeps the not-active classification.
+            "CREATING" | "DELETING" => {
+                return Err(StorageError::TableNotFound(table_name.to_owned()));
+            }
+            _ => return Err(StorageError::TableNotActive(table_name.to_owned())),
+        }
+
+        let key_schema: Vec<KeySchemaElement> =
+            serde_json::from_str(&ks_str).map_err(|e| StorageError::Internal(e.to_string()))?;
+        let attribute_definitions: Vec<AttributeDefinition> =
+            serde_json::from_str(&ad_str).map_err(|e| StorageError::Internal(e.to_string()))?;
+        let stream_specification: Option<StreamSpecification> = stream_spec_str
+            .as_deref()
+            .map(serde_json::from_str)
+            .transpose()
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        // Full secondary-index metadata rides on the (cached) TableKeyInfo so
+        // per-index consumed-capacity accounting avoids a separate
+        // describe_table round-trip on every write; it also supplies `has_lsi`.
+        let (global_secondary_indexes, local_secondary_indexes) =
+            self.fetch_all_index_info(&table_id).await?;
+        let has_lsi = !local_secondary_indexes.is_empty();
+        // Vector indexes ride on the cached key info too, so the write path can
+        // decide whether any maintenance is needed without a query, and so the
+        // engine can validate vector attributes on writes.
+        let vector_indexes = self.fetch_vector_index_key_info(&table_id).await?;
+
+        let key_info = TableKeyInfo {
+            table_name: table_name.to_owned(),
+            account_id: account_id.to_owned(),
+            table_id,
+            base_key_schema: key_schema.clone(),
+            key_schema,
+            attribute_definitions,
+            has_lsi,
+            global_secondary_indexes,
+            local_secondary_indexes,
+            stream_specification,
+            // Every field is populated, with no `..Default::default()` spread: a
+            // new core field should break this site and force a decision about
+            // whether the write path needs it, rather than silently defaulting.
+            vector_indexes,
+        };
+        // Catalog metadata that cannot describe its own sort key would make the
+        // keyed read paths fall back to a partition-only lookup and return the
+        // wrong item, so refuse it here rather than serve a wrong answer (#259).
+        key_info
+            .validate_sort_key_definitions()
+            .map_err(StorageError::Internal)?;
+        Ok(key_info)
+    }
+
+    /// Fetch the vector indexes of a table in the shape the engine caches.
+    ///
+    /// Note what this cannot carry: `VectorIndexKeyInfo` has no distance
+    /// function, so a search still reads the catalog for it. Widening that
+    /// type would remove the last per-search catalog read.
+    async fn fetch_vector_index_key_info(
+        &self,
+        table_id: &str,
+    ) -> Result<Vec<extenddb_core::types::VectorIndexKeyInfo>, StorageError> {
+        let rows: Vec<(String, i64, String, Option<String>, String)> = db::query_as(
+            "SELECT index_name, dimensions, vector_attribute, search_schema, projection \
+             FROM vector_indexes WHERE table_id = ?",
+        )
+        .bind(table_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for (index_name, dimensions, vector_attribute, search_schema, projection) in rows {
+            let attr: extenddb_core::types::VectorAttribute =
+                serde_json::from_str(&vector_attribute)
+                    .map_err(|e| StorageError::Internal(format!("vector_attribute: {e}")))?;
+            let search_schema = match search_schema.as_deref() {
+                Some(json) => serde_json::from_str(json)
+                    .map_err(|e| StorageError::Internal(format!("search_schema: {e}")))?,
+                None => Vec::new(),
+            };
+            let projection: extenddb_core::types::Projection = serde_json::from_str(&projection)
+                .map_err(|e| StorageError::Internal(format!("vector projection: {e}")))?;
+            out.push(extenddb_core::types::VectorIndexKeyInfo {
+                index_name,
+                dimensions: u32::try_from(dimensions).map_err(|_| {
+                    StorageError::Internal(format!("vector dimensions out of range: {dimensions}"))
+                })?,
+                vector_attribute_name: attr.attribute_name,
+                search_schema,
+                projection,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Fetch every secondary index defined on a table, split into
+    /// `(global_secondary_indexes, local_secondary_indexes)`.
+    async fn fetch_all_index_info(
+        &self,
+        table_id: &str,
+    ) -> Result<(Vec<IndexInfo>, Vec<IndexInfo>), StorageError> {
+        let rows: Vec<(String, String, String, String, String)> = db::query_as(
+            "SELECT index_name, index_type, index_id, key_schema, projection \
+             FROM indexes WHERE table_id = ?",
+        )
+        .bind(table_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let mut infos = Vec::new();
+        for (index_name, idx_type_str, index_id, ks_json, proj_json) in rows {
+            let index_type = match idx_type_str.as_str() {
+                "GSI" => IndexType::Gsi,
+                "LSI" => IndexType::Lsi,
+                other => {
+                    return Err(StorageError::Internal(format!(
+                        "unknown index type in database: {other}"
+                    )));
+                }
+            };
+            let key_schema: Vec<KeySchemaElement> = serde_json::from_str(&ks_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let projection: Projection = serde_json::from_str(&proj_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let info = IndexInfo {
+                index_name,
+                index_id,
+                index_type,
+                key_schema,
+                projection,
+            };
+            infos.push(info);
+        }
+        // Grouped by core rather than matched here, so a new IndexType variant
+        // does not break this backend. The string parse above already rejects
+        // any kind this backend cannot have created.
+        let grouped = extenddb_core::types::partition_indexes(infos);
+        Ok((grouped.gsis, grouped.lsis))
+    }
+
+    /// Fetch `IndexInfo` for a secondary index, validating the table is ACTIVE.
+    pub(crate) async fn fetch_index_info(
+        &self,
+        account_id: &str,
+        table_name: &str,
+        index_name: &str,
+    ) -> Result<IndexInfo, StorageError> {
+        let row: Option<(String, String)> = db::query_as(
+            "SELECT table_id, table_status FROM tables WHERE account_id = ? AND table_name = ?",
+        )
+        .bind(account_id)
+        .bind(table_name)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let (table_id, status) =
+            row.ok_or_else(|| StorageError::TableNotFound(table_name.to_owned()))?;
+        match status.as_str() {
+            "ACTIVE" => {}
+            // A table still being created, or being deleted, is not usable for
+            // data-plane operations; DynamoDB reports it as not found (not
+            // in-use). UPDATING keeps the not-active classification.
+            "CREATING" | "DELETING" => {
+                return Err(StorageError::TableNotFound(table_name.to_owned()));
+            }
+            _ => return Err(StorageError::TableNotActive(table_name.to_owned())),
+        }
+        self.fetch_index_info_by_table_id(&table_id, index_name)
+            .await
+    }
+
+    /// Fetch `IndexInfo` using a known `table_id`.
+    pub(crate) async fn fetch_index_info_by_table_id(
+        &self,
+        table_id: &str,
+        index_name: &str,
+    ) -> Result<IndexInfo, StorageError> {
+        let row: Option<(String, String, String, String)> = db::query_as(
+            "SELECT index_type, index_id, key_schema, projection \
+             FROM indexes WHERE table_id = ? AND index_name = ?",
+        )
+        .bind(table_id)
+        .bind(index_name)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let (idx_type_str, index_id, ks_str, proj_str) =
+            row.ok_or_else(|| StorageError::IndexNotFound(index_name.to_owned()))?;
+
+        let index_type = match idx_type_str.as_str() {
+            "GSI" => IndexType::Gsi,
+            "LSI" => IndexType::Lsi,
+            other => {
+                return Err(StorageError::Internal(format!(
+                    "unknown index type in database: {other}"
+                )));
+            }
+        };
+        let key_schema: Vec<KeySchemaElement> =
+            serde_json::from_str(&ks_str).map_err(|e| StorageError::Internal(e.to_string()))?;
+        let projection: Projection =
+            serde_json::from_str(&proj_str).map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        Ok(IndexInfo {
+            index_name: index_name.to_owned(),
+            index_id,
+            index_type,
+            key_schema,
+            projection,
+        })
+    }
+}
+
+#[cfg(test)]
+mod index_data_table_tests {
+    use crate::db;
+    use crate::store::DuckDbEngine;
+    use extenddb_core::types::{
+        AttributeDefinition, KeySchemaElement, KeyType, ScalarAttributeType,
+    };
+
+    fn hash(name: &str) -> KeySchemaElement {
+        KeySchemaElement {
+            attribute_name: name.to_owned(),
+            key_type: KeyType::Hash,
+        }
+    }
+
+    fn range(name: &str) -> KeySchemaElement {
+        KeySchemaElement {
+            attribute_name: name.to_owned(),
+            key_type: KeyType::Range,
+        }
+    }
+
+    fn attr(name: &str, t: ScalarAttributeType) -> AttributeDefinition {
+        AttributeDefinition {
+            attribute_name: name.to_owned(),
+            attribute_type: t,
+        }
+    }
+
+    /// Create an index data table through the real DDL path.
+    async fn make_index_table(
+        index_key_schema: &[KeySchemaElement],
+        attr_defs: &[AttributeDefinition],
+        base_key_schema: &[KeySchemaElement],
+        base_attr_defs: &[AttributeDefinition],
+    ) -> db::Pool {
+        let pool = db::Pool::open(":memory:", 1).await.unwrap();
+        let mut tx = pool.begin().await.unwrap();
+        DuckDbEngine::create_index_data_table(
+            &mut tx,
+            "probe",
+            index_key_schema,
+            attr_defs,
+            base_key_schema,
+            base_attr_defs,
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+        pool
+    }
+
+    /// Column list of a named index, in definition order, read from DuckDB's
+    /// catalog. The SQLite backend asserts on `EXPLAIN QUERY PLAN` here; DuckDB's
+    /// optimizer chooses a sequential scan below a row-count threshold whatever
+    /// indexes exist, so on a probe table the plan says nothing about the index.
+    /// The index definition does.
+    async fn index_columns(pool: &db::Pool, index_name: &str) -> Vec<String> {
+        let row: Option<(String,)> = db::query_as(
+            "SELECT CAST(expressions AS VARCHAR) FROM duckdb_indexes() WHERE index_name = ?",
+        )
+        .bind(index_name)
+        .fetch_optional(pool)
+        .await
+        .unwrap();
+        let Some((expr,)) = row else {
+            return Vec::new();
+        };
+        expr.trim_matches(|c| c == '[' || c == ']')
+            .split(',')
+            .map(|c| c.trim().trim_matches('"').to_owned())
+            .filter(|c| !c.is_empty())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn reverse_lookup_delete_has_an_index_composite_base_key() {
+        let pool = make_index_table(
+            &[hash("gsi_pk"), range("gsi_sk")],
+            &[
+                attr("gsi_pk", ScalarAttributeType::S),
+                attr("gsi_sk", ScalarAttributeType::S),
+            ],
+            &[hash("id"), range("ts")],
+            &[
+                attr("id", ScalarAttributeType::S),
+                attr("ts", ScalarAttributeType::S),
+            ],
+        )
+        .await;
+
+        assert_eq!(
+            index_columns(&pool, "idx_base_key_probe").await,
+            vec!["base_pk".to_owned(), "base_sk_s".to_owned()],
+            "reverse-lookup DELETE must be served by the base-key index"
+        );
+    }
+
+    #[tokio::test]
+    async fn reverse_lookup_delete_has_an_index_hash_only_base_key() {
+        let pool = make_index_table(
+            &[hash("gsi_pk"), range("gsi_sk")],
+            &[
+                attr("gsi_pk", ScalarAttributeType::S),
+                attr("gsi_sk", ScalarAttributeType::S),
+            ],
+            &[hash("id")],
+            &[attr("id", ScalarAttributeType::S)],
+        )
+        .await;
+
+        assert_eq!(
+            index_columns(&pool, "idx_base_key_probe").await,
+            vec!["base_pk".to_owned()],
+            "hash-only base key must still index the reverse lookup"
+        );
+    }
+
+    /// The ordering index is only created when the index declares a sort key, so
+    /// a sort-key-less index is the case where the base-key index is the *only*
+    /// secondary index. It must still be created, which is why that block is
+    /// unconditional.
+    #[tokio::test]
+    async fn reverse_lookup_delete_has_an_index_when_index_has_no_sort_key() {
+        let pool = make_index_table(
+            &[hash("gsi_pk")],
+            &[attr("gsi_pk", ScalarAttributeType::S)],
+            &[hash("id"), range("ts")],
+            &[
+                attr("id", ScalarAttributeType::S),
+                attr("ts", ScalarAttributeType::S),
+            ],
+        )
+        .await;
+
+        assert_eq!(
+            index_columns(&pool, "idx_base_key_probe").await,
+            vec!["base_pk".to_owned(), "base_sk_s".to_owned()],
+            "an index with no sort key still needs the base-key index"
+        );
+        assert!(
+            index_columns(&pool, "idx_order_probe").await.is_empty(),
+            "no ordering index without a sort key"
+        );
+    }
+
+    /// Guards the column order. An index on `(base_sk_s, base_pk)` would also
+    /// satisfy a composite lookup, but would not serve a `base_pk`-only lookup,
+    /// so pin that the index leads with `base_pk`.
+    #[tokio::test]
+    async fn base_key_index_leads_with_base_pk() {
+        let pool = make_index_table(
+            &[hash("gsi_pk"), range("gsi_sk")],
+            &[
+                attr("gsi_pk", ScalarAttributeType::S),
+                attr("gsi_sk", ScalarAttributeType::S),
+            ],
+            &[hash("id"), range("ts")],
+            &[
+                attr("id", ScalarAttributeType::S),
+                attr("ts", ScalarAttributeType::S),
+            ],
+        )
+        .await;
+
+        assert_eq!(
+            index_columns(&pool, "idx_base_key_probe")
+                .await
+                .first()
+                .map(String::as_str),
+            Some("base_pk"),
+            "base-key index must lead with base_pk"
+        );
+    }
+}

--- a/crates/storage-duckdb/src/data/delete_item.rs
+++ b/crates/storage-duckdb/src/data/delete_item.rs
@@ -1,0 +1,120 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `delete_item` for the DuckDB backend.
+
+use extenddb_core::expression::{Expr, ExpressionMaps};
+use extenddb_core::types::{Item, TableKeyInfo};
+use extenddb_storage::StreamCapture;
+use extenddb_storage::error::StorageError;
+
+use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
+use super::query::check_condition;
+use super::tx_helpers::{delete_item_in_tx, fetch_item_in_tx, write_stream_record_in_tx};
+use crate::store::DuckDbEngine;
+
+impl DuckDbEngine {
+    pub(crate) async fn delete_item_impl(
+        &self,
+        key_info: &TableKeyInfo,
+        key: &Item,
+        return_old: bool,
+        condition: Option<&Expr>,
+        maps: &ExpressionMaps,
+        stream: Option<&StreamCapture>,
+    ) -> Result<Option<Item>, StorageError> {
+        // Read the propagation delay BEFORE taking the write lock. It is a
+        // runtime setting, not an invariant of this write, so it does not need
+        // to be read under the lock, and the lock serialises every write in the
+        // process: work done inside it is the backend's throughput bottleneck.
+        let system_delay = self.index_propagation_delay().await;
+        let _writer = self.write_lock.lock().await;
+        // Read the index set after acquiring the write lock so a concurrently
+        // added GSI (UpdateTable holds the same lock) is not missed.
+        let indexes = fetch_indexes_for_table(&key_info.table_id, &self.pool).await?;
+
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let old = fetch_item_in_tx(&mut tx, key_info, key).await?;
+
+        if condition.is_some() {
+            let empty = Item::new();
+            let target = old.as_ref().unwrap_or(&empty);
+            if let Err(e) = check_condition(condition, target, maps) {
+                return match e {
+                    StorageError::ConditionFailed(_) => Err(StorageError::ConditionFailed(old)),
+                    other => Err(other),
+                };
+            }
+        }
+
+        // Only mutate when an item actually exists; deleting a missing item is
+        // a no-op (no row removed, no index change, no stream record).
+        let mut enqueued = false;
+        if old.is_some() {
+            delete_item_in_tx(&mut tx, key_info, key).await?;
+
+            if !indexes.is_empty() {
+                sync_indexes(
+                    &mut tx,
+                    &key_info.key_schema,
+                    &key_info.attribute_definitions,
+                    &indexes,
+                    old.as_ref(),
+                    None,
+                    system_delay,
+                )
+                .await?;
+            }
+            // Vector rows for this base item are removed too. `new_item` is None,
+            // so this is a pure removal, applied in this transaction when the
+            // propagation delay is 0 and enqueued otherwise.
+            if !key_info.vector_indexes.is_empty()
+                && crate::data::vector_index::maintain_vector_indexes(
+                    &mut tx,
+                    &key_info.table_id,
+                    &key_info.key_schema,
+                    &key_info.attribute_definitions,
+                    old.as_ref(),
+                    None,
+                    system_delay,
+                )
+                .await?
+                    > 0
+            {
+                enqueued = true;
+            }
+            if enqueue_async_indexes(
+                &mut tx,
+                key_info,
+                &indexes,
+                old.as_ref(),
+                None,
+                system_delay,
+            )
+            .await?
+                > 0
+            {
+                enqueued = true;
+            }
+
+            if let Some(capture) = stream {
+                write_stream_record_in_tx(&mut tx, key_info, capture, old.as_ref(), None).await?;
+            }
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        if enqueued {
+            self.gsi_notify.notify_waiters();
+        }
+
+        Ok(if return_old { old } else { None })
+    }
+}

--- a/crates/storage-duckdb/src/data/index.rs
+++ b/crates/storage-duckdb/src/data/index.rs
@@ -1,0 +1,813 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! GSI/LSI index maintenance for the DuckDB backend.
+//!
+//! Synchronous indexes (LSIs and zero-delay GSIs) are reconciled in the base
+//! write transaction. Async GSIs are deferred via the `gsi_pending` queue —
+//! **one self-describing row per index**: each row snapshots the base key
+//! schema, attribute definitions, and its single target index definition, so
+//! the worker applies with zero catalog reads. Each row carries its index's own
+//! (jittered) propagation delay, and `ready_at` is kept monotonic within the
+//! base key's `worker_partition` so jitter cannot reorder updates to one item.
+//! Index key columns follow D2 — `N` keys are stored as the order-preserving
+//! TEXT encoding, `S` as TEXT, `B` as BLOB — via [`sk_bound`].
+
+use crate::db;
+use extenddb_core::types::{
+    AttributeDefinition, Item, KeySchemaElement, Projection, ProjectionType, ScalarAttributeType,
+    TableKeyInfo,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::{composite_pk_to_text, parse_sk, sk_column, sk_column_n};
+use serde::{Deserialize, Serialize};
+
+use super::{BoundValue, all_sort_key_info, index_table_name, sk_bound};
+
+/// Number of partitions a base key can hash to. Updates to one base item share
+/// a partition; `ready_at` is clamped monotonic within a partition so the
+/// single drain worker (which orders by `id`) applies them in order. More
+/// partitions reduce false serialization between unrelated keys; there is no
+/// concurrency cost because DuckDB has a single writer.
+const NUM_PARTITIONS: u64 = 16;
+
+/// Stable partition for a base-table key (FNV-1a, mapped to a partition). A
+/// local hash keeps the mapping fixed for a key across builds (`std`'s hasher
+/// is not guaranteed stable).
+fn partition_for(base_pk_text: &str) -> i64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325; // FNV-1a offset basis
+    for byte in base_pk_text.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3); // FNV prime
+    }
+    (hash % NUM_PARTITIONS) as i64
+}
+
+/// Jittered propagation delay (ms), uniform in `[delay_ms / 2, delay_ms]`.
+///
+/// Simulates DynamoDB's eventual-consistency variability (a fixed delay is
+/// perfectly predictable) while keeping the configured delay a meaningful lower
+/// bound — jittering all the way to ~0 would make the delay almost meaningless.
+/// `delay_ms <= 1` is returned unchanged. Callers only enqueue async indexes,
+/// so `delay_ms >= 1`.
+fn jitter_delay_ms(delay_ms: u64) -> u64 {
+    if delay_ms <= 1 {
+        delay_ms
+    } else {
+        use rand::Rng;
+        rand::rng().random_range(delay_ms / 2 + 1..=delay_ms)
+    }
+}
+
+/// A single target index definition, snapshotted at enqueue time. The
+/// propagation delay is not stored — it is already encoded in the row's
+/// `ready_at`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct GsiIndexDef {
+    pub(crate) index_id: String,
+    pub(crate) key_schema: Vec<KeySchemaElement>,
+    pub(crate) projection: Projection,
+}
+
+/// Self-describing apply context serialized into `gsi_pending.index_context`.
+/// One per row → exactly one target index, so the worker needs no catalog read.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct GsiApplyContext {
+    pub(crate) base_key_schema: Vec<KeySchemaElement>,
+    pub(crate) attribute_definitions: Vec<AttributeDefinition>,
+    pub(crate) index: GsiIndexDef,
+}
+
+/// What one `gsi_pending` row asks the worker to do: maintain a GSI, or maintain a
+/// vector index. One queue serves both so that updates to a single base item stay
+/// ordered across index kinds, which two queues drained independently could not
+/// guarantee.
+///
+/// `untagged` is load-bearing, not stylistic. A GSI context serializes to exactly
+/// the bytes it did before this enum existed, so rows already on disk from an
+/// earlier version still deserialize, and rows written now are still readable by
+/// one. That matters more than it looks: an unparseable `index_context` is treated
+/// as a poison row and *dropped*, so a tagged representation would silently discard
+/// every in-flight GSI update across an upgrade.
+///
+/// The variants are unambiguous by shape rather than by tag: a GSI context requires
+/// `index` and a vector context requires `vector`, and no writer emits the other's
+/// field, so for any context this code produces exactly one variant matches.
+/// `pending_context_tests` pins both directions, including a verbatim legacy payload.
+///
+/// To be exact rather than reassuring: a hand-corrupted payload carrying BOTH fields
+/// would match `Gsi`, because untagged tries variants in declaration order and
+/// ignores unknown fields. That is unreachable from any serializer here, and a
+/// genuinely malformed context is already dropped as a poison row, so it is a
+/// property of the representation worth knowing rather than a case to defend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum PendingApplyContext {
+    Gsi(GsiApplyContext),
+    Vector(super::vector_index::VectorApplyContext),
+}
+
+impl PendingApplyContext {
+    /// The base table's key schema, which both kinds carry and the queue needs in
+    /// order to place the row in its base key's partition.
+    fn base_key_schema(&self) -> &[KeySchemaElement] {
+        match self {
+            Self::Gsi(c) => &c.base_key_schema,
+            Self::Vector(c) => &c.base_key_schema,
+        }
+    }
+}
+
+/// Apply one claimed row to whichever index kind it describes.
+///
+/// Both arms tolerate a data table that no longer exists, so a base table or index
+/// dropped while a row was in flight is applied-as-skip rather than logged and
+/// dropped as unprocessable.
+pub(crate) async fn apply_pending_context(
+    tx: &mut db::Transaction,
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+    context: &PendingApplyContext,
+) -> Result<(), StorageError> {
+    match context {
+        PendingApplyContext::Gsi(c) => apply_claimed_row(tx, old_item, new_item, c).await,
+        PendingApplyContext::Vector(c) => {
+            super::vector_index::apply_vector_context(tx, old_item, new_item, c).await
+        }
+    }
+}
+
+/// Metadata for a single index, used on the write path and by the GSI worker.
+pub(crate) struct IndexMeta {
+    pub(super) index_id: String,
+    pub(super) index_name: String,
+    pub(super) index_type: String,
+    pub(super) key_schema: Vec<KeySchemaElement>,
+    pub(super) projection: Projection,
+    /// Per-GSI propagation delay (ms). `None` = use system default; `Some(0)` =
+    /// synchronous.
+    pub(super) propagation_delay_ms: Option<i64>,
+}
+
+/// Fetch all index metadata for a table from the catalog.
+pub(crate) async fn fetch_indexes_for_table(
+    table_id: &str,
+    pool: &db::Pool,
+) -> Result<Vec<IndexMeta>, StorageError> {
+    let rows: Vec<(String, String, String, String, String, Option<i64>)> = db::query_as(
+        "SELECT index_id, index_name, index_type, key_schema, projection, propagation_delay_ms \
+         FROM indexes WHERE table_id = ?",
+    )
+    .bind(table_id)
+    .fetch_all(pool)
+    .await
+    .map_err(crate::duckdb_util::map_db_err)?;
+
+    rows.into_iter()
+        .map(|(index_id, index_name, index_type, ks, proj, delay)| {
+            Ok(IndexMeta {
+                index_id,
+                index_name,
+                index_type,
+                key_schema: serde_json::from_str(&ks)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?,
+                projection: serde_json::from_str(&proj)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?,
+                propagation_delay_ms: delay,
+            })
+        })
+        .collect()
+}
+
+/// Effective GSI propagation delay (ms): per-GSI override, else system default.
+/// `Some(0)` forces synchronous; negative is treated as "use system default".
+pub(crate) fn effective_delay(idx: &IndexMeta, system_default: u64) -> u64 {
+    match idx.propagation_delay_ms {
+        Some(0) => 0,
+        Some(ms) if ms > 0 => ms as u64,
+        _ => system_default,
+    }
+}
+
+/// Enqueue async GSI propagation for a write: **one self-describing
+/// `gsi_pending` row per async index**, each honoring its own effective delay.
+///
+/// Returns the number of rows enqueued so callers can skip waking the worker
+/// when nothing was queued. Must run inside the base write transaction so the
+/// pending rows commit atomically with the item mutation.
+pub(crate) async fn enqueue_async_indexes(
+    tx: &mut db::Transaction,
+    key_info: &TableKeyInfo,
+    indexes: &[IndexMeta],
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+    system_default_delay: u64,
+) -> Result<usize, StorageError> {
+    let mut enqueued = 0usize;
+    for idx in indexes {
+        if idx.index_type == "LSI" {
+            continue; // LSIs are always synchronous.
+        }
+        let delay = effective_delay(idx, system_default_delay);
+        if delay == 0 {
+            continue; // Synchronous GSI — handled in-txn by sync_indexes.
+        }
+        let context = GsiApplyContext {
+            base_key_schema: key_info.key_schema.clone(),
+            attribute_definitions: key_info.attribute_definitions.clone(),
+            index: GsiIndexDef {
+                index_id: idx.index_id.clone(),
+                key_schema: idx.key_schema.clone(),
+                projection: idx.projection.clone(),
+            },
+        };
+        enqueue_pending_row(
+            tx,
+            &key_info.table_id,
+            old_item,
+            new_item,
+            delay,
+            &PendingApplyContext::Gsi(context),
+        )
+        .await?;
+        enqueued += 1;
+    }
+    Ok(enqueued)
+}
+
+/// Insert one self-describing `gsi_pending` row inside the base write transaction
+/// (zero crash window). Shared by the GSI and vector write paths, which is what puts
+/// both index kinds in one totally ordered queue.
+///
+/// `delay_ms` is the effective delay; a jitter in `[delay/2, delay]` is applied.
+/// `ready_at` is clamped to `max(now + jitter, MAX(ready_at) in the base key's
+/// partition)` so a later write that draws a smaller jitter can never become
+/// eligible before an earlier one — preserving per-key FIFO when the worker drains
+/// the partition in `id` order.
+pub(crate) async fn enqueue_pending_row(
+    tx: &mut db::Transaction,
+    table_id: &str,
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+    delay_ms: u64,
+    context: &PendingApplyContext,
+) -> Result<(), StorageError> {
+    let old_json = old_item
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let new_json = new_item
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let context_json =
+        serde_json::to_string(context).map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    // Route all updates for one base item to a single partition (per-key FIFO).
+    // The base key is immutable: `new_item` carries it for puts/updates,
+    // `old_item` for deletes. Both context kinds describe the same base table, so
+    // a GSI row and a vector row for one item hash to the same partition and stay
+    // mutually ordered.
+    let worker_partition = match new_item.or(old_item) {
+        Some(item) => partition_for(&composite_pk_to_text(item, context.base_key_schema())?),
+        None => 0,
+    };
+
+    // ready_at as RFC 3339 so it compares correctly (lexically) against the
+    // worker's RFC 3339 `now` cutoff and against other rows' ready_at.
+    let jittered = jitter_delay_ms(delay_ms);
+    let candidate = crate::duckdb_util::format_timestamp(
+        time::OffsetDateTime::now_utc()
+            + time::Duration::milliseconds(i64::try_from(jittered).unwrap_or(i64::MAX)),
+    );
+    // Monotonic clamp within the partition (RFC 3339 strings sort lexically).
+    let part_max: Option<String> =
+        db::query_scalar("SELECT MAX(ready_at) FROM gsi_pending WHERE worker_partition = ?")
+            .bind(worker_partition)
+            .fetch_one(&mut **tx)
+            .await
+            .map_err(crate::duckdb_util::map_db_err)?;
+    let ready_at = match part_max {
+        Some(prev) if prev > candidate => prev,
+        _ => candidate,
+    };
+
+    db::query(
+        "INSERT INTO gsi_pending \
+         (table_id, worker_partition, old_item, new_item, index_context, ready_at) \
+         VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(table_id)
+    .bind(worker_partition)
+    .bind(&old_json)
+    .bind(&new_json)
+    .bind(&context_json)
+    .bind(&ready_at)
+    .execute(&mut **tx)
+    .await
+    .map_err(crate::duckdb_util::map_db_err)?;
+    Ok(())
+}
+
+/// Project an item according to an index's projection configuration.
+pub(crate) fn project_item_for_index(
+    item: &Item,
+    index_ks: &[KeySchemaElement],
+    base_ks: &[KeySchemaElement],
+    projection: &Projection,
+) -> Item {
+    match projection.projection_type {
+        ProjectionType::All => item.clone(),
+        ProjectionType::KeysOnly | ProjectionType::Include => {
+            let mut projected = Item::new();
+            for ks in base_ks.iter().chain(index_ks.iter()) {
+                if let Some(v) = item.get(&ks.attribute_name) {
+                    projected.insert(ks.attribute_name.clone(), v.clone());
+                }
+            }
+            if projection.projection_type == ProjectionType::Include
+                && let Some(attrs) = &projection.non_key_attributes
+            {
+                for attr in attrs {
+                    if let Some(v) = item.get(attr) {
+                        projected.insert(attr.clone(), v.clone());
+                    }
+                }
+            }
+            projected
+        }
+    }
+}
+
+/// Whether an item carries every key attribute an index requires.
+pub(crate) fn item_has_index_keys(item: &Item, index_ks: &[KeySchemaElement]) -> bool {
+    index_ks
+        .iter()
+        .all(|ks| item.contains_key(&ks.attribute_name))
+}
+
+/// Synchronously reconcile index tables for a base-item change — but only for
+/// indexes that are synchronous: LSIs (always) and GSIs whose effective delay
+/// is 0. GSIs with a non-zero delay are deferred via `gsi_pending` and applied
+/// by the worker, so they are skipped here.
+pub(crate) async fn sync_indexes(
+    tx: &mut db::Transaction,
+    base_key_schema: &[KeySchemaElement],
+    attr_defs: &[AttributeDefinition],
+    indexes: &[IndexMeta],
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+    system_default_delay: u64,
+) -> Result<(), StorageError> {
+    let base_sks = all_sort_key_info(base_key_schema, attr_defs);
+    for idx in indexes {
+        if idx.index_type != "LSI" && effective_delay(idx, system_default_delay) != 0 {
+            continue; // Async GSI — applied later by the propagation worker.
+        }
+        let idx_table = index_table_name(&idx.index_id);
+        let idx_sks = all_sort_key_info(&idx.key_schema, attr_defs);
+
+        if let Some(old) = old_item
+            && item_has_index_keys(old, &idx.key_schema)
+        {
+            delete_index_row_multi(tx, &idx_table, old, base_key_schema, &base_sks).await?;
+        }
+
+        if let Some(new) = new_item
+            && item_has_index_keys(new, &idx.key_schema)
+        {
+            let projected =
+                project_item_for_index(new, &idx.key_schema, base_key_schema, &idx.projection);
+            insert_index_row_multi(
+                tx,
+                &idx_table,
+                new,
+                &projected,
+                &idx.key_schema,
+                base_key_schema,
+                &idx_sks,
+                &base_sks,
+            )
+            .await?;
+        }
+    }
+    Ok(())
+}
+
+/// Delete an index row identified by its base-table key columns.
+pub(crate) async fn delete_index_row_multi(
+    tx: &mut db::Transaction,
+    idx_table: &str,
+    item: &Item,
+    base_ks: &[KeySchemaElement],
+    base_sks: &[(&str, ScalarAttributeType)],
+) -> Result<(), StorageError> {
+    let base_pk_text = composite_pk_to_text(item, base_ks)?;
+
+    let mut where_parts = vec!["base_pk = ?".to_owned()];
+    for (i, &(_, sk_type)) in base_sks.iter().enumerate() {
+        where_parts.push(format!("base_{} = ?", sk_column_n(i, sk_type)));
+    }
+    let sql = format!(
+        "DELETE FROM {idx_table} WHERE {}",
+        where_parts.join(" AND ")
+    );
+
+    let mut query = db::query(&sql).bind(base_pk_text);
+    for &(sk_name, sk_type) in base_sks {
+        // Bind a value for every placeholder, mirroring insert_index_row_multi:
+        // a missing sort-key attribute binds an empty string rather than
+        // skipping the bind (which would desynchronise placeholders and binds).
+        let bound = match item.get(sk_name) {
+            Some(v) => sk_bound(&parse_sk(v, sk_type)?),
+            None => BoundValue::Text(String::new()),
+        };
+        query = super::bind_bound!(query, bound);
+    }
+    query
+        .execute(&mut **tx)
+        .await
+        .map_err(crate::duckdb_util::map_db_err)?;
+    Ok(())
+}
+
+/// Insert (or replace) an index row for a base item.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn insert_index_row_multi(
+    tx: &mut db::Transaction,
+    idx_table: &str,
+    item: &Item,
+    projected: &Item,
+    index_ks: &[KeySchemaElement],
+    base_ks: &[KeySchemaElement],
+    idx_sks: &[(&str, ScalarAttributeType)],
+    base_sks: &[(&str, ScalarAttributeType)],
+) -> Result<(), StorageError> {
+    let idx_pk_text = composite_pk_to_text(item, index_ks)?;
+    let base_pk_text = composite_pk_to_text(item, base_ks)?;
+    let item_json =
+        serde_json::to_string(projected).map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    // Columns and the matching bound values, in column order.
+    let mut cols = vec!["pk".to_owned()];
+    let mut values: Vec<BoundValue> = vec![BoundValue::Text(idx_pk_text)];
+
+    for (i, &(sk_name, sk_type)) in idx_sks.iter().enumerate() {
+        cols.push(sk_column_n(i, sk_type));
+        if let Some(v) = item.get(sk_name) {
+            values.push(sk_bound(&parse_sk(v, sk_type)?));
+        } else {
+            values.push(BoundValue::Text(String::new()));
+        }
+    }
+
+    cols.push("base_pk".to_owned());
+    values.push(BoundValue::Text(base_pk_text));
+
+    for (i, &(sk_name, sk_type)) in base_sks.iter().enumerate() {
+        cols.push(format!("base_{}", sk_column_n(i, sk_type)));
+        if let Some(v) = item.get(sk_name) {
+            values.push(sk_bound(&parse_sk(v, sk_type)?));
+        } else {
+            values.push(BoundValue::Text(String::new()));
+        }
+    }
+
+    cols.push("item_data".to_owned());
+    values.push(BoundValue::Text(item_json));
+
+    let placeholders = vec!["?"; cols.len()].join(", ");
+    let sql = format!(
+        "INSERT OR REPLACE INTO {idx_table} ({}) VALUES ({placeholders})",
+        cols.join(", ")
+    );
+
+    let mut query = db::query(&sql);
+    for v in values {
+        query = super::bind_bound!(query, v);
+    }
+    query
+        .execute(&mut **tx)
+        .await
+        .map_err(crate::duckdb_util::map_db_err)?;
+    Ok(())
+}
+
+/// Helper: derive the sort-key column name used by an index data table for the
+/// Nth index sort key. Exposed for query routing.
+#[allow(dead_code)]
+pub(crate) fn index_sk_column(index: usize, sk_type: ScalarAttributeType) -> String {
+    if index == 0 {
+        sk_column(sk_type).to_owned()
+    } else {
+        sk_column_n(index, sk_type)
+    }
+}
+
+/// True if a storage error is a "missing table" error (the `_ddb_*` index table
+/// or a `_vidx_*` vector table was dropped, e.g. the base table was deleted
+/// while a `gsi_pending` row was in flight). Such rows are benignly skipped.
+pub(crate) fn is_no_such_table(e: &StorageError) -> bool {
+    matches!(e, StorageError::Internal(msg) if msg.contains("no such table"))
+}
+
+/// Apply one claimed `gsi_pending` row to its single target index, within the
+/// worker's transaction, using the row's self-describing `index_context` — no
+/// catalog read. A missing index data table (the base table was deleted while
+/// the row was in flight) is skipped benignly.
+pub(crate) async fn apply_claimed_row(
+    tx: &mut db::Transaction,
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+    context: &GsiApplyContext,
+) -> Result<(), StorageError> {
+    let base_sks = all_sort_key_info(&context.base_key_schema, &context.attribute_definitions);
+    let idx = &context.index;
+    let idx_table = index_table_name(&idx.index_id);
+    let idx_sks = all_sort_key_info(&idx.key_schema, &context.attribute_definitions);
+
+    if let Some(old) = old_item
+        && item_has_index_keys(old, &idx.key_schema)
+    {
+        delete_index_row_multi(tx, &idx_table, old, &context.base_key_schema, &base_sks)
+            .await
+            .or_else(|e| if is_no_such_table(&e) { Ok(()) } else { Err(e) })?;
+    }
+    if let Some(new) = new_item
+        && item_has_index_keys(new, &idx.key_schema)
+    {
+        let projected = project_item_for_index(
+            new,
+            &idx.key_schema,
+            &context.base_key_schema,
+            &idx.projection,
+        );
+        insert_index_row_multi(
+            tx,
+            &idx_table,
+            new,
+            &projected,
+            &idx.key_schema,
+            &context.base_key_schema,
+            &idx_sks,
+            &base_sks,
+        )
+        .await
+        .or_else(|e| if is_no_such_table(&e) { Ok(()) } else { Err(e) })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod pending_context_tests {
+    use super::{GsiApplyContext, GsiIndexDef, PendingApplyContext};
+    use crate::data::vector_index::{VectorApplyContext, VectorIndexMeta};
+    use crate::db;
+    use extenddb_core::types::{
+        AttributeDefinition, KeySchemaElement, KeyType, Projection, ProjectionType,
+        ScalarAttributeType,
+    };
+
+    /// A context written by a build that predates vector rows, verbatim. It must
+    /// still deserialize.
+    ///
+    /// This is the test that protects an upgrade. A row whose `index_context` fails
+    /// to parse is treated as poison and DROPPED, so if the representation had
+    /// changed incompatibly, every GSI update in flight at the moment of the upgrade
+    /// would have been discarded silently, with the item written and its index never
+    /// catching up.
+    const LEGACY_GSI_CONTEXT: &str = r#"{
+        "base_key_schema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+        "attribute_definitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+        "index": {
+            "index_id": "idx-1",
+            "key_schema": [{"AttributeName": "gsipk", "KeyType": "HASH"}],
+            "projection": {"ProjectionType": "ALL"}
+        }
+    }"#;
+
+    fn base_ks() -> Vec<KeySchemaElement> {
+        vec![KeySchemaElement {
+            attribute_name: "pk".to_owned(),
+            key_type: KeyType::Hash,
+        }]
+    }
+
+    fn base_ad() -> Vec<AttributeDefinition> {
+        vec![AttributeDefinition {
+            attribute_name: "pk".to_owned(),
+            attribute_type: ScalarAttributeType::S,
+        }]
+    }
+
+    fn gsi_context() -> GsiApplyContext {
+        GsiApplyContext {
+            base_key_schema: base_ks(),
+            attribute_definitions: base_ad(),
+            index: GsiIndexDef {
+                index_id: "idx-1".to_owned(),
+                key_schema: vec![KeySchemaElement {
+                    attribute_name: "gsipk".to_owned(),
+                    key_type: KeyType::Hash,
+                }],
+                projection: Projection {
+                    projection_type: ProjectionType::All,
+                    non_key_attributes: None,
+                },
+            },
+        }
+    }
+
+    fn vector_context() -> VectorApplyContext {
+        VectorApplyContext {
+            base_key_schema: base_ks(),
+            attribute_definitions: base_ad(),
+            table_id: "t-1".to_owned(),
+            vector: VectorIndexMeta {
+                index_id: "vidx-1".to_owned(),
+                dimensions: 2,
+                vector_attribute_name: "emb".to_owned(),
+                projection: Projection {
+                    projection_type: ProjectionType::KeysOnly,
+                    non_key_attributes: None,
+                },
+                hash_attribute_name: Some("tenant".to_owned()),
+                search_schema_attribute_names: vec!["tenant".to_owned()],
+            },
+        }
+    }
+
+    #[test]
+    fn a_legacy_gsi_context_still_deserializes_as_a_gsi_row() {
+        let parsed: PendingApplyContext =
+            serde_json::from_str(LEGACY_GSI_CONTEXT).expect("legacy context must still parse");
+        match parsed {
+            PendingApplyContext::Gsi(c) => assert_eq!(c.index.index_id, "idx-1"),
+            PendingApplyContext::Vector(_) => {
+                panic!("a legacy GSI context must not be read as a vector row")
+            }
+        }
+    }
+
+    /// The bytes a GSI row writes today are the bytes it wrote before the enum
+    /// existed, so a row written by this build is still readable by the previous
+    /// one. `untagged` is what buys this, and this test is what keeps it.
+    #[test]
+    fn wrapping_a_gsi_context_does_not_change_its_serialized_form() {
+        let bare = serde_json::to_string(&gsi_context()).expect("bare");
+        let wrapped =
+            serde_json::to_string(&PendingApplyContext::Gsi(gsi_context())).expect("wrapped");
+        assert_eq!(
+            bare, wrapped,
+            "the queue's on-disk format must not change for GSI rows"
+        );
+    }
+
+    /// A vector context round-trips and carries no GSI discriminant field.
+    ///
+    /// Note what this does NOT guard: it still passes if `untagged` is removed, so it
+    /// is not the protection for on-disk compatibility. The two tests above are, and
+    /// both fail without `untagged`. This one pins the shape contract that makes the
+    /// discrimination possible in the first place.
+    #[test]
+    fn a_vector_context_round_trips_and_carries_no_gsi_discriminant() {
+        let json = serde_json::to_string(&PendingApplyContext::Vector(vector_context()))
+            .expect("serialize");
+        assert!(
+            !json.contains("\"index\":"),
+            "a vector context must not carry the GSI discriminant field: {json}"
+        );
+        let parsed: PendingApplyContext = serde_json::from_str(&json).expect("deserialize");
+        match parsed {
+            PendingApplyContext::Vector(c) => {
+                assert_eq!(c.vector.index_id, "vidx-1");
+                assert_eq!(c.table_id, "t-1");
+                assert_eq!(c.vector.dimensions, 2);
+                assert_eq!(c.vector.hash_attribute_name.as_deref(), Some("tenant"));
+                assert_eq!(c.vector.search_schema_attribute_names, ["tenant"]);
+                assert_eq!(
+                    c.vector.projection.projection_type,
+                    ProjectionType::KeysOnly
+                );
+            }
+            PendingApplyContext::Gsi(_) => panic!("a vector context must not be read as a GSI row"),
+        }
+    }
+
+    /// A GSI row and a vector row for the SAME base item must land in the same queue
+    /// partition, which is what makes them mutually ordered.
+    ///
+    /// This is the claim that reusing one queue buys ordering ACROSS index kinds, and
+    /// it holds only because both contexts hash the same base key rather than
+    /// anything index-specific. Asserted on the partition because the partition is the
+    /// mechanism: two kinds hashing differently would land in separate partitions,
+    /// each monotonic on its own, leaving the relative order of a GSI and a vector
+    /// update to one item unconstrained.
+    ///
+    /// Driven through the real `enqueue_pending_row` rather than a test shim, so it is
+    /// the production path being measured.
+    #[tokio::test]
+    async fn a_gsi_row_and_a_vector_row_for_one_item_share_a_partition() {
+        let engine = crate::DuckDbEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+
+        let the_item: extenddb_core::types::Item =
+            serde_json::from_str(r#"{"pk":{"S":"shared-key"},"emb":{"L":[{"N":"1"}]}}"#)
+                .expect("item");
+        let mut tx = engine.pool.begin().await.expect("tx");
+        for context in [
+            PendingApplyContext::Gsi(gsi_context()),
+            PendingApplyContext::Vector(vector_context()),
+        ] {
+            super::enqueue_pending_row(&mut tx, "t-1", None, Some(&the_item), 60_000, &context)
+                .await
+                .expect("enqueue");
+        }
+        tx.commit().await.expect("commit");
+
+        let partitions: Vec<(i64,)> =
+            db::query_as("SELECT DISTINCT worker_partition FROM gsi_pending")
+                .fetch_all(&engine.pool)
+                .await
+                .expect("partitions");
+        assert_eq!(
+            partitions.len(),
+            1,
+            "a GSI row and a vector row for one base item must share a partition, or \
+             their relative order is unconstrained"
+        );
+        let (depth,): (i64,) = db::query_as("SELECT COUNT(*) FROM gsi_pending")
+            .fetch_one(&engine.pool)
+            .await
+            .expect("depth");
+        assert_eq!(
+            depth, 2,
+            "both kinds must have enqueued, so one partition is not an artefact of a \
+             missing row"
+        );
+    }
+
+    /// A catalog created before the rename must keep honouring its operator's value.
+    ///
+    /// This is the compatibility property the whole fallback exists for, and the cost
+    /// of getting it wrong is not cosmetic: the server refuses to start on a
+    /// catalog-version mismatch rather than migrating, so nothing ever rewrites the old
+    /// row. Reading past it would silently reset a configured delay to the default, and
+    /// since 0 means synchronous, the silent change would be from strict to eventually
+    /// consistent, which is exactly the direction that turns a passing test suite into
+    /// a flaky one somewhere else.
+    #[tokio::test]
+    async fn a_pre_rename_catalog_still_honours_its_configured_delay() {
+        let engine = crate::DuckDbEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+
+        // Reshape the catalog to look as it did before the rename: the legacy key
+        // only, carrying a deliberately non-default value.
+        db::query("DELETE FROM settings WHERE key = 'index_propagation_delay_ms'")
+            .execute(&engine.pool)
+            .await
+            .expect("drop canonical row");
+        db::query("INSERT INTO settings (key, value) VALUES ('gsi_propagation_delay_ms', '0')")
+            .execute(&engine.pool)
+            .await
+            .expect("seed legacy row");
+
+        assert_eq!(
+            engine.index_propagation_delay().await,
+            0,
+            "a value set under the pre-rename key must still be honoured, or an \
+             operator's synchronous setting silently becomes asynchronous"
+        );
+    }
+
+    /// With both rows present the canonical one wins, deterministically.
+    ///
+    /// Reachable if an operator sets the legacy key on a build that predates the
+    /// canonicalising write path and then upgrades. Without the explicit ordering the
+    /// winner would be whichever row DuckDB happened to return first.
+    #[tokio::test]
+    async fn the_canonical_key_wins_when_both_are_present() {
+        let engine = crate::DuckDbEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+
+        db::query(
+            "INSERT OR REPLACE INTO settings (key, value) \
+             VALUES ('index_propagation_delay_ms', '7'), ('gsi_propagation_delay_ms', '999')",
+        )
+        .execute(&engine.pool)
+        .await
+        .expect("seed both rows");
+
+        assert_eq!(
+            engine.index_propagation_delay().await,
+            7,
+            "the canonical key must take precedence over the deprecated alias"
+        );
+    }
+}

--- a/crates/storage-duckdb/src/data/mod.rs
+++ b/crates/storage-duckdb/src/data/mod.rs
@@ -1,0 +1,187 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-DynamoDB-table data storage for the DuckDB backend.
+//!
+//! Each virtual DynamoDB table maps to a DuckDB table named `_ddb_<table_id>`;
+//! each secondary index maps to `_ddb_<index_id>`. The full item is stored as
+//! JSON `TEXT` in `item_data`; key columns exist only for lookup and ordering.
+//!
+//! # Key column types (design decision D2)
+//!
+//! - Partition key (`pk`): always `TEXT` via the shared `pk_to_text` (equality
+//!   only) — identical to the PostgreSQL backend.
+//! - Sort key, by attribute type:
+//!   - `S` → `sk_s TEXT` (DuckDB BINARY collation = DynamoDB UTF-8 byte order).
+//!   - `N` → `sk_n TEXT` holding [`encode_orderable_number`], so lexicographic
+//!     order equals numeric order with full 38-digit precision (never `DOUBLE`).
+//!   - `B` → `sk_b BLOB` (memcmp = DynamoDB unsigned byte order).
+//!
+//! The exact, full-precision value is always preserved in `item_data` JSON, so
+//! reads lose nothing; the typed key columns are used only for
+//! lookup/range/ordering.
+
+use extenddb_core::types::{
+    AttributeDefinition, Item, KeySchemaElement, KeyType, ScalarAttributeType,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::SortKeyValue;
+
+use crate::number_key::encode_orderable_number;
+
+mod data_engine;
+mod ddl;
+mod delete_item;
+mod index;
+mod put_item;
+mod query;
+mod query_scan;
+mod transactions;
+mod tx_helpers;
+mod update_item;
+pub(crate) mod vector_index;
+
+pub(crate) use index::{
+    PendingApplyContext, apply_pending_context, insert_index_row_multi, project_item_for_index,
+};
+pub(crate) use tx_helpers::upsert_item_in_tx;
+
+/// Quoted SQL identifier for a virtual DynamoDB table's data table.
+pub(crate) fn data_table_name(table_id: &str) -> String {
+    format!("\"_ddb_{table_id}\"")
+}
+
+/// Quoted SQL identifier for a GSI/LSI data table.
+pub(crate) fn index_table_name(index_id: &str) -> String {
+    format!("\"_ddb_{index_id}\"")
+}
+
+/// Quoted SQL identifier for a vector-index data table.
+///
+/// The name carries the base `table_id` as well as the `index_id` so every vector
+/// table belonging to a DynamoDB table is discoverable from the table alone. That
+/// is what lets `drop_data_table` clean them up: by the time it runs, the catalog
+/// rows have already been cascade-deleted inside the same transaction, so the
+/// index ids can no longer be read from `vector_indexes`.
+///
+/// One row per vector rather than a packed blob per partition. Measured
+/// 2026-08-06: a packed blob reads 2 to 4x faster but makes every write
+/// O(partition), since inserting one vector rewrites the whole blob (390 MB for
+/// a 100k-vector partition at 1024 dimensions). Vector indexes are maintained on
+/// every write to an indexed attribute, so that trade is not available.
+pub(crate) fn vector_table_name(table_id: &str, index_id: &str) -> String {
+    format!("\"_vidx_{table_id}_{index_id}\"")
+}
+
+/// `GLOB` pattern matching every vector data table of one DynamoDB table.
+///
+/// `GLOB` rather than `LIKE` because the pattern itself is full of underscores, and
+/// in `LIKE` an underscore is a single-character wildcard: `_vidx_<id>_%` would match
+/// far more than it appears to. It can only ever over-match, since a wildcard also
+/// matches a literal underscore, and no other table could share the UUID, so `LIKE`
+/// was safe in practice. It was not safe for the stated reason, though, and a comment
+/// that justifies the wrong half is worse than none.
+///
+/// `GLOB` treats `_` literally and uses `*` for the wildcard, so the pattern means
+/// what it reads. `table_id` is a server-generated UUID, which contains no `GLOB`
+/// metacharacters either.
+pub(crate) fn vector_table_glob_pattern(table_id: &str) -> String {
+    format!("_vidx_{table_id}_*")
+}
+
+/// All RANGE key attributes in key-schema order, paired with their scalar type.
+pub(crate) fn all_sort_key_info<'a>(
+    key_schema: &'a [KeySchemaElement],
+    attr_defs: &'a [AttributeDefinition],
+) -> Vec<(&'a str, ScalarAttributeType)> {
+    key_schema
+        .iter()
+        .filter(|ks| ks.key_type == KeyType::Range)
+        .filter_map(|ks| {
+            attr_defs
+                .iter()
+                .find(|ad| ad.attribute_name == ks.attribute_name)
+                .map(|ad| (ks.attribute_name.as_str(), ad.attribute_type))
+        })
+        .collect()
+}
+
+/// Deserialize an `item_data` JSON value into an `Item`.
+pub(crate) fn json_to_item(v: serde_json::Value) -> Result<Item, StorageError> {
+    serde_json::from_value(v).map_err(|e| StorageError::Internal(e.to_string()))
+}
+
+/// A value bound to a sort-key column, already mapped to its DuckDB storage
+/// representation per D2.
+#[derive(Debug, Clone)]
+pub(crate) enum BoundValue {
+    /// `TEXT` — used for `S` (raw string) and `N` (order-preserving encoding).
+    Text(String),
+    /// `BLOB` — used for `B`.
+    Blob(Vec<u8>),
+}
+
+/// Map a parsed sort-key value to its DuckDB storage representation (D2):
+/// `S` → TEXT, `N` → order-preserving TEXT, `B` → BLOB.
+pub(crate) fn sk_bound(sk: &SortKeyValue) -> BoundValue {
+    match sk {
+        SortKeyValue::S(s) => BoundValue::Text(s.clone()),
+        SortKeyValue::N(n) => BoundValue::Text(encode_orderable_number(n)),
+        SortKeyValue::B(b) => BoundValue::Blob(b.clone()),
+    }
+}
+
+/// Bind a [`BoundValue`] onto a positional `sqlx` query.
+macro_rules! bind_bound {
+    ($query:expr, $bound:expr) => {
+        match $bound {
+            crate::data::BoundValue::Text(s) => $query.bind(s),
+            crate::data::BoundValue::Blob(b) => $query.bind(b),
+        }
+    };
+}
+
+/// Bind `pk` then a sort-key value, then `fetch_optional` a single JSON column.
+macro_rules! bind_sk_fetch_optional {
+    ($sql:expr, $pk:expr, $sk:expr, $executor:expr) => {{
+        let __q = crate::db::query_as::<(serde_json::Value,)>($sql).bind($pk);
+        let __q = match crate::data::sk_bound($sk) {
+            crate::data::BoundValue::Text(s) => __q.bind(s),
+            crate::data::BoundValue::Blob(b) => __q.bind(b),
+        };
+        __q.fetch_optional($executor)
+            .await
+            .map_err(|e| extenddb_storage::error::StorageError::Internal(e.to_string()))
+    }};
+}
+
+/// Bind `pk`, a sort-key value, then `item_json`, and `execute`.
+macro_rules! bind_sk_execute {
+    ($sql:expr, $pk:expr, $sk:expr, $item_json:expr, $executor:expr) => {{
+        let __q = crate::db::query($sql).bind($pk);
+        let __q = match crate::data::sk_bound($sk) {
+            crate::data::BoundValue::Text(s) => __q.bind(s),
+            crate::data::BoundValue::Blob(b) => __q.bind(b),
+        };
+        __q.bind($item_json)
+            .execute($executor)
+            .await
+            .map_err(|e| extenddb_storage::error::StorageError::Internal(e.to_string()))
+    }};
+}
+
+/// Bind `pk` then a sort-key value, and `execute` (no item payload).
+macro_rules! bind_sk_only_execute {
+    ($sql:expr, $pk:expr, $sk:expr, $executor:expr) => {{
+        let __q = crate::db::query($sql).bind($pk);
+        let __q = match crate::data::sk_bound($sk) {
+            crate::data::BoundValue::Text(s) => __q.bind(s),
+            crate::data::BoundValue::Blob(b) => __q.bind(b),
+        };
+        __q.execute($executor)
+            .await
+            .map_err(|e| extenddb_storage::error::StorageError::Internal(e.to_string()))
+    }};
+}
+
+pub(crate) use {bind_bound, bind_sk_execute, bind_sk_fetch_optional, bind_sk_only_execute};

--- a/crates/storage-duckdb/src/data/put_item.rs
+++ b/crates/storage-duckdb/src/data/put_item.rs
@@ -1,0 +1,190 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `put_item` and `get_item` for the DuckDB backend.
+//!
+//! Writes acquire the engine write lock (D1) and run in a transaction, so the
+//! condition check, the write, index sync, and stream capture are one atomic
+//! unit with no competing writer — no `INSERT ... ON CONFLICT DO NOTHING` race
+//! dance is needed.
+
+use crate::db;
+use extenddb_core::expression::{Expr, ExpressionMaps};
+use extenddb_core::types::{Item, TableKeyInfo};
+use extenddb_storage::StreamCapture;
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::{pk_to_text, sk_column, sk_info};
+
+use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
+use super::query::check_condition;
+use super::tx_helpers::{fetch_item_in_tx, upsert_item_in_tx, write_stream_record_in_tx};
+use super::{bind_sk_fetch_optional, data_table_name, json_to_item};
+use crate::store::DuckDbEngine;
+
+impl DuckDbEngine {
+    pub(crate) async fn put_item_impl(
+        &self,
+        key_info: &TableKeyInfo,
+        item: Item,
+        return_old: bool,
+        condition: Option<&Expr>,
+        maps: &ExpressionMaps,
+        stream: Option<&StreamCapture>,
+    ) -> Result<Option<Item>, StorageError> {
+        // Read the index set only after acquiring the write lock, so a GSI added
+        // by a concurrent UpdateTable (which holds the same lock) cannot be missed
+        // and left unmaintained by this write.
+        // Read the propagation delay BEFORE taking the write lock. It is a
+        // runtime setting, not an invariant of this write, so it does not need
+        // to be read under the lock, and the lock serialises every write in the
+        // process: work done inside it is the backend's throughput bottleneck.
+        let system_delay = self.index_propagation_delay().await;
+        let _writer = self.write_lock.lock().await;
+        let indexes = fetch_indexes_for_table(&key_info.table_id, &self.pool).await?;
+
+        // Index key attributes present in the item must match their declared
+        // scalar type and be non-empty, matching real DynamoDB. This is up-front
+        // input validation (a top-level ValidationException), so it runs before
+        // any write work. Mirrors the PostgreSQL backend.
+        if !indexes.is_empty() {
+            let index_refs: Vec<extenddb_core::validation::IndexKeyRef<'_>> = indexes
+                .iter()
+                .map(|idx| extenddb_core::validation::IndexKeyRef {
+                    index_name: &idx.index_name,
+                    key_schema: &idx.key_schema,
+                })
+                .collect();
+            extenddb_core::validation::validate_index_keys(
+                &item,
+                &index_refs,
+                &key_info.attribute_definitions,
+            )
+            .map_err(|e| StorageError::Validation(e.to_string()))?;
+        }
+
+        let need_old = condition.is_some() || return_old || !indexes.is_empty() || stream.is_some();
+
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let old = if need_old {
+            fetch_item_in_tx(&mut tx, key_info, &item).await?
+        } else {
+            None
+        };
+
+        if condition.is_some() {
+            let empty = Item::new();
+            let target = old.as_ref().unwrap_or(&empty);
+            if let Err(e) = check_condition(condition, target, maps) {
+                return match e {
+                    StorageError::ConditionFailed(_) => Err(StorageError::ConditionFailed(old)),
+                    other => Err(other),
+                };
+            }
+        }
+
+        upsert_item_in_tx(&mut tx, key_info, &item).await?;
+
+        // Synchronous indexes (LSIs + zero-delay GSIs) are applied in-txn;
+        // async GSIs are enqueued into gsi_pending within the same txn.
+        if !indexes.is_empty() {
+            sync_indexes(
+                &mut tx,
+                &key_info.key_schema,
+                &key_info.attribute_definitions,
+                &indexes,
+                old.as_ref(),
+                Some(&item),
+                system_delay,
+            )
+            .await?;
+        }
+        let enqueued_gsi = enqueue_async_indexes(
+            &mut tx,
+            key_info,
+            &indexes,
+            old.as_ref(),
+            Some(&item),
+            system_delay,
+        )
+        .await?
+            > 0;
+        // Vector indexes: applied in this transaction when the propagation delay is
+        // 0, otherwise enqueued alongside the async GSI work. Gated on the cached
+        // key info so a table without them costs no extra query, and deliberately
+        // outside the `indexes` guard above: a table may have a vector index and no
+        // GSI or LSI at all.
+        let enqueued_vector = if key_info.vector_indexes.is_empty() {
+            false
+        } else {
+            crate::data::vector_index::maintain_vector_indexes(
+                &mut tx,
+                &key_info.table_id,
+                &key_info.key_schema,
+                &key_info.attribute_definitions,
+                old.as_ref(),
+                Some(&item),
+                system_delay,
+            )
+            .await?
+                > 0
+        };
+        let enqueued = enqueued_gsi || enqueued_vector;
+
+        if let Some(capture) = stream {
+            write_stream_record_in_tx(&mut tx, key_info, capture, old.as_ref(), Some(&item))
+                .await?;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        if enqueued {
+            self.gsi_notify.notify_waiters();
+        }
+
+        Ok(if return_old { old } else { None })
+    }
+
+    pub(crate) async fn get_item_impl(
+        &self,
+        key_info: &TableKeyInfo,
+        key: &Item,
+    ) -> Result<Option<Item>, StorageError> {
+        let ddb_table = data_table_name(&key_info.table_id);
+        let pk_name = &key_info.key_schema[0].attribute_name;
+        let pk_value = key
+            .get(pk_name)
+            .ok_or_else(|| StorageError::Internal("missing partition key".to_owned()))?;
+        let pk_text = pk_to_text(pk_value)?;
+
+        let json_opt = if let Some((sk_name, sk_type)) =
+            sk_info(&key_info.key_schema, &key_info.attribute_definitions)
+        {
+            let sk_value = key
+                .get(sk_name)
+                .ok_or_else(|| StorageError::Internal("missing sort key".to_owned()))?;
+            let sk = extenddb_storage::util::parse_sk(sk_value, sk_type)?;
+            let sk_col = sk_column(sk_type);
+            let sql = format!("SELECT item_data FROM {ddb_table} WHERE pk = ? AND {sk_col} = ?");
+            let row: Option<(serde_json::Value,)> =
+                bind_sk_fetch_optional!(&sql, pk_text.as_ref(), &sk, &self.pool)?;
+            row.map(|(v,)| v)
+        } else {
+            let sql = format!("SELECT item_data FROM {ddb_table} WHERE pk = ?");
+            let row: Option<(serde_json::Value,)> = db::query_as(&sql)
+                .bind(pk_text.as_ref())
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            row.map(|(v,)| v)
+        };
+
+        json_opt.map(json_to_item).transpose()
+    }
+}

--- a/crates/storage-duckdb/src/data/query.rs
+++ b/crates/storage-duckdb/src/data/query.rs
@@ -1,0 +1,233 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared query helpers: condition evaluation, key-condition SQL fragments,
+//! and dynamic query execution.
+//!
+//! Sort-key comparisons bind through [`super::sk_bound`], so `N` keys are
+//! compared as their order-preserving TEXT encoding (D2): `>`, `<`, `BETWEEN`
+//! all remain numerically correct. `begins_with` applies only to `S` (string
+//! prefix via the maximal code point `char(1114111)`) and `B` (byte-range via
+//! an incremented upper bound); DynamoDB rejects `begins_with` on `N`.
+
+use crate::db;
+use extenddb_core::expression::{self, CompareOp, Expr, ExpressionMaps, SortKeyCondition};
+use extenddb_core::types::{
+    AttributeValue, Item, KeySchemaElement, ScalarAttributeType, extract_key,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::{SortKeyValue, parse_sk};
+
+use super::BoundValue;
+
+/// Evaluate an optional condition expression against an item.
+/// Returns `ConditionFailed(None)` when the condition evaluates to false.
+pub(super) fn check_condition(
+    condition: Option<&Expr>,
+    item: &Item,
+    maps: &ExpressionMaps,
+) -> Result<(), StorageError> {
+    if let Some(cond) = condition {
+        let passed = expression::evaluate_condition(cond, item, maps)
+            .map_err(|e| StorageError::Validation(e.to_string()))?;
+        if !passed {
+            return Err(StorageError::ConditionFailed(None));
+        }
+    }
+    Ok(())
+}
+
+/// Resolve a key-condition placeholder expression to its `AttributeValue`.
+pub(super) fn resolve_expr_to_av(
+    expr: &Expr,
+    maps: &ExpressionMaps,
+) -> Result<AttributeValue, StorageError> {
+    match expr {
+        Expr::Placeholder(name) => maps
+            .resolve_value(name)
+            .cloned()
+            .map_err(|e| StorageError::Validation(e.to_string())),
+        _ => Err(StorageError::Internal(
+            "expected placeholder in key condition".to_owned(),
+        )),
+    }
+}
+
+/// SQL `WHERE` fragment for a sort-key condition on `sk_col`, together with the
+/// values to bind for it.
+///
+/// The fragment and its bind list are returned from one function on purpose.
+/// `begins_with` on a binary key sometimes has no upper bound at all (see
+/// [`binary_prefix_upper_bound`]), so the placeholder count is not fixed by the
+/// condition kind alone. Building the SQL in one place and the binds in another
+/// meant the two could disagree about how many placeholders exist, which is a
+/// bind-offset corruption rather than a visible error.
+pub(super) fn build_sk_sql_and_binds(
+    sk_cond: &SortKeyCondition,
+    sk_col: &str,
+    sk_type: ScalarAttributeType,
+    maps: &ExpressionMaps,
+) -> Result<(String, Vec<SortKeyValue>), StorageError> {
+    match sk_cond {
+        SortKeyCondition::Compare { op, value, .. } => {
+            let sql_op = match op {
+                CompareOp::Eq => "=",
+                CompareOp::Ne => "<>",
+                CompareOp::Lt => "<",
+                CompareOp::Le => "<=",
+                CompareOp::Gt => ">",
+                CompareOp::Ge => ">=",
+            };
+            Ok((
+                format!(" AND {sk_col} {sql_op} ?"),
+                vec![parse_sk(&resolve_expr_to_av(value, maps)?, sk_type)?],
+            ))
+        }
+        SortKeyCondition::Between { low, high, .. } => Ok((
+            format!(" AND {sk_col} BETWEEN ? AND ?"),
+            vec![
+                parse_sk(&resolve_expr_to_av(low, maps)?, sk_type)?,
+                parse_sk(&resolve_expr_to_av(high, maps)?, sk_type)?,
+            ],
+        )),
+        SortKeyCondition::BeginsWith { prefix, .. } => {
+            let sk = parse_sk(&resolve_expr_to_av(prefix, maps)?, sk_type)?;
+            match sk {
+                SortKeyValue::B(b) => match binary_prefix_upper_bound(&b) {
+                    Some(upper) => Ok((
+                        format!(" AND {sk_col} >= ? AND {sk_col} < ?"),
+                        vec![SortKeyValue::B(b), SortKeyValue::B(upper)],
+                    )),
+                    // Every byte string with this prefix is in range and there is
+                    // no finite value above them all, so the only correct upper
+                    // bound is none. Emitting one anyway is what silently dropped
+                    // rows.
+                    None => Ok((format!(" AND {sk_col} >= ?"), vec![SortKeyValue::B(b)])),
+                },
+                // For strings the SQL upper bound is `? || chr(1114111)`,
+                // so the same prefix is bound twice.
+                SortKeyValue::S(s) => Ok((
+                    format!(" AND {sk_col} >= ? AND {sk_col} < (? || chr(1114111))"),
+                    vec![SortKeyValue::S(s.clone()), SortKeyValue::S(s)],
+                )),
+                SortKeyValue::N(_) => Err(StorageError::Validation(
+                    "begins_with is not supported on numeric sort keys".to_owned(),
+                )),
+            }
+        }
+    }
+}
+
+/// Exclusive upper bound for a binary prefix range, or `None` when the range is
+/// unbounded above.
+///
+/// The bound is the smallest byte string greater than every string having
+/// `prefix` as a prefix. Found by incrementing the last byte below `0xFF` and
+/// discarding everything after it: `[1, 2]` yields `[1, 3]`, so `[1, 2, 9]` is
+/// still included but `[1, 3]` is not.
+///
+/// `None` when every byte is `0xFF`, which includes the empty prefix. No finite
+/// bound exists in that case, because a longer all-`0xFF` string always sorts
+/// after any candidate: with `[0xFF]` the strings `[0xFF, 0xFF]`,
+/// `[0xFF, 0xFF, 0xFF]` and so on continue without end. The previous code
+/// returned `vec![0xFF; prefix.len() + 1]` here, which is a value inside the
+/// matching set rather than above it, so rows were silently dropped: for an
+/// empty prefix it produced `[0xFF]`, which excluded every key sorting at or
+/// after it, and `begins_with([])` then returned part of the partition while
+/// reporting success. Returning `None` and omitting the predicate is the only
+/// correct answer that does not depend on a maximum key length, which is
+/// operator-configurable via `max_sort_key_size_bytes`.
+fn binary_prefix_upper_bound(prefix: &[u8]) -> Option<Vec<u8>> {
+    let mut out = prefix.to_vec();
+    while let Some(last) = out.last_mut() {
+        if *last < 0xFF {
+            *last += 1;
+            return Some(out);
+        }
+        out.pop();
+    }
+    None
+}
+
+/// Build a `LastEvaluatedKey` from an item's key attributes.
+pub(super) fn build_key(item: &Item, key_schema: &[KeySchemaElement]) -> Item {
+    extract_key(item, key_schema)
+}
+
+/// Execute a dynamically-built query, binding `BoundValue`s positionally.
+pub(super) async fn execute_dynamic_query(
+    sql: &str,
+    values: Vec<BoundValue>,
+    pool: &db::Pool,
+) -> Result<Vec<serde_json::Value>, StorageError> {
+    let mut query = db::query_as::<(serde_json::Value,)>(sql);
+    for v in values {
+        query = match v {
+            BoundValue::Text(s) => query.bind(s),
+            BoundValue::Blob(b) => query.bind(b),
+        };
+    }
+    let rows: Vec<(serde_json::Value,)> = query
+        .fetch_all(pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    Ok(rows.into_iter().map(|(v,)| v).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::binary_prefix_upper_bound;
+
+    /// Every byte string having `prefix` as a prefix must sort below the bound,
+    /// and the bound itself must not. Asserted against explicit witnesses rather
+    /// than trusting the arithmetic, since the defect this replaces was an
+    /// off-by-domain error that looked arithmetically reasonable.
+    #[test]
+    fn the_bound_excludes_itself_and_includes_every_extension() {
+        let upper = binary_prefix_upper_bound(&[1, 2]).expect("finite bound exists");
+        assert_eq!(upper, vec![1, 3]);
+        for witness in [
+            vec![1, 2],
+            vec![1, 2, 0],
+            vec![1, 2, 0xFF],
+            vec![1, 2, 9, 9],
+        ] {
+            assert!(witness < upper, "{witness:?} must be inside the range");
+        }
+        assert!(vec![1, 3] >= upper, "the bound must be exclusive");
+    }
+
+    /// A trailing `0xFF` carries: the last byte below `0xFF` is incremented and
+    /// everything after it is discarded.
+    #[test]
+    fn a_trailing_all_ones_byte_carries_into_the_previous_byte() {
+        assert_eq!(binary_prefix_upper_bound(&[1, 0xFF]), Some(vec![2]));
+        assert_eq!(binary_prefix_upper_bound(&[1, 0xFF, 0xFF]), Some(vec![2]));
+        let upper = binary_prefix_upper_bound(&[1, 0xFF]).expect("finite bound exists");
+        assert!(vec![1, 0xFF, 0xFF] < upper, "extension must be included");
+    }
+
+    /// The empty prefix matches everything, so no upper bound can exist. This is
+    /// the case that silently dropped rows: the old code returned `[0xFF]`, which
+    /// excluded every key sorting at or after it, so `begins_with([])` returned
+    /// part of the partition and reported success.
+    #[test]
+    fn an_empty_prefix_has_no_upper_bound() {
+        assert_eq!(binary_prefix_upper_bound(&[]), None);
+    }
+
+    /// Same defect one length up, and not only for the empty prefix: an all-`0xFF`
+    /// prefix of any length has no finite bound, because a longer all-`0xFF`
+    /// string always sorts after any candidate. The old code returned
+    /// `[0xFF, 0xFF]` for `[0xFF]`, which wrongly excluded `[0xFF, 0xFF, 0xFF]`.
+    #[test]
+    fn an_all_ones_prefix_has_no_upper_bound_at_any_length() {
+        for prefix in [vec![0xFF], vec![0xFF, 0xFF], vec![0xFF; 8]] {
+            assert_eq!(
+                binary_prefix_upper_bound(&prefix),
+                None,
+                "no finite bound exists above {prefix:?}"
+            );
+        }
+    }
+}

--- a/crates/storage-duckdb/src/data/query_scan.rs
+++ b/crates/storage-duckdb/src/data/query_scan.rs
@@ -1,0 +1,465 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `query` and `scan` for the DuckDB backend.
+//!
+//! Mirrors the PostgreSQL backend's index routing and pagination. For index
+//! operations the engine passes `key_info.key_schema` = index key schema and
+//! `key_info.base_key_schema` = base table key schema, so the index `sk_*`
+//! columns are addressed by the index sort key and `base_*` columns provide
+//! tie-breakers. DuckDB differences: positional `?` placeholders, no `COLLATE`
+//! (the default BINARY collation already matches DynamoDB byte order, and `N`
+//! keys are stored as the order-preserving TEXT encoding per D2), and
+//! `rowid % total_segments` for parallel scan.
+
+use std::fmt::Write;
+
+use extenddb_core::expression::{ExpressionMaps, KeyCondition, PathElement};
+use extenddb_core::types::{Item, ScalarAttributeType, TableKeyInfo};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::{
+    encode_netstring_composite, parse_sk, pk_to_text, sk_column, sk_column_n, sk_info,
+};
+
+use super::query::{build_key, build_sk_sql_and_binds, execute_dynamic_query, resolve_expr_to_av};
+use super::{
+    BoundValue, all_sort_key_info, data_table_name, index_table_name, json_to_item, sk_bound,
+};
+use crate::store::DuckDbEngine;
+
+impl DuckDbEngine {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn query_impl(
+        &self,
+        key_info: &TableKeyInfo,
+        key_condition: &KeyCondition,
+        maps: &ExpressionMaps,
+        forward: bool,
+        limit: Option<i64>,
+        exclusive_start_key: Option<&Item>,
+        index_name: Option<&str>,
+    ) -> Result<(Vec<Item>, Option<Item>), StorageError> {
+        let (ddb_table, is_lsi) = if let Some(idx_name) = index_name {
+            let info = self
+                .fetch_index_info_by_table_id(&key_info.table_id, idx_name)
+                .await?;
+            (
+                index_table_name(&info.index_id),
+                info.index_type == extenddb_core::types::IndexType::Lsi,
+            )
+        } else {
+            (data_table_name(&key_info.table_id), false)
+        };
+
+        // Partition key (composite via netstring when multi-HASH).
+        let pk_text = if key_condition.extra_pk_conditions.is_empty() {
+            pk_to_text(&resolve_expr_to_av(&key_condition.pk_value, maps)?)?.into_owned()
+        } else {
+            let mut parts =
+                vec![pk_to_text(&resolve_expr_to_av(&key_condition.pk_value, maps)?)?.into_owned()];
+            for (_, value) in &key_condition.extra_pk_conditions {
+                parts.push(pk_to_text(&resolve_expr_to_av(value, maps)?)?.into_owned());
+            }
+            encode_netstring_composite(&parts)
+        };
+
+        let sk_info_val = sk_info(&key_info.key_schema, &key_info.attribute_definitions);
+        let all_sks = all_sort_key_info(&key_info.key_schema, &key_info.attribute_definitions);
+        let base_sk_info: Option<(String, ScalarAttributeType)> = if index_name.is_some() {
+            sk_info(&key_info.base_key_schema, &key_info.attribute_definitions)
+                .map(|(n, t)| (n.to_owned(), t))
+        } else {
+            None
+        };
+
+        let mut sql = format!("SELECT item_data FROM {ddb_table} WHERE pk = ?");
+        let mut binds: Vec<BoundValue> = vec![BoundValue::Text(pk_text)];
+
+        // Primary sort-key condition.
+        if let (Some(sk_cond), Some((_, sk_type))) = (&key_condition.sk_condition, sk_info_val) {
+            let (sk_sql, sk_binds) =
+                build_sk_sql_and_binds(sk_cond, sk_column(sk_type), sk_type, maps)?;
+            sql.push_str(&sk_sql);
+            for v in &sk_binds {
+                binds.push(sk_bound(v));
+            }
+        }
+
+        // Extra RANGE-key equality conditions (multi-RANGE schemas).
+        for (path, value) in &key_condition.extra_sk_conditions {
+            let Some(attr_name) = resolve_attr_name(path, maps) else {
+                continue;
+            };
+            if let Some(pos) = all_sks.iter().position(|(n, _)| *n == attr_name)
+                && pos > 0
+            {
+                let (_, sk_type) = all_sks[pos];
+                let _ = write!(sql, " AND {} = ?", sk_column_n(pos, sk_type));
+                binds.push(sk_bound(&parse_sk(
+                    &resolve_expr_to_av(value, maps)?,
+                    sk_type,
+                )?));
+            }
+        }
+
+        // Pagination.
+        if exclusive_start_key.is_some() && sk_info_val.is_none() && index_name.is_none() {
+            return Ok((Vec::new(), None));
+        }
+        if let Some(start_key) = exclusive_start_key {
+            append_query_pagination(
+                &mut sql,
+                &mut binds,
+                start_key,
+                sk_info_val,
+                base_sk_info.as_ref(),
+                key_info,
+                index_name.is_some(),
+                is_lsi,
+                forward,
+            )?;
+        }
+
+        // ORDER BY.
+        let dir = if forward { "ASC" } else { "DESC" };
+        if let Some((_, sk_type)) = sk_info_val {
+            let sk_col = sk_column(sk_type);
+            if let Some((_, base_type)) = &base_sk_info {
+                let base_col = format!("base_{}", sk_column(*base_type));
+                if is_lsi {
+                    let _ = write!(sql, " ORDER BY {sk_col} {dir}, {base_col} {dir}");
+                } else {
+                    // GSI: order by the full base primary key after the index SK
+                    // so the ordering matches the pagination tie-breaker exactly.
+                    // Ordering by base SK alone leaves rows that share an index SK
+                    // and a base SK in an arbitrary order, which no
+                    // ExclusiveStartKey can resume from deterministically.
+                    let _ = write!(sql, " ORDER BY {sk_col} {dir}, base_pk ASC, {base_col} ASC");
+                }
+            } else if index_name.is_some() {
+                let _ = write!(sql, " ORDER BY {sk_col} {dir}, base_pk ASC");
+            } else {
+                let _ = write!(sql, " ORDER BY {sk_col} {dir}");
+            }
+        } else if index_name.is_some() {
+            if let Some((_, base_type)) = &base_sk_info {
+                let base_col = format!("base_{}", sk_column(*base_type));
+                let _ = write!(sql, " ORDER BY base_pk {dir}, {base_col} {dir}");
+            } else {
+                let _ = write!(sql, " ORDER BY base_pk {dir}");
+            }
+        }
+
+        let fetch_limit = limit.map_or(1_000_001, |l| l + 1);
+        let _ = write!(sql, " LIMIT {fetch_limit}");
+
+        let rows = execute_dynamic_query(&sql, binds, &self.pool).await?;
+        finalize(rows, limit, &key_info.key_schema)
+    }
+
+    pub(crate) async fn scan_impl(
+        &self,
+        key_info: &TableKeyInfo,
+        limit: Option<i64>,
+        exclusive_start_key: Option<&Item>,
+        segment: Option<i64>,
+        total_segments: Option<i64>,
+        index_name: Option<&str>,
+    ) -> Result<(Vec<Item>, Option<Item>), StorageError> {
+        let ddb_table = if let Some(idx_name) = index_name {
+            let info = self
+                .fetch_index_info_by_table_id(&key_info.table_id, idx_name)
+                .await?;
+            index_table_name(&info.index_id)
+        } else {
+            data_table_name(&key_info.table_id)
+        };
+
+        let sk_info_val = sk_info(&key_info.key_schema, &key_info.attribute_definitions);
+        let base_sk_info: Option<(String, ScalarAttributeType)> = if index_name.is_some() {
+            sk_info(&key_info.base_key_schema, &key_info.attribute_definitions)
+                .map(|(n, t)| (n.to_owned(), t))
+        } else {
+            None
+        };
+
+        let mut sql = format!("SELECT item_data FROM {ddb_table}");
+        let mut conditions: Vec<String> = Vec::new();
+        let mut binds: Vec<BoundValue> = Vec::new();
+
+        // Parallel scan: disjoint rowid partitioning. seg/total are validated
+        // non-negative integers at the engine layer, safe to interpolate.
+        if let (Some(seg), Some(total)) = (segment, total_segments) {
+            conditions.push(format!("(rowid % {total}) = {seg}"));
+        }
+
+        if let Some(start_key) = exclusive_start_key {
+            let pk_name = &key_info.key_schema[0].attribute_name;
+            if !start_key.contains_key(pk_name) {
+                return Err(StorageError::Validation(
+                    "The provided starting key is invalid: The provided key element does not match the schema".to_owned(),
+                ));
+            }
+            let pk_text = pk_to_text(start_key.get(pk_name).unwrap())?.into_owned();
+
+            if index_name.is_some() {
+                if let Some((sk_name, sk_type)) = sk_info_val {
+                    let sk_col = sk_column(sk_type);
+                    let sk_bv = start_key
+                        .get(sk_name)
+                        .map(|v| parse_sk(v, sk_type))
+                        .transpose()?
+                        .map(|s| sk_bound(&s));
+                    let base_pk_text = base_pk_from_start_key(start_key, key_info)?;
+                    if let Some((base_name, base_type)) = &base_sk_info {
+                        let base_col = format!("base_{}", sk_column(*base_type));
+                        conditions.push(format!(
+                            "(pk, {sk_col}, base_pk, {base_col}) > (?, ?, ?, ?)"
+                        ));
+                        binds.push(BoundValue::Text(pk_text));
+                        binds.push(sk_bv.unwrap_or(BoundValue::Text(String::new())));
+                        binds.push(BoundValue::Text(base_pk_text));
+                        if let Some(v) = start_key.get(base_name.as_str()) {
+                            binds.push(sk_bound(&parse_sk(v, *base_type)?));
+                        } else {
+                            binds.push(BoundValue::Text(String::new()));
+                        }
+                    } else {
+                        conditions.push(format!("(pk, {sk_col}, base_pk) > (?, ?, ?)"));
+                        binds.push(BoundValue::Text(pk_text));
+                        binds.push(sk_bv.unwrap_or(BoundValue::Text(String::new())));
+                        binds.push(BoundValue::Text(base_pk_text));
+                    }
+                } else {
+                    // Hash-only GSI. Include the base sort key in the
+                    // pagination predicate when the base table has one: the
+                    // index PRIMARY KEY is (pk, base_pk, base_sk*), so (pk,
+                    // base_pk) alone is not a total order and would skip rows
+                    // sharing a (pk, base_pk) across a page boundary.
+                    let base_pk_text = base_pk_from_start_key(start_key, key_info)?;
+                    if let Some((base_name, base_type)) = &base_sk_info {
+                        let base_col = format!("base_{}", sk_column(*base_type));
+                        conditions.push(format!("(pk, base_pk, {base_col}) > (?, ?, ?)"));
+                        binds.push(BoundValue::Text(pk_text));
+                        binds.push(BoundValue::Text(base_pk_text));
+                        if let Some(v) = start_key.get(base_name.as_str()) {
+                            binds.push(sk_bound(&parse_sk(v, *base_type)?));
+                        } else {
+                            binds.push(BoundValue::Text(String::new()));
+                        }
+                    } else {
+                        conditions.push("(pk, base_pk) > (?, ?)".to_owned());
+                        binds.push(BoundValue::Text(pk_text));
+                        binds.push(BoundValue::Text(base_pk_text));
+                    }
+                }
+            } else if let Some((sk_name, sk_type)) = sk_info_val {
+                let sk_col = sk_column(sk_type);
+                conditions.push(format!("(pk, {sk_col}) > (?, ?)"));
+                binds.push(BoundValue::Text(pk_text));
+                if let Some(v) = start_key.get(sk_name) {
+                    binds.push(sk_bound(&parse_sk(v, sk_type)?));
+                } else {
+                    binds.push(BoundValue::Text(String::new()));
+                }
+            } else {
+                conditions.push("pk > ?".to_owned());
+                binds.push(BoundValue::Text(pk_text));
+            }
+        }
+
+        if !conditions.is_empty() {
+            sql.push_str(" WHERE ");
+            sql.push_str(&conditions.join(" AND "));
+        }
+
+        // Deterministic ordering for pagination.
+        if index_name.is_some() {
+            if let Some((_, sk_type)) = sk_info_val {
+                let sk_col = sk_column(sk_type);
+                if let Some((_, base_type)) = &base_sk_info {
+                    let base_col = format!("base_{}", sk_column(*base_type));
+                    let _ = write!(sql, " ORDER BY pk, {sk_col}, base_pk, {base_col}");
+                } else {
+                    let _ = write!(sql, " ORDER BY pk, {sk_col}, base_pk");
+                }
+            } else if let Some((_, base_type)) = &base_sk_info {
+                // Hash-only GSI on a composite-key base table: order by the full
+                // index key so it is a total order matching the pagination
+                // predicate above.
+                let base_col = format!("base_{}", sk_column(*base_type));
+                let _ = write!(sql, " ORDER BY pk, base_pk, {base_col}");
+            } else {
+                let _ = write!(sql, " ORDER BY pk, base_pk");
+            }
+        } else if let Some((_, sk_type)) = sk_info_val {
+            let _ = write!(sql, " ORDER BY pk, {}", sk_column(sk_type));
+        } else {
+            sql.push_str(" ORDER BY pk");
+        }
+
+        let fetch_limit = limit.map_or(1_000_001, |l| l + 1);
+        let _ = write!(sql, " LIMIT {fetch_limit}");
+
+        let rows = execute_dynamic_query(&sql, binds, &self.pool).await?;
+        finalize(rows, limit, &key_info.key_schema)
+    }
+}
+
+/// Resolve a key-condition path's attribute name, handling `#name` references.
+fn resolve_attr_name(path: &[PathElement], maps: &ExpressionMaps) -> Option<String> {
+    match path.first() {
+        Some(PathElement::Attribute(name)) => {
+            if let Some(reference) = name.strip_prefix('#') {
+                maps.names.get(reference).cloned()
+            } else {
+                Some(name.clone())
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Extract the base-table partition key text from a (combined) start key.
+fn base_pk_from_start_key(
+    start_key: &Item,
+    key_info: &TableKeyInfo,
+) -> Result<String, StorageError> {
+    let base_pk_attr = &key_info.base_key_schema[0].attribute_name;
+    start_key
+        .get(base_pk_attr)
+        .map(pk_to_text)
+        .transpose()?
+        .map(|c| c.into_owned())
+        .ok_or_else(|| {
+            StorageError::Validation(
+                "The provided starting key is invalid: missing base table partition key".to_owned(),
+            )
+        })
+}
+
+/// Append the query pagination predicate and its binds, mirroring the
+/// PostgreSQL `build_pagination_where` cases.
+#[allow(clippy::too_many_arguments)]
+fn append_query_pagination(
+    sql: &mut String,
+    binds: &mut Vec<BoundValue>,
+    start_key: &Item,
+    sk_info_val: Option<(&str, ScalarAttributeType)>,
+    base_sk_info: Option<&(String, ScalarAttributeType)>,
+    key_info: &TableKeyInfo,
+    is_index: bool,
+    is_lsi: bool,
+    forward: bool,
+) -> Result<(), StorageError> {
+    let cmp = if forward { ">" } else { "<" };
+
+    if let Some((sk_name, sk_type)) = sk_info_val {
+        let sk_col = sk_column(sk_type);
+        let sk_bv = start_key
+            .get(sk_name)
+            .map(|v| parse_sk(v, sk_type))
+            .transpose()?
+            .map(|s| sk_bound(&s));
+
+        if let Some((base_name, base_type)) = base_sk_info {
+            let base_col = format!("base_{}", sk_column(*base_type));
+            let sk_bv = sk_bv.unwrap_or(BoundValue::Text(String::new()));
+            let base_sk_bv = if let Some(v) = start_key.get(base_name.as_str()) {
+                sk_bound(&parse_sk(v, *base_type)?)
+            } else {
+                BoundValue::Text(String::new())
+            };
+
+            if is_lsi {
+                // LSI: every row shares the queried partition key, so the base
+                // table's sort key alone identifies a row uniquely, and it is a
+                // user-visible sort dimension so it follows ScanIndexForward.
+                let _ = write!(
+                    sql,
+                    " AND ({sk_col} {cmp} ? OR ({sk_col} = ? AND {base_col} {cmp} ?))"
+                );
+                binds.push(sk_bv.clone());
+                binds.push(sk_bv);
+                binds.push(base_sk_bv);
+            } else {
+                // GSI: the tie-breaker must be the FULL base primary key. Rows
+                // in a GSI partition are unique on (index SK, base PK, base SK),
+                // not on (index SK, base SK): many base partitions can project
+                // the same index SK and the same base SK. Comparing base SK
+                // alone made a page-two query return nothing whenever the rows
+                // sharing an index SK also shared a base SK, so a paginating
+                // client silently stopped after page one.
+                let base_pk_bv = BoundValue::Text(base_pk_from_start_key(start_key, key_info)?);
+                let _ = write!(
+                    sql,
+                    " AND ({sk_col} {cmp} ? OR ({sk_col} = ? AND (base_pk > ? \
+                     OR (base_pk = ? AND {base_col} > ?))))"
+                );
+                binds.push(sk_bv.clone());
+                binds.push(sk_bv);
+                binds.push(base_pk_bv.clone());
+                binds.push(base_pk_bv);
+                binds.push(base_sk_bv);
+            }
+        } else if is_index {
+            let _ = write!(
+                sql,
+                " AND ({sk_col} {cmp} ? OR ({sk_col} = ? AND base_pk > ?))"
+            );
+            let sk_bv = sk_bv.unwrap_or(BoundValue::Text(String::new()));
+            binds.push(sk_bv.clone());
+            binds.push(sk_bv);
+            binds.push(BoundValue::Text(base_pk_from_start_key(
+                start_key, key_info,
+            )?));
+        } else {
+            let _ = write!(sql, " AND {sk_col} {cmp} ?");
+            binds.push(sk_bv.unwrap_or(BoundValue::Text(String::new())));
+        }
+    } else if is_index {
+        let base_pk_text = base_pk_from_start_key(start_key, key_info)?;
+        if let Some((base_name, base_type)) = base_sk_info {
+            let base_col = format!("base_{}", sk_column(*base_type));
+            let _ = write!(
+                sql,
+                " AND (base_pk > ? OR (base_pk = ? AND {base_col} > ?))"
+            );
+            binds.push(BoundValue::Text(base_pk_text.clone()));
+            binds.push(BoundValue::Text(base_pk_text));
+            if let Some(v) = start_key.get(base_name.as_str()) {
+                binds.push(sk_bound(&parse_sk(v, *base_type)?));
+            } else {
+                binds.push(BoundValue::Text(String::new()));
+            }
+        } else {
+            let _ = write!(sql, " AND base_pk > ?");
+            binds.push(BoundValue::Text(base_pk_text));
+        }
+    }
+    Ok(())
+}
+
+/// Trim the over-fetched extra row, deserialize items, and derive the
+/// `LastEvaluatedKey` (storage-side: the queried table's own key; the engine
+/// enriches index LEKs with base-table key attributes).
+fn finalize(
+    rows: Vec<serde_json::Value>,
+    limit: Option<i64>,
+    key_schema: &[extenddb_core::types::KeySchemaElement],
+) -> Result<(Vec<Item>, Option<Item>), StorageError> {
+    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+    let actual_limit = limit.map_or(1_000_000_usize, |l| l.max(0) as usize);
+    let has_more = rows.len() > actual_limit;
+    let items: Vec<Item> = rows
+        .into_iter()
+        .take(actual_limit)
+        .map(json_to_item)
+        .collect::<Result<Vec<_>, _>>()?;
+    let last_key = if has_more {
+        items.last().map(|item| build_key(item, key_schema))
+    } else {
+        None
+    };
+    Ok((items, last_key))
+}

--- a/crates/storage-duckdb/src/data/transactions.rs
+++ b/crates/storage-duckdb/src/data/transactions.rs
@@ -1,0 +1,506 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `TransactGetItems` / `TransactWriteItems` and idempotency-token cleanup.
+//!
+//! Writes run under the engine write lock (D1) in a single transaction, so all
+//! operations, the idempotency check, and stream capture commit atomically or
+//! roll back together. Reads run in one transaction for a consistent snapshot.
+
+use crate::db;
+use std::collections::HashMap;
+
+use extenddb_core::expression::{self, ExpressionMaps};
+use extenddb_core::types::{CancellationReason, Item, ReturnValuesOnConditionCheckFailure};
+use extenddb_core::validation;
+use extenddb_storage::error::StorageError;
+use extenddb_storage::{IdempotencyKey, TransactGetOp, TransactWriteOp};
+
+use super::index::{IndexMeta, enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
+use super::tx_helpers::{
+    check_idempotency_token_in_tx, delete_item_in_tx, fetch_item_for_update, fetch_item_in_tx,
+    upsert_item_in_tx, write_stream_record_in_tx,
+};
+use crate::duckdb_util::format_timestamp;
+use crate::store::DuckDbEngine;
+
+impl DuckDbEngine {
+    pub(crate) async fn transact_get_items_impl(
+        &self,
+        ops: &[TransactGetOp<'_>],
+    ) -> Result<Vec<Option<Item>>, StorageError> {
+        // Validate keys first, collecting per-item reasons (all-or-nothing).
+        let mut reasons = Vec::with_capacity(ops.len());
+        let mut any_failed = false;
+        for op in ops {
+            match validation::validate_key_only(
+                op.key,
+                &op.key_info.key_schema,
+                &op.key_info.attribute_definitions,
+            ) {
+                Ok(()) => reasons.push(CancellationReason::none()),
+                Err(e) => {
+                    any_failed = true;
+                    reasons.push(CancellationReason::validation_error(e.to_string()));
+                }
+            }
+        }
+        if any_failed {
+            return Err(StorageError::TransactionCanceled(reasons));
+        }
+
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let mut results = Vec::with_capacity(ops.len());
+        for op in ops {
+            results.push(fetch_item_in_tx(&mut tx, op.key_info, op.key).await?);
+        }
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        Ok(results)
+    }
+
+    pub(crate) async fn transact_write_items_impl(
+        &self,
+        ops: &[TransactWriteOp<'_>],
+        idempotency: Option<IdempotencyKey<'_>>,
+    ) -> Result<(), StorageError> {
+        // Read the propagation delay BEFORE taking the write lock. It is a
+        // runtime setting, not an invariant of this write, so it does not need
+        // to be read under the lock, and the lock serialises every write in the
+        // process: work done inside it is the backend's throughput bottleneck.
+        let system_delay = self.index_propagation_delay().await;
+        let _writer = self.write_lock.lock().await;
+        // Fetch index metadata per distinct table AFTER acquiring the write lock,
+        // so a GSI added by a concurrent UpdateTable (same lock) is not missed and
+        // left unmaintained by these writes.
+        let mut table_indexes: HashMap<String, Vec<IndexMeta>> = HashMap::new();
+        for op in ops {
+            let name = op_table_name(op);
+            if !table_indexes.contains_key(name) {
+                let indexes = fetch_indexes_for_table(op_table_id(op), &self.pool).await?;
+                table_indexes.insert(name.to_owned(), indexes);
+            }
+        }
+
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        if let Some(key) = idempotency {
+            // Idempotency is per-account: the same ClientRequestToken in two
+            // accounts must not collide. The engine passes the caller's
+            // account explicitly.
+            check_idempotency_token_in_tx(&mut tx, key.account_id, key.token, key.fingerprint)
+                .await?;
+        }
+
+        let mut reasons: Vec<CancellationReason> = Vec::with_capacity(ops.len());
+        let mut op_items: Vec<(Option<Item>, Option<Item>)> = Vec::with_capacity(ops.len());
+        let mut any_failed = false;
+
+        for op in ops {
+            let indexes = &table_indexes[op_table_name(op)];
+            match execute_transact_write_op(
+                &mut tx,
+                op,
+                indexes,
+                self.max_item_size_bytes,
+                system_delay,
+            )
+            .await
+            {
+                Ok(items) => {
+                    op_items.push(items);
+                    reasons.push(CancellationReason::none());
+                }
+                Err(TxnOpError::Cancel(r)) => {
+                    op_items.push((None, None));
+                    any_failed = true;
+                    reasons.push(r);
+                }
+                Err(TxnOpError::Validation(msg)) => {
+                    // Up-front input validation (e.g. empty secondary-index key):
+                    // abort the whole transaction with a top-level
+                    // ValidationException, not a per-item cancellation reason.
+                    return Err(StorageError::Validation(msg));
+                }
+                Err(TxnOpError::Storage(e)) => return Err(e),
+            }
+        }
+
+        if any_failed {
+            // Dropping `tx` without commit rolls back all writes.
+            return Err(StorageError::TransactionCanceled(reasons));
+        }
+
+        // Capture stream records after all writes are staged.
+        for (op, (old_item, new_item)) in ops.iter().zip(op_items.iter()) {
+            let capture = match op {
+                TransactWriteOp::Put { stream, .. }
+                | TransactWriteOp::Delete { stream, .. }
+                | TransactWriteOp::Update { stream, .. } => stream.as_ref(),
+                TransactWriteOp::ConditionCheck { .. } => None,
+            };
+            if let Some(capture) = capture {
+                write_stream_record_in_tx(
+                    &mut tx,
+                    op_key_info(op),
+                    capture,
+                    old_item.as_ref(),
+                    new_item.as_ref(),
+                )
+                .await?;
+            }
+        }
+
+        // Persist index work for each op inside the same transaction: async GSI
+        // rows, and vector maintenance which is applied here when the propagation
+        // delay is 0 and enqueued otherwise.
+        //
+        // Deliberately after every op is staged rather than inside each op, so
+        // there is one call site instead of three. Both paths stay atomic with the
+        // item writes either way: the synchronous apply runs in this transaction,
+        // and a pending row is inserted into it, so a cancelled transaction leaves
+        // neither behind. The vector apply reads only the op's own before/after
+        // items, never the base table, so its position relative to the other ops'
+        // staged writes cannot change its result.
+        let mut needs_notify = false;
+        for (op, (old_item, new_item)) in ops.iter().zip(op_items.iter()) {
+            let indexes = &table_indexes[op_table_name(op)];
+            if old_item.is_some() || new_item.is_some() {
+                let n = enqueue_async_indexes(
+                    &mut tx,
+                    op_key_info(op),
+                    indexes,
+                    old_item.as_ref(),
+                    new_item.as_ref(),
+                    system_delay,
+                )
+                .await?;
+                if n > 0 {
+                    needs_notify = true;
+                }
+                let key_info = op_key_info(op);
+                if !key_info.vector_indexes.is_empty() {
+                    let n = crate::data::vector_index::maintain_vector_indexes(
+                        &mut tx,
+                        &key_info.table_id,
+                        &key_info.key_schema,
+                        &key_info.attribute_definitions,
+                        old_item.as_ref(),
+                        new_item.as_ref(),
+                        system_delay,
+                    )
+                    .await?;
+                    if n > 0 {
+                        needs_notify = true;
+                    }
+                }
+            }
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        if needs_notify {
+            self.gsi_notify.notify_waiters();
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn cleanup_expired_idempotency_tokens_impl(
+        &self,
+        max_age_seconds: i64,
+    ) -> Result<u64, StorageError> {
+        let cutoff = format_timestamp(
+            time::OffsetDateTime::now_utc() - time::Duration::seconds(max_age_seconds),
+        );
+        let result = db::query("DELETE FROM idempotency_tokens WHERE created_at < ?")
+            .bind(&cutoff)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        Ok(result.rows_affected())
+    }
+}
+
+fn op_table_name<'a>(op: &'a TransactWriteOp<'_>) -> &'a str {
+    &op_key_info(op).table_name
+}
+
+fn op_table_id<'a>(op: &'a TransactWriteOp<'_>) -> &'a str {
+    &op_key_info(op).table_id
+}
+
+fn op_key_info<'a>(op: &'a TransactWriteOp<'_>) -> &'a extenddb_core::types::TableKeyInfo {
+    match op {
+        TransactWriteOp::Put { key_info, .. }
+        | TransactWriteOp::Delete { key_info, .. }
+        | TransactWriteOp::Update { key_info, .. }
+        | TransactWriteOp::ConditionCheck { key_info, .. } => key_info,
+    }
+}
+
+enum TxnOpError {
+    Cancel(CancellationReason),
+    /// Up-front input validation failure — aborts the whole transaction with a
+    /// top-level `ValidationException` (not a per-item cancellation reason).
+    Validation(String),
+    Storage(StorageError),
+}
+
+/// Build [`validation::IndexKeyRef`] views over the table's indexes for
+/// secondary-index key validation.
+pub(crate) fn index_key_refs(indexes: &[IndexMeta]) -> Vec<validation::IndexKeyRef<'_>> {
+    indexes
+        .iter()
+        .map(|idx| validation::IndexKeyRef {
+            index_name: &idx.index_name,
+            key_schema: &idx.key_schema,
+        })
+        .collect()
+}
+
+/// Execute one transact-write op, returning `(old, new)` images for stream
+/// capture, or a cancellation reason on a failed condition / validation.
+async fn execute_transact_write_op(
+    tx: &mut db::Transaction,
+    op: &TransactWriteOp<'_>,
+    indexes: &[IndexMeta],
+    max_item_size_bytes: usize,
+    system_delay: u64,
+) -> Result<(Option<Item>, Option<Item>), TxnOpError> {
+    match op {
+        TransactWriteOp::Put {
+            key_info,
+            item,
+            condition,
+            maps,
+            return_values_on_ccf,
+            ..
+        } => {
+            validation::validate_item_keys(
+                item,
+                &key_info.key_schema,
+                &key_info.attribute_definitions,
+            )
+            .map_err(|e| TxnOpError::Cancel(CancellationReason::validation_error(e.to_string())))?;
+            // Secondary-index key faults split by kind: a type mismatch is a
+            // per-item cancellation reason; an empty index key is up-front input
+            // validation (a top-level ValidationException).
+            let idx_refs = index_key_refs(indexes);
+            validation::validate_index_key_types(item, &idx_refs, &key_info.attribute_definitions)
+                .map_err(|e| {
+                    TxnOpError::Cancel(CancellationReason::validation_error(e.to_string()))
+                })?;
+            validation::validate_index_key_not_empty(
+                item,
+                &idx_refs,
+                validation::SecondaryIndexEmptyContext::Item,
+            )
+            .map_err(|e| TxnOpError::Validation(e.to_string()))?;
+            let existing = fetch_item_for_update(tx, key_info, item)
+                .await
+                .map_err(TxnOpError::Storage)?;
+            let empty = Item::new();
+            eval_condition(
+                *condition,
+                existing.as_ref().unwrap_or(&empty),
+                maps,
+                *return_values_on_ccf,
+                existing.as_ref(),
+            )?;
+            upsert_item_in_tx(tx, key_info, item)
+                .await
+                .map_err(TxnOpError::Storage)?;
+            if !indexes.is_empty() {
+                sync_indexes(
+                    tx,
+                    &key_info.key_schema,
+                    &key_info.attribute_definitions,
+                    indexes,
+                    existing.as_ref(),
+                    Some(item),
+                    system_delay,
+                )
+                .await
+                .map_err(TxnOpError::Storage)?;
+            }
+            Ok((existing, Some((*item).clone())))
+        }
+        TransactWriteOp::Delete {
+            key_info,
+            key,
+            condition,
+            maps,
+            return_values_on_ccf,
+            ..
+        } => {
+            validation::validate_batch_key_only(
+                key,
+                &key_info.key_schema,
+                &key_info.attribute_definitions,
+            )
+            .map_err(|e| TxnOpError::Cancel(CancellationReason::validation_error(e.to_string())))?;
+            let existing = fetch_item_for_update(tx, key_info, key)
+                .await
+                .map_err(TxnOpError::Storage)?;
+            let empty = Item::new();
+            eval_condition(
+                *condition,
+                existing.as_ref().unwrap_or(&empty),
+                maps,
+                *return_values_on_ccf,
+                existing.as_ref(),
+            )?;
+            delete_item_in_tx(tx, key_info, key)
+                .await
+                .map_err(TxnOpError::Storage)?;
+            if !indexes.is_empty() {
+                sync_indexes(
+                    tx,
+                    &key_info.key_schema,
+                    &key_info.attribute_definitions,
+                    indexes,
+                    existing.as_ref(),
+                    None,
+                    system_delay,
+                )
+                .await
+                .map_err(TxnOpError::Storage)?;
+            }
+            Ok((existing, None))
+        }
+        TransactWriteOp::Update {
+            key_info,
+            key,
+            actions,
+            condition,
+            maps,
+            return_values_on_ccf,
+            ..
+        } => {
+            validation::validate_batch_key_only(
+                key,
+                &key_info.key_schema,
+                &key_info.attribute_definitions,
+            )
+            .map_err(|e| TxnOpError::Cancel(CancellationReason::validation_error(e.to_string())))?;
+            let existing = fetch_item_for_update(tx, key_info, key)
+                .await
+                .map_err(TxnOpError::Storage)?;
+            let empty = Item::new();
+            eval_condition(
+                *condition,
+                existing.as_ref().unwrap_or(&empty),
+                maps,
+                *return_values_on_ccf,
+                existing.as_ref(),
+            )?;
+            let mut item = existing.clone().unwrap_or_else(|| (*key).clone());
+            expression::apply_update_validated(
+                actions,
+                &mut item,
+                maps,
+                &key_info.vector_indexes,
+                &key_info.attribute_definitions,
+            )
+            .map_err(|e| TxnOpError::Cancel(CancellationReason::validation_error(e.to_string())))?;
+            validation::validate_item_size(&item, max_item_size_bytes).map_err(|e| {
+                TxnOpError::Cancel(CancellationReason::validation_error(e.to_string()))
+            })?;
+            // Secondary-index key validation on the post-update item: a type
+            // mismatch is a cancellation reason; setting an index key to an
+            // empty value is a top-level ValidationException.
+            let idx_refs = index_key_refs(indexes);
+            validation::validate_index_key_types(&item, &idx_refs, &key_info.attribute_definitions)
+                .map_err(|e| {
+                    TxnOpError::Cancel(CancellationReason::validation_error(e.to_string()))
+                })?;
+            validation::validate_index_key_not_empty(
+                &item,
+                &idx_refs,
+                validation::SecondaryIndexEmptyContext::UpdateExpression,
+            )
+            .map_err(|e| TxnOpError::Validation(e.to_string()))?;
+            upsert_item_in_tx(tx, key_info, &item)
+                .await
+                .map_err(TxnOpError::Storage)?;
+            if !indexes.is_empty() {
+                sync_indexes(
+                    tx,
+                    &key_info.key_schema,
+                    &key_info.attribute_definitions,
+                    indexes,
+                    existing.as_ref(),
+                    Some(&item),
+                    system_delay,
+                )
+                .await
+                .map_err(TxnOpError::Storage)?;
+            }
+            Ok((existing, Some(item)))
+        }
+        TransactWriteOp::ConditionCheck {
+            key_info,
+            key,
+            condition,
+            maps,
+            return_values_on_ccf,
+        } => {
+            validation::validate_batch_key_only(
+                key,
+                &key_info.key_schema,
+                &key_info.attribute_definitions,
+            )
+            .map_err(|e| TxnOpError::Cancel(CancellationReason::validation_error(e.to_string())))?;
+            let existing = fetch_item_for_update(tx, key_info, key)
+                .await
+                .map_err(TxnOpError::Storage)?;
+            let empty = Item::new();
+            eval_condition(
+                Some(condition),
+                existing.as_ref().unwrap_or(&empty),
+                maps,
+                *return_values_on_ccf,
+                existing.as_ref(),
+            )?;
+            Ok((None, None))
+        }
+    }
+}
+
+/// Evaluate a transaction op's condition, producing a `CancellationReason` on
+/// failure (attaching the old item when `ReturnValuesOnConditionCheckFailure`
+/// is `AllOld`).
+fn eval_condition(
+    condition: Option<&expression::Expr>,
+    item: &Item,
+    maps: &ExpressionMaps,
+    return_values_on_ccf: ReturnValuesOnConditionCheckFailure,
+    existing: Option<&Item>,
+) -> Result<(), TxnOpError> {
+    if let Some(cond) = condition {
+        let passed = expression::evaluate_condition(cond, item, maps)
+            .map_err(|e| TxnOpError::Cancel(CancellationReason::validation_error(e.to_string())))?;
+        if !passed {
+            let returned = if return_values_on_ccf == ReturnValuesOnConditionCheckFailure::AllOld {
+                existing.cloned()
+            } else {
+                None
+            };
+            return Err(TxnOpError::Cancel(
+                CancellationReason::condition_check_failed_with_item(returned),
+            ));
+        }
+    }
+    Ok(())
+}

--- a/crates/storage-duckdb/src/data/tx_helpers.rs
+++ b/crates/storage-duckdb/src/data/tx_helpers.rs
@@ -1,0 +1,379 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Transaction helpers shared by the write path and transactions module:
+//! in-transaction item fetch/upsert/delete, monotonic stream sequencing,
+//! atomic stream-record capture, and idempotency-token checks.
+//!
+//! There is no `SELECT ... FOR UPDATE`: the engine's `write_lock` serializes
+//! all writers (design decision D1), so an in-transaction read followed by a
+//! write is already atomic with respect to other writers.
+
+use crate::db;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use extenddb_core::types::{
+    AttributeValue, Item, StreamEventName, StreamRecord, StreamRecordData, StreamViewType,
+    TableKeyInfo, item_size_bytes,
+};
+use extenddb_storage::StreamCapture;
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::{pk_to_text, sk_column, sk_info};
+
+use super::{
+    bind_sk_execute, bind_sk_fetch_optional, bind_sk_only_execute, data_table_name, json_to_item,
+};
+use crate::duckdb_util::format_timestamp;
+
+/// Fetch a single item within a transaction by primary key.
+pub(super) async fn fetch_item_in_tx(
+    tx: &mut db::Transaction,
+    key_info: &TableKeyInfo,
+    key: &Item,
+) -> Result<Option<Item>, StorageError> {
+    let ddb_table = data_table_name(&key_info.table_id);
+    let pk_name = &key_info.key_schema[0].attribute_name;
+    let pk_value = key
+        .get(pk_name)
+        .ok_or_else(|| StorageError::Internal("missing partition key".to_owned()))?;
+    let pk_text = pk_to_text(pk_value)?;
+
+    let json_opt = if let Some((sk_name, sk_type)) =
+        sk_info(&key_info.key_schema, &key_info.attribute_definitions)
+    {
+        let sk_value = key
+            .get(sk_name)
+            .ok_or_else(|| StorageError::Internal("missing sort key".to_owned()))?;
+        let sk = extenddb_storage::util::parse_sk(sk_value, sk_type)?;
+        let sk_col = sk_column(sk_type);
+        let sql = format!("SELECT item_data FROM {ddb_table} WHERE pk = ? AND {sk_col} = ?");
+        let row: Option<(serde_json::Value,)> =
+            bind_sk_fetch_optional!(&sql, pk_text.as_ref(), &sk, &mut **tx)?;
+        row.map(|(v,)| v)
+    } else {
+        let sql = format!("SELECT item_data FROM {ddb_table} WHERE pk = ?");
+        let row: Option<(serde_json::Value,)> = db::query_as(&sql)
+            .bind(pk_text.as_ref())
+            .fetch_optional(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        row.map(|(v,)| v)
+    };
+
+    json_opt.map(json_to_item).transpose()
+}
+
+/// Fetch for write. DuckDB has no `FOR UPDATE`; the engine write lock provides
+/// the serialization, so this is the same as `fetch_item_in_tx`.
+pub(super) async fn fetch_item_for_update(
+    tx: &mut db::Transaction,
+    key_info: &TableKeyInfo,
+    key: &Item,
+) -> Result<Option<Item>, StorageError> {
+    fetch_item_in_tx(tx, key_info, key).await
+}
+
+/// Insert or replace an item within a transaction.
+pub(crate) async fn upsert_item_in_tx(
+    tx: &mut db::Transaction,
+    key_info: &TableKeyInfo,
+    item: &Item,
+) -> Result<(), StorageError> {
+    let ddb_table = data_table_name(&key_info.table_id);
+    let pk_name = &key_info.key_schema[0].attribute_name;
+    let pk_value = item
+        .get(pk_name)
+        .ok_or_else(|| StorageError::Internal("missing partition key".to_owned()))?;
+    let pk_text = pk_to_text(pk_value)?;
+    let item_json =
+        serde_json::to_string(item).map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    if let Some((sk_name, sk_type)) = sk_info(&key_info.key_schema, &key_info.attribute_definitions)
+    {
+        let sk_value = item
+            .get(sk_name)
+            .ok_or_else(|| StorageError::Internal("missing sort key".to_owned()))?;
+        let sk = extenddb_storage::util::parse_sk(sk_value, sk_type)?;
+        let sk_col = sk_column(sk_type);
+        let sql = format!(
+            "INSERT INTO {ddb_table} (pk, {sk_col}, item_data) VALUES (?, ?, ?) \
+             ON CONFLICT (pk, {sk_col}) DO UPDATE SET item_data = excluded.item_data"
+        );
+        bind_sk_execute!(&sql, pk_text.as_ref(), &sk, &item_json, &mut **tx)?;
+    } else {
+        let sql = format!(
+            "INSERT INTO {ddb_table} (pk, item_data) VALUES (?, ?) \
+             ON CONFLICT (pk) DO UPDATE SET item_data = excluded.item_data"
+        );
+        db::query(&sql)
+            .bind(pk_text.as_ref())
+            .bind(&item_json)
+            .execute(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+    }
+    Ok(())
+}
+
+/// Delete an item by key within a transaction.
+pub(super) async fn delete_item_in_tx(
+    tx: &mut db::Transaction,
+    key_info: &TableKeyInfo,
+    key: &Item,
+) -> Result<(), StorageError> {
+    let ddb_table = data_table_name(&key_info.table_id);
+    let pk_name = &key_info.key_schema[0].attribute_name;
+    let pk_value = key
+        .get(pk_name)
+        .ok_or_else(|| StorageError::Internal("missing partition key".to_owned()))?;
+    let pk_text = pk_to_text(pk_value)?;
+
+    if let Some((sk_name, sk_type)) = sk_info(&key_info.key_schema, &key_info.attribute_definitions)
+    {
+        let sk_value = key
+            .get(sk_name)
+            .ok_or_else(|| StorageError::Internal("missing sort key".to_owned()))?;
+        let sk = extenddb_storage::util::parse_sk(sk_value, sk_type)?;
+        let sk_col = sk_column(sk_type);
+        let sql = format!("DELETE FROM {ddb_table} WHERE pk = ? AND {sk_col} = ?");
+        bind_sk_only_execute!(&sql, pk_text.as_ref(), &sk, &mut **tx)?;
+    } else {
+        let sql = format!("DELETE FROM {ddb_table} WHERE pk = ?");
+        db::query(&sql)
+            .bind(pk_text.as_ref())
+            .execute(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+    }
+    Ok(())
+}
+
+/// Allocate the next monotonic stream sequence number within a transaction.
+async fn next_stream_seq(tx: &mut db::Transaction) -> Result<i64, StorageError> {
+    db::query("UPDATE seq_counters SET value = value + 1 WHERE name = 'stream'")
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let value: i64 = db::query_scalar("SELECT value FROM seq_counters WHERE name = 'stream'")
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    Ok(value)
+}
+
+/// Write a stream record in the same transaction as the data write, so capture
+/// is atomic with the mutation (a hard requirement for correct streams).
+pub(super) async fn write_stream_record_in_tx(
+    tx: &mut db::Transaction,
+    key_info: &TableKeyInfo,
+    capture: &StreamCapture,
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+) -> Result<(), StorageError> {
+    let event_name = match (old_item, new_item) {
+        (None, Some(_)) => StreamEventName::Insert,
+        (Some(_), Some(_)) => StreamEventName::Modify,
+        (Some(_), None) => StreamEventName::Remove,
+        (None, None) => return Ok(()),
+    };
+    let source = new_item.or(old_item).expect("one image present");
+
+    // Keys are the primary-key attributes from whichever image is present.
+    let keys: Item = key_info
+        .key_schema
+        .iter()
+        .filter_map(|ks| {
+            source
+                .get(&ks.attribute_name)
+                .map(|v| (ks.attribute_name.clone(), v.clone()))
+        })
+        .collect();
+
+    let new_image = matches!(
+        capture.view_type,
+        StreamViewType::NewImage | StreamViewType::NewAndOldImages
+    )
+    .then(|| new_item.cloned())
+    .flatten();
+    let old_image = matches!(
+        capture.view_type,
+        StreamViewType::OldImage | StreamViewType::NewAndOldImages
+    )
+    .then(|| old_item.cloned())
+    .flatten();
+
+    let size_bytes = i64::try_from(item_size_bytes(source)).unwrap_or(i64::MAX);
+
+    // Hash the partition key to a shard.
+    let pk_name = &key_info.key_schema[0].attribute_name;
+    let pk_str = source
+        .get(pk_name)
+        .map(|v| match v {
+            AttributeValue::S(s) => s.clone(),
+            AttributeValue::N(n) => n.clone(),
+            AttributeValue::B(b) => BASE64.encode(b),
+            _ => String::new(),
+        })
+        .unwrap_or_default();
+
+    let shards: Vec<(String,)> =
+        db::query_as("SELECT shard_id FROM stream_shards WHERE table_id = ? ORDER BY shard_id")
+            .bind(&key_info.table_id)
+            .fetch_all(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+    if shards.is_empty() {
+        return Ok(()); // Streams not enabled for this table.
+    }
+    let idx = (crc32fast::hash(pk_str.as_bytes()) as usize) % shards.len();
+    let shard_id = shards[idx].0.clone();
+
+    let seq = format!("{:021}", next_stream_seq(tx).await?);
+    let approximate_creation_date_time = i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    )
+    .unwrap_or(i64::MAX);
+
+    let record = StreamRecord {
+        event_id: uuid::Uuid::new_v4().to_string(),
+        event_name,
+        event_version: "1.1".to_owned(),
+        event_source: "aws:dynamodb".to_owned(),
+        aws_region: capture.region.to_string(),
+        dynamodb: StreamRecordData {
+            approximate_creation_date_time,
+            keys,
+            new_image,
+            old_image,
+            sequence_number: seq.clone(),
+            size_bytes,
+            stream_view_type: capture.view_type,
+        },
+        user_identity: capture.user_identity.clone(),
+    };
+    let record_json =
+        serde_json::to_string(&record).map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    db::query(
+        "INSERT INTO stream_records (shard_id, sequence_number, table_id, event_name, record_data) \
+         VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(&shard_id)
+    .bind(&seq)
+    .bind(&key_info.table_id)
+    .bind(format!("{:?}", record.event_name))
+    .bind(&record_json)
+    .execute(&mut **tx)
+    .await
+    .map_err(|e| StorageError::Internal(e.to_string()))?;
+    Ok(())
+}
+
+/// Check (and record) an idempotency token within a transaction. Tokens are
+/// valid for 10 minutes; the cutoff is computed in Rust as RFC 3339 so it
+/// compares correctly against the stored RFC 3339 `created_at`.
+pub(super) async fn check_idempotency_token_in_tx(
+    tx: &mut db::Transaction,
+    account_id: &str,
+    token: &str,
+    fingerprint: &str,
+) -> Result<(), StorageError> {
+    let cutoff = format_timestamp(time::OffsetDateTime::now_utc() - time::Duration::minutes(10));
+    let existing: Option<(String,)> = db::query_as(
+        "SELECT fingerprint FROM idempotency_tokens \
+         WHERE account_id = ? AND token = ? AND created_at > ?",
+    )
+    .bind(account_id)
+    .bind(token)
+    .bind(&cutoff)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    if let Some((stored_fp,)) = existing {
+        return if stored_fp == fingerprint {
+            Err(StorageError::IdempotentReplay)
+        } else {
+            Err(StorageError::IdempotentMismatch)
+        };
+    }
+
+    let now = format_timestamp(time::OffsetDateTime::now_utc());
+    db::query(
+        "INSERT INTO idempotency_tokens (account_id, token, fingerprint, created_at) \
+         VALUES (?, ?, ?, ?) \
+         ON CONFLICT (account_id, token) DO UPDATE SET fingerprint = excluded.fingerprint, \
+         created_at = excluded.created_at",
+    )
+    .bind(account_id)
+    .bind(token)
+    .bind(fingerprint)
+    .bind(&now)
+    .execute(&mut **tx)
+    .await
+    .map_err(|e| StorageError::Internal(e.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod idempotency_tests {
+    use super::check_idempotency_token_in_tx;
+    use crate::db;
+    use extenddb_storage::error::StorageError;
+
+    async fn pool_with_schema() -> db::Pool {
+        let pool = db::Pool::open(":memory:", 1).await.unwrap();
+        db::query(
+            "CREATE TABLE idempotency_tokens (\
+                 account_id  TEXT NOT NULL,\
+                 token       TEXT NOT NULL,\
+                 fingerprint TEXT NOT NULL,\
+                 created_at  TEXT NOT NULL DEFAULT (strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ')),\
+                 PRIMARY KEY (account_id, token)\
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    async fn check(
+        pool: &db::Pool,
+        account: &str,
+        token: &str,
+        fp: &str,
+    ) -> Result<(), StorageError> {
+        let mut tx = pool.begin().await.unwrap();
+        let r = check_idempotency_token_in_tx(&mut tx, account, token, fp).await;
+        tx.commit().await.unwrap();
+        r
+    }
+
+    #[tokio::test]
+    async fn idempotency_is_scoped_per_account() {
+        let pool = pool_with_schema().await;
+
+        // First use of (acctA, tok) records it.
+        check(&pool, "acctA", "tok", "fpX").await.unwrap();
+
+        // Same account + token + fingerprint = idempotent replay.
+        assert!(matches!(
+            check(&pool, "acctA", "tok", "fpX").await,
+            Err(StorageError::IdempotentReplay)
+        ));
+
+        // Same account + token, different fingerprint = mismatch.
+        assert!(matches!(
+            check(&pool, "acctA", "tok", "fpY").await,
+            Err(StorageError::IdempotentMismatch)
+        ));
+
+        // Regression: a DIFFERENT account reusing the same token value must be
+        // independent — not a replay and not a mismatch.
+        check(&pool, "acctB", "tok", "fpX").await.unwrap();
+    }
+}

--- a/crates/storage-duckdb/src/data/update_item.rs
+++ b/crates/storage-duckdb/src/data/update_item.rs
@@ -1,0 +1,155 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `update_item` for the DuckDB backend.
+//!
+//! UpdateItem is an upsert: when the item is absent a new one is created from
+//! the key plus the applied actions. The condition is evaluated against the
+//! pre-update image (or an empty item), then update actions are applied and the
+//! result is validated and written — all under the engine write lock (D1).
+
+use extenddb_core::expression::{self, Expr, ExpressionMaps, UpdateAction};
+use extenddb_core::types::{Item, TableKeyInfo};
+use extenddb_core::validation;
+use extenddb_storage::StreamCapture;
+use extenddb_storage::error::StorageError;
+
+use super::index::{enqueue_async_indexes, fetch_indexes_for_table, sync_indexes};
+use super::query::check_condition;
+use super::transactions::index_key_refs;
+use super::tx_helpers::{fetch_item_in_tx, upsert_item_in_tx, write_stream_record_in_tx};
+use crate::store::DuckDbEngine;
+
+impl DuckDbEngine {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn update_item_impl(
+        &self,
+        key_info: &TableKeyInfo,
+        key: &Item,
+        actions: &[UpdateAction],
+        return_old: bool,
+        return_new: bool,
+        condition: Option<&Expr>,
+        maps: &ExpressionMaps,
+        stream: Option<&StreamCapture>,
+    ) -> Result<(Option<Item>, Option<Item>), StorageError> {
+        // Read the propagation delay BEFORE taking the write lock. It is a
+        // runtime setting, not an invariant of this write, so it does not need
+        // to be read under the lock, and the lock serialises every write in the
+        // process: work done inside it is the backend's throughput bottleneck.
+        let system_delay = self.index_propagation_delay().await;
+        let _writer = self.write_lock.lock().await;
+        // Read the index set after acquiring the write lock so a concurrently
+        // added GSI (UpdateTable holds the same lock) is not missed.
+        let indexes = fetch_indexes_for_table(&key_info.table_id, &self.pool).await?;
+
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let old = fetch_item_in_tx(&mut tx, key_info, key).await?;
+
+        if condition.is_some() {
+            let empty = Item::new();
+            let target = old.as_ref().unwrap_or(&empty);
+            if let Err(e) = check_condition(condition, target, maps) {
+                return match e {
+                    StorageError::ConditionFailed(_) => Err(StorageError::ConditionFailed(old)),
+                    other => Err(other),
+                };
+            }
+        }
+
+        // Start from the existing image, or from the key for a fresh upsert.
+        let mut item = old.clone().unwrap_or_else(|| key.clone());
+        expression::apply_update_validated(
+            actions,
+            &mut item,
+            maps,
+            &key_info.vector_indexes,
+            &key_info.attribute_definitions,
+        )
+        .map_err(|e| StorageError::Validation(e.to_string()))?;
+        validation::validate_item_size(&item, self.max_item_size_bytes)
+            .map_err(|e| StorageError::Validation(e.to_string()))?;
+        // Secondary-index key validation on the post-update item, matching the
+        // TransactWriteItems update path: a wrong-typed index key attribute or
+        // an index key set to an empty value is a ValidationException up front,
+        // rather than silently producing a malformed / unmatchable index row.
+        if !indexes.is_empty() {
+            let idx_refs = index_key_refs(&indexes);
+            validation::validate_index_key_types(&item, &idx_refs, &key_info.attribute_definitions)
+                .map_err(|e| StorageError::Validation(e.to_string()))?;
+            validation::validate_index_key_not_empty(
+                &item,
+                &idx_refs,
+                validation::SecondaryIndexEmptyContext::UpdateExpression,
+            )
+            .map_err(|e| StorageError::Validation(e.to_string()))?;
+        }
+
+        upsert_item_in_tx(&mut tx, key_info, &item).await?;
+
+        if !indexes.is_empty() {
+            sync_indexes(
+                &mut tx,
+                &key_info.key_schema,
+                &key_info.attribute_definitions,
+                &indexes,
+                old.as_ref(),
+                Some(&item),
+                system_delay,
+            )
+            .await?;
+        }
+        let enqueued_gsi = enqueue_async_indexes(
+            &mut tx,
+            key_info,
+            &indexes,
+            old.as_ref(),
+            Some(&item),
+            system_delay,
+        )
+        .await?
+            > 0;
+        // Vector indexes: applied in this transaction when the propagation delay is
+        // 0, otherwise enqueued alongside the async GSI work. Gated on the cached
+        // key info so a table without them costs no extra query, and kept outside
+        // the `indexes` guard because a table may have a vector index and no GSI.
+        let enqueued_vector = if key_info.vector_indexes.is_empty() {
+            false
+        } else {
+            crate::data::vector_index::maintain_vector_indexes(
+                &mut tx,
+                &key_info.table_id,
+                &key_info.key_schema,
+                &key_info.attribute_definitions,
+                old.as_ref(),
+                Some(&item),
+                system_delay,
+            )
+            .await?
+                > 0
+        };
+        let enqueued = enqueued_gsi || enqueued_vector;
+
+        if let Some(capture) = stream {
+            write_stream_record_in_tx(&mut tx, key_info, capture, old.as_ref(), Some(&item))
+                .await?;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        if enqueued {
+            self.gsi_notify.notify_waiters();
+        }
+
+        let old_ret = if return_old { old } else { None };
+        let new_ret = if return_new { Some(item) } else { None };
+        Ok((old_ret, new_ret))
+    }
+}

--- a/crates/storage-duckdb/src/data/vector_index.rs
+++ b/crates/storage-duckdb/src/data/vector_index.rs
@@ -1,0 +1,1078 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Vector index maintenance on the write path.
+//!
+//! Vector indexes are **eventually consistent**, the same model the service gives
+//! them and the same model a GSI has here, so maintenance runs on the existing
+//! `gsi_pending` queue rather than in the base write transaction. [`maintain_vector_indexes`]
+//! is the single entry point and owns that choice: a propagation delay of 0 keeps
+//! the work in the caller's transaction, any other delay enqueues it.
+//!
+//! Reusing the GSI queue is what makes the asynchronous path correct rather than
+//! merely deferred, and none of these properties would come free from a queue of
+//! its own:
+//!
+//! * **Crash safety.** The pending row is inserted in the base write transaction,
+//!   so there is no window in which the item is committed and the index work is
+//!   not yet durable. The worker claims and applies in one transaction, so a crash
+//!   mid-apply rolls back and the row is retried. At-least-once delivery is safe
+//!   because applying a row is idempotent: it deletes the base key's row and
+//!   reinserts it from the snapshotted item.
+//! * **Per-key ordering, across index kinds.** The row's partition is a hash of the
+//!   *base* key, so a vector row and a GSI row for the same item share a partition,
+//!   `ready_at` is clamped monotonic within it, and the worker drains in `id` order.
+//!   Two writes to one item therefore reach both index kinds in write order even
+//!   though the delay is jittered.
+//! * **Snapshot semantics.** The row carries its own [`VectorApplyContext`], so the
+//!   worker needs no catalog read and an index dropped, or redefined, between
+//!   enqueue and apply cannot make a queued write unapplicable or retroactively
+//!   change how it was indexed.
+//!
+//! A write to a table whose items do not carry the vector still enqueues, because
+//! the removal is the point: an item that loses its vector attribute must leave the
+//! index, and skipping the enqueue would leave the stale row in place forever.
+
+use crate::db;
+use serde::{Deserialize, Serialize};
+
+use extenddb_core::types::{AttributeDefinition, Item, KeySchemaElement, SearchSchemaElementType};
+use extenddb_core::validation::{vector_components, vector_norm};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::pk_to_text;
+
+use super::{BoundValue, all_sort_key_info, sk_bound, vector_table_name};
+use crate::vector_search::partition_value;
+
+/// A vector index as the write path needs it.
+///
+/// Serializable because the asynchronous path snapshots it verbatim into the
+/// pending row's [`VectorApplyContext`]. The write path and the worker therefore
+/// apply from the *same* description of the index, which is the property that stops
+/// a queued write from being reinterpreted under a later definition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct VectorIndexMeta {
+    pub index_id: String,
+    pub dimensions: usize,
+    pub vector_attribute_name: String,
+    /// The index's projection, applied to the stored row exactly as the GSI path
+    /// applies its own. Not applying it was an unexplained divergence from the
+    /// sibling, and it made a search return attributes the index does not project.
+    pub projection: extenddb_core::types::Projection,
+    /// The single HASH element's attribute name, when the index declares one.
+    /// `None` means the index is unscoped and every row shares one partition.
+    pub hash_attribute_name: Option<String>,
+    /// Every attribute named by the SearchSchema, HASH and INLINE_FILTER alike.
+    ///
+    /// These are projected regardless of `ProjectionType`, which is the documented
+    /// rule for a vector index and is NOT GSI `KEYS_ONLY` semantics: `KEYS_ONLY`
+    /// on a vector index projects the base primary key, the vector attribute and
+    /// the inline filter attributes. Withholding them is not merely a reporting
+    /// difference, it breaks search: the filter is evaluated against the stored
+    /// payload, so a missing filter attribute makes every row fail the predicate
+    /// and a filtered search match nothing.
+    pub search_schema_attribute_names: Vec<String>,
+}
+
+/// Load the vector indexes of a table.
+///
+/// Read inside the write transaction rather than taken from the cached
+/// `TableKeyInfo`, because the cache carries the search schema but not the index
+/// id, and the id is what names the data table.
+pub(crate) async fn fetch_vector_indexes_for_table(
+    tx: &mut db::Transaction,
+    table_id: &str,
+) -> Result<Vec<VectorIndexMeta>, StorageError> {
+    let rows: Vec<(String, i64, String, Option<String>, String)> = db::query_as(
+        "SELECT index_id, dimensions, vector_attribute, search_schema, projection \
+         FROM vector_indexes WHERE table_id = ?",
+    )
+    .bind(table_id)
+    .fetch_all(&mut **tx)
+    .await
+    .map_err(crate::duckdb_util::map_db_err)?;
+
+    let mut out = Vec::with_capacity(rows.len());
+    for (index_id, dimensions, vector_attribute, search_schema, projection) in rows {
+        let attr: extenddb_core::types::VectorAttribute =
+            serde_json::from_str(&vector_attribute)
+                .map_err(|e| StorageError::Internal(format!("vector_attribute: {e}")))?;
+        let (hash_attribute_name, search_schema_attribute_names) = match search_schema.as_deref() {
+            Some(json) => {
+                let elements: Vec<extenddb_core::types::SearchSchemaElement> =
+                    serde_json::from_str(json)
+                        .map_err(|e| StorageError::Internal(format!("search_schema: {e}")))?;
+                let hash = elements
+                    .iter()
+                    .find(|e| e.element_type == SearchSchemaElementType::Hash)
+                    .map(|e| e.attribute_name.clone());
+                let all = elements
+                    .into_iter()
+                    .map(|e| e.attribute_name)
+                    .collect::<Vec<_>>();
+                (hash, all)
+            }
+            None => (None, Vec::new()),
+        };
+        let projection: extenddb_core::types::Projection = serde_json::from_str(&projection)
+            .map_err(|e| StorageError::Internal(format!("vector projection: {e}")))?;
+        out.push(VectorIndexMeta {
+            index_id,
+            dimensions: usize::try_from(dimensions).map_err(|_| {
+                StorageError::Internal(format!("vector dimensions out of range: {dimensions}"))
+            })?,
+            vector_attribute_name: attr.attribute_name,
+            hash_attribute_name,
+            search_schema_attribute_names,
+            projection,
+        });
+    }
+    Ok(out)
+}
+
+/// Whether an item belongs in a vector index.
+///
+/// It must carry the vector attribute, and the HASH attribute when the index
+/// declares one: without the latter the row could not be placed in a partition,
+/// and putting it in the unscoped partition would make it visible to searches of
+/// every other partition. Not an error, exactly as a GSI silently omits an item
+/// missing its index key.
+fn item_is_indexable(item: &Item, meta: &VectorIndexMeta) -> bool {
+    if !item.contains_key(&meta.vector_attribute_name) {
+        return false;
+    }
+    match &meta.hash_attribute_name {
+        Some(name) => item.contains_key(name),
+        None => true,
+    }
+}
+
+/// The partition column value for an item under one index.
+fn item_partition(item: &Item, meta: &VectorIndexMeta) -> Result<String, StorageError> {
+    match &meta.hash_attribute_name {
+        Some(name) => {
+            let value = item.get(name).ok_or_else(|| {
+                StorageError::Internal(
+                    "indexable check passed but the hash attribute is absent".to_owned(),
+                )
+            })?;
+            partition_value(Some((name.as_str(), value)))
+        }
+        None => partition_value(None),
+    }
+}
+
+/// Base-key bind values for a row, in key-schema order.
+fn base_key_binds(
+    item: &Item,
+    base_key_schema: &[KeySchemaElement],
+    attr_defs: &[AttributeDefinition],
+) -> Result<Vec<BoundValue>, StorageError> {
+    let base_sks = all_sort_key_info(base_key_schema, attr_defs);
+    let pk_attr = &base_key_schema[0].attribute_name;
+    let pk = item.get(pk_attr).ok_or_else(|| {
+        StorageError::Internal("item written without its partition key".to_owned())
+    })?;
+    let mut binds = vec![BoundValue::Text(pk_to_text(pk)?.into_owned())];
+    for &(name, sk_type) in &base_sks {
+        // Sort keys use the same storage representation as the GSI/LSI tables:
+        // order-preserving text for numbers and a BLOB for binary. Encoding them
+        // any other way would still be self-consistent here but would diverge
+        // from every other index table for the same item.
+        match item.get(name) {
+            Some(value) => binds.push(sk_bound(&extenddb_storage::util::parse_sk(value, sk_type)?)),
+            None => binds.push(BoundValue::Text(String::new())),
+        }
+    }
+    Ok(binds)
+}
+
+/// Column names for the base key, in key-schema order.
+fn base_key_columns(
+    base_key_schema: &[KeySchemaElement],
+    attr_defs: &[AttributeDefinition],
+) -> Vec<String> {
+    let base_sks = all_sort_key_info(base_key_schema, attr_defs);
+    let mut cols = vec!["base_pk".to_owned()];
+    for (i, &(_, sk_type)) in base_sks.iter().enumerate() {
+        cols.push(format!(
+            "base_{}",
+            extenddb_storage::util::sk_column_n(i, sk_type)
+        ));
+    }
+    cols
+}
+
+/// Everything the propagation worker needs to apply one vector index update,
+/// serialized into `gsi_pending.index_context`.
+///
+/// `table_id` is carried here even though the queue row has a `table_id` column of
+/// its own, because a vector data table is named from the table id *and* the index
+/// id. Reading it from the context preserves the invariant that the context alone
+/// is sufficient, rather than splitting one apply's inputs across a column and a
+/// JSON blob. Both are written from the same variable in the same statement, so
+/// they cannot disagree.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct VectorApplyContext {
+    pub(crate) base_key_schema: Vec<KeySchemaElement>,
+    pub(crate) attribute_definitions: Vec<AttributeDefinition>,
+    pub(crate) table_id: String,
+    /// Deliberately named `vector` rather than `index`: it is the field whose
+    /// presence lets the untagged `PendingApplyContext` tell a vector row from a
+    /// GSI row by shape alone. See that type for why the discriminant is a shape
+    /// and not a tag.
+    pub(crate) vector: VectorIndexMeta,
+}
+
+/// Maintain every vector index on a table for one item write.
+///
+/// The single entry point for the write path, and the one place that decides
+/// between synchronous and asynchronous. `delay_ms` of 0 applies in the caller's
+/// transaction; anything else enqueues one `gsi_pending` row per index. Returns the
+/// number of rows enqueued, so the caller knows whether to wake the worker, and
+/// returns 0 for the synchronous path because there is nothing to wake.
+///
+/// Keeping the branch here rather than at each call site matters: there are seven
+/// write paths, and a single one that enqueued while also applying inline would
+/// double-apply, while one that did neither would silently stop indexing.
+///
+/// `old_item` and `new_item` follow the same convention as `sync_indexes`: a put
+/// supplies both when replacing, a delete supplies only the old.
+pub(crate) async fn maintain_vector_indexes(
+    tx: &mut db::Transaction,
+    table_id: &str,
+    base_key_schema: &[KeySchemaElement],
+    attr_defs: &[AttributeDefinition],
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+    delay_ms: u64,
+) -> Result<usize, StorageError> {
+    // Read inside the transaction rather than from the cached `TableKeyInfo`: the
+    // cache carries the search schema but not the index id, and the id is what
+    // names the data table.
+    let metas = fetch_vector_indexes_for_table(tx, table_id).await?;
+    if metas.is_empty() {
+        return Ok(0);
+    }
+    let key_cols = base_key_columns(base_key_schema, attr_defs);
+
+    if delay_ms == 0 {
+        for meta in &metas {
+            apply_vector_index(
+                tx,
+                table_id,
+                meta,
+                base_key_schema,
+                attr_defs,
+                &key_cols,
+                old_item,
+                new_item,
+            )
+            .await?;
+        }
+        return Ok(0);
+    }
+
+    let mut enqueued = 0usize;
+    for meta in metas {
+        // Enqueued even when the new item carries no vector: the removal is the
+        // work in that case, and skipping it would leave a stale row indexed.
+        let context = super::index::PendingApplyContext::Vector(VectorApplyContext {
+            base_key_schema: base_key_schema.to_vec(),
+            attribute_definitions: attr_defs.to_vec(),
+            table_id: table_id.to_owned(),
+            vector: meta,
+        });
+        super::index::enqueue_pending_row(tx, table_id, old_item, new_item, delay_ms, &context)
+            .await?;
+        enqueued += 1;
+    }
+    Ok(enqueued)
+}
+
+/// Apply one claimed vector pending row, from its self-describing context.
+///
+/// A missing data table is skipped rather than treated as a failure: the base table
+/// or the index itself can be dropped while a row is in flight, which is a routine
+/// race and not a defect.
+///
+/// This is log hygiene rather than data safety, and worth being exact about. The
+/// batch already guards every row with a savepoint, so without this the row would be
+/// rolled back and dropped, reaching the same end state by a noisier route. What the
+/// tolerance changes is that an expected race stops emitting an ERROR line, which
+/// otherwise trains operators to ignore the one signal that says a row was thrown
+/// away. Matches the GSI sibling, so both arms of the dispatcher behave alike.
+pub(crate) async fn apply_vector_context(
+    tx: &mut db::Transaction,
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+    context: &VectorApplyContext,
+) -> Result<(), StorageError> {
+    let key_cols = base_key_columns(&context.base_key_schema, &context.attribute_definitions);
+    apply_vector_index(
+        tx,
+        &context.table_id,
+        &context.vector,
+        &context.base_key_schema,
+        &context.attribute_definitions,
+        &key_cols,
+        old_item,
+        new_item,
+    )
+    .await
+    .or_else(|e| {
+        if super::index::is_no_such_table(&e) {
+            Ok(())
+        } else {
+            Err(e)
+        }
+    })
+}
+
+/// Apply an item write to a single vector index.
+///
+/// The delete-then-insert shape matters. An item can move between partitions when
+/// its HASH attribute changes, and the row is keyed by the base item rather than by
+/// the partition, so an insert alone would leave the old partition's row in place
+/// and the item would be findable in two partitions at once.
+///
+/// The delete keys off `old_item.or(new_item)` because the base key is immutable, so
+/// either carries it. That is what lets a put whose caller had no reason to read the
+/// old item still displace the row it replaces.
+#[allow(clippy::too_many_arguments)]
+async fn apply_vector_index(
+    tx: &mut db::Transaction,
+    table_id: &str,
+    meta: &VectorIndexMeta,
+    base_key_schema: &[KeySchemaElement],
+    attr_defs: &[AttributeDefinition],
+    key_cols: &[String],
+    old_item: Option<&Item>,
+    new_item: Option<&Item>,
+) -> Result<(), StorageError> {
+    let vec_table = vector_table_name(table_id, &meta.index_id);
+    let where_clause = key_cols
+        .iter()
+        .map(|c| format!("{c} = ?"))
+        .collect::<Vec<_>>()
+        .join(" AND ");
+
+    // Remove any existing row for this base item first, whatever partition it
+    // was in.
+    if let Some(source) = old_item.or(new_item) {
+        let binds = base_key_binds(source, base_key_schema, attr_defs)?;
+        let sql = format!("DELETE FROM {vec_table} WHERE {where_clause}");
+        let mut q = db::query(&sql);
+        for b in binds {
+            q = super::bind_bound!(q, b);
+        }
+        q.execute(&mut **tx)
+            .await
+            .map_err(crate::duckdb_util::map_db_err)?;
+    }
+
+    let Some(new_item) = new_item else {
+        return Ok(()); // A delete: removal above is the whole of the work.
+    };
+    insert_vector_row(
+        tx,
+        table_id,
+        meta,
+        new_item,
+        base_key_schema,
+        attr_defs,
+        key_cols,
+        VectorRowConflict::Fail,
+    )
+    .await
+}
+
+/// Write one item's row into one vector index.
+///
+/// Shared by the write path and by backfill deliberately. These are the only two
+/// producers of a vector row, and a second copy of this logic would be free to
+/// drift: a backfilled row shaped differently from a live-written one would search
+/// correctly right up until the difference mattered, with nothing to catch it.
+///
+/// A non-indexable item is a no-op rather than an error, which is what makes a
+/// backfill over a table where only some items carry the vector work.
+/// How [`insert_vector_row`] treats a primary-key conflict.
+///
+/// `Fail` is the write path's contract: every apply reaches the insert through
+/// `apply_vector_index`, which deletes the base key's row first, so a conflict
+/// there means a broken invariant and must be loud. `KeepExisting` is the
+/// BACKFILL's contract: in synchronous-visibility mode
+/// (`index_propagation_delay_ms == 0`) a base write landing mid-backfill is
+/// applied to the CREATING index inline rather than queued, and each backfill
+/// batch reads the base table LIVE under the write lock, so a row already
+/// present was written from the same or a newer base image than the one the
+/// backfill just read; keeping it is correct and inserting over it would only
+/// fail the whole build. Without this, that collision wedged the index in
+/// CREATING permanently (proven by test below).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VectorRowConflict {
+    Fail,
+    KeepExisting,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn insert_vector_row(
+    tx: &mut db::Transaction,
+    table_id: &str,
+    meta: &VectorIndexMeta,
+    item: &Item,
+    base_key_schema: &[KeySchemaElement],
+    attr_defs: &[AttributeDefinition],
+    key_cols: &[String],
+    on_conflict: VectorRowConflict,
+) -> Result<(), StorageError> {
+    if !item_is_indexable(item, meta) {
+        return Ok(());
+    }
+    let vec_table = vector_table_name(table_id, &meta.index_id);
+
+    let value = item.get(&meta.vector_attribute_name).ok_or_else(|| {
+        StorageError::Internal("indexable check passed but the vector is absent".to_owned())
+    })?;
+    let components = vector_components(value).ok_or_else(|| {
+        // Core validates the write before it reaches storage, so a malformed
+        // vector here means validation was bypassed rather than that a caller
+        // sent bad input.
+        StorageError::Internal(
+            "vector attribute reached storage without passing validation".to_owned(),
+        )
+    })?;
+    if components.len() != meta.dimensions {
+        return Err(StorageError::Internal(format!(
+            "vector has {} components, index declares {}",
+            components.len(),
+            meta.dimensions
+        )));
+    }
+
+    let mut blob = Vec::with_capacity(components.len() * 4);
+    for x in &components {
+        blob.extend_from_slice(&x.to_le_bytes());
+    }
+    let norm = vector_norm(&components);
+    let part = item_partition(item, meta)?;
+    // Projected exactly as the GSI sibling projects, so a search returns what
+    // the index declares and no more.
+    let mut projected =
+        super::index::project_item_for_index(item, &[], base_key_schema, &meta.projection);
+    // The SearchSchema attributes are always projected, whatever the
+    // ProjectionType. See `search_schema_attribute_names` for why: the inline
+    // filter is evaluated against this payload, so dropping the attribute would
+    // silently turn every filtered search into a zero-result search.
+    for name in &meta.search_schema_attribute_names {
+        if !projected.contains_key(name)
+            && let Some(v) = item.get(name)
+        {
+            projected.insert(name.clone(), v.clone());
+        }
+    }
+    // The vector itself is not kept in the payload: it is already in the `vec`
+    // column as `f32`, which is the width the service validates against, and the
+    // search path rebuilds the attribute from those bits. Keeping a verbatim
+    // decimal copy here duplicated 10 to 15 KB per row at 1024 dimensions and
+    // would have returned the client's original precision where the service
+    // returns the narrowed value.
+    projected.remove(&meta.vector_attribute_name);
+    let item_json = serde_json::to_string(&projected)
+        .map_err(|e| StorageError::Internal(format!("serialize item: {e}")))?;
+
+    // On the write path this stays a plain INSERT, deliberately, where the GSI
+    // sibling uses INSERT OR REPLACE: every apply reaches here through
+    // `apply_vector_index`, which unconditionally deletes the base key's row
+    // first, so a conflict means a broken invariant and must fail loudly. The
+    // backfill passes `KeepExisting` instead; see [`VectorRowConflict`] for
+    // why an existing row is the same-or-newer generation there and must win.
+    let cols = std::iter::once("part".to_owned())
+        .chain(key_cols.iter().cloned())
+        .chain(["vec".to_owned(), "nrm".to_owned(), "item_data".to_owned()])
+        .collect::<Vec<_>>();
+    let placeholders = vec!["?"; cols.len()].join(", ");
+    let verb = match on_conflict {
+        VectorRowConflict::Fail => "INSERT",
+        VectorRowConflict::KeepExisting => "INSERT OR IGNORE",
+    };
+    let sql = format!(
+        "{verb} INTO {vec_table} ({}) VALUES ({placeholders})",
+        cols.join(", ")
+    );
+    let key_binds = base_key_binds(item, base_key_schema, attr_defs)?;
+    let mut q = db::query(&sql).bind(part);
+    for b in key_binds {
+        q = super::bind_bound!(q, b);
+    }
+    q.bind(blob)
+        .bind(f64::from(norm))
+        .bind(item_json)
+        .execute(&mut **tx)
+        .await
+        .map_err(crate::duckdb_util::map_db_err)?;
+    Ok(())
+}
+
+/// Populate a newly created vector index from the base table.
+///
+/// Batched by offset exactly as `backfill_gsi` is, and for the same reason: a table
+/// large enough to be worth indexing is too large to hold in memory. Returns the
+/// number of rows written, which is what distinguishes "backfilled nothing because
+/// no item carries the vector" from "backfilled nothing because the scan is broken".
+/// Everything a backfill needs that does not change between batches.
+///
+/// Bundled because the alternative was an eight-argument function threaded through two
+/// drivers, where the only per-batch values are the page size and the cursor.
+struct BackfillPlan<'a> {
+    table_id: &'a str,
+    meta: &'a VectorIndexMeta,
+    base_key_schema: &'a [KeySchemaElement],
+    attr_defs: &'a [AttributeDefinition],
+    key_cols: Vec<String>,
+}
+
+impl<'a> BackfillPlan<'a> {
+    fn new(
+        table_id: &'a str,
+        meta: &'a VectorIndexMeta,
+        base_key_schema: &'a [KeySchemaElement],
+        attr_defs: &'a [AttributeDefinition],
+    ) -> Self {
+        Self {
+            table_id,
+            meta,
+            base_key_schema,
+            attr_defs,
+            key_cols: base_key_columns(base_key_schema, attr_defs),
+        }
+    }
+}
+
+/// Backfill one batch of existing rows into the vector index.
+///
+/// Returns `(written, fetched, last_rowid)`. `fetched` distinguishes a short read
+/// (the end) from a full one, and `last_rowid` is the cursor to resume from.
+///
+/// Pagination is by KEY, not by `OFFSET`. Offset anchors on a position, so removing any
+/// already-scanned row shifts every later position by one and the next batch skips a
+/// row entirely. That row is then missing from the index permanently, and no queue
+/// entry can repair it, because the skipped row was never written to: only the removed
+/// one was. Reproduced before this change: one removal during a backfill left the row
+/// at the batch boundary absent from the index.
+///
+/// The cursor is `rowid`, not `pk`, and the difference is a correctness matter rather
+/// than a preference. Composite-key base tables have `PRIMARY KEY (pk, sk*)`, so `pk`
+/// alone is not unique; a `pk > last_pk` cursor whose batch boundary fell inside one
+/// partition's sort-key group excluded every remaining row sharing that `pk`,
+/// permanently, on both the UpdateTable path and startup reconciliation (which share
+/// this function). Reproduced: a five-row partition scanned with a batch of three
+/// indexed four rows and skipped two. `rowid` is unique regardless of the key layout,
+/// so one query shape serves both. It is a valid cursor because the base tables are
+/// ordinary rowid tables and every write is `INSERT ... ON CONFLICT DO UPDATE`
+/// (`tx_helpers.rs`), which updates in place and never reassigns a rowid; rows
+/// inserted after a batch passed their rowid position are the concurrent writes the
+/// queue hold already captures and replays after ACTIVE.
+///
+/// It was unreachable while the whole backfill ran in one transaction, and became
+/// reachable the moment batches started committing independently.
+/// One batch's outcome: rows indexed, rows skipped as poison, rows fetched
+/// (for termination), and the cursor for the next batch.
+struct BatchOutcome {
+    written: usize,
+    skipped: usize,
+    fetched: i64,
+    last_rowid: i64,
+}
+
+async fn backfill_vector_batch(
+    tx: &mut db::Transaction,
+    plan: &BackfillPlan<'_>,
+    limit: i64,
+    after_rowid: i64,
+) -> Result<BatchOutcome, StorageError> {
+    let base_table = super::data_table_name(plan.table_id);
+    // `rowid > ?` with -1 as the initial cursor: DuckDB rowids start at 0, so
+    // the first batch needs no separate query shape.
+    let sql =
+        format!("SELECT rowid, item_data FROM {base_table} WHERE rowid > ? ORDER BY rowid LIMIT ?");
+    let rows: Vec<(i64, String)> = db::query_as(&sql)
+        .bind(after_rowid)
+        .bind(limit)
+        .fetch_all(&mut **tx)
+        .await
+        .map_err(crate::duckdb_util::map_db_err)?;
+    let fetched = i64::try_from(rows.len()).unwrap_or(limit);
+    let last_rowid = rows.last().map_or(after_rowid, |(rid, _)| *rid);
+    let mut written = 0usize;
+    let mut skipped = 0usize;
+    for (rowid, item_json) in rows {
+        // Poison classification. The live write path treats a malformed vector
+        // as an invariant violation and errors loudly, because core validation
+        // ran before storage was reached. That reasoning is FALSE here: rows
+        // written before the index existed never passed vector validation, so
+        // a malformed or wrong-dimension vector in the base table is expected
+        // input for a backfill, not a bug. Propagating it wedged the build in
+        // an infinite recovery loop: the error left the index CREATING, the
+        // watchdog re-ran the rebuild, and the same row failed again, forever,
+        // while the CREATING hold also froze every queued index write for the
+        // table. A row whose stored bytes cannot enter the index is skipped
+        // and counted instead, exactly as a GSI omits an item whose key
+        // attribute has the wrong type. Transient failures (the INSERT itself
+        // erroring) still propagate: those are retryable and must not drop
+        // rows.
+        let Ok(item) = serde_json::from_str::<Item>(&item_json) else {
+            tracing::warn!(
+                rowid,
+                index = %plan.meta.index_id,
+                "backfill: stored item is unparseable; skipping row"
+            );
+            skipped += 1;
+            continue;
+        };
+        if !item_is_indexable(&item, plan.meta) {
+            continue;
+        }
+        let vector_ok = item
+            .get(&plan.meta.vector_attribute_name)
+            .and_then(vector_components)
+            .is_some_and(|c| c.len() == plan.meta.dimensions);
+        if !vector_ok {
+            tracing::warn!(
+                rowid,
+                index = %plan.meta.index_id,
+                "backfill: vector attribute malformed or wrong dimension; skipping row"
+            );
+            skipped += 1;
+            continue;
+        }
+        insert_vector_row(
+            tx,
+            plan.table_id,
+            plan.meta,
+            &item,
+            plan.base_key_schema,
+            plan.attr_defs,
+            &plan.key_cols,
+            VectorRowConflict::KeepExisting,
+        )
+        .await?;
+        written += 1;
+    }
+    Ok(BatchOutcome {
+        written,
+        skipped,
+        fetched,
+        last_rowid,
+    })
+}
+
+/// A completed backfill: rows indexed and rows skipped as poison. `skipped`
+/// is recorded on the catalog row so an ACTIVE index that deliberately omits
+/// rows says so, rather than the omission being indistinguishable from a bug.
+pub(crate) struct BackfillOutcome {
+    pub(crate) written: usize,
+    pub(crate) skipped: usize,
+}
+
+/// Backfill the index in independently committed batches, releasing DuckDB's write
+/// lock between them.
+///
+/// This is what lets the base table stay writable while an index builds, which is how
+/// the service behaves: the table remains ACTIVE and accepts writes throughout, and
+/// only the index reports CREATING. Holding one transaction for the whole backfill
+/// would block every write until it finished.
+///
+/// Releasing the lock is also what creates the ordering hazard this design has to
+/// answer. A write landing mid-backfill is enqueued, and if it were applied before the
+/// backfill wrote its older snapshot of the same item, the index would converge on the
+/// stale generation. The queue worker therefore refuses to claim any row for a table
+/// whose vector index is still CREATING, so those writes accumulate and are applied
+/// only after this returns and the index flips to ACTIVE.
+///
+/// A crash part-way leaves the index in CREATING with some rows written, which
+/// `reconcile_incomplete_vector_indexes` repairs at startup by rebuilding it.
+pub(crate) async fn backfill_vector_index_in_batches(
+    pool: &db::Pool,
+    write_lock: &tokio::sync::Mutex<()>,
+    table_id: &str,
+    meta: &VectorIndexMeta,
+    base_key_schema: &[KeySchemaElement],
+    attr_defs: &[AttributeDefinition],
+    batch_delay: std::time::Duration,
+) -> Result<BackfillOutcome, StorageError> {
+    const BATCH: i64 = 500;
+    let plan = BackfillPlan::new(table_id, meta, base_key_schema, attr_defs);
+    let mut cursor: i64 = -1;
+    let mut written = 0usize;
+    let mut skipped = 0usize;
+    loop {
+        let outcome = {
+            let _writer = write_lock.lock().await;
+            let mut tx = pool.begin().await.map_err(crate::duckdb_util::map_db_err)?;
+            let result = backfill_vector_batch(&mut tx, &plan, BATCH, cursor).await?;
+            tx.commit().await.map_err(crate::duckdb_util::map_db_err)?;
+            result
+        };
+        written += outcome.written;
+        skipped += outcome.skipped;
+        if outcome.fetched < BATCH {
+            break;
+        }
+        cursor = outcome.last_rowid;
+        // Outside the lock, so a write can actually proceed during the pause. Zero in
+        // production; a test sets it so a write is guaranteed to land mid-backfill.
+        if !batch_delay.is_zero() {
+            tokio::time::sleep(batch_delay).await;
+        }
+    }
+    Ok(BackfillOutcome { written, skipped })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+
+    /// A composite-key table whose partition spans a batch boundary must still
+    /// backfill every row.
+    ///
+    /// This is the regression test for a silent data-loss defect: the cursor was
+    /// `pk > last_pk`, and on a table with `PRIMARY KEY (pk, sk_s)` a batch ending
+    /// inside one partition's sort-key group excluded every remaining row sharing
+    /// that `pk`. Five rows in one partition scanned with a batch of three indexed
+    /// four and skipped two, permanently, on both the UpdateTable path and startup
+    /// reconciliation, which share `backfill_vector_batch`. The rowid cursor cannot
+    /// lose rows because rowid is unique whatever the key layout.
+    ///
+    /// Driven through `backfill_vector_batch` directly with a batch of 3 rather
+    /// than through the drivers, because they hardcode a 500-row batch and seeding
+    /// 501 rows would test the same lines slower.
+    #[tokio::test]
+    async fn a_composite_key_partition_straddling_a_batch_boundary_is_fully_backfilled() {
+        use extenddb_core::types::{
+            AttributeDefinition, KeySchemaElement, KeyType, ScalarAttributeType,
+        };
+        let engine = crate::DuckDbEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+
+        let ks = vec![
+            KeySchemaElement {
+                attribute_name: "pk".to_owned(),
+                key_type: KeyType::Hash,
+            },
+            KeySchemaElement {
+                attribute_name: "sk".to_owned(),
+                key_type: KeyType::Range,
+            },
+        ];
+        let ad = vec![
+            AttributeDefinition {
+                attribute_name: "pk".to_owned(),
+                attribute_type: ScalarAttributeType::S,
+            },
+            AttributeDefinition {
+                attribute_name: "sk".to_owned(),
+                attribute_type: ScalarAttributeType::S,
+            },
+        ];
+
+        let table_id = "t-composite";
+        let mut tx = engine.pool.begin().await.expect("tx");
+        crate::DuckDbEngine::create_data_table(&mut tx, table_id, &ks, &ad)
+            .await
+            .expect("base table");
+        crate::DuckDbEngine::create_vector_data_table(&mut tx, table_id, "vidx-1", &ks, &ad)
+            .await
+            .expect("vector table");
+
+        // One partition with five sort keys plus a second partition, so the batch
+        // of three ends INSIDE partition "a": exactly the boundary that lost rows.
+        let base_table = super::super::data_table_name(table_id);
+        for (pk, sk) in [
+            ("a", "1"),
+            ("a", "2"),
+            ("a", "3"),
+            ("a", "4"),
+            ("a", "5"),
+            ("b", "1"),
+        ] {
+            db::query(&format!(
+                "INSERT INTO {base_table} (pk, sk_s, item_data) VALUES (?, ?, ?)"
+            ))
+            .bind(pk)
+            .bind(sk)
+            .bind(format!(
+                r#"{{"pk":{{"S":"{pk}"}},"sk":{{"S":"{sk}"}},"emb":{{"L":[{{"N":"1"}},{{"N":"0"}}]}}}}"#
+            ))
+            .execute(&mut *tx)
+            .await
+            .expect("seed");
+        }
+
+        let meta = VectorIndexMeta {
+            index_id: "vidx-1".to_owned(),
+            dimensions: 2,
+            vector_attribute_name: "emb".to_owned(),
+            projection: extenddb_core::types::Projection {
+                projection_type: extenddb_core::types::ProjectionType::All,
+                non_key_attributes: None,
+            },
+            hash_attribute_name: None,
+            search_schema_attribute_names: Vec::new(),
+        };
+        let plan = BackfillPlan::new(table_id, &meta, &ks, &ad);
+
+        let mut cursor: i64 = -1;
+        let mut written = 0usize;
+        loop {
+            let outcome = backfill_vector_batch(&mut tx, &plan, 3, cursor)
+                .await
+                .expect("batch");
+            written += outcome.written;
+            if outcome.fetched < 3 {
+                break;
+            }
+            cursor = outcome.last_rowid;
+        }
+        tx.commit().await.expect("commit");
+
+        assert_eq!(
+            written, 6,
+            "every row must be indexed; the pk-only cursor wrote 4 and skipped 2"
+        );
+        let vec_table = super::super::vector_table_name(table_id, "vidx-1");
+        let (rows,): (i64,) = db::query_as(&format!("SELECT COUNT(*) FROM {vec_table}"))
+            .fetch_one(&engine.pool)
+            .await
+            .expect("count");
+        assert_eq!(rows, 6, "the index must hold all six rows");
+    }
+
+    /// A row whose stored bytes cannot enter the index is skipped and counted,
+    /// not propagated. Propagating it wedged the build permanently: the error
+    /// left the index CREATING, the watchdog re-ran the rebuild, the same row
+    /// failed again, and the CREATING hold froze every queued index write for
+    /// the table. This is the review finding on this file: "non-conformant
+    /// items keep failing and the index creation will be stuck in recovery
+    /// loop forever".
+    ///
+    /// Discriminating by construction: the poison rows (a wrong-dimension
+    /// vector, a non-list vector, and unparseable item bytes) sit BETWEEN good
+    /// rows, so the pre-fix behaviour (error on first poison row, nothing
+    /// after it indexed) cannot produce these counts.
+    #[tokio::test]
+    async fn poison_rows_are_skipped_and_counted_rather_than_wedging_the_backfill() {
+        use extenddb_core::types::{
+            AttributeDefinition, KeySchemaElement, KeyType, ScalarAttributeType,
+        };
+        let engine = crate::DuckDbEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+
+        let ks = vec![KeySchemaElement {
+            attribute_name: "pk".to_owned(),
+            key_type: KeyType::Hash,
+        }];
+        let ad = vec![AttributeDefinition {
+            attribute_name: "pk".to_owned(),
+            attribute_type: ScalarAttributeType::S,
+        }];
+
+        let table_id = "t-poison";
+        let mut tx = engine.pool.begin().await.expect("tx");
+        crate::DuckDbEngine::create_data_table(&mut tx, table_id, &ks, &ad)
+            .await
+            .expect("base table");
+        crate::DuckDbEngine::create_vector_data_table(&mut tx, table_id, "vidx-p", &ks, &ad)
+            .await
+            .expect("vector table");
+
+        let base_table = super::super::data_table_name(table_id);
+        // good, wrong-dimension, good, non-list vector, unparseable, good.
+        let rows: [(&str, String); 6] = [
+            (
+                "g1",
+                r#"{"pk":{"S":"g1"},"emb":{"L":[{"N":"1"},{"N":"0"}]}}"#.to_owned(),
+            ),
+            (
+                "p1",
+                r#"{"pk":{"S":"p1"},"emb":{"L":[{"N":"1"}]}}"#.to_owned(),
+            ),
+            (
+                "g2",
+                r#"{"pk":{"S":"g2"},"emb":{"L":[{"N":"0"},{"N":"1"}]}}"#.to_owned(),
+            ),
+            (
+                "p2",
+                r#"{"pk":{"S":"p2"},"emb":{"S":"not-a-vector"}}"#.to_owned(),
+            ),
+            ("p3", "{not json".to_owned()),
+            (
+                "g3",
+                r#"{"pk":{"S":"g3"},"emb":{"L":[{"N":"1"},{"N":"1"}]}}"#.to_owned(),
+            ),
+        ];
+        for (pk, item) in &rows {
+            db::query(&format!(
+                "INSERT INTO {base_table} (pk, item_data) VALUES (?, ?)"
+            ))
+            .bind(pk)
+            .bind(item)
+            .execute(&mut *tx)
+            .await
+            .expect("seed");
+        }
+
+        let meta = VectorIndexMeta {
+            index_id: "vidx-p".to_owned(),
+            dimensions: 2,
+            vector_attribute_name: "emb".to_owned(),
+            projection: extenddb_core::types::Projection {
+                projection_type: extenddb_core::types::ProjectionType::All,
+                non_key_attributes: None,
+            },
+            hash_attribute_name: None,
+            search_schema_attribute_names: Vec::new(),
+        };
+        let plan = BackfillPlan::new(table_id, &meta, &ks, &ad);
+
+        let outcome = backfill_vector_batch(&mut tx, &plan, 100, 0)
+            .await
+            .expect("a batch containing poison rows must still complete");
+        tx.commit().await.expect("commit");
+
+        assert_eq!(outcome.written, 3, "the three good rows are indexed");
+        assert_eq!(outcome.skipped, 3, "the three poison rows are counted");
+
+        // The good rows AFTER the poison rows made it in, which is the part the
+        // pre-fix behaviour cannot do: it stopped at p1.
+        let vec_table = super::super::vector_table_name(table_id, "vidx-p");
+        let (rows,): (i64,) = db::query_as(&format!("SELECT COUNT(*) FROM {vec_table}"))
+            .fetch_one(&engine.pool)
+            .await
+            .expect("count");
+        assert_eq!(rows, 3);
+    }
+    /// A synchronous-visibility write (`index_propagation_delay_ms == 0`)
+    /// landing mid-backfill is applied to the CREATING index inline, bypassing
+    /// the queue's CREATING-hold. When the backfill later reaches that base
+    /// key it must keep the row the inline write produced rather than fail the
+    /// whole build on the primary-key conflict: each batch reads the base
+    /// table live under the write lock, so an existing row was written from
+    /// the same or a newer base image than the one the batch just read. Before
+    /// `VectorRowConflict::KeepExisting`, this collision errored the backfill
+    /// and wedged the index in CREATING permanently.
+    #[tokio::test]
+    async fn a_synchronous_write_landing_mid_backfill_does_not_wedge_the_build() {
+        use extenddb_core::types::{
+            AttributeDefinition, KeySchemaElement, KeyType, ScalarAttributeType,
+        };
+        let engine = crate::DuckDbEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+
+        let ks = vec![KeySchemaElement {
+            attribute_name: "pk".to_owned(),
+            key_type: KeyType::Hash,
+        }];
+        let ad = vec![AttributeDefinition {
+            attribute_name: "pk".to_owned(),
+            attribute_type: ScalarAttributeType::S,
+        }];
+
+        let table_id = "t-inline-collision";
+        let mut tx = engine.pool.begin().await.expect("tx");
+        crate::DuckDbEngine::create_data_table(&mut tx, table_id, &ks, &ad)
+            .await
+            .expect("base table");
+        crate::DuckDbEngine::create_vector_data_table(&mut tx, table_id, "vidx-c", &ks, &ad)
+            .await
+            .expect("vector table");
+        // Catalog rows: a table and its index still CREATING with a build in
+        // flight, which is the state a mid-backfill write observes.
+        db::query("INSERT INTO accounts (account_id, account_name) VALUES ('a', 'a')")
+            .execute(&mut *tx)
+            .await
+            .expect("account row");
+        db::query(
+            "INSERT INTO tables (account_id, table_name, key_schema, attribute_definitions, \
+             billing_mode, table_status, creation_date_time, table_arn, table_id) \
+             VALUES ('a', 't', '[]', '[]', 'PAY_PER_REQUEST', 'ACTIVE', 'now', 'arn', ?)",
+        )
+        .bind(table_id)
+        .execute(&mut *tx)
+        .await
+        .expect("table row");
+        db::query(
+            "INSERT INTO vector_indexes (table_id, index_name, index_id, dimensions, \
+             distance_function, vector_attribute, search_schema, projection, index_status, \
+             backfilling) \
+             VALUES (?, 'vidx-c', 'vidx-c', 2, 'COSINE', ?, NULL, ?, 'CREATING', 1)",
+        )
+        .bind(table_id)
+        .bind(r#"{"AttributeName":"emb"}"#)
+        .bind(r#"{"ProjectionType":"ALL"}"#)
+        .execute(&mut *tx)
+        .await
+        .expect("index row");
+        let base_table = super::super::data_table_name(table_id);
+        db::query(&format!(
+            "INSERT INTO {base_table} (pk, item_data) VALUES ('z', ?)"
+        ))
+        .bind(r#"{"pk":{"S":"z"},"emb":{"L":[{"N":"1"},{"N":"0"}]}}"#)
+        .execute(&mut *tx)
+        .await
+        .expect("seed base row");
+
+        // The inline write: at delay 0 maintenance applies to the CREATING
+        // index directly rather than enqueueing.
+        let item: extenddb_core::types::Item =
+            serde_json::from_str(r#"{"pk":{"S":"z"},"emb":{"L":[{"N":"1"},{"N":"0"}]}}"#)
+                .expect("item");
+        let enqueued = maintain_vector_indexes(&mut tx, table_id, &ks, &ad, None, Some(&item), 0)
+            .await
+            .expect("inline maintenance");
+        assert_eq!(
+            enqueued, 0,
+            "delay 0 must take the inline arm, not the queue"
+        );
+        tx.commit().await.expect("commit");
+
+        // The backfill now reaches the same base key and must complete rather
+        // than error on the conflict, leaving exactly one row for the key.
+        let write_lock = tokio::sync::Mutex::new(());
+        let meta =
+            fetch_vector_indexes_for_table(&mut engine.pool.begin().await.expect("tx"), table_id)
+                .await
+                .expect("metas")
+                .into_iter()
+                .find(|m| m.index_id == "vidx-c")
+                .expect("meta");
+        let outcome = backfill_vector_index_in_batches(
+            &engine.pool,
+            &write_lock,
+            table_id,
+            &meta,
+            &ks,
+            &ad,
+            std::time::Duration::ZERO,
+        )
+        .await
+        .expect("backfill must not wedge on the inline write's row");
+        assert_eq!(outcome.skipped, 0);
+        let vec_table = super::super::vector_table_name(table_id, "vidx-c");
+        let (rows,): (i64,) = db::query_as(&format!("SELECT COUNT(*) FROM {vec_table}"))
+            .fetch_one(&engine.pool)
+            .await
+            .expect("count");
+        assert_eq!(
+            rows, 1,
+            "one base key must yield one index row, not a duplicate"
+        );
+    }
+}

--- a/crates/storage-duckdb/src/db.rs
+++ b/crates/storage-duckdb/src/db.rs
@@ -1,0 +1,1074 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! A thin asynchronous facade over the synchronous `duckdb` crate.
+//!
+//! DuckDB has no `sqlx` driver, so this module supplies the small `sqlx`-shaped
+//! surface the rest of the crate uses: a connection [`Pool`], positional
+//! [`query`] / [`query_as`] / [`query_scalar`] builders with `.bind()`, and a
+//! [`Transaction`] that commits explicitly and rolls back on drop. Everything
+//! else in the crate is written against this module rather than against
+//! `duckdb` directly, which keeps the storage code free of blocking calls.
+//!
+//! # Execution model
+//!
+//! `duckdb::Connection` is `Send` but not `Sync`, and every call on it blocks.
+//! Each pooled connection therefore lives in a slot (`tokio::sync::Mutex<Option
+//! <Connection>>`); running a statement takes the connection out of its slot,
+//! moves it onto a `spawn_blocking` thread for the duration of the call, and
+//! puts it back afterwards. A transaction holds its slot for its whole lifetime,
+//! so every statement in it runs on the same connection.
+//!
+//! All connections in a pool are `try_clone()`s of one root connection, so they
+//! share a single DuckDB database instance. That is what makes an in-memory
+//! database usable from a pool of more than one connection (unlike SQLite, where
+//! `:memory:` is private to the connection that opened it), and it is also what
+//! DuckDB requires for file-backed databases: one process may hold one database
+//! instance per file, so a second, independently opened handle on the same path
+//! would be refused. [`Pool::open`] keeps a process-wide registry of root
+//! connections keyed by canonical path for exactly that reason.
+
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
+
+use duckdb::Connection;
+use duckdb::types::Value;
+use tokio::sync::{Mutex, OwnedMutexGuard};
+
+// ── Errors ─────────────────────────────────────────────────────────────
+
+/// Error type for every operation in this module.
+#[derive(Debug)]
+pub enum Error {
+    /// The underlying DuckDB call failed.
+    Db(duckdb::Error),
+    /// A blocking task panicked or was cancelled; the connection it held is
+    /// gone and will be re-created on next use.
+    Worker(String),
+    /// A column could not be converted to the requested Rust type.
+    Decode(String),
+    /// `fetch_one` found no row.
+    RowNotFound,
+    /// The pool has no usable connection and could not open one.
+    Connection(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Db(e) => write!(f, "{e}"),
+            Error::Worker(e) => write!(f, "database worker failed: {e}"),
+            Error::Decode(e) => write!(f, "column decode error: {e}"),
+            Error::RowNotFound => write!(
+                f,
+                "no rows returned by a query that expected at least one row"
+            ),
+            Error::Connection(e) => write!(f, "connection error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<duckdb::Error> for Error {
+    fn from(e: duckdb::Error) -> Self {
+        Error::Db(e)
+    }
+}
+
+impl Error {
+    /// The DuckDB error message, if this error carries one.
+    pub fn message(&self) -> Option<&str> {
+        match self {
+            Error::Db(duckdb::Error::DuckDBFailure(_, Some(msg))) => Some(msg.as_str()),
+            Error::Db(duckdb::Error::DuckDBFailure(_, None)) => None,
+            Error::Db(_) => None,
+            _ => None,
+        }
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+// ── Connection registry ────────────────────────────────────────────────
+
+/// Shared root connection for one database path.
+struct Root {
+    conn: StdMutex<Connection>,
+}
+
+impl Root {
+    fn clone_conn(&self) -> Result<Connection> {
+        let guard = self
+            .conn
+            .lock()
+            .map_err(|_| Error::Connection("root connection poisoned".to_owned()))?;
+        guard.try_clone().map_err(Error::Db)
+    }
+}
+
+/// Process-wide registry of root connections for file-backed databases.
+///
+/// DuckDB allows a single database instance per file per process; every pool
+/// over the same file must clone from one root. In-memory databases are never
+/// registered: each `Pool::open(":memory:")` is its own private database, which
+/// is what callers (and the test-suite) expect.
+fn registry() -> &'static StdMutex<HashMap<String, Arc<Root>>> {
+    static REGISTRY: OnceLock<StdMutex<HashMap<String, Arc<Root>>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| StdMutex::new(HashMap::new()))
+}
+
+/// Whether a configured path denotes an in-memory database.
+pub fn is_memory_path(path: &str) -> bool {
+    path == ":memory:" || path.is_empty()
+}
+
+/// Forget the registered root connection for `path`, closing it once every
+/// pool cloned from it has been dropped. Used before deleting the database
+/// file so DuckDB releases its lock.
+pub fn forget_path(path: &str) {
+    if let Ok(mut map) = registry().lock() {
+        map.remove(&canonical_key(path));
+    }
+}
+
+fn canonical_key(path: &str) -> String {
+    std::fs::canonicalize(path)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| path.to_owned())
+}
+
+// ── Pool ───────────────────────────────────────────────────────────────
+
+type Slot = Arc<Mutex<Option<Connection>>>;
+
+struct PoolInner {
+    root: Arc<Root>,
+    slots: Vec<Slot>,
+    next: AtomicUsize,
+}
+
+/// A fixed-size pool of connections over one DuckDB database.
+#[derive(Clone)]
+pub struct Pool {
+    inner: Arc<PoolInner>,
+}
+
+impl std::fmt::Debug for Pool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Pool")
+            .field("size", &self.inner.slots.len())
+            .finish()
+    }
+}
+
+impl Pool {
+    /// Open (creating if necessary) the database at `path` with `size`
+    /// connections. `":memory:"` opens a private in-memory database.
+    pub async fn open(path: &str, size: u32) -> Result<Self> {
+        let path = path.to_owned();
+        let size = size.max(1) as usize;
+        tokio::task::spawn_blocking(move || Self::open_blocking(&path, size))
+            .await
+            .map_err(|e| Error::Worker(e.to_string()))?
+    }
+
+    fn open_blocking(path: &str, size: usize) -> Result<Self> {
+        let root = if is_memory_path(path) {
+            Arc::new(Root {
+                conn: StdMutex::new(Connection::open_in_memory()?),
+            })
+        } else {
+            let mut map = registry()
+                .lock()
+                .map_err(|_| Error::Connection("registry poisoned".to_owned()))?;
+            // Open first so the file exists for canonicalisation.
+            let key = canonical_key(path);
+            if let Some(existing) = map.get(&key) {
+                Arc::clone(existing)
+            } else {
+                let conn = Connection::open(path)?;
+                let key = canonical_key(path);
+                let root = Arc::new(Root {
+                    conn: StdMutex::new(conn),
+                });
+                map.insert(key, Arc::clone(&root));
+                root
+            }
+        };
+        let mut slots = Vec::with_capacity(size);
+        for _ in 0..size {
+            slots.push(Arc::new(Mutex::new(Some(root.clone_conn()?))));
+        }
+        Ok(Self {
+            inner: Arc::new(PoolInner {
+                root,
+                slots,
+                next: AtomicUsize::new(0),
+            }),
+        })
+    }
+
+    /// Open a pool that shares the database of `other` (a fresh set of
+    /// connections onto the same instance).
+    pub fn sibling(&self, size: u32) -> Result<Self> {
+        let size = size.max(1) as usize;
+        let mut slots = Vec::with_capacity(size);
+        for _ in 0..size {
+            slots.push(Arc::new(Mutex::new(Some(self.inner.root.clone_conn()?))));
+        }
+        Ok(Self {
+            inner: Arc::new(PoolInner {
+                root: Arc::clone(&self.inner.root),
+                slots,
+                next: AtomicUsize::new(0),
+            }),
+        })
+    }
+
+    /// Number of connections in the pool.
+    pub fn size(&self) -> usize {
+        self.inner.slots.len()
+    }
+
+    /// Acquire a connection slot, preferring an idle one.
+    async fn acquire(&self) -> Result<Held> {
+        let n = self.inner.slots.len();
+        let start = self.inner.next.fetch_add(1, Ordering::Relaxed) % n;
+        let mut guard = None;
+        for i in 0..n {
+            let slot = &self.inner.slots[(start + i) % n];
+            if let Ok(g) = Arc::clone(slot).try_lock_owned() {
+                guard = Some(g);
+                break;
+            }
+        }
+        let mut guard = match guard {
+            Some(g) => g,
+            None => Arc::clone(&self.inner.slots[start]).lock_owned().await,
+        };
+        if guard.is_none() {
+            // A previous blocking task panicked and took the connection with
+            // it; re-create it from the root.
+            let root = Arc::clone(&self.inner.root);
+            let conn = tokio::task::spawn_blocking(move || root.clone_conn())
+                .await
+                .map_err(|e| Error::Worker(e.to_string()))??;
+            *guard = Some(conn);
+        }
+        Ok(Held { guard })
+    }
+
+    /// Begin a transaction on a pooled connection.
+    pub async fn begin(&self) -> Result<Transaction> {
+        let mut held = self.acquire().await?;
+        held.run(Box::new(|c| c.execute_batch("BEGIN TRANSACTION")))
+            .await?;
+        Ok(Transaction {
+            state: TxState {
+                held: Some(held),
+                finished: false,
+            },
+        })
+    }
+}
+
+/// A connection slot held by a caller.
+struct Held {
+    guard: OwnedMutexGuard<Option<Connection>>,
+}
+
+/// A unit of blocking work run against a connection.
+pub type Job<R> = Box<dyn FnOnce(&Connection) -> duckdb::Result<R> + Send + 'static>;
+
+impl Held {
+    async fn run<R: Send + 'static>(&mut self, job: Job<R>) -> Result<R> {
+        let conn = self
+            .guard
+            .take()
+            .ok_or_else(|| Error::Connection("connection slot is empty".to_owned()))?;
+        let (conn, result) = tokio::task::spawn_blocking(move || {
+            let r = job(&conn);
+            (conn, r)
+        })
+        .await
+        .map_err(|e| Error::Worker(e.to_string()))?;
+        *self.guard = Some(conn);
+        result.map_err(Error::Db)
+    }
+}
+
+// ── Executor ───────────────────────────────────────────────────────────
+
+/// Something a statement can run on: a pool (autocommit, any connection) or a
+/// transaction (its pinned connection).
+pub trait Executor: Send {
+    fn run<R: Send + 'static>(self, job: Job<R>) -> impl Future<Output = Result<R>> + Send;
+}
+
+impl Executor for &Pool {
+    async fn run<R: Send + 'static>(self, job: Job<R>) -> Result<R> {
+        let mut held = self.acquire().await?;
+        held.run(job).await
+    }
+}
+
+impl Executor for &mut TxState {
+    async fn run<R: Send + 'static>(self, job: Job<R>) -> Result<R> {
+        let held = self
+            .held
+            .as_mut()
+            .ok_or_else(|| Error::Connection("transaction already finished".to_owned()))?;
+        held.run(job).await
+    }
+}
+
+impl Executor for &mut Transaction {
+    fn run<R: Send + 'static>(self, job: Job<R>) -> impl Future<Output = Result<R>> + Send {
+        (&mut self.state).run(job)
+    }
+}
+
+// ── Transaction ────────────────────────────────────────────────────────
+
+/// Transaction state: the pinned connection and whether it has ended.
+pub struct TxState {
+    held: Option<Held>,
+    finished: bool,
+}
+
+/// An open transaction. Dropping it without `commit` rolls it back.
+pub struct Transaction {
+    state: TxState,
+}
+
+impl Deref for Transaction {
+    type Target = TxState;
+    fn deref(&self) -> &TxState {
+        &self.state
+    }
+}
+
+impl DerefMut for Transaction {
+    fn deref_mut(&mut self) -> &mut TxState {
+        &mut self.state
+    }
+}
+
+impl Transaction {
+    /// Commit the transaction and release the connection.
+    pub async fn commit(mut self) -> Result<()> {
+        self.state.finished = true;
+        let mut held = self
+            .state
+            .held
+            .take()
+            .ok_or_else(|| Error::Connection("transaction already finished".to_owned()))?;
+        held.run(Box::new(|c| c.execute_batch("COMMIT"))).await
+    }
+
+    /// Roll the transaction back and release the connection.
+    pub async fn rollback(mut self) -> Result<()> {
+        self.state.finished = true;
+        let mut held = self
+            .state
+            .held
+            .take()
+            .ok_or_else(|| Error::Connection("transaction already finished".to_owned()))?;
+        held.run(Box::new(|c| c.execute_batch("ROLLBACK"))).await
+    }
+}
+
+impl Drop for TxState {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        // Best-effort synchronous rollback. A ROLLBACK is cheap in DuckDB and
+        // the alternative is leaking an open transaction on a pooled
+        // connection, which would poison every later statement on it.
+        if let Some(held) = self.held.as_mut()
+            && let Some(conn) = held.guard.as_ref()
+        {
+            let _ = conn.execute_batch("ROLLBACK");
+        }
+    }
+}
+
+// ── Encoding (bind parameters) ─────────────────────────────────────────
+
+/// Types that can be bound as a positional parameter.
+pub trait Encode {
+    fn encode(self) -> Value;
+}
+
+macro_rules! encode_int {
+    ($($t:ty),*) => {$(
+        impl Encode for $t {
+            fn encode(self) -> Value { Value::BigInt(i64::try_from(self).unwrap_or(i64::MAX)) }
+        }
+        impl Encode for &$t {
+            fn encode(self) -> Value { (*self).encode() }
+        }
+    )*};
+}
+encode_int!(i8, i16, i32, i64, u8, u16, u32, u64, usize);
+
+impl Encode for f64 {
+    fn encode(self) -> Value {
+        Value::Double(self)
+    }
+}
+impl Encode for &f64 {
+    fn encode(self) -> Value {
+        Value::Double(*self)
+    }
+}
+impl Encode for f32 {
+    fn encode(self) -> Value {
+        Value::Float(self)
+    }
+}
+impl Encode for bool {
+    // Catalog booleans are stored as 0/1 integers (see `schema.rs`), so a bool
+    // parameter must compare as an integer rather than a BOOLEAN.
+    fn encode(self) -> Value {
+        Value::BigInt(i64::from(self))
+    }
+}
+impl Encode for &bool {
+    fn encode(self) -> Value {
+        (*self).encode()
+    }
+}
+impl Encode for String {
+    fn encode(self) -> Value {
+        Value::Text(self)
+    }
+}
+impl Encode for &String {
+    fn encode(self) -> Value {
+        Value::Text(self.clone())
+    }
+}
+impl Encode for &str {
+    fn encode(self) -> Value {
+        Value::Text(self.to_owned())
+    }
+}
+impl Encode for &&str {
+    fn encode(self) -> Value {
+        Value::Text((*self).to_owned())
+    }
+}
+impl Encode for std::borrow::Cow<'_, str> {
+    fn encode(self) -> Value {
+        Value::Text(self.into_owned())
+    }
+}
+impl Encode for &std::borrow::Cow<'_, str> {
+    fn encode(self) -> Value {
+        Value::Text(self.to_string())
+    }
+}
+impl Encode for Vec<u8> {
+    fn encode(self) -> Value {
+        Value::Blob(self)
+    }
+}
+impl Encode for &Vec<u8> {
+    fn encode(self) -> Value {
+        Value::Blob(self.clone())
+    }
+}
+impl Encode for &[u8] {
+    fn encode(self) -> Value {
+        Value::Blob(self.to_vec())
+    }
+}
+impl Encode for serde_json::Value {
+    fn encode(self) -> Value {
+        Value::Text(self.to_string())
+    }
+}
+impl Encode for &serde_json::Value {
+    fn encode(self) -> Value {
+        Value::Text(self.to_string())
+    }
+}
+impl Encode for time::OffsetDateTime {
+    fn encode(self) -> Value {
+        Value::Text(crate::duckdb_util::format_timestamp(self))
+    }
+}
+impl Encode for &time::OffsetDateTime {
+    fn encode(self) -> Value {
+        (*self).encode()
+    }
+}
+impl<T: Encode> Encode for Option<T> {
+    fn encode(self) -> Value {
+        match self {
+            Some(v) => v.encode(),
+            None => Value::Null,
+        }
+    }
+}
+impl<T> Encode for &Option<T>
+where
+    for<'a> &'a T: Encode,
+{
+    fn encode(self) -> Value {
+        match self {
+            Some(v) => v.encode(),
+            None => Value::Null,
+        }
+    }
+}
+impl Encode for Value {
+    fn encode(self) -> Value {
+        self
+    }
+}
+
+// ── Decoding (result columns) ──────────────────────────────────────────
+
+/// Types that can be read from a result column.
+pub trait Decode: Sized {
+    fn decode(v: &Value) -> Result<Self>;
+}
+
+fn decode_err(want: &str, v: &Value) -> Error {
+    Error::Decode(format!("expected {want}, got {v:?}"))
+}
+
+fn value_to_i128(v: &Value) -> Option<i128> {
+    Some(match v {
+        Value::Boolean(b) => i128::from(*b),
+        Value::TinyInt(i) => i128::from(*i),
+        Value::SmallInt(i) => i128::from(*i),
+        Value::Int(i) => i128::from(*i),
+        Value::BigInt(i) => i128::from(*i),
+        Value::HugeInt(i) => *i,
+        Value::UHugeInt(i) => i128::try_from(*i).ok()?,
+        Value::UTinyInt(i) => i128::from(*i),
+        Value::USmallInt(i) => i128::from(*i),
+        Value::UInt(i) => i128::from(*i),
+        Value::UBigInt(i) => i128::from(*i),
+        Value::Double(d) if d.fract() == 0.0 => *d as i128,
+        Value::Float(d) if d.fract() == 0.0 => *d as i128,
+        Value::Decimal(d) if d.scale() == 0 => d.value(),
+        Value::Text(s) => s.trim().parse::<i128>().ok()?,
+        _ => return None,
+    })
+}
+
+impl Decode for i64 {
+    fn decode(v: &Value) -> Result<Self> {
+        value_to_i128(v)
+            .and_then(|i| i64::try_from(i).ok())
+            .ok_or_else(|| decode_err("integer", v))
+    }
+}
+impl Decode for i32 {
+    fn decode(v: &Value) -> Result<Self> {
+        value_to_i128(v)
+            .and_then(|i| i32::try_from(i).ok())
+            .ok_or_else(|| decode_err("integer", v))
+    }
+}
+impl Decode for u64 {
+    fn decode(v: &Value) -> Result<Self> {
+        value_to_i128(v)
+            .and_then(|i| u64::try_from(i).ok())
+            .ok_or_else(|| decode_err("unsigned integer", v))
+    }
+}
+impl Decode for u32 {
+    fn decode(v: &Value) -> Result<Self> {
+        value_to_i128(v)
+            .and_then(|i| u32::try_from(i).ok())
+            .ok_or_else(|| decode_err("unsigned integer", v))
+    }
+}
+impl Decode for bool {
+    fn decode(v: &Value) -> Result<Self> {
+        match v {
+            Value::Boolean(b) => Ok(*b),
+            other => value_to_i128(other)
+                .map(|i| i != 0)
+                .ok_or_else(|| decode_err("boolean", v)),
+        }
+    }
+}
+impl Decode for f64 {
+    fn decode(v: &Value) -> Result<Self> {
+        match v {
+            Value::Double(d) => Ok(*d),
+            Value::Float(f) => Ok(f64::from(*f)),
+            Value::Decimal(d) => Ok(d.value() as f64 / 10f64.powi(i32::from(d.scale()))),
+            Value::Text(s) => s.trim().parse::<f64>().map_err(|_| decode_err("double", v)),
+            other => value_to_i128(other)
+                .map(|i| i as f64)
+                .ok_or_else(|| decode_err("double", v)),
+        }
+    }
+}
+impl Decode for f32 {
+    fn decode(v: &Value) -> Result<Self> {
+        f64::decode(v).map(|d| d as f32)
+    }
+}
+impl Decode for String {
+    fn decode(v: &Value) -> Result<Self> {
+        match v {
+            Value::Text(s) | Value::Enum(s) => Ok(s.clone()),
+            Value::Blob(b) => String::from_utf8(b.clone()).map_err(|_| decode_err("text", v)),
+            Value::Boolean(b) => Ok(b.to_string()),
+            Value::Double(d) => Ok(d.to_string()),
+            Value::Float(d) => Ok(d.to_string()),
+            other => value_to_i128(other)
+                .map(|i| i.to_string())
+                .ok_or_else(|| decode_err("text", v)),
+        }
+    }
+}
+impl Decode for Vec<u8> {
+    fn decode(v: &Value) -> Result<Self> {
+        match v {
+            Value::Blob(b) | Value::Geometry(b) => Ok(b.clone()),
+            Value::Text(s) => Ok(s.clone().into_bytes()),
+            _ => Err(decode_err("blob", v)),
+        }
+    }
+}
+impl Decode for serde_json::Value {
+    fn decode(v: &Value) -> Result<Self> {
+        match v {
+            Value::Text(s) => serde_json::from_str(s).map_err(|e| Error::Decode(e.to_string())),
+            Value::Blob(b) => serde_json::from_slice(b).map_err(|e| Error::Decode(e.to_string())),
+            _ => Err(decode_err("json text", v)),
+        }
+    }
+}
+impl Decode for time::OffsetDateTime {
+    fn decode(v: &Value) -> Result<Self> {
+        match v {
+            Value::Text(s) => {
+                crate::duckdb_util::parse_timestamp(s).map_err(|e| Error::Decode(e.to_string()))
+            }
+            Value::Timestamp(unit, raw) => {
+                let nanos: i128 = match unit {
+                    duckdb::types::TimeUnit::Second => i128::from(*raw) * 1_000_000_000,
+                    duckdb::types::TimeUnit::Millisecond => i128::from(*raw) * 1_000_000,
+                    duckdb::types::TimeUnit::Microsecond => i128::from(*raw) * 1_000,
+                    duckdb::types::TimeUnit::Nanosecond => i128::from(*raw),
+                };
+                time::OffsetDateTime::from_unix_timestamp_nanos(nanos)
+                    .map_err(|e| Error::Decode(e.to_string()))
+            }
+            _ => Err(decode_err("timestamp", v)),
+        }
+    }
+}
+impl<T: Decode> Decode for Option<T> {
+    fn decode(v: &Value) -> Result<Self> {
+        match v {
+            Value::Null => Ok(None),
+            other => T::decode(other).map(Some),
+        }
+    }
+}
+impl Decode for Value {
+    fn decode(v: &Value) -> Result<Self> {
+        Ok(v.clone())
+    }
+}
+
+// ── Rows ───────────────────────────────────────────────────────────────
+
+/// A fully materialised result row.
+pub type Row = Vec<Value>;
+
+/// Types constructible from a result row, by column position.
+pub trait FromRow: Sized {
+    fn from_row(row: &Row) -> Result<Self>;
+}
+
+fn col(row: &Row, i: usize) -> Result<&Value> {
+    row.get(i)
+        .ok_or_else(|| Error::Decode(format!("row has {} columns, wanted index {i}", row.len())))
+}
+
+macro_rules! impl_from_row_tuple {
+    ($($idx:tt : $t:ident),+) => {
+        impl<$($t: Decode),+> FromRow for ($($t,)+) {
+            fn from_row(row: &Row) -> Result<Self> {
+                Ok(($($t::decode(col(row, $idx)?)?,)+))
+            }
+        }
+    };
+}
+impl_from_row_tuple!(0: A);
+impl_from_row_tuple!(0: A, 1: B);
+impl_from_row_tuple!(0: A, 1: B, 2: C);
+impl_from_row_tuple!(0: A, 1: B, 2: C, 3: D);
+impl_from_row_tuple!(0: A, 1: B, 2: C, 3: D, 4: E);
+impl_from_row_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F);
+impl_from_row_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G);
+impl_from_row_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H);
+impl_from_row_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I);
+impl_from_row_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J);
+
+/// Implement [`FromRow`] for a struct whose fields are selected in declaration
+/// order (the crate's `*_COLUMNS` constants guarantee that order).
+#[macro_export]
+macro_rules! impl_from_row {
+    ($name:ident { $($field:ident),+ $(,)? }) => {
+        impl $crate::db::FromRow for $name {
+            fn from_row(row: &$crate::db::Row) -> $crate::db::Result<Self> {
+                let mut __i = 0usize;
+                $(
+                    let $field = $crate::db::Decode::decode(
+                        row.get(__i).ok_or_else(|| $crate::db::Error::Decode(
+                            format!("row has {} columns, wanted index {}", row.len(), __i)))?)?;
+                    __i += 1;
+                )+
+                let _ = __i;
+                Ok(Self { $($field),+ })
+            }
+        }
+    };
+}
+
+// ── Statement helpers (blocking side) ──────────────────────────────────
+
+fn run_query(conn: &Connection, sql: &str, params: &[Value]) -> duckdb::Result<Vec<Row>> {
+    let mut stmt = conn.prepare(sql)?;
+    let mut rows = stmt.query(duckdb::params_from_iter(params.iter()))?;
+    let ncols = rows.as_ref().map_or(0, |s| s.column_count());
+    let mut out = Vec::new();
+    while let Some(row) = rows.next()? {
+        let mut vals = Vec::with_capacity(ncols);
+        for i in 0..ncols {
+            vals.push(row.get_ref(i)?.to_owned());
+        }
+        out.push(vals);
+    }
+    Ok(out)
+}
+
+fn run_execute(conn: &Connection, sql: &str, params: &[Value]) -> duckdb::Result<u64> {
+    let mut stmt = conn.prepare(sql)?;
+    // A statement with a RETURNING clause produces a result set, and DuckDB
+    // reports zero changed rows for it; count the returned rows instead so
+    // `rows_affected` means the same thing it does for a plain statement.
+    if has_returning_clause(sql) {
+        let mut rows = stmt.query(duckdb::params_from_iter(params.iter()))?;
+        let mut n = 0u64;
+        while rows.next()?.is_some() {
+            n += 1;
+        }
+        return Ok(n);
+    }
+    let n = stmt.execute(duckdb::params_from_iter(params.iter()))?;
+    Ok(n as u64)
+}
+
+fn has_returning_clause(sql: &str) -> bool {
+    sql.split_whitespace()
+        .any(|w| w.eq_ignore_ascii_case("RETURNING"))
+}
+
+// ── Query builders ─────────────────────────────────────────────────────
+
+/// Outcome of an `execute`.
+#[derive(Debug, Clone, Copy)]
+pub struct QueryResult {
+    rows_affected: u64,
+}
+
+impl QueryResult {
+    pub fn rows_affected(&self) -> u64 {
+        self.rows_affected
+    }
+}
+
+/// A statement with positional parameters, run for its side effects.
+pub struct Query {
+    sql: String,
+    params: Vec<Value>,
+}
+
+/// Build a statement. Parameters are `?` placeholders bound with [`Query::bind`].
+pub fn query(sql: &str) -> Query {
+    Query {
+        sql: sql.to_owned(),
+        params: Vec::new(),
+    }
+}
+
+impl Query {
+    pub fn bind<T: Encode>(mut self, v: T) -> Self {
+        self.params.push(v.encode());
+        self
+    }
+
+    pub async fn execute<E: Executor>(self, exec: E) -> Result<QueryResult> {
+        let Query { sql, params } = self;
+        let n = exec
+            .run(Box::new(move |c| run_execute(c, &sql, &params)))
+            .await?;
+        Ok(QueryResult { rows_affected: n })
+    }
+
+    pub async fn fetch_all<E: Executor>(self, exec: E) -> Result<Vec<Row>> {
+        let Query { sql, params } = self;
+        exec.run(Box::new(move |c| run_query(c, &sql, &params)))
+            .await
+    }
+}
+
+/// A statement whose rows decode into `T`.
+pub struct QueryAs<T> {
+    q: Query,
+    _t: PhantomData<fn() -> T>,
+}
+
+/// Build a typed statement; rows decode via [`FromRow`].
+pub fn query_as<T: FromRow>(sql: &str) -> QueryAs<T> {
+    QueryAs {
+        q: query(sql),
+        _t: PhantomData,
+    }
+}
+
+impl<T: FromRow + Send + 'static> QueryAs<T> {
+    pub fn bind<V: Encode>(mut self, v: V) -> Self {
+        self.q = self.q.bind(v);
+        self
+    }
+
+    pub async fn fetch_all<E: Executor>(self, exec: E) -> Result<Vec<T>> {
+        let rows = self.q.fetch_all(exec).await?;
+        rows.iter().map(T::from_row).collect()
+    }
+
+    pub async fn fetch_optional<E: Executor>(self, exec: E) -> Result<Option<T>> {
+        let rows = self.q.fetch_all(exec).await?;
+        rows.first().map(T::from_row).transpose()
+    }
+
+    pub async fn fetch_one<E: Executor>(self, exec: E) -> Result<T> {
+        self.fetch_optional(exec).await?.ok_or(Error::RowNotFound)
+    }
+}
+
+/// A statement whose first column decodes into `T`.
+pub struct QueryScalar<T> {
+    q: Query,
+    _t: PhantomData<fn() -> T>,
+}
+
+/// Build a single-column statement; the first column decodes via [`Decode`].
+pub fn query_scalar<T: Decode>(sql: &str) -> QueryScalar<T> {
+    QueryScalar {
+        q: query(sql),
+        _t: PhantomData,
+    }
+}
+
+impl<T: Decode + Send + 'static> QueryScalar<T> {
+    pub fn bind<V: Encode>(mut self, v: V) -> Self {
+        self.q = self.q.bind(v);
+        self
+    }
+
+    pub async fn fetch_all<E: Executor>(self, exec: E) -> Result<Vec<T>> {
+        let rows = self.q.fetch_all(exec).await?;
+        rows.iter().map(|r| T::decode(col(r, 0)?)).collect()
+    }
+
+    pub async fn fetch_optional<E: Executor>(self, exec: E) -> Result<Option<T>> {
+        let rows = self.q.fetch_all(exec).await?;
+        rows.first().map(|r| T::decode(col(r, 0)?)).transpose()
+    }
+
+    pub async fn fetch_one<E: Executor>(self, exec: E) -> Result<T> {
+        self.fetch_optional(exec).await?.ok_or(Error::RowNotFound)
+    }
+}
+
+/// A multi-statement script, run as a batch.
+pub struct RawSql {
+    sql: String,
+}
+
+/// Build a multi-statement batch (DDL scripts); no parameters.
+pub fn raw_sql(sql: &str) -> RawSql {
+    RawSql {
+        sql: sql.to_owned(),
+    }
+}
+
+impl RawSql {
+    pub async fn execute<E: Executor>(self, exec: E) -> Result<()> {
+        let sql = self.sql;
+        exec.run(Box::new(move |c| c.execute_batch(&sql))).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn round_trip_types() {
+        let pool = Pool::open(":memory:", 2).await.unwrap();
+        raw_sql(
+            "CREATE TABLE t(k TEXT PRIMARY KEY, n BIGINT, d DOUBLE, b BLOB, j TEXT, flag BIGINT)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        let json = serde_json::json!({"a": [1, 2]});
+        let r = query("INSERT INTO t VALUES (?, ?, ?, ?, ?, ?)")
+            .bind("k1")
+            .bind(42i64)
+            .bind(1.5f64)
+            .bind(vec![0u8, 1, 2])
+            .bind(&json)
+            .bind(true)
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert_eq!(r.rows_affected(), 1);
+        let row: (String, i64, f64, Vec<u8>, serde_json::Value, bool) =
+            query_as("SELECT k, n, d, b, j, flag FROM t WHERE k = ?")
+                .bind("k1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row, ("k1".to_owned(), 42, 1.5, vec![0, 1, 2], json, true));
+        let count: i64 = query_scalar("SELECT COUNT(*) FROM t")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 1);
+        let exists: bool = query_scalar("SELECT EXISTS(SELECT 1 FROM t WHERE k = 'nope')")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert!(!exists);
+        let missing: Option<(String,)> = query_as("SELECT k FROM t WHERE k = 'nope'")
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+        assert!(missing.is_none());
+        let sum: i64 = query_scalar("SELECT SUM(n) FROM t")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(sum, 42);
+    }
+
+    #[tokio::test]
+    async fn transaction_rolls_back_on_drop_and_commits_explicitly() {
+        let pool = Pool::open(":memory:", 2).await.unwrap();
+        raw_sql("CREATE TABLE t(k TEXT PRIMARY KEY)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        {
+            let mut tx = pool.begin().await.unwrap();
+            query("INSERT INTO t VALUES ('a')")
+                .execute(&mut *tx)
+                .await
+                .unwrap();
+            // dropped without commit
+        }
+        let n: i64 = query_scalar("SELECT COUNT(*) FROM t")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(n, 0);
+        let mut tx = pool.begin().await.unwrap();
+        query("INSERT INTO t VALUES ('a')")
+            .execute(&mut *tx)
+            .await
+            .unwrap();
+        let inner: &mut TxState = &mut tx;
+        let seen: i64 = query_scalar("SELECT COUNT(*) FROM t")
+            .fetch_one(inner)
+            .await
+            .unwrap();
+        assert_eq!(seen, 1);
+        tx.commit().await.unwrap();
+        let n: i64 = query_scalar("SELECT COUNT(*) FROM t")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(n, 1);
+    }
+
+    #[tokio::test]
+    async fn in_memory_pool_shares_one_database_across_connections() {
+        let pool = Pool::open(":memory:", 4).await.unwrap();
+        raw_sql("CREATE TABLE t(k TEXT)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        for i in 0..8 {
+            query("INSERT INTO t VALUES (?)")
+                .bind(i)
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
+        let n: i64 = query_scalar("SELECT COUNT(*) FROM t")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(n, 8);
+        let sibling = pool.sibling(2).unwrap();
+        let n: i64 = query_scalar("SELECT COUNT(*) FROM t")
+            .fetch_one(&sibling)
+            .await
+            .unwrap();
+        assert_eq!(n, 8);
+    }
+
+    #[tokio::test]
+    async fn separate_in_memory_pools_are_independent() {
+        let a = Pool::open(":memory:", 1).await.unwrap();
+        let b = Pool::open(":memory:", 1).await.unwrap();
+        raw_sql("CREATE TABLE only_a(k TEXT)")
+            .execute(&a)
+            .await
+            .unwrap();
+        let exists: bool = query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM duckdb_tables() WHERE table_name = 'only_a')",
+        )
+        .fetch_one(&b)
+        .await
+        .unwrap();
+        assert!(!exists);
+    }
+
+    #[tokio::test]
+    async fn returning_via_execute_counts_rows() {
+        let pool = Pool::open(":memory:", 1).await.unwrap();
+        raw_sql("CREATE TABLE t(k TEXT); INSERT INTO t VALUES ('a'), ('b')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let r = query("DELETE FROM t RETURNING k")
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert_eq!(r.rows_affected(), 2);
+    }
+}

--- a/crates/storage-duckdb/src/delete_table.rs
+++ b/crates/storage-duckdb/src/delete_table.rs
@@ -1,0 +1,169 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `delete_table` implementation for `DuckDbEngine`.
+//!
+//! With `control_plane_delay_seconds < 1` the table and its data tables are
+//! dropped immediately; otherwise the table is marked DELETING with a scheduled
+//! transition that the control-plane worker completes.
+
+use crate::db;
+use extenddb_core::types::{DeleteTableInput, TableDescription, TableStatus};
+use extenddb_storage::error::StorageError;
+
+use crate::duckdb_util::format_timestamp;
+use crate::store::DuckDbEngine;
+use crate::table_helpers::{INDEX_COLUMNS, IndexRow, TABLE_COLUMNS, TableRow};
+
+impl DuckDbEngine {
+    pub(crate) async fn delete_table_impl(
+        &self,
+        account_id: &str,
+        input: DeleteTableInput,
+    ) -> Result<TableDescription, StorageError> {
+        Self::validate_account_id(account_id)?;
+
+        let row: Option<TableRow> = db::query_as(&format!(
+            "SELECT {TABLE_COLUMNS} FROM tables \
+             WHERE account_id = ? AND table_name = ? AND table_status IN ('ACTIVE', 'CREATING')"
+        ))
+        .bind(account_id)
+        .bind(&input.table_name)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let row = row.ok_or_else(|| StorageError::TableNotFound(input.table_name.clone()))?;
+        if row.deletion_protection_enabled {
+            return Err(StorageError::DeletionProtected(row.table_arn.clone()));
+        }
+
+        let index_rows: Vec<IndexRow> = db::query_as(&format!(
+            "SELECT {INDEX_COLUMNS} FROM indexes WHERE table_id = ?"
+        ))
+        .bind(&row.table_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let delay_secs: f64 = db::query_scalar::<String>(
+            "SELECT value FROM settings WHERE key = 'control_plane_delay_seconds'",
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?
+        .and_then(|v| v.parse::<f64>().ok())
+        .unwrap_or(0.25);
+
+        let index_ids: Vec<String> = index_rows.iter().map(|r| r.index_id.clone()).collect();
+        let table_id = row.table_id.clone();
+        let table_arn = row.table_arn.clone();
+
+        if delay_secs < 1.0 {
+            let _writer = self.write_lock.lock().await;
+            let mut tx = self
+                .pool
+                .begin()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            // A vector index with `backfilling` set is an UpdateTable build in
+            // flight (the with-table path never sets the column), and the
+            // service refuses to delete the table underneath one; the refusal
+            // clears when the index flips ACTIVE or its create is cancelled.
+            // Checked INSIDE the immediate transaction rather than before it,
+            // so a build whose catalog row commits while this call is waiting
+            // on the write lock is still caught: the check and the cascade
+            // delete are atomic against a concurrent UpdateTable.
+            Self::refuse_if_index_build_in_flight(&mut tx, &row.table_id, &input.table_name)
+                .await?;
+            db::query("DELETE FROM tags WHERE resource_arn = ?")
+                .bind(&table_arn)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            // No foreign keys in DuckDB: remove indexes, stream shards/records
+            // explicitly before the table row.
+            crate::referential::delete_table_children(&mut tx, &table_id)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            db::query("DELETE FROM tables WHERE table_id = ?")
+                .bind(&table_id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            for idx_id in &index_ids {
+                Self::drop_index_data_table(&mut tx, idx_id).await?;
+            }
+            Self::drop_data_table(&mut tx, &table_id).await?;
+            // Drop any still-pending GSI propagation rows for this table in the
+            // same transaction that drops the tables, so the worker doesn't
+            // waste a claim→deserialize→skip cycle on now-orphaned rows.
+            db::query("DELETE FROM gsi_pending WHERE table_id = ?")
+                .bind(&table_id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            tx.commit()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+        } else {
+            let transition = format_timestamp(
+                time::OffsetDateTime::now_utc() + time::Duration::seconds_f64(delay_secs),
+            );
+            let _writer = self.write_lock.lock().await;
+            let mut tx = self
+                .pool
+                .begin()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            // Same in-flight-build refusal as the immediate branch, and inside
+            // the transaction that flips the table to DELETING for the same
+            // reason: without it, a build committing between an earlier check
+            // and this flip would have its table deleted underneath it.
+            Self::refuse_if_index_build_in_flight(&mut tx, &row.table_id, &input.table_name)
+                .await?;
+            db::query(
+                "UPDATE tables SET table_status = 'DELETING', status_transition_at = ? \
+                 WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(&transition)
+            .bind(account_id)
+            .bind(&input.table_name)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            tx.commit()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            self.control_plane_notify.notify_one();
+        }
+
+        let desc = self.build_table_description_from_row(account_id, row, index_rows)?;
+        Ok(TableDescription {
+            table_status: TableStatus::Deleting,
+            ..desc
+        })
+    }
+
+    /// Refuse the operation while any UpdateTable-created vector index build is
+    /// in flight on the table (`backfilling IS NOT NULL`; the with-table path
+    /// never sets the column). Must be called inside a `BEGIN IMMEDIATE`
+    /// transaction so the answer is atomic with the caller's own writes.
+    async fn refuse_if_index_build_in_flight(
+        tx: &mut db::Transaction,
+        table_id: &str,
+        table_name: &str,
+    ) -> Result<(), StorageError> {
+        let in_flight: Option<(i64,)> = db::query_as(
+            "SELECT 1 FROM vector_indexes WHERE table_id = ? AND backfilling IS NOT NULL LIMIT 1",
+        )
+        .bind(table_id)
+        .fetch_optional(&mut **tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+        if in_flight.is_some() {
+            return Err(StorageError::IndexesInUse(table_name.to_owned()));
+        }
+        Ok(())
+    }
+}

--- a/crates/storage-duckdb/src/duckdb_util.rs
+++ b/crates/storage-duckdb/src/duckdb_util.rs
@@ -1,0 +1,161 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared helpers for the DuckDB backend: path normalisation, RFC 3339
+//! timestamp conversion, and constraint-violation classification.
+
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+
+use crate::db;
+
+/// Normalize a configured path or connection string into a path DuckDB opens.
+///
+/// Accepts the in-memory sentinel `:memory:`, a bare filesystem path, or a
+/// `duckdb:` / `duckdb://` URL (the scheme is stripped). Nothing else is
+/// interpreted: DuckDB takes a path, not a URL.
+pub(crate) fn duckdb_path(path_or_url: &str) -> String {
+    if let Some(rest) = path_or_url.strip_prefix("duckdb://") {
+        rest.to_owned()
+    } else if let Some(rest) = path_or_url.strip_prefix("duckdb:") {
+        rest.to_owned()
+    } else {
+        path_or_url.to_owned()
+    }
+}
+
+/// Format a timestamp as RFC 3339 UTC, matching the catalog's stored format.
+pub(crate) fn format_timestamp(ts: OffsetDateTime) -> String {
+    ts.to_offset(time::UtcOffset::UTC)
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| ts.to_string())
+}
+
+/// Parse a catalog timestamp string into an `OffsetDateTime`.
+///
+/// Accepts RFC 3339 (the canonical stored form, e.g. `2026-06-08T12:00:00.123Z`)
+/// and tolerates a bare `YYYY-MM-DD HH:MM:SS[.ffffff]` form (assumed UTC), which
+/// is what DuckDB produces when a `TIMESTAMP` is cast to text.
+pub(crate) fn parse_timestamp(s: &str) -> Result<OffsetDateTime, time::error::Parse> {
+    if let Ok(dt) = OffsetDateTime::parse(s, &Rfc3339) {
+        return Ok(dt);
+    }
+    let mut normalized = s.replace(' ', "T");
+    if !normalized.ends_with('Z') && !normalized.contains('+') {
+        normalized.push('Z');
+    }
+    OffsetDateTime::parse(&normalized, &Rfc3339)
+}
+
+/// True if the error is a DuckDB UNIQUE / PRIMARY KEY constraint violation.
+pub(crate) fn is_unique_violation(e: &db::Error) -> bool {
+    e.message().is_some_and(|msg| {
+        msg.contains("violates primary key constraint")
+            || msg.contains("violates unique constraint")
+            || msg.contains("Duplicate key")
+    })
+}
+
+/// True if the error is a DuckDB FOREIGN KEY constraint violation.
+///
+/// The catalog schema declares no foreign keys (DuckDB cannot cascade deletes,
+/// so referential integrity is maintained explicitly by the stores), but the
+/// classifier is kept so any constraint that is later added maps correctly.
+pub(crate) fn is_fk_violation(e: &db::Error) -> bool {
+    e.message()
+        .is_some_and(|msg| msg.contains("foreign key constraint"))
+}
+
+/// Map a database error to a `StorageError`, classifying transient failures.
+///
+/// Transient means retry is expected to succeed: a lost worker connection, an
+/// I/O failure, or a DuckDB optimistic-concurrency conflict (`Conflict on
+/// update`, or a transaction invalidated by another writer). Everything else is
+/// `Internal`, which the queue worker treats as poison. The classification errs
+/// narrow on purpose: a mis-classified poison row retries forever (visible,
+/// bounded to one row), while a mis-classified transient error drops a row
+/// silently.
+pub(crate) fn map_db_err(e: db::Error) -> extenddb_storage::error::StorageError {
+    use extenddb_storage::error::StorageError;
+    let transient = match &e {
+        db::Error::Worker(_) | db::Error::Connection(_) => true,
+        db::Error::Db(duckdb::Error::DuckDBFailure(_, Some(msg))) => {
+            msg.contains("Conflict on update")
+                || msg.contains("TransactionContext Error")
+                || msg.contains("IO Error")
+                || msg.contains("Could not set lock")
+        }
+        _ => false,
+    };
+    if transient {
+        StorageError::Transient(e.to_string())
+    } else {
+        StorageError::Internal(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duckdb_path_variants() {
+        assert_eq!(duckdb_path(":memory:"), ":memory:");
+        assert_eq!(duckdb_path("extenddb.duckdb"), "extenddb.duckdb");
+        assert_eq!(duckdb_path("duckdb:/var/lib/x.duckdb"), "/var/lib/x.duckdb");
+        assert_eq!(
+            duckdb_path("duckdb:///var/lib/x.duckdb"),
+            "/var/lib/x.duckdb"
+        );
+    }
+
+    #[test]
+    fn timestamp_round_trips_rfc3339() {
+        let now = OffsetDateTime::now_utc();
+        let s = format_timestamp(now);
+        let parsed = parse_timestamp(&s).expect("parse RFC3339");
+        assert_eq!(parsed.unix_timestamp(), now.unix_timestamp());
+    }
+
+    #[test]
+    fn timestamp_parses_bare_datetime() {
+        let parsed = parse_timestamp("2026-06-08 12:00:00").expect("parse bare datetime");
+        assert_eq!(parsed.year(), 2026);
+        assert_eq!(parsed.offset(), time::UtcOffset::UTC);
+        let parsed = parse_timestamp("2026-06-08 12:00:00.123456").expect("parse with micros");
+        assert_eq!(parsed.millisecond(), 123);
+    }
+}
+
+#[cfg(test)]
+mod map_db_err_tests {
+    use super::map_db_err;
+    use crate::db;
+    use extenddb_storage::error::StorageError;
+
+    #[test]
+    fn worker_errors_are_transient() {
+        let e = db::Error::Worker("thread died".to_owned());
+        assert!(matches!(map_db_err(e), StorageError::Transient(_)));
+    }
+
+    #[test]
+    fn connection_errors_are_transient() {
+        assert!(matches!(
+            map_db_err(db::Error::Connection("slot empty".to_owned())),
+            StorageError::Transient(_)
+        ));
+    }
+
+    /// Anything not positively identified as retryable stays Internal, which
+    /// the worker treats as poison. Narrow on purpose: a mis-classified poison
+    /// row retries forever (visible), a mis-classified transient error drops a
+    /// row silently.
+    #[test]
+    fn unknown_errors_stay_internal() {
+        assert!(matches!(
+            map_db_err(db::Error::RowNotFound),
+            StorageError::Internal(_)
+        ));
+    }
+}

--- a/crates/storage-duckdb/src/hooks.rs
+++ b/crates/storage-duckdb/src/hooks.rs
@@ -1,0 +1,90 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `ServerRuntimeHooks` for the DuckDB backend: spawns the background workers
+//! (control-plane poller, table-size refresh, stream/idempotency cleanup, TTL
+//! sweep).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use extenddb_storage::hooks::{ServerRuntimeHooks, WorkerContext};
+
+use crate::store::DuckDbEngine;
+use crate::workers;
+
+pub(crate) struct DuckDbRuntimeHooks {
+    pub(crate) engine: Arc<DuckDbEngine>,
+    pub(crate) control_plane_notify: Arc<tokio::sync::Notify>,
+}
+
+#[async_trait]
+impl ServerRuntimeHooks for DuckDbRuntimeHooks {
+    async fn spawn_workers(&self, ctx: &WorkerContext) -> Vec<tokio::task::JoinHandle<()>> {
+        // Backend-specific workers. Each takes the shutdown token and returns
+        // at its next tick after cancellation; the handles are returned so
+        // `serve` can drain them.
+        let engine = self.engine.clone();
+        let notify = self.control_plane_notify.clone();
+        let catalog_store = ctx.catalog_store.clone();
+        let token = ctx.shutdown.clone();
+        let control_plane = tokio::spawn(async move {
+            workers::poll_control_plane_transitions(engine, notify, catalog_store, token).await;
+        });
+
+        let engine = self.engine.clone();
+        let token = ctx.shutdown.clone();
+        let table_size =
+            tokio::spawn(async move { workers::table_size_refresh_worker(engine, token).await });
+
+        let engine = self.engine.clone();
+        let metrics = ctx.metrics.clone();
+        let token = ctx.shutdown.clone();
+        let stream_cleanup = tokio::spawn(async move {
+            workers::stream_record_cleanup_worker(engine, metrics, token).await;
+        });
+
+        let engine = self.engine.clone();
+        let metrics = ctx.metrics.clone();
+        let token = ctx.shutdown.clone();
+        let idempotency_cleanup = tokio::spawn(async move {
+            workers::idempotency_token_cleanup_worker(engine, metrics, token).await;
+        });
+
+        let engine = self.engine.clone();
+        let metrics = ctx.metrics.clone();
+        let token = ctx.shutdown.clone();
+        let ttl_cleanup =
+            tokio::spawn(async move { workers::ttl_cleanup_worker(engine, metrics, token).await });
+
+        // GSI propagation: drain gsi_pending after each write / on a sweep.
+        let engine = self.engine.clone();
+        let gsi_notify = engine.gsi_notify();
+        let token = ctx.shutdown.clone();
+        let gsi_propagation = tokio::spawn(async move {
+            workers::gsi_propagation_worker(engine, gsi_notify, token).await;
+        });
+
+        // Keep the cached GSI propagation delay in sync with the setting.
+        let index_delay_cache = self.engine.index_propagation_delay_cache.clone();
+        let catalog_store = ctx.catalog_store.clone();
+        let token = ctx.shutdown.clone();
+        let gsi_delay = tokio::spawn(async move {
+            workers::poll_index_propagation_delay(catalog_store, index_delay_cache, token).await;
+        });
+
+        vec![
+            control_plane,
+            table_size,
+            stream_cleanup,
+            idempotency_cleanup,
+            ttl_cleanup,
+            gsi_propagation,
+            gsi_delay,
+        ]
+    }
+
+    fn backend_info(&self) -> Option<String> {
+        Some("storage=duckdb (single-file)".to_owned())
+    }
+}

--- a/crates/storage-duckdb/src/lib.rs
+++ b/crates/storage-duckdb/src/lib.rs
@@ -1,0 +1,291 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! DuckDB storage backend for ExtendDB.
+//!
+//! Implements the full `StorageEngine` + `CatalogStore` trait surface using
+//! DuckDB via `sqlx`, persisting to a single file (or `:memory:` for testing).
+//! WAL mode enables concurrent readers; writers are serialized by the engine
+//! (see `store`).
+//!
+//! # Design decisions vs the PostgreSQL backend
+//!
+//! - Placeholders: `?` positional (not `$N`).
+//! - Concurrency: single WAL-mode pool; an engine-level write lock plus
+//!   `BEGIN IMMEDIATE` replaces `SERIALIZABLE` / `FOR UPDATE`.
+//! - Numbers: `N` sort keys stored as order-preserving TEXT (never `DOUBLE`),
+//!   full precision retained in the item JSON. See `docs/design-decisions.md`.
+//! - One file holds catalog and data (no separate catalog/data databases).
+//!
+//! NOTE: this is the catalog-layer build slice. The data-plane engine modules
+//! and the `ServerComponents` registration are added in the engine slice.
+
+mod admin_store;
+mod authorization_store;
+mod backup;
+mod bootstrapper;
+mod catalog_store;
+pub mod config;
+mod create_table;
+mod credential_store;
+mod data;
+pub(crate) mod db;
+mod delete_table;
+mod duckdb_util;
+mod hooks;
+mod management_store;
+mod metadata;
+mod number_key;
+mod operations;
+mod referential;
+mod schema;
+mod store;
+mod stream;
+mod table_engine;
+mod table_helpers;
+mod update_table;
+mod vector_bench;
+mod vector_search;
+mod worker;
+mod workers;
+
+/// Default secondary-index propagation delay (milliseconds) when the
+/// `index_propagation_delay_ms` setting is absent. Mirrors the value seeded by
+/// the catalog schema, and is the single definition used by both the live read
+/// on the write path and the background refresh worker.
+pub(crate) const DEFAULT_INDEX_PROPAGATION_DELAY_MS: u64 = 10;
+
+/// Read the propagation-delay setting, preferring the canonical key and falling back
+/// to the pre-rename one.
+///
+/// A catalog created before the rename holds the operator's value under the old name,
+/// and the server refuses to start on a catalog-version mismatch rather than migrating,
+/// so no upgrade step ever rewrites that row. Reading past it would silently reset a
+/// configured delay to the default; since 0 means synchronous, the silent change would
+/// be from strict to eventually consistent. `ORDER BY ... DESC` makes the preference
+/// deterministic when both rows exist.
+pub(crate) const INDEX_PROPAGATION_DELAY_QUERY: &str = "SELECT value FROM settings \
+     WHERE key IN ('index_propagation_delay_ms', 'gsi_propagation_delay_ms') \
+     ORDER BY key = 'index_propagation_delay_ms' DESC LIMIT 1";
+
+pub use bootstrapper::DuckDbBootstrapper;
+pub use catalog_store::DuckDbCatalogStore;
+pub use config::DuckDbConfig;
+pub use credential_store::DuckDbCredentialStore;
+pub use schema::CATALOG_VERSION;
+pub use store::DuckDbEngine;
+
+/// The DuckDB backend, for installation via
+/// [`extenddb_storage::set_backend`] in a thin bin.
+///
+/// Bundles the bootstrapper, operations engine, config deserializer, and the
+/// settings/diagnostics/server-components factories under the `duckdb` name,
+/// which also selects the `[storage.duckdb]` config section.
+#[must_use]
+pub fn backend() -> extenddb_storage::Backend {
+    extenddb_storage::Backend {
+        name: "duckdb",
+        bootstrapper: duckdb_bootstrapper_factory,
+        storage_config: config::deserialize_config,
+        operations: &operations::DuckDbOperationsEngine,
+        settings_store: duckdb_settings_store_factory,
+        diagnostics_store: duckdb_diagnostics_store_factory,
+        server_components: duckdb_server_components_factory,
+    }
+}
+
+use extenddb_storage::diagnostics::DiagnosticsStore;
+use extenddb_storage::diagnostics_store::DiagnosticsStoreError;
+use extenddb_storage::management_store::SettingsStore;
+use extenddb_storage::settings_store::SettingsStoreError;
+
+use crate::duckdb_util::duckdb_path;
+
+/// Open a small catalog-only pool for the settings/diagnostics factories,
+/// applying the same PRAGMAs as the engine.
+async fn catalog_pool(connection_string: &str) -> Result<db::Pool, db::Error> {
+    db::Pool::open(&duckdb_path(connection_string), 4).await
+}
+
+// ── Bootstrapper ───────────────────────────────────────────────────────
+
+fn duckdb_bootstrapper_factory(
+    config_path: String,
+    cli_args: Vec<String>,
+) -> futures::future::BoxFuture<
+    'static,
+    Result<
+        Box<dyn extenddb_storage::bootstrapper::Bootstrapper>,
+        extenddb_storage::error::StorageError,
+    >,
+> {
+    Box::pin(async move {
+        let store = DuckDbBootstrapper::from_config(&config_path, &cli_args).await?;
+        Ok(Box::new(store) as Box<dyn extenddb_storage::bootstrapper::Bootstrapper>)
+    })
+}
+
+// ── Operations engine ──────────────────────────────────────────────────
+
+// ── Config deserializer ────────────────────────────────────────────────
+
+// ── Settings store factory ─────────────────────────────────────────────
+
+fn duckdb_settings_store_factory(
+    connection_string: &str,
+) -> futures::future::BoxFuture<'static, Result<Box<dyn SettingsStore>, SettingsStoreError>> {
+    let connection_string = connection_string.to_owned();
+    Box::pin(async move {
+        let pool = catalog_pool(&connection_string)
+            .await
+            .map_err(|e| SettingsStoreError::ConnectionFailed(e.to_string()))?;
+        Ok(Box::new(DuckDbCatalogStore::new(pool)) as Box<dyn SettingsStore>)
+    })
+}
+
+// ── Diagnostics store factory ──────────────────────────────────────────
+
+fn duckdb_diagnostics_store_factory(
+    connection_string: &str,
+) -> futures::future::BoxFuture<'static, Result<Box<dyn DiagnosticsStore>, DiagnosticsStoreError>> {
+    let connection_string = connection_string.to_owned();
+    Box::pin(async move {
+        let pool = catalog_pool(&connection_string)
+            .await
+            .map_err(|e| DiagnosticsStoreError::ConnectionFailed(e.to_string()))?;
+        Ok(Box::new(DuckDbCatalogStore::new(pool)) as Box<dyn DiagnosticsStore>)
+    })
+}
+
+// ── Server components factory ──────────────────────────────────────────
+
+use std::sync::Arc;
+
+use extenddb_auth::CredentialStore;
+use extenddb_storage::server_components::{BackendError, ServerComponents};
+
+use crate::hooks::DuckDbRuntimeHooks;
+
+/// Maximum DynamoDB item size in bytes (post-update validation bound).
+const MAX_ITEM_SIZE_BYTES: usize = 400_000;
+
+fn duckdb_server_components_factory(
+    config: &dyn extenddb_storage::config::StorageConfig,
+    region: &str,
+    options: extenddb_storage::server_components::ServerComponentsOptions,
+) -> futures::future::BoxFuture<'static, Result<ServerComponents, BackendError>> {
+    let db_path = config.connection_config().to_owned();
+    let pool_size = config.max_connections();
+    let region = region.to_owned();
+    Box::pin(async move {
+        let engine = DuckDbEngine::new(&db_path, pool_size, &region, MAX_ITEM_SIZE_BYTES)
+            .await
+            .map_err(|e| BackendError::ConnectionFailed {
+                backend: "duckdb".to_owned(),
+                details: e.to_string(),
+            })?;
+
+        // In-memory databases do not persist across the `init` process, so the
+        // catalog must be bootstrapped here, at serve time, on the engine's own
+        // shared connection (a second pool would open a separate empty DB).
+        // A dev-mode build extends the same bootstrap to an uninitialized FILE
+        // database (`bootstrap_if_uninitialized`), so zero-config dev serve
+        // works with a persistent path too; every bootstrap step is guarded
+        // (IF NOT EXISTS / INSERT OR IGNORE), so re-running on an initialized
+        // file is a no-op. Production builds keep the explicit-`init` contract.
+        let in_memory = db::is_memory_path(&duckdb_path(&db_path));
+        if in_memory || options.bootstrap_if_uninitialized {
+            let admin_user = std::env::var("EXTENDDB_ADMIN_USER").ok();
+            let admin_password = std::env::var("EXTENDDB_ADMIN_PASSWORD").ok();
+            if let Some(password) = engine
+                .bootstrap_ephemeral(admin_user.as_deref(), admin_password.as_deref())
+                .await
+                .map_err(|e| BackendError::InitializationFailed(e.to_string()))?
+            {
+                let user = admin_user.as_deref().unwrap_or("admin");
+                let durability = if in_memory {
+                    "In-memory backend: ephemeral admin credentials (lost on restart)"
+                } else {
+                    "Bootstrapped file backend: admin credentials (stored in the database)"
+                };
+                println!("\n  {durability}\n  Username: {user}\n  Password: {password}\n");
+            }
+        }
+
+        engine.check_catalog_version().await.map_err(|e| match e {
+            extenddb_storage::error::StorageError::CatalogVersionMismatch { expected, found } => {
+                BackendError::CatalogVersionMismatch { expected, found }
+            }
+            other => BackendError::InitializationFailed(other.to_string()),
+        })?;
+
+        // Recover any in-flight control-plane transitions from a prior run.
+        match engine.process_control_plane_transitions().await {
+            Ok(transitions) => {
+                for (name, transition) in &transitions {
+                    tracing::info!("Recovered table '{name}': {transition}");
+                }
+            }
+            Err(e) => tracing::error!("Failed to recover control plane transitions: {e}"),
+        }
+
+        // Rebuild any GSI left mid-backfill (status CREATING) by a prior crash.
+        match engine.reconcile_incomplete_gsis().await {
+            Ok(n) if n > 0 => tracing::info!("Reconciled {n} incomplete GSI(s) at startup"),
+            Ok(_) => {}
+            Err(e) => tracing::error!("Failed to reconcile incomplete GSIs: {e}"),
+        }
+
+        // Same for a vector index. A separate pass rather than a shared one, because
+        // the two live in different catalog tables and are built by different code;
+        // a failure to reconcile one must not skip the other.
+        match engine.reconcile_incomplete_vector_indexes().await {
+            Ok(n) if n > 0 => {
+                tracing::info!("Reconciled {n} incomplete vector index(es) at startup");
+            }
+            Ok(_) => {}
+            Err(e) => tracing::error!("Failed to reconcile incomplete vector indexes: {e}"),
+        }
+
+        let control_plane_notify = engine.control_plane_notify();
+        let engine = Arc::new(engine);
+
+        // Catalog + auth queries: a file-backed database opens a dedicated
+        // catalog pool over the same file; an in-memory database must reuse the
+        // engine's single shared connection (its data lives only there).
+        let catalog_pool = engine
+            .pool
+            .sibling(4)
+            .map_err(|e| BackendError::ConnectionFailed {
+                backend: "duckdb".to_owned(),
+                details: format!("catalog pool: {e}"),
+            })?;
+
+        let enc_key: Option<String> =
+            db::query_scalar("SELECT value FROM settings WHERE key = 'encryption_key'")
+                .fetch_optional(&catalog_pool)
+                .await
+                .map_err(|e| {
+                    BackendError::InitializationFailed(format!("fetch encryption key: {e}"))
+                })?;
+        let enc_key = enc_key.ok_or(BackendError::MissingEncryptionKey)?;
+
+        let catalog_store: Arc<dyn extenddb_storage::CatalogStore> = Arc::new(
+            DuckDbCatalogStore::with_encryption_key(catalog_pool.clone(), enc_key.clone()),
+        );
+        let credential_store: Arc<dyn CredentialStore> =
+            Arc::new(DuckDbCredentialStore::new(catalog_pool, enc_key));
+
+        let runtime_hooks = Box::new(DuckDbRuntimeHooks {
+            engine: engine.clone(),
+            control_plane_notify,
+        });
+
+        Ok(ServerComponents {
+            engine,
+            catalog_store,
+            credential_store,
+            runtime_hooks: Some(runtime_hooks),
+        })
+    })
+}

--- a/crates/storage-duckdb/src/management_store/access_keys.rs
+++ b/crates/storage-duckdb/src/management_store/access_keys.rs
@@ -1,0 +1,220 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Access-key management for `DuckDbCatalogStore`, including key generation
+//! and AES-256-GCM secret encryption.
+//!
+//! Secrets are encrypted with the catalog encryption key before storage. The
+//! ciphertext layout is `nonce(12) || aes_gcm_ciphertext`, with the
+//! `access_key_id` bound as additional authenticated data (AAD) so a stored
+//! secret cannot be transplanted onto a different key id.
+
+use crate::db;
+use aes_gcm::aead::{Aead, Payload};
+use aes_gcm::{Aes256Gcm, Key, KeyInit, Nonce};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use extenddb_storage::management_store::{AccessKeyCreated, OpError, OpResult};
+use time::OffsetDateTime;
+
+use crate::catalog_store::DuckDbCatalogStore;
+use crate::duckdb_util::{is_fk_violation, is_unique_violation, parse_timestamp};
+
+impl DuckDbCatalogStore {
+    /// Resolve the AES-256-GCM encryption key (base64), preferring the cached
+    /// value and falling back to the `settings` table.
+    async fn resolve_encryption_key(&self) -> OpResult<String> {
+        if let Some(k) = self.encryption_key() {
+            return Ok(k.to_string());
+        }
+        let row: Option<(String,)> =
+            db::query_as("SELECT value FROM settings WHERE key = 'encryption_key'")
+                .fetch_optional(self.pool())
+                .await
+                .map_err(|e| OpError::Internal(format!("fetch encryption key: {e}")))?;
+        row.map(|(v,)| v)
+            .ok_or_else(|| OpError::Internal("Encryption key not configured".to_owned()))
+    }
+
+    pub(crate) async fn create_access_key_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> OpResult<AccessKeyCreated> {
+        let enc_key = self.resolve_encryption_key().await?;
+        let access_key_id = generate_access_key_id();
+        let secret_access_key = generate_secret_key();
+        let encrypted = encrypt_secret(&secret_access_key, &enc_key, &access_key_id)
+            .map_err(|e| OpError::Internal(format!("encrypt secret: {e}")))?;
+
+        crate::referential::ensure_user_exists(self.pool(), account_id, user_name).await?;
+        db::query(
+            "INSERT INTO access_keys \
+             (access_key_id, secret_key_encrypted, account_id, user_name) \
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(&access_key_id)
+        .bind(&encrypted)
+        .bind(account_id)
+        .bind(user_name)
+        .execute(self.pool())
+        .await
+        .map_err(|e| {
+            if is_fk_violation(&e) {
+                OpError::NotFound("IAM user not found".to_owned())
+            } else {
+                tracing::error!("create_access_key: {e}");
+                OpError::Internal("Database error".to_owned())
+            }
+        })?;
+
+        Ok(AccessKeyCreated {
+            access_key_id,
+            secret_access_key,
+        })
+    }
+
+    pub(crate) async fn delete_access_key_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        key_id: &str,
+    ) -> OpResult<()> {
+        let result = db::query(
+            "DELETE FROM access_keys \
+             WHERE access_key_id = ? AND account_id = ? AND user_name = ?",
+        )
+        .bind(key_id)
+        .bind(account_id)
+        .bind(user_name)
+        .execute(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("delete_access_key: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        if result.rows_affected() == 0 {
+            return Err(OpError::NotFound("Access key not found".to_owned()));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn list_access_keys_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> OpResult<Vec<(String, bool, OffsetDateTime)>> {
+        let rows: Vec<(String, bool, String)> = db::query_as(
+            "SELECT access_key_id, is_active, created_at FROM access_keys \
+             WHERE account_id = ? AND user_name = ? ORDER BY created_at",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("list_access_keys: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        rows.into_iter()
+            .map(|(id, active, ts)| {
+                Ok((
+                    id,
+                    active,
+                    parse_timestamp(&ts)
+                        .map_err(|e| OpError::Internal(format!("parse created_at: {e}")))?,
+                ))
+            })
+            .collect()
+    }
+
+    pub(crate) async fn import_access_key_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        access_key_id: &str,
+        secret_access_key: &str,
+    ) -> OpResult<()> {
+        let enc_key = self.resolve_encryption_key().await?;
+        let encrypted = encrypt_secret(secret_access_key, &enc_key, access_key_id)
+            .map_err(|e| OpError::Internal(format!("encrypt secret: {e}")))?;
+
+        crate::referential::ensure_user_exists(self.pool(), account_id, user_name).await?;
+        db::query(
+            "INSERT INTO access_keys \
+             (access_key_id, secret_key_encrypted, account_id, user_name) \
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(access_key_id)
+        .bind(&encrypted)
+        .bind(account_id)
+        .bind(user_name)
+        .execute(self.pool())
+        .await
+        .map(|_| ())
+        .map_err(|e| {
+            if is_unique_violation(&e) {
+                OpError::AlreadyExists("Access key ID already exists".to_owned())
+            } else if is_fk_violation(&e) {
+                OpError::NotFound("IAM user not found".to_owned())
+            } else {
+                tracing::error!("import_access_key: {e}");
+                OpError::Internal("Database error".to_owned())
+            }
+        })
+    }
+}
+
+// ── Key generation & crypto helpers ─────────────────────────────────────
+
+/// Generate a 20-character access key id (`AKIAEXTENDDB` + 8 uppercase
+/// alphanumerics), matching the prefix convention used across ExtendDB backends
+/// so generated keys are distinguishable from real AWS keys.
+fn generate_access_key_id() -> String {
+    const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    let mut rng = rand::rng();
+    let suffix: String = (0..8)
+        .map(|_| CHARSET[rand::Rng::random_range(&mut rng, 0..CHARSET.len())] as char)
+        .collect();
+    format!("AKIAEXTENDDB{suffix}")
+}
+
+/// Generate a 40-character secret access key, matching the AWS secret shape.
+fn generate_secret_key() -> String {
+    const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut rng = rand::rng();
+    let suffix: String = (0..32)
+        .map(|_| CHARSET[rand::Rng::random_range(&mut rng, 0..CHARSET.len())] as char)
+        .collect();
+    format!("extenddb{suffix}")
+}
+
+/// Encrypt a secret with AES-256-GCM. Output is `nonce(12) || ciphertext`,
+/// with `aad` (the access key id) bound as additional authenticated data.
+fn encrypt_secret(plaintext: &str, key_b64: &str, aad: &str) -> Result<Vec<u8>, String> {
+    let key_bytes = BASE64
+        .decode(key_b64)
+        .map_err(|e| format!("decode encryption key: {e}"))?;
+    if key_bytes.len() != 32 {
+        return Err("encryption key must be 32 bytes".to_owned());
+    }
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key_bytes));
+
+    let nonce_bytes: [u8; 12] = rand::random();
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let ciphertext = cipher
+        .encrypt(
+            nonce,
+            Payload {
+                msg: plaintext.as_bytes(),
+                aad: aad.as_bytes(),
+            },
+        )
+        .map_err(|e| format!("encrypt: {e}"))?;
+
+    let mut out = Vec::with_capacity(12 + ciphertext.len());
+    out.extend_from_slice(&nonce_bytes);
+    out.extend_from_slice(&ciphertext);
+    Ok(out)
+}

--- a/crates/storage-duckdb/src/management_store/accounts.rs
+++ b/crates/storage-duckdb/src/management_store/accounts.rs
@@ -1,0 +1,195 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Account management operations for `DuckDbCatalogStore`.
+
+use crate::db;
+use extenddb_storage::management_store::{AccountDetail, OpError, OpResult};
+use time::OffsetDateTime;
+
+use crate::catalog_store::DuckDbCatalogStore;
+use crate::duckdb_util::{is_unique_violation, parse_timestamp};
+
+impl DuckDbCatalogStore {
+    pub(crate) async fn create_account_impl(
+        &self,
+        account_id: &str,
+        account_name: &str,
+    ) -> OpResult<()> {
+        db::query("INSERT INTO accounts (account_id, account_name) VALUES (?, ?)")
+            .bind(account_id)
+            .bind(account_name)
+            .execute(self.pool())
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                if is_unique_violation(&e) {
+                    OpError::AlreadyExists("Account already exists".to_owned())
+                } else {
+                    tracing::error!("create_account: {e}");
+                    OpError::Internal("Database error".to_owned())
+                }
+            })
+    }
+
+    pub(crate) async fn delete_account_impl(&self, account_id: &str) -> OpResult<()> {
+        // Refuse to delete an account that still owns tables; all other IAM
+        // children are removed explicitly (DuckDB has no cascading deletes).
+        let exists: bool =
+            db::query_scalar("SELECT EXISTS(SELECT 1 FROM accounts WHERE account_id = ?)")
+                .bind(account_id)
+                .fetch_one(self.pool())
+                .await
+                .map_err(|e| {
+                    tracing::error!("delete_account check: {e}");
+                    OpError::Internal("Database error".to_owned())
+                })?;
+        if !exists {
+            return Err(OpError::NotFound("Account not found".to_owned()));
+        }
+
+        let (table_count,): (i64,) =
+            db::query_as("SELECT COUNT(*) FROM tables WHERE account_id = ?")
+                .bind(account_id)
+                .fetch_one(self.pool())
+                .await
+                .map_err(|e| {
+                    tracing::error!("delete_account table count: {e}");
+                    OpError::Internal("Database error".to_owned())
+                })?;
+        if table_count > 0 {
+            return Err(OpError::HasDependents(
+                "Cannot delete account with existing tables. Delete all tables first.".to_owned(),
+            ));
+        }
+
+        crate::referential::delete_with_children(
+            self.pool(),
+            "delete_account",
+            async |tx| crate::referential::delete_account_children(tx, account_id).await,
+            "DELETE FROM accounts WHERE account_id = ?",
+            &[account_id],
+            "Account not found",
+        )
+        .await
+    }
+
+    pub(crate) async fn list_all_accounts_impl(&self) -> OpResult<Vec<(String, String)>> {
+        db::query_as("SELECT account_id, account_name FROM accounts ORDER BY account_id")
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| {
+                tracing::error!("list_all_accounts: {e}");
+                OpError::Internal("Database error".to_owned())
+            })
+    }
+
+    pub(crate) async fn default_account_id_impl(&self) -> OpResult<Option<String>> {
+        db::query_scalar("SELECT value FROM settings WHERE key = 'default_account_id'")
+            .fetch_optional(self.pool())
+            .await
+            .map_err(|e| {
+                tracing::error!("default_account_id: {e}");
+                OpError::Internal("Database error".to_owned())
+            })
+    }
+
+    pub(crate) async fn list_all_accounts_full_impl(
+        &self,
+    ) -> OpResult<Vec<(String, String, OffsetDateTime)>> {
+        let rows: Vec<(String, String, String)> = db::query_as(
+            "SELECT account_id, account_name, created_at FROM accounts ORDER BY account_id",
+        )
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("list_all_accounts_full: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        rows.into_iter()
+            .map(|(id, name, ts)| {
+                Ok((
+                    id,
+                    name,
+                    parse_timestamp(&ts)
+                        .map_err(|e| OpError::Internal(format!("parse created_at: {e}")))?,
+                ))
+            })
+            .collect()
+    }
+
+    pub(crate) async fn list_accounts_for_impl(
+        &self,
+        account_id: &str,
+    ) -> OpResult<Vec<(String, String)>> {
+        db::query_as("SELECT account_id, account_name FROM accounts WHERE account_id = ?")
+            .bind(account_id)
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| {
+                tracing::error!("list_accounts_for: {e}");
+                OpError::Internal("Database error".to_owned())
+            })
+    }
+
+    pub(crate) async fn get_account_detail_impl(
+        &self,
+        account_id: &str,
+    ) -> OpResult<Option<AccountDetail>> {
+        let acct: Option<(String,)> =
+            db::query_as("SELECT account_name FROM accounts WHERE account_id = ?")
+                .bind(account_id)
+                .fetch_optional(self.pool())
+                .await
+                .map_err(|e| {
+                    tracing::error!("get_account_detail: {e}");
+                    OpError::Internal("Database error".to_owned())
+                })?;
+        let Some((account_name,)) = acct else {
+            return Ok(None);
+        };
+
+        let names = |rows: Vec<(String,)>| rows.into_iter().map(|(n,)| n).collect::<Vec<_>>();
+
+        let users: Vec<(String,)> =
+            db::query_as("SELECT user_name FROM iam_users WHERE account_id = ? ORDER BY user_name")
+                .bind(account_id)
+                .fetch_all(self.pool())
+                .await
+                .map_err(|e| OpError::Internal(format!("get_account_detail users: {e}")))?;
+
+        let groups: Vec<(String,)> = db::query_as(
+            "SELECT group_name FROM iam_groups WHERE account_id = ? ORDER BY group_name",
+        )
+        .bind(account_id)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_account_detail groups: {e}")))?;
+
+        let roles: Vec<(String,)> =
+            db::query_as("SELECT role_name FROM iam_roles WHERE account_id = ? ORDER BY role_name")
+                .bind(account_id)
+                .fetch_all(self.pool())
+                .await
+                .map_err(|e| OpError::Internal(format!("get_account_detail roles: {e}")))?;
+
+        Ok(Some(AccountDetail {
+            account_name,
+            users: names(users),
+            groups: names(groups),
+            roles: names(roles),
+        }))
+    }
+
+    pub(crate) async fn dashboard_counts_impl(&self) -> OpResult<(i64, i64)> {
+        let (accounts,): (i64,) = db::query_as("SELECT COUNT(*) FROM accounts")
+            .fetch_one(self.pool())
+            .await
+            .map_err(|e| OpError::Internal(format!("dashboard_counts accounts: {e}")))?;
+        let (admins,): (i64,) = db::query_as("SELECT COUNT(*) FROM admin_users")
+            .fetch_one(self.pool())
+            .await
+            .map_err(|e| OpError::Internal(format!("dashboard_counts admins: {e}")))?;
+        Ok((accounts, admins))
+    }
+}

--- a/crates/storage-duckdb/src/management_store/groups.rs
+++ b/crates/storage-duckdb/src/management_store/groups.rs
@@ -1,0 +1,191 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Group management operations for `DuckDbCatalogStore`.
+
+use crate::db;
+use extenddb_storage::management_store::{GroupDetail, GroupListEntry, OpError, OpResult};
+
+use crate::catalog_store::DuckDbCatalogStore;
+use crate::duckdb_util::{is_fk_violation, is_unique_violation, parse_timestamp};
+
+impl DuckDbCatalogStore {
+    pub(crate) async fn create_group_impl(
+        &self,
+        account_id: &str,
+        group_name: &str,
+    ) -> OpResult<()> {
+        let group_arn = format!("arn:aws:iam::{account_id}:group/{group_name}");
+        crate::referential::ensure_account_exists(self.pool(), account_id).await?;
+        db::query("INSERT INTO iam_groups (account_id, group_name, group_arn) VALUES (?, ?, ?)")
+            .bind(account_id)
+            .bind(group_name)
+            .bind(&group_arn)
+            .execute(self.pool())
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                if is_unique_violation(&e) {
+                    OpError::AlreadyExists("IAM group already exists".to_owned())
+                } else if is_fk_violation(&e) {
+                    OpError::NotFound("Account not found".to_owned())
+                } else {
+                    tracing::error!("create_group: {e}");
+                    OpError::Internal("Database error".to_owned())
+                }
+            })
+    }
+
+    pub(crate) async fn delete_group_impl(
+        &self,
+        account_id: &str,
+        group_name: &str,
+    ) -> OpResult<()> {
+        crate::referential::delete_with_children(
+            self.pool(),
+            "delete_group",
+            async |tx| crate::referential::delete_group_children(tx, account_id, group_name).await,
+            "DELETE FROM iam_groups WHERE account_id = ? AND group_name = ?",
+            &[account_id, group_name],
+            "IAM group not found",
+        )
+        .await
+    }
+
+    pub(crate) async fn list_groups_impl(&self, account_id: &str) -> OpResult<Vec<GroupListEntry>> {
+        let rows: Vec<(String, String, String, String)> = db::query_as(
+            "SELECT account_id, group_name, group_arn, created_at \
+             FROM iam_groups WHERE account_id = ? ORDER BY group_name",
+        )
+        .bind(account_id)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("list_groups: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        rows.into_iter()
+            .map(|(aid, gn, arn, ts)| {
+                Ok((
+                    aid,
+                    gn,
+                    arn,
+                    parse_timestamp(&ts)
+                        .map_err(|e| OpError::Internal(format!("parse created_at: {e}")))?,
+                ))
+            })
+            .collect()
+    }
+
+    pub(crate) async fn get_group_detail_impl(
+        &self,
+        account_id: &str,
+        group_name: &str,
+    ) -> OpResult<Option<GroupDetail>> {
+        let exists: bool = db::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM iam_groups WHERE account_id = ? AND group_name = ?)",
+        )
+        .bind(account_id)
+        .bind(group_name)
+        .fetch_one(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_group_detail exists: {e}")))?;
+        if !exists {
+            return Ok(None);
+        }
+
+        let names = |rows: Vec<(String,)>| rows.into_iter().map(|(n,)| n).collect::<Vec<_>>();
+
+        let members: Vec<(String,)> = db::query_as(
+            "SELECT user_name FROM iam_group_members \
+             WHERE account_id = ? AND group_name = ? ORDER BY user_name",
+        )
+        .bind(account_id)
+        .bind(group_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_group_detail members: {e}")))?;
+
+        let policies: Vec<(String,)> = db::query_as(
+            "SELECT policy_name FROM iam_policies \
+             WHERE account_id = ? AND principal_type = 'group' AND principal_name = ? \
+             ORDER BY policy_name",
+        )
+        .bind(account_id)
+        .bind(group_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_group_detail policies: {e}")))?;
+
+        let all_users: Vec<(String,)> =
+            db::query_as("SELECT user_name FROM iam_users WHERE account_id = ? ORDER BY user_name")
+                .bind(account_id)
+                .fetch_all(self.pool())
+                .await
+                .map_err(|e| OpError::Internal(format!("get_group_detail all_users: {e}")))?;
+
+        Ok(Some(GroupDetail {
+            members: names(members),
+            policies: names(policies),
+            all_users: names(all_users),
+        }))
+    }
+
+    pub(crate) async fn add_group_member_impl(
+        &self,
+        account_id: &str,
+        group_name: &str,
+        user_name: &str,
+    ) -> OpResult<()> {
+        crate::referential::ensure_group_exists(self.pool(), account_id, group_name)
+            .await
+            .map_err(|_| OpError::NotFound("Group or user not found".to_owned()))?;
+        crate::referential::ensure_user_exists(self.pool(), account_id, user_name)
+            .await
+            .map_err(|_| OpError::NotFound("Group or user not found".to_owned()))?;
+        db::query(
+            "INSERT INTO iam_group_members (account_id, group_name, user_name) VALUES (?, ?, ?)",
+        )
+        .bind(account_id)
+        .bind(group_name)
+        .bind(user_name)
+        .execute(self.pool())
+        .await
+        .map(|_| ())
+        .map_err(|e| {
+            if is_unique_violation(&e) {
+                OpError::AlreadyExists("User is already a member of this group".to_owned())
+            } else if is_fk_violation(&e) {
+                OpError::NotFound("Group or user not found".to_owned())
+            } else {
+                tracing::error!("add_group_member: {e}");
+                OpError::Internal("Database error".to_owned())
+            }
+        })
+    }
+
+    pub(crate) async fn remove_group_member_impl(
+        &self,
+        account_id: &str,
+        group_name: &str,
+        user_name: &str,
+    ) -> OpResult<()> {
+        let result = db::query(
+            "DELETE FROM iam_group_members \
+             WHERE account_id = ? AND group_name = ? AND user_name = ?",
+        )
+        .bind(account_id)
+        .bind(group_name)
+        .bind(user_name)
+        .execute(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("remove_group_member: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        if result.rows_affected() == 0 {
+            return Err(OpError::NotFound("Membership not found".to_owned()));
+        }
+        Ok(())
+    }
+}

--- a/crates/storage-duckdb/src/management_store/mod.rs
+++ b/crates/storage-duckdb/src/management_store/mod.rs
@@ -1,0 +1,635 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `ManagementStore` implementation for `DuckDbCatalogStore`.
+//!
+//! The IAM surface is split across submodules by entity (`accounts`, `users`,
+//! `groups`, `roles`, `policies`, `access_keys`), each providing inherent
+//! `*_impl` methods. This module declares those submodules and implements the
+//! `ManagementStore` trait by delegating to them, plus the session-storage and
+//! caller-tag lookups that don't belong to a single entity.
+
+mod access_keys;
+mod accounts;
+mod groups;
+mod policies;
+mod roles;
+mod users;
+
+use crate::db;
+use extenddb_storage::management_store::{
+    AccessKeyCreated, AccountDetail, GroupDetail, GroupListEntry, ManagementStore, OpError,
+    OpResult, RoleDetail, RoleListEntry, UserDetail, UserListEntry,
+};
+use futures::future::BoxFuture;
+use time::OffsetDateTime;
+
+use crate::catalog_store::DuckDbCatalogStore;
+use crate::duckdb_util::format_timestamp;
+
+impl ManagementStore for DuckDbCatalogStore {
+    // ── Accounts ───────────────────────────────────────────────────
+
+    fn create_account(&self, account_id: &str, account_name: &str) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, account_name) = (account_id.to_owned(), account_name.to_owned());
+        Box::pin(async move { self.create_account_impl(&account_id, &account_name).await })
+    }
+
+    fn delete_account(&self, account_id: &str) -> BoxFuture<'_, OpResult<()>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.delete_account_impl(&account_id).await })
+    }
+
+    fn list_all_accounts(&self) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        Box::pin(async move { self.list_all_accounts_impl().await })
+    }
+
+    fn default_account_id(&self) -> BoxFuture<'_, OpResult<Option<String>>> {
+        Box::pin(async move { self.default_account_id_impl().await })
+    }
+
+    fn list_all_accounts_full(
+        &self,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, String, OffsetDateTime)>>> {
+        Box::pin(async move { self.list_all_accounts_full_impl().await })
+    }
+
+    fn list_accounts_for(
+        &self,
+        account_id: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.list_accounts_for_impl(&account_id).await })
+    }
+
+    fn get_account_detail(
+        &self,
+        account_id: &str,
+    ) -> BoxFuture<'_, OpResult<Option<AccountDetail>>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.get_account_detail_impl(&account_id).await })
+    }
+
+    fn dashboard_counts(&self) -> BoxFuture<'_, OpResult<(i64, i64)>> {
+        Box::pin(async move { self.dashboard_counts_impl().await })
+    }
+
+    // ── Users ──────────────────────────────────────────────────────
+
+    fn create_user(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        password_hash: Option<&str>,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name) = (account_id.to_owned(), user_name.to_owned());
+        let password_hash = password_hash.map(str::to_owned);
+        Box::pin(async move {
+            self.create_user_impl(&account_id, &user_name, password_hash.as_deref())
+                .await
+        })
+    }
+
+    fn delete_user(&self, account_id: &str, user_name: &str) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name) = (account_id.to_owned(), user_name.to_owned());
+        Box::pin(async move { self.delete_user_impl(&account_id, &user_name).await })
+    }
+
+    fn list_users(&self, account_id: &str) -> BoxFuture<'_, OpResult<Vec<UserListEntry>>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.list_users_impl(&account_id).await })
+    }
+
+    fn get_user_detail(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<UserDetail>>> {
+        let (account_id, user_name) = (account_id.to_owned(), user_name.to_owned());
+        Box::pin(async move { self.get_user_detail_impl(&account_id, &user_name).await })
+    }
+
+    fn verify_iam_user_password(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        password: &str,
+    ) -> BoxFuture<'_, OpResult<bool>> {
+        let (account_id, user_name, password) = (
+            account_id.to_owned(),
+            user_name.to_owned(),
+            password.to_owned(),
+        );
+        Box::pin(async move {
+            self.verify_iam_user_password_impl(&account_id, &user_name, &password)
+                .await
+        })
+    }
+
+    fn change_user_password(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        password_hash: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name, password_hash) = (
+            account_id.to_owned(),
+            user_name.to_owned(),
+            password_hash.to_owned(),
+        );
+        Box::pin(async move {
+            self.change_user_password_impl(&account_id, &user_name, &password_hash)
+                .await
+        })
+    }
+
+    // ── User tags ──────────────────────────────────────────────────
+
+    fn tag_user(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        tags: &[(String, String)],
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name, tags) =
+            (account_id.to_owned(), user_name.to_owned(), tags.to_vec());
+        Box::pin(async move { self.tag_user_impl(&account_id, &user_name, &tags).await })
+    }
+
+    fn untag_user(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        tag_keys: &[String],
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name, tag_keys) = (
+            account_id.to_owned(),
+            user_name.to_owned(),
+            tag_keys.to_vec(),
+        );
+        Box::pin(async move {
+            self.untag_user_impl(&account_id, &user_name, &tag_keys)
+                .await
+        })
+    }
+
+    fn list_user_tags(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        let (account_id, user_name) = (account_id.to_owned(), user_name.to_owned());
+        Box::pin(async move { self.list_user_tags_impl(&account_id, &user_name).await })
+    }
+
+    // ── Groups ─────────────────────────────────────────────────────
+
+    fn create_group(&self, account_id: &str, group_name: &str) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, group_name) = (account_id.to_owned(), group_name.to_owned());
+        Box::pin(async move { self.create_group_impl(&account_id, &group_name).await })
+    }
+
+    fn delete_group(&self, account_id: &str, group_name: &str) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, group_name) = (account_id.to_owned(), group_name.to_owned());
+        Box::pin(async move { self.delete_group_impl(&account_id, &group_name).await })
+    }
+
+    fn list_groups(&self, account_id: &str) -> BoxFuture<'_, OpResult<Vec<GroupListEntry>>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.list_groups_impl(&account_id).await })
+    }
+
+    fn get_group_detail(
+        &self,
+        account_id: &str,
+        group_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<GroupDetail>>> {
+        let (account_id, group_name) = (account_id.to_owned(), group_name.to_owned());
+        Box::pin(async move { self.get_group_detail_impl(&account_id, &group_name).await })
+    }
+
+    fn add_group_member(
+        &self,
+        account_id: &str,
+        group_name: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, group_name, user_name) = (
+            account_id.to_owned(),
+            group_name.to_owned(),
+            user_name.to_owned(),
+        );
+        Box::pin(async move {
+            self.add_group_member_impl(&account_id, &group_name, &user_name)
+                .await
+        })
+    }
+
+    fn remove_group_member(
+        &self,
+        account_id: &str,
+        group_name: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, group_name, user_name) = (
+            account_id.to_owned(),
+            group_name.to_owned(),
+            user_name.to_owned(),
+        );
+        Box::pin(async move {
+            self.remove_group_member_impl(&account_id, &group_name, &user_name)
+                .await
+        })
+    }
+
+    // ── Roles ──────────────────────────────────────────────────────
+
+    fn create_role(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        trust_policy: &serde_json::Value,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, role_name, trust_policy) = (
+            account_id.to_owned(),
+            role_name.to_owned(),
+            trust_policy.clone(),
+        );
+        Box::pin(async move {
+            self.create_role_impl(&account_id, &role_name, &trust_policy)
+                .await
+        })
+    }
+
+    fn delete_role(&self, account_id: &str, role_name: &str) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, role_name) = (account_id.to_owned(), role_name.to_owned());
+        Box::pin(async move { self.delete_role_impl(&account_id, &role_name).await })
+    }
+
+    fn list_roles(&self, account_id: &str) -> BoxFuture<'_, OpResult<Vec<RoleListEntry>>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.list_roles_impl(&account_id).await })
+    }
+
+    fn get_role_detail(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<RoleDetail>>> {
+        let (account_id, role_name) = (account_id.to_owned(), role_name.to_owned());
+        Box::pin(async move { self.get_role_detail_impl(&account_id, &role_name).await })
+    }
+
+    fn get_role_trust_policy(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<serde_json::Value>>> {
+        let (account_id, role_name) = (account_id.to_owned(), role_name.to_owned());
+        Box::pin(async move {
+            self.get_role_trust_policy_impl(&account_id, &role_name)
+                .await
+        })
+    }
+
+    // ── Role tags ──────────────────────────────────────────────────
+
+    fn tag_role(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        tags: &[(String, String)],
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, role_name, tags) =
+            (account_id.to_owned(), role_name.to_owned(), tags.to_vec());
+        Box::pin(async move { self.tag_role_impl(&account_id, &role_name, &tags).await })
+    }
+
+    fn untag_role(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        tag_keys: &[String],
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, role_name, tag_keys) = (
+            account_id.to_owned(),
+            role_name.to_owned(),
+            tag_keys.to_vec(),
+        );
+        Box::pin(async move {
+            self.untag_role_impl(&account_id, &role_name, &tag_keys)
+                .await
+        })
+    }
+
+    fn list_role_tags(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        let (account_id, role_name) = (account_id.to_owned(), role_name.to_owned());
+        Box::pin(async move { self.list_role_tags_impl(&account_id, &role_name).await })
+    }
+
+    // ── Policies ───────────────────────────────────────────────────
+
+    fn put_policy(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+        policy_name: &str,
+        document: &serde_json::Value,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, principal_type, principal_name, policy_name, document) = (
+            account_id.to_owned(),
+            principal_type.to_owned(),
+            principal_name.to_owned(),
+            policy_name.to_owned(),
+            document.clone(),
+        );
+        Box::pin(async move {
+            self.put_policy_impl(
+                &account_id,
+                &principal_type,
+                &principal_name,
+                &policy_name,
+                &document,
+            )
+            .await
+        })
+    }
+
+    fn delete_policy(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+        policy_name: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, principal_type, principal_name, policy_name) = (
+            account_id.to_owned(),
+            principal_type.to_owned(),
+            principal_name.to_owned(),
+            policy_name.to_owned(),
+        );
+        Box::pin(async move {
+            self.delete_policy_impl(&account_id, &principal_type, &principal_name, &policy_name)
+                .await
+        })
+    }
+
+    fn list_policies(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, serde_json::Value, OffsetDateTime)>>> {
+        let (account_id, principal_type, principal_name) = (
+            account_id.to_owned(),
+            principal_type.to_owned(),
+            principal_name.to_owned(),
+        );
+        Box::pin(async move {
+            self.list_policies_impl(&account_id, &principal_type, &principal_name)
+                .await
+        })
+    }
+
+    // ── Permissions boundaries ─────────────────────────────────────
+
+    fn set_user_boundary(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        document: &serde_json::Value,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name, document) = (
+            account_id.to_owned(),
+            user_name.to_owned(),
+            document.clone(),
+        );
+        Box::pin(async move {
+            self.set_user_boundary_impl(&account_id, &user_name, &document)
+                .await
+        })
+    }
+
+    fn get_user_boundary(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<serde_json::Value>>> {
+        let (account_id, user_name) = (account_id.to_owned(), user_name.to_owned());
+        Box::pin(async move { self.get_user_boundary_impl(&account_id, &user_name).await })
+    }
+
+    fn delete_user_boundary(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name) = (account_id.to_owned(), user_name.to_owned());
+        Box::pin(async move {
+            self.delete_user_boundary_impl(&account_id, &user_name)
+                .await
+        })
+    }
+
+    fn set_role_boundary(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        document: &serde_json::Value,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, role_name, document) = (
+            account_id.to_owned(),
+            role_name.to_owned(),
+            document.clone(),
+        );
+        Box::pin(async move {
+            self.set_role_boundary_impl(&account_id, &role_name, &document)
+                .await
+        })
+    }
+
+    fn get_role_boundary(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> BoxFuture<'_, OpResult<Option<serde_json::Value>>> {
+        let (account_id, role_name) = (account_id.to_owned(), role_name.to_owned());
+        Box::pin(async move { self.get_role_boundary_impl(&account_id, &role_name).await })
+    }
+
+    fn delete_role_boundary(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, role_name) = (account_id.to_owned(), role_name.to_owned());
+        Box::pin(async move {
+            self.delete_role_boundary_impl(&account_id, &role_name)
+                .await
+        })
+    }
+
+    // ── Access keys ────────────────────────────────────────────────
+
+    fn create_access_key(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<AccessKeyCreated>> {
+        let (account_id, user_name) = (account_id.to_owned(), user_name.to_owned());
+        Box::pin(async move { self.create_access_key_impl(&account_id, &user_name).await })
+    }
+
+    fn delete_access_key(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        key_id: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name, key_id) = (
+            account_id.to_owned(),
+            user_name.to_owned(),
+            key_id.to_owned(),
+        );
+        Box::pin(async move {
+            self.delete_access_key_impl(&account_id, &user_name, &key_id)
+                .await
+        })
+    }
+
+    fn list_access_keys(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, bool, OffsetDateTime)>>> {
+        let (account_id, user_name) = (account_id.to_owned(), user_name.to_owned());
+        Box::pin(async move { self.list_access_keys_impl(&account_id, &user_name).await })
+    }
+
+    fn import_access_key(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        access_key_id: &str,
+        secret_access_key: &str,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let (account_id, user_name, access_key_id, secret_access_key) = (
+            account_id.to_owned(),
+            user_name.to_owned(),
+            access_key_id.to_owned(),
+            secret_access_key.to_owned(),
+        );
+        Box::pin(async move {
+            self.import_access_key_impl(&account_id, &user_name, &access_key_id, &secret_access_key)
+                .await
+        })
+    }
+
+    // ── Sessions (AssumeRole) ──────────────────────────────────────
+
+    #[allow(clippy::too_many_arguments)]
+    fn store_session(
+        &self,
+        session_token: &str,
+        access_key_id: &str,
+        secret_key_encrypted: &[u8],
+        account_id: &str,
+        role_name: &str,
+        session_name: &str,
+        session_tags: &Option<serde_json::Value>,
+        session_policy: &Option<serde_json::Value>,
+        expires_at: OffsetDateTime,
+    ) -> BoxFuture<'_, OpResult<()>> {
+        let session_token = session_token.to_owned();
+        let access_key_id = access_key_id.to_owned();
+        let secret_key_encrypted = secret_key_encrypted.to_vec();
+        let account_id = account_id.to_owned();
+        let role_name = role_name.to_owned();
+        let session_name = session_name.to_owned();
+        let session_tags = session_tags.as_ref().map(ToString::to_string);
+        let session_policy = session_policy.as_ref().map(ToString::to_string);
+        let expires = format_timestamp(expires_at);
+        Box::pin(async move {
+            db::query(
+                "INSERT INTO iam_sessions \
+                 (session_token, access_key_id, secret_key_encrypted, account_id, role_name, \
+                  session_name, session_tags, session_policy, expires_at) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&session_token)
+            .bind(&access_key_id)
+            .bind(&secret_key_encrypted)
+            .bind(&account_id)
+            .bind(&role_name)
+            .bind(&session_name)
+            .bind(&session_tags)
+            .bind(&session_policy)
+            .bind(&expires)
+            .execute(self.pool())
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                tracing::error!("store_session: {e}");
+                OpError::Internal("Database error".to_owned())
+            })
+        })
+    }
+
+    // ── Caller tags (trust-policy evaluation) ──────────────────────
+
+    fn fetch_caller_tags(
+        &self,
+        account_id: &str,
+        resource: &str,
+    ) -> BoxFuture<'_, OpResult<Vec<(String, String)>>> {
+        let account_id = account_id.to_owned();
+        let resource = resource.to_owned();
+        Box::pin(async move {
+            // Resolve the principal kind and name from the ARN resource part.
+            if let Some(rest) = resource.split(":user/").nth(1) {
+                let user_name = rest.trim_end_matches('/');
+                return db::query_as(
+                    "SELECT tag_key, tag_value FROM iam_user_tags \
+                     WHERE account_id = ? AND user_name = ? ORDER BY tag_key",
+                )
+                .bind(&account_id)
+                .bind(user_name)
+                .fetch_all(self.pool())
+                .await
+                .map_err(|e| {
+                    tracing::error!("fetch_caller_tags (user): {e}");
+                    OpError::Internal("Database error".to_owned())
+                });
+            }
+
+            // assumed-role/RoleName/SessionName or role/RoleName → role tags.
+            let role_name = resource
+                .split(":assumed-role/")
+                .nth(1)
+                .or_else(|| resource.split(":role/").nth(1))
+                .map(|rest| rest.split('/').next().unwrap_or(rest));
+
+            if let Some(role_name) = role_name {
+                return db::query_as(
+                    "SELECT tag_key, tag_value FROM iam_role_tags \
+                     WHERE account_id = ? AND role_name = ? ORDER BY tag_key",
+                )
+                .bind(&account_id)
+                .bind(role_name)
+                .fetch_all(self.pool())
+                .await
+                .map_err(|e| {
+                    tracing::error!("fetch_caller_tags (role): {e}");
+                    OpError::Internal("Database error".to_owned())
+                });
+            }
+
+            Ok(Vec::new())
+        })
+    }
+}

--- a/crates/storage-duckdb/src/management_store/policies.rs
+++ b/crates/storage-duckdb/src/management_store/policies.rs
@@ -1,0 +1,234 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! IAM policy CRUD and permissions boundaries for `DuckDbCatalogStore`.
+
+use crate::db;
+use extenddb_storage::management_store::{OpError, OpResult};
+use time::OffsetDateTime;
+
+use crate::catalog_store::DuckDbCatalogStore;
+use crate::duckdb_util::parse_timestamp;
+
+impl DuckDbCatalogStore {
+    pub(crate) async fn put_policy_impl(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+        policy_name: &str,
+        document: &serde_json::Value,
+    ) -> OpResult<()> {
+        let doc = serde_json::to_string(document)
+            .map_err(|e| OpError::Internal(format!("serialize policy: {e}")))?;
+        db::query(
+            "INSERT INTO iam_policies \
+             (account_id, principal_type, principal_name, policy_name, policy_document) \
+             VALUES (?, ?, ?, ?, ?) \
+             ON CONFLICT(account_id, principal_type, principal_name, policy_name) \
+             DO UPDATE SET policy_document = excluded.policy_document",
+        )
+        .bind(account_id)
+        .bind(principal_type)
+        .bind(principal_name)
+        .bind(policy_name)
+        .bind(&doc)
+        .execute(self.pool())
+        .await
+        .map(|_| ())
+        .map_err(|e| {
+            tracing::error!("put_policy: {e}");
+            OpError::Internal("Database error".to_owned())
+        })
+    }
+
+    pub(crate) async fn delete_policy_impl(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+        policy_name: &str,
+    ) -> OpResult<()> {
+        let result = db::query(
+            "DELETE FROM iam_policies \
+             WHERE account_id = ? AND principal_type = ? AND principal_name = ? AND policy_name = ?",
+        )
+        .bind(account_id)
+        .bind(principal_type)
+        .bind(principal_name)
+        .bind(policy_name)
+        .execute(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("delete_policy: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        if result.rows_affected() == 0 {
+            return Err(OpError::NotFound("Policy not found".to_owned()));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn list_policies_impl(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+    ) -> OpResult<Vec<(String, serde_json::Value, OffsetDateTime)>> {
+        let rows: Vec<(String, String, String)> = db::query_as(
+            "SELECT policy_name, policy_document, created_at FROM iam_policies \
+             WHERE account_id = ? AND principal_type = ? AND principal_name = ? \
+             ORDER BY policy_name",
+        )
+        .bind(account_id)
+        .bind(principal_type)
+        .bind(principal_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("list_policies: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        rows.into_iter()
+            .map(|(name, doc, ts)| {
+                Ok((
+                    name,
+                    serde_json::from_str(&doc)
+                        .map_err(|e| OpError::Internal(format!("parse policy doc: {e}")))?,
+                    parse_timestamp(&ts)
+                        .map_err(|e| OpError::Internal(format!("parse created_at: {e}")))?,
+                ))
+            })
+            .collect()
+    }
+
+    // ── Permissions boundaries ─────────────────────────────────────
+
+    async fn set_boundary(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+        document: &serde_json::Value,
+    ) -> OpResult<()> {
+        let doc = serde_json::to_string(document)
+            .map_err(|e| OpError::Internal(format!("serialize boundary: {e}")))?;
+        db::query(
+            "INSERT INTO iam_permissions_boundaries \
+             (account_id, principal_type, principal_name, policy_document) \
+             VALUES (?, ?, ?, ?) \
+             ON CONFLICT(account_id, principal_type, principal_name) \
+             DO UPDATE SET policy_document = excluded.policy_document",
+        )
+        .bind(account_id)
+        .bind(principal_type)
+        .bind(principal_name)
+        .bind(&doc)
+        .execute(self.pool())
+        .await
+        .map(|_| ())
+        .map_err(|e| {
+            tracing::error!("set_boundary: {e}");
+            OpError::Internal("Database error".to_owned())
+        })
+    }
+
+    async fn get_boundary(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+    ) -> OpResult<Option<serde_json::Value>> {
+        let row: Option<(String,)> = db::query_as(
+            "SELECT policy_document FROM iam_permissions_boundaries \
+             WHERE account_id = ? AND principal_type = ? AND principal_name = ?",
+        )
+        .bind(account_id)
+        .bind(principal_type)
+        .bind(principal_name)
+        .fetch_optional(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("get_boundary: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        row.map(|(d,)| {
+            serde_json::from_str(&d).map_err(|e| OpError::Internal(format!("parse boundary: {e}")))
+        })
+        .transpose()
+    }
+
+    async fn delete_boundary(
+        &self,
+        account_id: &str,
+        principal_type: &str,
+        principal_name: &str,
+    ) -> OpResult<()> {
+        db::query(
+            "DELETE FROM iam_permissions_boundaries \
+             WHERE account_id = ? AND principal_type = ? AND principal_name = ?",
+        )
+        .bind(account_id)
+        .bind(principal_type)
+        .bind(principal_name)
+        .execute(self.pool())
+        .await
+        .map(|_| ())
+        .map_err(|e| {
+            tracing::error!("delete_boundary: {e}");
+            OpError::Internal("Database error".to_owned())
+        })
+    }
+
+    pub(crate) async fn set_user_boundary_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        document: &serde_json::Value,
+    ) -> OpResult<()> {
+        self.set_boundary(account_id, "user", user_name, document)
+            .await
+    }
+
+    pub(crate) async fn get_user_boundary_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> OpResult<Option<serde_json::Value>> {
+        self.get_boundary(account_id, "user", user_name).await
+    }
+
+    pub(crate) async fn delete_user_boundary_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> OpResult<()> {
+        self.delete_boundary(account_id, "user", user_name).await
+    }
+
+    pub(crate) async fn set_role_boundary_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        document: &serde_json::Value,
+    ) -> OpResult<()> {
+        self.set_boundary(account_id, "role", role_name, document)
+            .await
+    }
+
+    pub(crate) async fn get_role_boundary_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> OpResult<Option<serde_json::Value>> {
+        self.get_boundary(account_id, "role", role_name).await
+    }
+
+    pub(crate) async fn delete_role_boundary_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> OpResult<()> {
+        self.delete_boundary(account_id, "role", role_name).await
+    }
+}

--- a/crates/storage-duckdb/src/management_store/roles.rs
+++ b/crates/storage-duckdb/src/management_store/roles.rs
@@ -1,0 +1,243 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Role management, trust-policy access, and role tags for `DuckDbCatalogStore`.
+//!
+//! Trust policies and policy documents are stored as JSON text; this module
+//! serializes `serde_json::Value` on write and parses it back on read.
+
+use crate::db;
+use extenddb_storage::management_store::{OpError, OpResult, RoleDetail, RoleListEntry};
+
+use crate::catalog_store::DuckDbCatalogStore;
+use crate::duckdb_util::{is_fk_violation, is_unique_violation, parse_timestamp};
+
+/// Parse a stored JSON-text column into a `serde_json::Value`.
+fn parse_json(s: &str, ctx: &str) -> OpResult<serde_json::Value> {
+    serde_json::from_str(s).map_err(|e| OpError::Internal(format!("{ctx} parse json: {e}")))
+}
+
+impl DuckDbCatalogStore {
+    pub(crate) async fn create_role_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        trust_policy: &serde_json::Value,
+    ) -> OpResult<()> {
+        let role_arn = format!("arn:aws:iam::{account_id}:role/{role_name}");
+        let trust = serde_json::to_string(trust_policy)
+            .map_err(|e| OpError::Internal(format!("serialize trust policy: {e}")))?;
+        crate::referential::ensure_account_exists(self.pool(), account_id).await?;
+        db::query(
+            "INSERT INTO iam_roles (account_id, role_name, role_arn, trust_policy) \
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(account_id)
+        .bind(role_name)
+        .bind(&role_arn)
+        .bind(&trust)
+        .execute(self.pool())
+        .await
+        .map(|_| ())
+        .map_err(|e| {
+            if is_unique_violation(&e) {
+                OpError::AlreadyExists("IAM role already exists".to_owned())
+            } else if is_fk_violation(&e) {
+                OpError::NotFound("Account not found".to_owned())
+            } else {
+                tracing::error!("create_role: {e}");
+                OpError::Internal("Database error".to_owned())
+            }
+        })
+    }
+
+    pub(crate) async fn delete_role_impl(&self, account_id: &str, role_name: &str) -> OpResult<()> {
+        crate::referential::delete_with_children(
+            self.pool(),
+            "delete_role",
+            async |tx| crate::referential::delete_role_children(tx, account_id, role_name).await,
+            "DELETE FROM iam_roles WHERE account_id = ? AND role_name = ?",
+            &[account_id, role_name],
+            "IAM role not found",
+        )
+        .await
+    }
+
+    pub(crate) async fn list_roles_impl(&self, account_id: &str) -> OpResult<Vec<RoleListEntry>> {
+        let rows: Vec<(String, String, String, String, String)> = db::query_as(
+            "SELECT account_id, role_name, role_arn, trust_policy, created_at \
+             FROM iam_roles WHERE account_id = ? ORDER BY role_name",
+        )
+        .bind(account_id)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("list_roles: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        rows.into_iter()
+            .map(|(aid, rn, arn, trust, ts)| {
+                Ok((
+                    aid,
+                    rn,
+                    arn,
+                    parse_json(&trust, "list_roles trust_policy")?,
+                    parse_timestamp(&ts)
+                        .map_err(|e| OpError::Internal(format!("parse created_at: {e}")))?,
+                ))
+            })
+            .collect()
+    }
+
+    pub(crate) async fn get_role_detail_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> OpResult<Option<RoleDetail>> {
+        let row: Option<(String,)> = db::query_as(
+            "SELECT trust_policy FROM iam_roles WHERE account_id = ? AND role_name = ?",
+        )
+        .bind(account_id)
+        .bind(role_name)
+        .fetch_optional(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_role_detail: {e}")))?;
+        let Some((trust,)) = row else {
+            return Ok(None);
+        };
+        let trust_policy = parse_json(&trust, "get_role_detail trust_policy")?;
+
+        let policies: Vec<(String,)> = db::query_as(
+            "SELECT policy_name FROM iam_policies \
+             WHERE account_id = ? AND principal_type = 'role' AND principal_name = ? \
+             ORDER BY policy_name",
+        )
+        .bind(account_id)
+        .bind(role_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_role_detail policies: {e}")))?;
+
+        let tags: Vec<(String, String)> = db::query_as(
+            "SELECT tag_key, tag_value FROM iam_role_tags \
+             WHERE account_id = ? AND role_name = ? ORDER BY tag_key",
+        )
+        .bind(account_id)
+        .bind(role_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_role_detail tags: {e}")))?;
+
+        Ok(Some(RoleDetail {
+            trust_policy,
+            policies: policies.into_iter().map(|(n,)| n).collect(),
+            tags,
+        }))
+    }
+
+    pub(crate) async fn get_role_trust_policy_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> OpResult<Option<serde_json::Value>> {
+        let row: Option<(String,)> = db::query_as(
+            "SELECT trust_policy FROM iam_roles WHERE account_id = ? AND role_name = ?",
+        )
+        .bind(account_id)
+        .bind(role_name)
+        .fetch_optional(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_role_trust_policy: {e}")))?;
+        row.map(|(t,)| parse_json(&t, "get_role_trust_policy"))
+            .transpose()
+    }
+
+    pub(crate) async fn tag_role_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        tags: &[(String, String)],
+    ) -> OpResult<()> {
+        let mut tx = self
+            .pool()
+            .begin()
+            .await
+            .map_err(|e| OpError::Internal(format!("tag_role begin: {e}")))?;
+        crate::referential::ensure_role_exists(&mut *tx, account_id, role_name).await?;
+        for (k, v) in tags {
+            db::query(
+                "INSERT INTO iam_role_tags (account_id, role_name, tag_key, tag_value) \
+                 VALUES (?, ?, ?, ?) \
+                 ON CONFLICT(account_id, role_name, tag_key) DO UPDATE SET tag_value = excluded.tag_value",
+            )
+            .bind(account_id)
+            .bind(role_name)
+            .bind(k)
+            .bind(v)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| {
+                if is_fk_violation(&e) {
+                    OpError::NotFound("IAM role not found".to_owned())
+                } else {
+                    tracing::error!("tag_role: {e}");
+                    OpError::Internal("Database error".to_owned())
+                }
+            })?;
+        }
+        tx.commit()
+            .await
+            .map_err(|e| OpError::Internal(format!("tag_role commit: {e}")))?;
+        Ok(())
+    }
+
+    pub(crate) async fn untag_role_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+        tag_keys: &[String],
+    ) -> OpResult<()> {
+        let mut tx = self
+            .pool()
+            .begin()
+            .await
+            .map_err(|e| OpError::Internal(format!("untag_role begin: {e}")))?;
+        for k in tag_keys {
+            db::query(
+                "DELETE FROM iam_role_tags WHERE account_id = ? AND role_name = ? AND tag_key = ?",
+            )
+            .bind(account_id)
+            .bind(role_name)
+            .bind(k)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| {
+                tracing::error!("untag_role: {e}");
+                OpError::Internal("Database error".to_owned())
+            })?;
+        }
+        tx.commit()
+            .await
+            .map_err(|e| OpError::Internal(format!("untag_role commit: {e}")))?;
+        Ok(())
+    }
+
+    pub(crate) async fn list_role_tags_impl(
+        &self,
+        account_id: &str,
+        role_name: &str,
+    ) -> OpResult<Vec<(String, String)>> {
+        db::query_as(
+            "SELECT tag_key, tag_value FROM iam_role_tags \
+             WHERE account_id = ? AND role_name = ? ORDER BY tag_key",
+        )
+        .bind(account_id)
+        .bind(role_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("list_role_tags: {e}");
+            OpError::Internal("Database error".to_owned())
+        })
+    }
+}

--- a/crates/storage-duckdb/src/management_store/users.rs
+++ b/crates/storage-duckdb/src/management_store/users.rs
@@ -1,0 +1,335 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! User management, console-password verification, and user tags for
+//! `DuckDbCatalogStore`.
+
+use crate::db;
+use extenddb_storage::management_store::{OpError, OpResult, UserDetail, UserListEntry};
+
+use crate::catalog_store::DuckDbCatalogStore;
+use crate::duckdb_util::{is_fk_violation, is_unique_violation, parse_timestamp};
+
+impl DuckDbCatalogStore {
+    pub(crate) async fn create_user_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        password_hash: Option<&str>,
+    ) -> OpResult<()> {
+        let user_arn = format!("arn:aws:iam::{account_id}:user/{user_name}");
+
+        let mut tx = self.pool().begin().await.map_err(|e| {
+            tracing::error!("create_user begin: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+
+        crate::referential::ensure_account_exists(&mut *tx, account_id).await?;
+        db::query(
+            "INSERT INTO iam_users (account_id, user_name, user_arn, password_hash) \
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .bind(&user_arn)
+        .bind(password_hash)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| {
+            if is_unique_violation(&e) {
+                OpError::AlreadyExists("IAM user already exists".to_owned())
+            } else if is_fk_violation(&e) {
+                OpError::NotFound("Account not found".to_owned())
+            } else {
+                tracing::error!("create_user: {e}");
+                OpError::Internal("Database error".to_owned())
+            }
+        })?;
+
+        // Seed a default self-service policy so the user can manage its own
+        // access keys and password without an administrator attaching one
+        // (parity with the PostgreSQL backend).
+        let self_service_policy = serde_json::json!({
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": [
+                    "iam:CreateAccessKey",
+                    "iam:DeleteAccessKey",
+                    "iam:ListAccessKeys",
+                    "iam:ChangePassword"
+                ],
+                "Resource": user_arn,
+            }]
+        })
+        .to_string();
+
+        db::query(
+            "INSERT INTO iam_policies \
+             (account_id, principal_type, principal_name, policy_name, policy_document) \
+             VALUES (?, 'user', ?, 'SelfServicePolicy', ?) ON CONFLICT DO NOTHING",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .bind(&self_service_policy)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| {
+            tracing::error!("seed self-service policy: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+
+        tx.commit().await.map_err(|e| {
+            tracing::error!("create_user commit: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        Ok(())
+    }
+
+    pub(crate) async fn delete_user_impl(&self, account_id: &str, user_name: &str) -> OpResult<()> {
+        crate::referential::delete_with_children(
+            self.pool(),
+            "delete_user",
+            async |tx| crate::referential::delete_user_children(tx, account_id, user_name).await,
+            "DELETE FROM iam_users WHERE account_id = ? AND user_name = ?",
+            &[account_id, user_name],
+            "IAM user not found",
+        )
+        .await
+    }
+
+    pub(crate) async fn list_users_impl(&self, account_id: &str) -> OpResult<Vec<UserListEntry>> {
+        let rows: Vec<(String, String, String, bool, String)> = db::query_as(
+            "SELECT account_id, user_name, user_arn, (password_hash IS NOT NULL), created_at \
+             FROM iam_users WHERE account_id = ? ORDER BY user_name",
+        )
+        .bind(account_id)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("list_users: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        rows.into_iter()
+            .map(|(aid, un, arn, has_pw, ts)| {
+                Ok((
+                    aid,
+                    un,
+                    arn,
+                    has_pw,
+                    parse_timestamp(&ts)
+                        .map_err(|e| OpError::Internal(format!("parse created_at: {e}")))?,
+                ))
+            })
+            .collect()
+    }
+
+    pub(crate) async fn get_user_detail_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> OpResult<Option<UserDetail>> {
+        let exists: bool = db::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM iam_users WHERE account_id = ? AND user_name = ?)",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .fetch_one(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_user_detail exists: {e}")))?;
+        if !exists {
+            return Ok(None);
+        }
+
+        let keys: Vec<(String, bool)> = db::query_as(
+            "SELECT access_key_id, is_active FROM access_keys \
+             WHERE account_id = ? AND user_name = ? ORDER BY created_at",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_user_detail keys: {e}")))?;
+
+        let policies: Vec<(String,)> = db::query_as(
+            "SELECT policy_name FROM iam_policies \
+             WHERE account_id = ? AND principal_type = 'user' AND principal_name = ? \
+             ORDER BY policy_name",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_user_detail policies: {e}")))?;
+
+        let tags: Vec<(String, String)> = db::query_as(
+            "SELECT tag_key, tag_value FROM iam_user_tags \
+             WHERE account_id = ? AND user_name = ? ORDER BY tag_key",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_user_detail tags: {e}")))?;
+
+        let groups: Vec<(String,)> = db::query_as(
+            "SELECT group_name FROM iam_group_members \
+             WHERE account_id = ? AND user_name = ? ORDER BY group_name",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| OpError::Internal(format!("get_user_detail groups: {e}")))?;
+
+        Ok(Some(UserDetail {
+            keys,
+            policies: policies.into_iter().map(|(n,)| n).collect(),
+            tags,
+            groups: groups.into_iter().map(|(n,)| n).collect(),
+        }))
+    }
+
+    pub(crate) async fn verify_iam_user_password_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        password: &str,
+    ) -> OpResult<bool> {
+        let row: Option<(Option<String>,)> = db::query_as(
+            "SELECT password_hash FROM iam_users WHERE account_id = ? AND user_name = ?",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .fetch_optional(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("verify_iam_user_password: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+
+        let Some((Some(hash),)) = row else {
+            // User absent or has no console password.
+            return Ok(false);
+        };
+        let password = password.to_owned();
+        let verified = tokio::task::spawn_blocking(move || bcrypt::verify(&password, &hash))
+            .await
+            .map_err(|e| OpError::Internal(format!("bcrypt task: {e}")))?
+            .unwrap_or(false);
+        Ok(verified)
+    }
+
+    pub(crate) async fn change_user_password_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        password_hash: &str,
+    ) -> OpResult<()> {
+        let result = db::query(
+            "UPDATE iam_users SET password_hash = ? WHERE account_id = ? AND user_name = ?",
+        )
+        .bind(password_hash)
+        .bind(account_id)
+        .bind(user_name)
+        .execute(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("change_user_password: {e}");
+            OpError::Internal("Database error".to_owned())
+        })?;
+        if result.rows_affected() == 0 {
+            return Err(OpError::NotFound("IAM user not found".to_owned()));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn tag_user_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        tags: &[(String, String)],
+    ) -> OpResult<()> {
+        let mut tx = self
+            .pool()
+            .begin()
+            .await
+            .map_err(|e| OpError::Internal(format!("tag_user begin: {e}")))?;
+        crate::referential::ensure_user_exists(&mut *tx, account_id, user_name).await?;
+        for (k, v) in tags {
+            db::query(
+                "INSERT INTO iam_user_tags (account_id, user_name, tag_key, tag_value) \
+                 VALUES (?, ?, ?, ?) \
+                 ON CONFLICT(account_id, user_name, tag_key) DO UPDATE SET tag_value = excluded.tag_value",
+            )
+            .bind(account_id)
+            .bind(user_name)
+            .bind(k)
+            .bind(v)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| {
+                if is_fk_violation(&e) {
+                    OpError::NotFound("IAM user not found".to_owned())
+                } else {
+                    tracing::error!("tag_user: {e}");
+                    OpError::Internal("Database error".to_owned())
+                }
+            })?;
+        }
+        tx.commit()
+            .await
+            .map_err(|e| OpError::Internal(format!("tag_user commit: {e}")))?;
+        Ok(())
+    }
+
+    pub(crate) async fn untag_user_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+        tag_keys: &[String],
+    ) -> OpResult<()> {
+        let mut tx = self
+            .pool()
+            .begin()
+            .await
+            .map_err(|e| OpError::Internal(format!("untag_user begin: {e}")))?;
+        for k in tag_keys {
+            db::query(
+                "DELETE FROM iam_user_tags WHERE account_id = ? AND user_name = ? AND tag_key = ?",
+            )
+            .bind(account_id)
+            .bind(user_name)
+            .bind(k)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| {
+                tracing::error!("untag_user: {e}");
+                OpError::Internal("Database error".to_owned())
+            })?;
+        }
+        tx.commit()
+            .await
+            .map_err(|e| OpError::Internal(format!("untag_user commit: {e}")))?;
+        Ok(())
+    }
+
+    pub(crate) async fn list_user_tags_impl(
+        &self,
+        account_id: &str,
+        user_name: &str,
+    ) -> OpResult<Vec<(String, String)>> {
+        db::query_as(
+            "SELECT tag_key, tag_value FROM iam_user_tags \
+             WHERE account_id = ? AND user_name = ? ORDER BY tag_key",
+        )
+        .bind(account_id)
+        .bind(user_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| {
+            tracing::error!("list_user_tags: {e}");
+            OpError::Internal("Database error".to_owned())
+        })
+    }
+}

--- a/crates/storage-duckdb/src/metadata.rs
+++ b/crates/storage-duckdb/src/metadata.rs
@@ -1,0 +1,396 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `MetadataEngine` trait implementation for `DuckDbEngine`: TTL configuration,
+//! resource tags, table statistics, and TTL-expiry scanning.
+//!
+//! Expired-item lookup uses `json_extract_string(item_data, ?)` with the JSON path
+//! bound as a parameter (`$."attr".N`), so the TTL attribute name is never
+//! interpolated into SQL. Table size uses `SUM(length(item_data))` (DuckDB has
+//! no per-table physical size function).
+
+use crate::db;
+use extenddb_core::types::{Item, Tag, TimeToLiveDescription, TimeToLiveStatus};
+use extenddb_storage::MetadataEngine;
+use extenddb_storage::error::StorageError;
+use futures::future::BoxFuture;
+
+use crate::data;
+use crate::store::DuckDbEngine;
+
+/// JSON path selecting a DynamoDB number attribute's value: `$."attr".N`.
+fn ttl_json_path(attr: &str) -> String {
+    // Escape embedded double quotes for the JSON path string. The value is
+    // bound as a parameter, so this is defense-in-depth, not SQL safety.
+    format!("$.\"{}\".N", attr.replace('"', "\"\""))
+}
+
+/// True if a TTL attribute name is safe to embed in a `CREATE INDEX` expression.
+fn safe_index_attr(attr: &str) -> bool {
+    !attr.is_empty()
+        && attr
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-'))
+}
+
+impl DuckDbEngine {
+    async fn table_id_for(
+        &self,
+        account_id: &str,
+        table_name: &str,
+    ) -> Result<String, StorageError> {
+        db::query_scalar("SELECT table_id FROM tables WHERE account_id = ? AND table_name = ?")
+            .bind(account_id)
+            .bind(table_name)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?
+            .ok_or_else(|| StorageError::TableNotFound(table_name.to_owned()))
+    }
+}
+
+impl MetadataEngine for DuckDbEngine {
+    fn describe_ttl(
+        &self,
+        account_id: &str,
+        table_name: &str,
+    ) -> BoxFuture<'_, Result<TimeToLiveDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        Box::pin(async move {
+            let row: Option<(Option<String>,)> = db::query_as(
+                "SELECT ttl_attribute FROM tables WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let (ttl_attr,) = row.ok_or_else(|| StorageError::TableNotFound(table_name.clone()))?;
+            Ok(match ttl_attr {
+                Some(attr) => TimeToLiveDescription {
+                    time_to_live_status: TimeToLiveStatus::Enabled,
+                    attribute_name: Some(attr),
+                },
+                None => TimeToLiveDescription {
+                    time_to_live_status: TimeToLiveStatus::Disabled,
+                    attribute_name: None,
+                },
+            })
+        })
+    }
+
+    fn update_ttl(
+        &self,
+        account_id: &str,
+        table_name: &str,
+        attribute_name: &str,
+        enabled: bool,
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        let attribute_name = attribute_name.to_owned();
+        Box::pin(async move {
+            let ttl_val: Option<&str> = if enabled { Some(&attribute_name) } else { None };
+            let result = db::query(
+                "UPDATE tables SET ttl_attribute = ?, ttl_index_ready = 0 \
+                 WHERE account_id = ? AND table_name = ? AND table_status = 'ACTIVE'",
+            )
+            .bind(ttl_val)
+            .bind(&account_id)
+            .bind(&table_name)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if result.rows_affected() == 0 {
+                let exists: Option<(String,)> = db::query_as(
+                    "SELECT table_status FROM tables WHERE account_id = ? AND table_name = ?",
+                )
+                .bind(&account_id)
+                .bind(&table_name)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+                return match exists {
+                    None => Err(StorageError::TableNotFound(table_name)),
+                    Some(_) => Err(StorageError::TableNotActive(table_name)),
+                };
+            }
+            Ok(())
+        })
+    }
+
+    fn tag_resource(&self, arn: &str, tags: &[Tag]) -> BoxFuture<'_, Result<(), StorageError>> {
+        let arn = arn.to_owned();
+        let tags = tags.to_vec();
+        Box::pin(async move {
+            for tag in &tags {
+                db::query(
+                    "INSERT INTO tags (resource_arn, tag_key, tag_value) VALUES (?, ?, ?) \
+                     ON CONFLICT (resource_arn, tag_key) DO UPDATE SET tag_value = excluded.tag_value",
+                )
+                .bind(&arn)
+                .bind(&tag.key)
+                .bind(&tag.value)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            }
+            Ok(())
+        })
+    }
+
+    fn untag_resource(
+        &self,
+        arn: &str,
+        tag_keys: &[String],
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let arn = arn.to_owned();
+        let tag_keys = tag_keys.to_vec();
+        Box::pin(async move {
+            for key in &tag_keys {
+                db::query("DELETE FROM tags WHERE resource_arn = ? AND tag_key = ?")
+                    .bind(&arn)
+                    .bind(key)
+                    .execute(&self.pool)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            }
+            Ok(())
+        })
+    }
+
+    fn list_tags(&self, arn: &str) -> BoxFuture<'_, Result<Vec<Tag>, StorageError>> {
+        let arn = arn.to_owned();
+        Box::pin(async move {
+            let rows: Vec<(String, String)> = db::query_as(
+                "SELECT tag_key, tag_value FROM tags WHERE resource_arn = ? ORDER BY tag_key",
+            )
+            .bind(&arn)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(rows
+                .into_iter()
+                .map(|(key, value)| Tag { key, value })
+                .collect())
+        })
+    }
+
+    fn tables_with_ttl(
+        &self,
+        account_id: &str,
+    ) -> BoxFuture<'_, Result<Vec<(String, String)>, StorageError>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move {
+            db::query_as(
+                "SELECT table_name, ttl_attribute FROM tables \
+                 WHERE account_id = ? AND ttl_attribute IS NOT NULL AND table_status = 'ACTIVE'",
+            )
+            .bind(&account_id)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))
+        })
+    }
+
+    fn all_tables_with_ttl(
+        &self,
+    ) -> BoxFuture<'_, Result<Vec<(String, String, String)>, StorageError>> {
+        Box::pin(async move {
+            db::query_as(
+                "SELECT account_id, table_name, ttl_attribute FROM tables \
+                 WHERE ttl_attribute IS NOT NULL AND table_status = 'ACTIVE'",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))
+        })
+    }
+
+    fn all_tables_with_ttl_index_ready(
+        &self,
+    ) -> BoxFuture<'_, Result<Vec<(String, String, String)>, StorageError>> {
+        Box::pin(async move {
+            db::query_as(
+                "SELECT account_id, table_name, ttl_attribute FROM tables \
+                 WHERE ttl_attribute IS NOT NULL AND ttl_index_ready = 1 AND table_status = 'ACTIVE'",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))
+        })
+    }
+
+    fn create_ttl_index(
+        &self,
+        account_id: &str,
+        table_name: &str,
+        ttl_attribute: &str,
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        let ttl_attribute = ttl_attribute.to_owned();
+        Box::pin(async move {
+            Self::validate_account_id(&account_id)?;
+            // Resolving the table id validates the table exists and is this
+            // account's, exactly as the SQLite path does before indexing.
+            let _table_id = self.table_id_for(&account_id, &table_name).await?;
+
+            // The SQLite backend builds an expression index on the TTL attribute
+            // here. DuckDB does not allow indexes over extension functions
+            // (`json_extract_string` is one), so the sweep runs as a filtered
+            // scan of `item_data`; `ttl_index_ready` still flips so the worker
+            // picks the table up on its next pass.
+            let _ = (&ttl_attribute, safe_index_attr, ttl_json_path);
+
+            db::query(
+                "UPDATE tables SET ttl_index_ready = 1 WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(())
+        })
+    }
+
+    fn drop_ttl_index(
+        &self,
+        account_id: &str,
+        table_name: &str,
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        Box::pin(async move {
+            Self::validate_account_id(&account_id)?;
+            let table_id = self.table_id_for(&account_id, &table_name).await?;
+            db::query(
+                "UPDATE tables SET ttl_index_ready = 0 WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let index_name = format!("idx_ttl_{table_id}");
+            db::query(&format!("DROP INDEX IF EXISTS \"{index_name}\""))
+                .execute(&self.pool)
+                .await
+                .map_err(|e| StorageError::Internal(format!("TTL index drop failed: {e}")))?;
+            Ok(())
+        })
+    }
+
+    fn find_expired_items_indexed(
+        &self,
+        account_id: &str,
+        table_name: &str,
+        ttl_attribute: &str,
+        limit: usize,
+    ) -> BoxFuture<'_, Result<Vec<Item>, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        let ttl_attribute = ttl_attribute.to_owned();
+        Box::pin(async move {
+            Self::validate_account_id(&account_id)?;
+            let table_id = self.table_id_for(&account_id, &table_name).await?;
+            let data_table = data::data_table_name(&table_id);
+            let path = ttl_json_path(&ttl_attribute);
+
+            let now = i64::try_from(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+            )
+            .unwrap_or(i64::MAX);
+            let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+
+            // Path bound as a parameter — TTL attribute never interpolated.
+            let sql = format!(
+                "SELECT item_data FROM {data_table} \
+                 WHERE TRY_CAST(json_extract_string(item_data, ?) AS BIGINT) BETWEEN 1 AND ? \
+                 ORDER BY TRY_CAST(json_extract_string(item_data, ?) AS BIGINT) LIMIT ?"
+            );
+            let rows: Vec<(String,)> = db::query_as(&sql)
+                .bind(&path)
+                .bind(now)
+                .bind(&path)
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            rows.into_iter()
+                .map(|(s,)| {
+                    serde_json::from_str(&s).map_err(|e| StorageError::Internal(e.to_string()))
+                })
+                .collect()
+        })
+    }
+
+    fn refresh_table_size(
+        &self,
+        account_id: &str,
+        table_name: &str,
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        Box::pin(async move {
+            Self::validate_account_id(&account_id)?;
+            let table_id = self.table_id_for(&account_id, &table_name).await?;
+            let data_table = data::data_table_name(&table_id);
+            let (item_count, table_size): (i64, i64) = db::query_as(&format!(
+                "SELECT COUNT(*), COALESCE(SUM(length(item_data)), 0) FROM {data_table}"
+            ))
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            db::query(
+                "UPDATE tables SET item_count = ?, table_size_bytes = ? \
+                 WHERE account_id = ? AND table_name = ? AND table_status = 'ACTIVE'",
+            )
+            .bind(item_count)
+            .bind(table_size)
+            .bind(&account_id)
+            .bind(&table_name)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(())
+        })
+    }
+
+    fn list_active_table_names(
+        &self,
+        account_id: &str,
+    ) -> BoxFuture<'_, Result<Vec<String>, StorageError>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move {
+            let rows: Vec<(String,)> = db::query_as(
+                "SELECT table_name FROM tables \
+                 WHERE account_id = ? AND table_status = 'ACTIVE' ORDER BY table_name",
+            )
+            .bind(&account_id)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(rows.into_iter().map(|(n,)| n).collect())
+        })
+    }
+
+    fn all_active_tables(&self) -> BoxFuture<'_, Result<Vec<(String, String)>, StorageError>> {
+        Box::pin(async move {
+            db::query_as(
+                "SELECT account_id, table_name FROM tables \
+                 WHERE table_status = 'ACTIVE' ORDER BY account_id, table_name",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))
+        })
+    }
+}

--- a/crates/storage-duckdb/src/number_key.rs
+++ b/crates/storage-duckdb/src/number_key.rs
@@ -1,0 +1,225 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Order-preserving encoding of DynamoDB numbers for use as DuckDB sort keys.
+//!
+//! DuckDB has no arbitrary-precision numeric type, and storing a `N` sort key
+//! as `DOUBLE` would truncate beyond ~15-17 significant digits, corrupting both
+//! ordering and equality. Instead we store `N` sort keys in a `TEXT` column
+//! holding a canonical, byte-lexicographically order-preserving encoding of the
+//! value, so DuckDB's default BINARY collation yields exact DynamoDB numeric
+//! ordering. The full-precision value is always retained in the item JSON, so
+//! reads lose nothing — this column exists only for ordering/range/equality.
+//!
+//! # Encoding
+//!
+//! A value is written in canonical normalized form `± 0.d₁d₂… × 10^E` (leading
+//! digit non-zero, no trailing zeros), then encoded as:
+//!
+//! - **class byte** — `'0'` negative, `'1'` zero, `'2'` positive — so the three
+//!   classes order negative < zero < positive.
+//! - **exponent** — `E` biased into a fixed-width 6-digit field. Positive
+//!   numbers use `E + BIAS` (increasing in `E`); negative numbers use
+//!   `BIAS - E` (decreasing in `E`) so larger magnitudes sort earlier.
+//! - **mantissa digits** — written verbatim for positives. For negatives each
+//!   digit `d` is complemented to `9 - d`, and a high terminator (`':'`, which
+//!   sorts above any digit) is appended so a longer (more negative) value sorts
+//!   before its prefix.
+//!
+//! Canonical normalization makes numerically-equal inputs (`5`, `5.0`, `+5`)
+//! encode identically, matching DynamoDB's number normalization for key
+//! equality.
+
+use bigdecimal::{BigDecimal, Zero};
+
+/// Exponent bias. Comfortably covers DynamoDB's exponent range (≈ -130..=126)
+/// within a fixed 6-digit field with wide margin.
+const EXP_BIAS: i64 = 100_000;
+const EXP_WIDTH: usize = 6;
+/// Terminator that sorts above any decimal digit (`'9'` = 0x39 < `':'` = 0x3A).
+const NEG_TERMINATOR: char = ':';
+
+/// Encode a `BigDecimal` into an order-preserving ASCII string such that, for
+/// all `a`, `b`: `a.cmp(b) == encode(a).cmp(&encode(b))`.
+///
+/// Precondition: `value` is a finite decimal within DynamoDB's supported numeric
+/// range. `BigDecimal` cannot represent NaN or ±Infinity, and the protocol /
+/// validation layer rejects non-numeric, NaN, and Infinity inputs before they
+/// reach this encoder, so those cases are not handled here.
+pub(crate) fn encode_orderable_number(value: &BigDecimal) -> String {
+    if value.is_zero() {
+        return "1".to_owned();
+    }
+
+    let negative = value < &BigDecimal::zero();
+    let magnitude = value.abs().normalized();
+
+    // value = mantissa_int * 10^(-scale); with no trailing zeros (normalized)
+    // and no leading zeros (decimal string), the normalized form is
+    // 0.<digits> × 10^E where E = digit_count - scale.
+    let (mantissa_int, scale) = magnitude.as_bigint_and_exponent();
+    let digits = mantissa_int.to_string();
+    let exponent = digits.len() as i64 - scale;
+
+    if negative {
+        let exp_code = format!("{:0width$}", EXP_BIAS - exponent, width = EXP_WIDTH);
+        let complemented: String = digits
+            .bytes()
+            .map(|b| char::from(b'9' - (b - b'0')))
+            .collect();
+        format!("0{exp_code}{complemented}{NEG_TERMINATOR}")
+    } else {
+        let exp_code = format!("{:0width$}", EXP_BIAS + exponent, width = EXP_WIDTH);
+        format!("2{exp_code}{digits}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cmp::Ordering;
+    use std::str::FromStr;
+
+    fn bd(s: &str) -> BigDecimal {
+        BigDecimal::from_str(s).expect("valid decimal")
+    }
+
+    fn enc(s: &str) -> String {
+        encode_orderable_number(&bd(s))
+    }
+
+    /// Core property: encoded byte order equals numeric order, for every pair.
+    fn assert_order_preserving(values: &[&str]) {
+        for a in values {
+            for b in values {
+                let numeric = bd(a).cmp(&bd(b));
+                let encoded = enc(a).cmp(&enc(b));
+                assert_eq!(
+                    numeric,
+                    encoded,
+                    "order mismatch for {a} vs {b}: numeric={numeric:?} encoded={encoded:?} \
+                     (enc(a)={:?}, enc(b)={:?})",
+                    enc(a),
+                    enc(b),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn ascending_sequence_spanning_sign_and_scale() {
+        // Deliberately spans negatives, zero, fractions, integers, and large
+        // and small magnitudes, listed in true numeric ascending order.
+        let ordered = [
+            "-1000000000000000000000000000000",
+            "-100",
+            "-10.5",
+            "-10",
+            "-1.0001",
+            "-1",
+            "-0.5",
+            "-0.05",
+            "-0.0000001",
+            "0",
+            "0.0000001",
+            "0.05",
+            "0.5",
+            "1",
+            "1.0001",
+            "10",
+            "10.5",
+            "100",
+            "1000000000000000000000000000000",
+        ];
+        // Each strictly less than the next.
+        for w in ordered.windows(2) {
+            assert!(
+                enc(w[0]) < enc(w[1]),
+                "expected enc({}) < enc({}) but got {:?} >= {:?}",
+                w[0],
+                w[1],
+                enc(w[0]),
+                enc(w[1]),
+            );
+        }
+        assert_order_preserving(&ordered);
+    }
+
+    #[test]
+    fn canonical_equality_for_equal_values() {
+        // Numerically equal values must encode identically (DynamoDB number
+        // normalization), so they compare Equal as sort keys.
+        for (a, b) in [
+            ("5", "5.0"),
+            ("5", "5.00"),
+            ("5", "+5"),
+            ("0", "0.0"),
+            ("0", "-0"),
+            ("-7.5", "-7.50"),
+            ("100", "1E2"),
+            ("0.1", "1E-1"),
+            ("12300", "1.23E4"),
+        ] {
+            assert_eq!(enc(a), enc(b), "{a} and {b} should encode identically");
+            assert_eq!(bd(a).cmp(&bd(b)), Ordering::Equal);
+        }
+    }
+
+    #[test]
+    fn full_precision_38_digit_extremes() {
+        // 38 significant digits differing only in the last digit must order
+        // correctly — the case that DOUBLE/f64 silently corrupts.
+        let lo = "1.2345678901234567890123456789012345678";
+        let hi = "1.2345678901234567890123456789012345679";
+        assert!(bd(lo) < bd(hi));
+        assert!(enc(lo) < enc(hi));
+
+        let neg_lo = "-1.2345678901234567890123456789012345679";
+        let neg_hi = "-1.2345678901234567890123456789012345678";
+        assert!(bd(neg_lo) < bd(neg_hi));
+        assert!(enc(neg_lo) < enc(neg_hi));
+
+        assert_order_preserving(&[lo, hi, neg_lo, neg_hi, "0"]);
+    }
+
+    #[test]
+    fn dynamodb_magnitude_bounds() {
+        // Near DynamoDB's documented positive/negative magnitude limits.
+        let vals = [
+            "-9.9999999999999999999999999999999999999E+125",
+            "-1E-130",
+            "0",
+            "1E-130",
+            "9.9999999999999999999999999999999999999E+125",
+        ];
+        for w in vals.windows(2) {
+            assert!(bd(w[0]) < bd(w[1]));
+            assert!(
+                enc(w[0]) < enc(w[1]),
+                "enc order failed at {} vs {}",
+                w[0],
+                w[1]
+            );
+        }
+        assert_order_preserving(&vals);
+    }
+
+    #[test]
+    fn same_exponent_varying_mantissa_length() {
+        // Prefix relationships within one decade, both signs.
+        assert_order_preserving(&[
+            "0.12", "0.123", "0.1234", "0.2", "-0.12", "-0.123", "-0.1234", "-0.2",
+        ]);
+        // Positive: shorter prefix is smaller (0.12 < 0.123).
+        assert!(enc("0.12") < enc("0.123"));
+        // Negative: more-negative (longer magnitude) is smaller (-0.123 < -0.12).
+        assert!(enc("-0.123") < enc("-0.12"));
+    }
+
+    #[test]
+    fn zero_sits_between_smallest_negative_and_smallest_positive() {
+        assert!(enc("-0.0000000001") < enc("0"));
+        assert!(enc("0") < enc("0.0000000001"));
+        assert_eq!(enc("0"), "1");
+    }
+}

--- a/crates/storage-duckdb/src/operations.rs
+++ b/crates/storage-duckdb/src/operations.rs
@@ -1,0 +1,62 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `OperationsEngine` implementation for the DuckDB backend.
+//!
+//! Provides the backend-specific CLI helpers (connection-string parsing,
+//! redaction, identifier validation, catalog version) used by `extenddb`
+//! lifecycle commands. DuckDB connection strings are filesystem paths with no
+//! embedded credentials, so redaction is a no-op.
+
+use extenddb_storage::error::StorageError;
+use extenddb_storage::operations::{ConnectionParts, OperationsEngine};
+
+use crate::schema::CATALOG_VERSION;
+
+/// Backend operations for the DuckDB engine.
+pub(crate) struct DuckDbOperationsEngine;
+
+impl OperationsEngine for DuckDbOperationsEngine {
+    fn parse_connection_string(&self, s: &str) -> Result<ConnectionParts, StorageError> {
+        // A DuckDB "connection string" is just a file path (or :memory:).
+        Ok(ConnectionParts {
+            host: s.to_owned(),
+            port: 0,
+            user: String::new(),
+            password: String::new(),
+            database: s.to_owned(),
+        })
+    }
+
+    fn redact_connection_string(&self, s: &str) -> String {
+        s.to_owned() // No credentials in a DuckDB path.
+    }
+
+    fn validate_identifier(&self, name: &str, label: &str) -> Result<(), StorageError> {
+        if name.is_empty() {
+            return Err(StorageError::Internal(format!("{label} must not be empty")));
+        }
+        // Defense-in-depth for any identifier interpolated into DDL. Backend
+        // table identifiers are `_ddb_<uuid>` (engine-controlled), but reject
+        // characters that could break a quoted identifier regardless.
+        if name.contains('"') || name.contains('\0') {
+            return Err(StorageError::Internal(format!(
+                "{label} contains characters invalid for a SQL identifier"
+            )));
+        }
+        if !name.is_ascii() {
+            return Err(StorageError::Internal(format!(
+                "{label} must contain only ASCII characters"
+            )));
+        }
+        Ok(())
+    }
+
+    fn catalog_version(&self) -> String {
+        CATALOG_VERSION.to_string()
+    }
+
+    fn is_sensitive_key(&self, _key: &str) -> bool {
+        false // DuckDB config carries no secrets.
+    }
+}

--- a/crates/storage-duckdb/src/referential.rs
+++ b/crates/storage-duckdb/src/referential.rs
@@ -1,0 +1,242 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Explicit referential integrity for the catalog.
+//!
+//! DuckDB accepts `FOREIGN KEY` declarations but supports neither `ON DELETE
+//! CASCADE` nor updates to rows that a foreign key still references, so the
+//! catalog schema declares no foreign keys at all (`schema.rs`). The
+//! parent/child relationships the PostgreSQL and SQLite backends enforce with
+//! constraints are enforced here instead: every parent delete removes its
+//! children in the same transaction, and every child insert that would have
+//! failed with a foreign-key violation first checks its parent exists.
+//!
+//! The existence checks are not atomic with the insert that follows in the
+//! autocommit paths. Both backends this one mirrors report a missing parent
+//! as `NotFound`, and that is what a lost race produces here too, just from a
+//! later read rather than from the constraint.
+
+use extenddb_storage::management_store::{OpError, OpResult};
+
+use crate::db;
+
+fn internal(context: &str, e: db::Error) -> OpError {
+    tracing::error!("{context}: {e}");
+    OpError::Internal("Database error".to_owned())
+}
+
+/// Delete everything owned by a DynamoDB table: index and vector-index
+/// metadata, stream shards, and stream records. The per-table data tables are
+/// dropped separately by the caller (`drop_data_table` / `drop_index_data_table`).
+pub(crate) async fn delete_table_children(
+    tx: &mut db::Transaction,
+    table_id: &str,
+) -> Result<(), db::Error> {
+    for sql in [
+        "DELETE FROM stream_records WHERE table_id = ?",
+        "DELETE FROM stream_shards WHERE table_id = ?",
+        "DELETE FROM indexes WHERE table_id = ?",
+        "DELETE FROM vector_indexes WHERE table_id = ?",
+    ] {
+        db::query(sql).bind(table_id).execute(&mut **tx).await?;
+    }
+    Ok(())
+}
+
+/// Delete every IAM object in an account. Tables are the caller's concern (an
+/// account with tables is refused before this runs).
+pub(crate) async fn delete_account_children(
+    tx: &mut db::Transaction,
+    account_id: &str,
+) -> Result<(), db::Error> {
+    for sql in [
+        "DELETE FROM iam_permissions_boundaries WHERE account_id = ?",
+        "DELETE FROM iam_policies WHERE account_id = ?",
+        "DELETE FROM iam_sessions WHERE account_id = ?",
+        "DELETE FROM iam_role_tags WHERE account_id = ?",
+        "DELETE FROM iam_roles WHERE account_id = ?",
+        "DELETE FROM iam_group_members WHERE account_id = ?",
+        "DELETE FROM iam_groups WHERE account_id = ?",
+        "DELETE FROM access_keys WHERE account_id = ?",
+        "DELETE FROM iam_user_tags WHERE account_id = ?",
+        "DELETE FROM iam_users WHERE account_id = ?",
+    ] {
+        db::query(sql).bind(account_id).execute(&mut **tx).await?;
+    }
+    Ok(())
+}
+
+/// Delete a user's tags, access keys, and group memberships.
+pub(crate) async fn delete_user_children(
+    tx: &mut db::Transaction,
+    account_id: &str,
+    user_name: &str,
+) -> Result<(), db::Error> {
+    for sql in [
+        "DELETE FROM iam_user_tags WHERE account_id = ? AND user_name = ?",
+        "DELETE FROM access_keys WHERE account_id = ? AND user_name = ?",
+        "DELETE FROM iam_group_members WHERE account_id = ? AND user_name = ?",
+    ] {
+        db::query(sql)
+            .bind(account_id)
+            .bind(user_name)
+            .execute(&mut **tx)
+            .await?;
+    }
+    Ok(())
+}
+
+/// Delete a group's memberships.
+pub(crate) async fn delete_group_children(
+    tx: &mut db::Transaction,
+    account_id: &str,
+    group_name: &str,
+) -> Result<(), db::Error> {
+    db::query("DELETE FROM iam_group_members WHERE account_id = ? AND group_name = ?")
+        .bind(account_id)
+        .bind(group_name)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+/// Delete a role's tags and sessions.
+pub(crate) async fn delete_role_children(
+    tx: &mut db::Transaction,
+    account_id: &str,
+    role_name: &str,
+) -> Result<(), db::Error> {
+    for sql in [
+        "DELETE FROM iam_role_tags WHERE account_id = ? AND role_name = ?",
+        "DELETE FROM iam_sessions WHERE account_id = ? AND role_name = ?",
+    ] {
+        db::query(sql)
+            .bind(account_id)
+            .bind(role_name)
+            .execute(&mut **tx)
+            .await?;
+    }
+    Ok(())
+}
+
+/// Delete a parent row and its children in one transaction on `pool`.
+///
+/// `children` runs first, then `parent_sql` bound with `binds`. Returns
+/// `NotFound(not_found)` when the parent row did not exist.
+pub(crate) async fn delete_with_children<F>(
+    pool: &db::Pool,
+    context: &str,
+    children: F,
+    parent_sql: &str,
+    binds: &[&str],
+    not_found: &str,
+) -> OpResult<()>
+where
+    F: for<'a> AsyncFnOnce(&'a mut db::Transaction) -> Result<(), db::Error>,
+{
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| internal(&format!("{context} begin"), e))?;
+    children(&mut tx)
+        .await
+        .map_err(|e| internal(&format!("{context} children"), e))?;
+    let mut q = db::query(parent_sql);
+    for b in binds {
+        q = q.bind(*b);
+    }
+    let result = q
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| internal(context, e))?;
+    if result.rows_affected() == 0 {
+        return Err(OpError::NotFound(not_found.to_owned()));
+    }
+    tx.commit()
+        .await
+        .map_err(|e| internal(&format!("{context} commit"), e))?;
+    Ok(())
+}
+
+async fn exists<E: db::Executor>(exec: E, sql: &str, binds: &[&str]) -> Result<bool, db::Error> {
+    let mut q = db::query_scalar::<bool>(sql);
+    for b in binds {
+        q = q.bind(*b);
+    }
+    q.fetch_one(exec).await
+}
+
+/// `NotFound("Account not found")` unless the account exists.
+pub(crate) async fn ensure_account_exists<E: db::Executor>(
+    exec: E,
+    account_id: &str,
+) -> OpResult<()> {
+    match exists(
+        exec,
+        "SELECT EXISTS(SELECT 1 FROM accounts WHERE account_id = ?)",
+        &[account_id],
+    )
+    .await
+    {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(OpError::NotFound("Account not found".to_owned())),
+        Err(e) => Err(internal("ensure_account_exists", e)),
+    }
+}
+
+/// `NotFound("IAM user not found")` unless the user exists.
+pub(crate) async fn ensure_user_exists<E: db::Executor>(
+    exec: E,
+    account_id: &str,
+    user_name: &str,
+) -> OpResult<()> {
+    match exists(
+        exec,
+        "SELECT EXISTS(SELECT 1 FROM iam_users WHERE account_id = ? AND user_name = ?)",
+        &[account_id, user_name],
+    )
+    .await
+    {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(OpError::NotFound("IAM user not found".to_owned())),
+        Err(e) => Err(internal("ensure_user_exists", e)),
+    }
+}
+
+/// `NotFound("IAM group not found")` unless the group exists.
+pub(crate) async fn ensure_group_exists<E: db::Executor>(
+    exec: E,
+    account_id: &str,
+    group_name: &str,
+) -> OpResult<()> {
+    match exists(
+        exec,
+        "SELECT EXISTS(SELECT 1 FROM iam_groups WHERE account_id = ? AND group_name = ?)",
+        &[account_id, group_name],
+    )
+    .await
+    {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(OpError::NotFound("IAM group not found".to_owned())),
+        Err(e) => Err(internal("ensure_group_exists", e)),
+    }
+}
+
+/// `NotFound("IAM role not found")` unless the role exists.
+pub(crate) async fn ensure_role_exists<E: db::Executor>(
+    exec: E,
+    account_id: &str,
+    role_name: &str,
+) -> OpResult<()> {
+    match exists(
+        exec,
+        "SELECT EXISTS(SELECT 1 FROM iam_roles WHERE account_id = ? AND role_name = ?)",
+        &[account_id, role_name],
+    )
+    .await
+    {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(OpError::NotFound("IAM role not found".to_owned())),
+        Err(e) => Err(internal("ensure_role_exists", e)),
+    }
+}

--- a/crates/storage-duckdb/src/schema.rs
+++ b/crates/storage-duckdb/src/schema.rs
@@ -1,0 +1,472 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Authoritative DuckDB catalog schema.
+//!
+//! Mirrors the semantics of the reference PostgreSQL catalog schema
+//! (`crates/storage-postgres/migrations/001_schema.sql`, catalog version
+//! 0.0.2). Table and column names are kept identical to PostgreSQL so the
+//! catalog/management stores remain portable across backends.
+//!
+//! Type mapping PostgreSQL → DuckDB:
+//! - `JSONB`        → `TEXT` (JSON serialized as a string)
+//! - `BYTEA`        → `BLOB`
+//! - `BOOLEAN`      → `BIGINT` (0/1)
+//! - `BIGINT`       → `BIGINT`
+//! - `DOUBLE PRECISION` → `DOUBLE` (`±Infinity` literals)
+//! - `TIMESTAMPTZ`  → `TEXT` in RFC 3339 UTC (`YYYY-MM-DDTHH:MM:SS.sssZ`)
+//! - `SEQUENCE`     → a `seq_counters` row updated inside the write transaction
+//!
+//! Per-DynamoDB-table data tables (`_ddb_<table_id>`) are NOT created here; they
+//! are created dynamically by `create_table`, exactly as in the PostgreSQL
+//! backend.
+
+use crate::db;
+use extenddb_storage::management_store::{OpError, OpResult};
+
+/// Compiled-in catalog version. Single source of truth for the DuckDB backend;
+/// mirrors the PostgreSQL backend's `CATALOG_VERSION`.
+pub const CATALOG_VERSION: extenddb_core::version::CatalogVersion =
+    extenddb_core::version::CatalogVersion::new(0, 0, 3);
+
+/// Complete catalog schema, applied once on a fresh database.
+///
+/// Every object uses `IF NOT EXISTS` so re-application is harmless. Foreign-key
+/// enforcement requires `PRAGMA foreign_keys = ON` on each connection (set in
+/// the engine's `after_connect` hook).
+pub const SCHEMA_SQL: &str = r#"
+-- Accounts — multi-account support (REQ-AUTH-005).
+CREATE TABLE IF NOT EXISTS accounts (
+    account_id TEXT PRIMARY KEY,
+    account_name TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL DEFAULT (strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ'))
+);
+
+-- Table metadata.
+CREATE TABLE IF NOT EXISTS tables (
+    account_id TEXT NOT NULL,
+    table_name TEXT NOT NULL,
+    key_schema TEXT NOT NULL,
+    attribute_definitions TEXT NOT NULL,
+    billing_mode TEXT NOT NULL DEFAULT 'PAY_PER_REQUEST',
+    provisioned_throughput TEXT,
+    stream_specification TEXT,
+    table_status TEXT NOT NULL DEFAULT 'CREATING',
+    creation_date_time TEXT NOT NULL DEFAULT (strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ')),
+    table_size_bytes BIGINT NOT NULL DEFAULT 0,
+    item_count BIGINT NOT NULL DEFAULT 0,
+    table_arn TEXT NOT NULL,
+    table_id TEXT NOT NULL,
+    ttl_attribute TEXT,
+    deletion_protection_enabled BIGINT NOT NULL DEFAULT 0,
+    status_transition_at TEXT,
+    stream_label TEXT,
+    ttl_index_ready BIGINT NOT NULL DEFAULT 0,
+    table_class TEXT,
+    sse_specification TEXT,
+    on_demand_throughput TEXT,
+    PRIMARY KEY (account_id, table_name),
+    CONSTRAINT tables_table_id_unique UNIQUE (table_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tables_pending_transition
+    ON tables (status_transition_at);
+
+-- Index metadata. index_id is always supplied by the engine (no DB-side UUID).
+CREATE TABLE IF NOT EXISTS indexes (
+    table_id TEXT NOT NULL,
+    index_id TEXT NOT NULL,
+    index_name TEXT NOT NULL,
+    index_type TEXT NOT NULL,
+    key_schema TEXT NOT NULL,
+    projection TEXT NOT NULL,
+    index_status TEXT NOT NULL DEFAULT 'ACTIVE',
+    provisioned_throughput TEXT,
+    propagation_delay_ms BIGINT,
+    PRIMARY KEY (table_id, index_name),
+    CONSTRAINT chk_propagation_delay_ms_non_negative
+        CHECK (propagation_delay_ms IS NULL OR propagation_delay_ms >= 0)
+);
+
+-- Vector index metadata. Kept out of `indexes` deliberately: a vector index is
+-- not described by a key schema, so reusing that table's `key_schema` column
+-- would mean storing something meaningless in a NOT NULL column. The engine
+-- supplies index_id, as it does for GSIs.
+--
+-- `search_schema` is nullable because the HASH element is optional (measured
+-- against the live service): with one the search is partition-scoped and
+-- SearchConditionExpression is required, without one it spans the table.
+--
+-- `backfilling` mirrors the measured lifecycle: false while CREATING before the
+-- scan starts, true while it runs, and the member is absent once ACTIVE. Stored
+-- as an integer so the ACTIVE state is representable as NULL rather than as a
+-- third boolean value.
+CREATE TABLE IF NOT EXISTS vector_indexes (
+    table_id TEXT NOT NULL,
+    index_id TEXT NOT NULL,
+    index_name TEXT NOT NULL,
+    dimensions BIGINT NOT NULL,
+    distance_function TEXT NOT NULL,
+    vector_attribute TEXT NOT NULL,
+    search_schema TEXT,
+    projection TEXT NOT NULL,
+    index_status TEXT NOT NULL DEFAULT 'CREATING',
+    backfilling BIGINT,
+    -- Items the backfill skipped because their stored bytes cannot enter the
+    -- index (unparseable row, malformed or wrong-dimension vector). NULL until
+    -- a backfill has completed; 0 afterwards when nothing was skipped. Kept so
+    -- an operator can see that an ACTIVE index deliberately omits rows, rather
+    -- than the build looping forever on them or dying part-way.
+    skipped_item_count BIGINT,
+    PRIMARY KEY (table_id, index_name),
+    CONSTRAINT chk_vector_dimensions_positive CHECK (dimensions > 0),
+    CONSTRAINT chk_vector_backfilling_bool
+        CHECK (backfilling IS NULL OR backfilling IN (0, 1)),
+    -- An ACTIVE index must not carry the member at all, which is what the
+    -- service does. Enforced here as well as in core, so a bug in the backend
+    -- cannot persist a state the wire contract forbids.
+    CONSTRAINT chk_vector_active_has_no_backfilling
+        CHECK (index_status <> 'ACTIVE' OR backfilling IS NULL)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_vector_indexes_index_id
+    ON vector_indexes (index_id);
+
+-- Resource tags.
+CREATE TABLE IF NOT EXISTS tags (
+    resource_arn TEXT NOT NULL,
+    tag_key TEXT NOT NULL,
+    tag_value TEXT NOT NULL,
+    PRIMARY KEY (resource_arn, tag_key)
+);
+
+-- Migration tracking.
+CREATE TABLE IF NOT EXISTS schema_history (
+    filename TEXT PRIMARY KEY,
+    applied_at TEXT NOT NULL DEFAULT (strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ'))
+);
+
+-- Settings (catalog version, data database name, runtime config).
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+-- Stream shards.
+CREATE TABLE IF NOT EXISTS stream_shards (
+    shard_id TEXT PRIMARY KEY,
+    table_id TEXT NOT NULL,
+    parent_shard_id TEXT,
+    starting_sequence_number TEXT NOT NULL,
+    ending_sequence_number TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_stream_shards_table ON stream_shards (table_id);
+
+-- Stream records.
+CREATE TABLE IF NOT EXISTS stream_records (
+    shard_id TEXT NOT NULL,
+    sequence_number TEXT NOT NULL,
+    table_id TEXT NOT NULL,
+    event_name TEXT NOT NULL,
+    record_data TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ')),
+    PRIMARY KEY (shard_id, sequence_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_stream_records_created ON stream_records (created_at);
+
+-- Admin users.
+CREATE TABLE IF NOT EXISTS admin_users (
+    admin_name TEXT PRIMARY KEY,
+    password_hash TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ'))
+);
+
+-- IAM users.
+CREATE TABLE IF NOT EXISTS iam_users (
+    account_id TEXT NOT NULL,
+    user_name TEXT NOT NULL,
+    user_arn TEXT NOT NULL UNIQUE,
+    password_hash TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ')),
+    PRIMARY KEY (account_id, user_name)
+);
+
+-- IAM user tags.
+CREATE TABLE IF NOT EXISTS iam_user_tags (
+    account_id TEXT NOT NULL,
+    user_name TEXT NOT NULL,
+    tag_key TEXT NOT NULL,
+    tag_value TEXT NOT NULL,
+    PRIMARY KEY (account_id, user_name, tag_key)
+);
+
+-- Access keys.
+CREATE TABLE IF NOT EXISTS access_keys (
+    access_key_id TEXT PRIMARY KEY,
+    secret_key_encrypted BLOB NOT NULL,
+    account_id TEXT NOT NULL,
+    user_name TEXT NOT NULL,
+    is_active BIGINT NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL DEFAULT (strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ'))
+);
+
+-- IAM groups.
+CREATE TABLE IF NOT EXISTS iam_groups (
+    account_id TEXT NOT NULL,
+    group_name TEXT NOT NULL,
+    group_arn TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL DEFAULT (strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ')),
+    PRIMARY KEY (account_id, group_name)
+);
+
+-- IAM group membership.
+CREATE TABLE IF NOT EXISTS iam_group_members (
+    account_id TEXT NOT NULL,
+    group_name TEXT NOT NULL,
+    user_name TEXT NOT NULL,
+    PRIMARY KEY (account_id, group_name, user_name)
+);
+
+-- IAM roles.
+CREATE TABLE IF NOT EXISTS iam_roles (
+    account_id TEXT NOT NULL,
+    role_name TEXT NOT NULL,
+    role_arn TEXT NOT NULL UNIQUE,
+    trust_policy TEXT NOT NULL,
+    permissions_boundary_arn TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ')),
+    PRIMARY KEY (account_id, role_name)
+);
+
+-- IAM role tags.
+CREATE TABLE IF NOT EXISTS iam_role_tags (
+    account_id TEXT NOT NULL,
+    role_name TEXT NOT NULL,
+    tag_key TEXT NOT NULL,
+    tag_value TEXT NOT NULL,
+    PRIMARY KEY (account_id, role_name, tag_key)
+);
+
+-- IAM sessions.
+CREATE TABLE IF NOT EXISTS iam_sessions (
+    session_token TEXT PRIMARY KEY,
+    access_key_id TEXT NOT NULL UNIQUE,
+    secret_key_encrypted BLOB NOT NULL,
+    account_id TEXT NOT NULL,
+    role_name TEXT NOT NULL,
+    session_name TEXT NOT NULL,
+    session_tags TEXT,
+    session_policy TEXT,
+    expires_at TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ'))
+);
+
+-- IAM policies.
+CREATE TABLE IF NOT EXISTS iam_policies (
+    account_id TEXT NOT NULL,
+    principal_type TEXT NOT NULL CHECK (principal_type IN ('user', 'group', 'role')),
+    principal_name TEXT NOT NULL,
+    policy_name TEXT NOT NULL,
+    policy_document TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ')),
+    PRIMARY KEY (account_id, principal_type, principal_name, policy_name)
+);
+
+-- IAM permissions boundaries.
+CREATE TABLE IF NOT EXISTS iam_permissions_boundaries (
+    account_id TEXT NOT NULL,
+    principal_type TEXT NOT NULL CHECK (principal_type IN ('user', 'role')),
+    principal_name TEXT NOT NULL,
+    policy_document TEXT NOT NULL,
+    PRIMARY KEY (account_id, principal_type, principal_name)
+);
+
+-- Idempotency tokens for TransactWriteItems.
+CREATE TABLE IF NOT EXISTS idempotency_tokens (
+    account_id  TEXT NOT NULL,
+    token       TEXT NOT NULL,
+    fingerprint TEXT NOT NULL,
+    created_at  TEXT NOT NULL DEFAULT (strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ')),
+    PRIMARY KEY (account_id, token)
+);
+
+CREATE INDEX IF NOT EXISTS idx_idempotency_tokens_created ON idempotency_tokens (created_at);
+
+-- Metrics (1-minute aggregation). ±Infinity seeds min / max in DuckDB DOUBLE,
+-- matching PostgreSQL's Infinity / -Infinity seed for min / max.
+CREATE TABLE IF NOT EXISTS metrics (
+    bucket TEXT NOT NULL,
+    metric TEXT NOT NULL,
+    table_name TEXT NOT NULL DEFAULT '',
+    index_name TEXT NOT NULL DEFAULT '',
+    operation TEXT NOT NULL DEFAULT '',
+    sum DOUBLE NOT NULL DEFAULT 0,
+    count BIGINT NOT NULL DEFAULT 0,
+    min DOUBLE NOT NULL DEFAULT 'Infinity'::DOUBLE,
+    max DOUBLE NOT NULL DEFAULT '-Infinity'::DOUBLE,
+    PRIMARY KEY (bucket, metric, table_name, index_name, operation)
+);
+
+CREATE INDEX IF NOT EXISTS idx_metrics_bucket ON metrics (bucket);
+
+-- Login attempt tracking.
+CREATE TABLE IF NOT EXISTS login_attempts (
+    principal     TEXT NOT NULL,
+    attempted_at  TEXT NOT NULL DEFAULT (strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ')),
+    success       BIGINT NOT NULL,
+    source_ip     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_login_attempts_principal_time
+    ON login_attempts (principal, attempted_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_login_attempts_source_ip_time
+    ON login_attempts (source_ip, attempted_at DESC);
+
+-- Backup metadata.
+CREATE TABLE IF NOT EXISTS backups (
+    backup_arn TEXT PRIMARY KEY,
+    backup_name TEXT NOT NULL,
+    table_id TEXT NOT NULL,
+    table_name TEXT NOT NULL,
+    account_id TEXT NOT NULL,
+    backup_status TEXT NOT NULL DEFAULT 'AVAILABLE',
+    backup_type TEXT NOT NULL DEFAULT 'USER',
+    backup_size_bytes BIGINT NOT NULL DEFAULT 0,
+    item_count BIGINT NOT NULL DEFAULT 0,
+    key_schema TEXT NOT NULL,
+    attribute_definitions TEXT NOT NULL,
+    billing_mode TEXT NOT NULL DEFAULT 'PAY_PER_REQUEST',
+    provisioned_throughput TEXT,
+    stream_specification TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_backups_table ON backups (account_id, table_name);
+
+-- Backup items.
+CREATE TABLE IF NOT EXISTS backup_items (
+    backup_arn TEXT NOT NULL,
+    pk TEXT NOT NULL,
+    sk TEXT,
+    item_data TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_backup_items_arn ON backup_items (backup_arn);
+
+-- Continuous backups / PITR status.
+CREATE TABLE IF NOT EXISTS continuous_backups (
+    account_id TEXT NOT NULL,
+    table_name TEXT NOT NULL,
+    pitr_enabled BIGINT NOT NULL DEFAULT 0,
+    earliest_restorable TEXT,
+    latest_restorable TEXT,
+    PRIMARY KEY (account_id, table_name)
+);
+
+-- Persistent queue for async GSI propagation. A row is inserted inside the
+-- base write transaction (zero crash window) and consumed by a background
+-- worker once `ready_at` has passed; survives process crash/restart.
+--
+-- One row per async index: each row is self-describing — `index_context`
+-- carries the base key schema, attribute definitions, and the single target
+-- index definition captured at enqueue, so the worker applies with zero
+-- catalog reads. `worker_partition` is a stable hash of the base table key;
+-- all updates to a given base item share a partition and `ready_at` is kept
+-- monotonically non-decreasing within it, so the worker (which drains in `id`
+-- order) preserves per-key FIFO even with randomized propagation jitter.
+CREATE SEQUENCE IF NOT EXISTS gsi_pending_seq;
+
+CREATE TABLE IF NOT EXISTS gsi_pending (
+    id BIGINT PRIMARY KEY DEFAULT nextval('gsi_pending_seq'),
+    table_id TEXT NOT NULL,
+    worker_partition BIGINT NOT NULL,
+    old_item TEXT,
+    new_item TEXT,
+    index_context TEXT NOT NULL,
+    ready_at TEXT NOT NULL DEFAULT (strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_gsi_pending_claim
+    ON gsi_pending (worker_partition, ready_at, id);
+
+-- Monotonic counters. Replaces PostgreSQL sequences. The stream counter is
+-- seeded to the current epoch in microseconds so sequence numbers are
+-- time-ordered and survive restarts (mirrors the PostgreSQL setval seed).
+CREATE TABLE IF NOT EXISTS seq_counters (
+    name TEXT PRIMARY KEY,
+    value BIGINT NOT NULL DEFAULT 0
+);
+
+INSERT OR IGNORE INTO seq_counters (name, value)
+    VALUES ('stream', CAST(epoch(now()) AS BIGINT) * 1000000);
+
+-- Seed settings (mirror PostgreSQL defaults).
+-- Recorded catalog version. Upserts rather than INSERT OR IGNORE: this schema is
+-- re-applied by `extenddb migrate`, and with IGNORE the recorded version would
+-- never advance, so a migration could add objects and still leave the server
+-- refusing to start on a version mismatch. Must stay in step with
+-- `CATALOG_VERSION` above; they are checked against each other in a test.
+INSERT INTO settings (key, value) VALUES ('catalog_version', '0.0.3')
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value;
+INSERT OR IGNORE INTO settings (key, value) VALUES ('control_plane_delay_seconds', '0.25');
+INSERT OR IGNORE INTO settings (key, value) VALUES ('index_propagation_delay_ms', '10');
+"#;
+
+/// Apply the full catalog schema to a fresh (or existing) database.
+///
+/// Idempotent: every statement uses `IF NOT EXISTS` / `INSERT OR IGNORE`.
+pub async fn apply(pool: &db::Pool) -> OpResult<()> {
+    db::raw_sql(SCHEMA_SQL)
+        .execute(pool)
+        .await
+        .map_err(|e| OpError::Internal(format!("apply catalog schema: {e}")))?;
+    Ok(())
+}
+
+/// Return whether a table with the given name exists in the catalog.
+pub async fn table_exists(pool: &db::Pool, name: &str) -> OpResult<bool> {
+    let exists: bool =
+        db::query_scalar("SELECT EXISTS(SELECT 1 FROM duckdb_tables() WHERE table_name = ?)")
+            .bind(name)
+            .fetch_one(pool)
+            .await
+            .map_err(|e| OpError::Internal(format!("table_exists({name}): {e}")))?;
+    Ok(exists)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CATALOG_VERSION, SCHEMA_SQL};
+
+    /// The schema seeds the recorded catalog version as a SQL literal, and the
+    /// server compares that recorded value against `CATALOG_VERSION` at startup.
+    /// If the two drift, a freshly initialised deployment refuses to serve with a
+    /// version mismatch, which is a confusing failure a long way from its cause.
+    #[test]
+    fn the_seeded_catalog_version_matches_the_compiled_constant() {
+        let expected = format!(
+            "INSERT INTO settings (key, value) VALUES ('catalog_version', '{CATALOG_VERSION}')"
+        );
+        assert!(
+            SCHEMA_SQL.contains(&expected),
+            "schema must seed catalog_version = {CATALOG_VERSION}; \
+             update the literal in SCHEMA_SQL when bumping CATALOG_VERSION"
+        );
+    }
+
+    /// The seed must upsert. With `INSERT OR IGNORE` the recorded version never
+    /// advances, so `extenddb migrate` would add the new objects and still leave
+    /// the server refusing to start.
+    #[test]
+    fn the_catalog_version_seed_upserts_rather_than_ignoring() {
+        assert!(
+            !SCHEMA_SQL
+                .contains("INSERT OR IGNORE INTO settings (key, value) VALUES ('catalog_version'"),
+            "catalog_version must not be seeded with INSERT OR IGNORE"
+        );
+    }
+}

--- a/crates/storage-duckdb/src/sqlite_util.rs
+++ b/crates/storage-duckdb/src/sqlite_util.rs
@@ -1,0 +1,152 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared helpers for the DuckDB backend: connection-URL building, RFC 3339
+//! timestamp conversion, and constraint-violation classification.
+
+use crate::db;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+
+/// Normalize a configured path or connection string into a sqlx-openable
+/// DuckDB URL.
+///
+/// Accepts a value that is already a `duckdb:` URL (returned unchanged), the
+/// in-memory sentinel `:memory:`, or a filesystem path (wrapped as a
+/// read-write-create file URL).
+pub(crate) fn duckdb_path(path_or_url: &str) -> String {
+    if path_or_url.starts_with("duckdb:") {
+        path_or_url.to_owned()
+    } else if path_or_url == ":memory:" {
+        "duckdb::memory:".to_owned()
+    } else {
+        format!("duckdb://{path_or_url}?mode=rwc")
+    }
+}
+
+/// Format a timestamp as RFC 3339 UTC, matching the catalog's stored format.
+pub(crate) fn format_timestamp(ts: OffsetDateTime) -> String {
+    ts.to_offset(time::UtcOffset::UTC)
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| ts.to_string())
+}
+
+/// Parse a catalog timestamp string into an `OffsetDateTime`.
+///
+/// Accepts RFC 3339 (the canonical stored form, e.g. `2026-06-08T12:00:00.123Z`)
+/// and tolerates DuckDB's bare `datetime()` form (`YYYY-MM-DD HH:MM:SS`, assumed
+/// UTC) for robustness against rows written by older tooling.
+pub(crate) fn parse_timestamp(s: &str) -> Result<OffsetDateTime, time::error::Parse> {
+    if let Ok(dt) = OffsetDateTime::parse(s, &Rfc3339) {
+        return Ok(dt);
+    }
+    // Fallback: "YYYY-MM-DD HH:MM:SS" (DuckDB datetime('now')), interpret as UTC.
+    let normalized = format!("{}Z", s.replace(' ', "T"));
+    OffsetDateTime::parse(&normalized, &Rfc3339)
+}
+
+/// True if the error is a DuckDB UNIQUE / PRIMARY KEY constraint violation.
+pub(crate) fn is_unique_violation(e: &db::Error) -> bool {
+    matches!(e, db::Error::Database(db) if {
+        let msg = db.message();
+        msg.contains("UNIQUE constraint failed") || msg.contains("PRIMARY KEY constraint failed")
+    })
+}
+
+/// True if the error is a DuckDB FOREIGN KEY constraint violation.
+pub(crate) fn is_fk_violation(e: &db::Error) -> bool {
+    matches!(e, db::Error::Database(db) if db.message().contains("FOREIGN KEY constraint failed"))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db;
+    use super::*;
+
+    #[test]
+    fn duckdb_path_variants() {
+        assert_eq!(duckdb_path(":memory:"), "duckdb::memory:");
+        assert_eq!(
+            duckdb_path("extenddb.duckdb"),
+            "duckdb://extenddb.duckdb?mode=rwc"
+        );
+        assert_eq!(
+            duckdb_path("duckdb://already.db?mode=rwc"),
+            "duckdb://already.db?mode=rwc"
+        );
+    }
+
+    #[test]
+    fn timestamp_round_trips_rfc3339() {
+        let now = OffsetDateTime::now_utc();
+        let s = format_timestamp(now);
+        let parsed = parse_timestamp(&s).expect("parse RFC3339");
+        // Equal to at least second precision.
+        assert_eq!(parsed.unix_timestamp(), now.unix_timestamp());
+    }
+
+    #[test]
+    fn timestamp_parses_bare_datetime() {
+        let parsed = parse_timestamp("2026-06-08 12:00:00").expect("parse bare datetime");
+        assert_eq!(parsed.year(), 2026);
+        assert_eq!(parsed.offset(), time::UtcOffset::UTC);
+    }
+}
+
+/// Map a sqlx error to a `StorageError`, classifying transient failures.
+///
+/// Transient means retry is expected to succeed: connection/pool trouble, I/O
+/// errors, and DuckDB's BUSY (5) / LOCKED (6) result codes, including their
+/// extended forms (`code & 0xff`). Everything else is `Internal`, which the
+/// queue worker treats as poison. The classification errs narrow on purpose: a
+/// mis-classified poison row retries forever (visible, bounded to one row),
+/// while a mis-classified transient error drops a row silently.
+pub(crate) fn map_db_err(e: db::Error) -> extenddb_storage::error::StorageError {
+    use extenddb_storage::error::StorageError;
+    let transient = match &e {
+        db::Error::Io(_) | db::Error::PoolTimedOut | db::Error::WorkerCrashed => true,
+        db::Error::Database(db) => db
+            .code()
+            .and_then(|c| c.parse::<i64>().ok())
+            .is_some_and(|code| matches!(code & 0xff, 5 | 6)),
+        _ => false,
+    };
+    if transient {
+        StorageError::Transient(e.to_string())
+    } else {
+        StorageError::Internal(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod map_db_err_tests {
+    use crate::db;
+    use super::map_db_err;
+    use extenddb_storage::error::StorageError;
+
+    #[test]
+    fn io_errors_are_transient() {
+        let e = db::Error::Io(std::io::Error::other("disk hiccup"));
+        assert!(matches!(map_db_err(e), StorageError::Transient(_)));
+    }
+
+    #[test]
+    fn pool_timeout_is_transient() {
+        assert!(matches!(
+            map_db_err(db::Error::PoolTimedOut),
+            StorageError::Transient(_)
+        ));
+    }
+
+    /// Anything not positively identified as retryable stays Internal, which
+    /// the worker treats as poison. Narrow on purpose: a mis-classified poison
+    /// row retries forever (visible), a mis-classified transient error drops a
+    /// row silently.
+    #[test]
+    fn unknown_errors_stay_internal() {
+        assert!(matches!(
+            map_db_err(db::Error::RowNotFound),
+            StorageError::Internal(_)
+        ));
+    }
+}

--- a/crates/storage-duckdb/src/store.rs
+++ b/crates/storage-duckdb/src/store.rs
@@ -1,0 +1,365 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Central DuckDB storage engine: connection pool, write serialization, and
+//! construction.
+//!
+//! # Concurrency model (design decision D1)
+//!
+//! WAL mode allows many concurrent readers alongside a single writer. DuckDB
+//! offers no `SERIALIZABLE` isolation knob, so to make condition-check-then-
+//! write atomic and free of write-skew the engine serializes all writers
+//! through `write_lock` and opens every write transaction with `BEGIN
+//! IMMEDIATE` via `pool.begin()`, so the condition read
+//! and its write hold DuckDB's reserved write lock up front. This is
+//! multi-pool-safe: the catalog/credential store opens a second pool over the
+//! same file, and `BEGIN IMMEDIATE` + `busy_timeout` prevent
+//! `SQLITE_BUSY_SNAPSHOT` (a deferred read-then-write whose snapshot is
+//! invalidated by another pool committing) rather than surfacing it as a 500.
+//! Reads run concurrently from the pool against WAL snapshots and take no lock.
+
+use crate::db;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+
+use extenddb_storage::error::StorageError;
+
+use tokio::sync::Mutex;
+
+use crate::INDEX_PROPAGATION_DELAY_QUERY;
+use crate::duckdb_util::duckdb_path;
+use crate::schema::CATALOG_VERSION;
+
+/// The DuckDB storage engine. Implements `StorageEngine` (all data/metadata/
+/// stream/worker/backup traits) over a single DuckDB database.
+#[derive(Clone)]
+pub struct DuckDbEngine {
+    pub(crate) pool: db::Pool,
+    pub(crate) region: String,
+    pub(crate) max_item_size_bytes: usize,
+    /// Wakes the control-plane poller when a table enters CREATING / DELETING.
+    pub(crate) control_plane_notify: Arc<tokio::sync::Notify>,
+    /// Cached default GSI propagation delay (ms); refreshed by a worker and
+    /// read on the write path to decide sync-vs-async index maintenance.
+    pub(crate) index_propagation_delay_cache: Arc<AtomicU64>,
+    /// Wakes the GSI propagation worker when a write enqueues into `gsi_pending`.
+    pub(crate) gsi_notify: Arc<tokio::sync::Notify>,
+    /// Serializes all writers (design decision D1). Held for the duration of
+    /// every write transaction so condition checks and writes are atomic and
+    /// `SQLITE_BUSY` cannot arise from competing writers.
+    pub(crate) write_lock: Arc<Mutex<()>>,
+    /// Index ids whose asynchronous backfill task is currently alive in THIS
+    /// process. What tells a stuck `CREATING` index apart from one still
+    /// building: a catalog row can say `CREATING` forever, but only a live task
+    /// appears here, and the entry is removed by a drop guard so a panicking
+    /// task deregisters too. The GSI worker recovers any `CREATING` index with
+    /// no entry, because nothing else ever will until a restart, and until then
+    /// the per-table queue hold blocks every write's index maintenance.
+    pub(crate) vector_builds_running: Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
+}
+
+impl DuckDbEngine {
+    /// Open (creating if necessary) the DuckDB database and build the engine.
+    ///
+    /// `path_or_url` accepts a filesystem path, `:memory:`, or a `duckdb:` URL.
+    pub async fn new(
+        path_or_url: &str,
+        pool_size: u32,
+        region: &str,
+        max_item_size_bytes: usize,
+    ) -> Result<Self, StorageError> {
+        let path = duckdb_path(path_or_url);
+        // Every connection in the pool is a clone of one root connection, so
+        // they share a single database instance. Unlike SQLite, an in-memory
+        // DuckDB database is shared by all connections cloned from it, so the
+        // ephemeral mode keeps a real pool rather than a single pinned handle.
+        let in_memory = crate::db::is_memory_path(&path);
+        let pool = crate::db::Pool::open(&path, pool_size.max(1))
+            .await
+            .map_err(|e| StorageError::Connection(e.to_string()))?;
+
+        // The database file stores the AES encryption key alongside the data it
+        // protects (encrypted access-key secrets, password hashes). Restrict the
+        // file and its WAL sidecar to owner read/write so other local users or
+        // processes cannot read it and decrypt secrets. In-memory databases
+        // have no file to protect.
+        #[cfg(unix)]
+        if !in_memory {
+            use std::os::unix::fs::PermissionsExt;
+            for suffix in ["", ".wal"] {
+                let f = format!("{path}{suffix}");
+                if std::path::Path::new(&f).exists() {
+                    let _ = std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o600));
+                }
+            }
+        }
+
+        let initial_index_delay: u64 = db::query_as::<(String,)>(INDEX_PROPAGATION_DELAY_QUERY)
+            .fetch_optional(&pool)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|(v,)| v.parse::<u64>().ok())
+            .unwrap_or(10);
+
+        Ok(Self {
+            pool,
+            region: region.to_owned(),
+            max_item_size_bytes,
+            control_plane_notify: Arc::new(tokio::sync::Notify::new()),
+            index_propagation_delay_cache: Arc::new(AtomicU64::new(initial_index_delay)),
+            gsi_notify: Arc::new(tokio::sync::Notify::new()),
+            write_lock: Arc::new(Mutex::new(())),
+            vector_builds_running: Arc::new(
+                std::sync::Mutex::new(std::collections::HashSet::new()),
+            ),
+        })
+    }
+
+    /// Handle to the control-plane notifier, for the background poller.
+    pub(crate) fn control_plane_notify(&self) -> Arc<tokio::sync::Notify> {
+        Arc::clone(&self.control_plane_notify)
+    }
+
+    /// Bootstrap an ephemeral catalog on the engine's own (shared) connection,
+    /// at serve time. Used for in-memory databases, whose state does not
+    /// survive the `init` process, so schema, encryption key, default account,
+    /// and admin user must be created when the server starts. Idempotent.
+    ///
+    /// Returns `Some(password)` when a new admin user was created with a
+    /// generated password (so the caller can surface it once), or `None` when
+    /// the admin already existed or the password came from the environment.
+    pub(crate) async fn bootstrap_ephemeral(
+        &self,
+        admin_user: Option<&str>,
+        admin_password: Option<&str>,
+    ) -> Result<Option<String>, StorageError> {
+        use extenddb_storage::bootstrapper::helpers;
+
+        let internal = |e: String| StorageError::Internal(e);
+
+        // Schema (creates settings, accounts, admin_users, … and seeds
+        // catalog_version + index_propagation_delay_ms).
+        crate::schema::apply(&self.pool)
+            .await
+            .map_err(|e| internal(format!("apply schema: {e:?}")))?;
+
+        // Encryption key.
+        let key_exists: bool =
+            db::query_scalar("SELECT EXISTS(SELECT 1 FROM settings WHERE key = 'encryption_key')")
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|e| internal(format!("check encryption key: {e}")))?;
+        if !key_exists {
+            let key = helpers::generate_encryption_key();
+            db::query("INSERT OR IGNORE INTO settings (key, value) VALUES ('encryption_key', ?)")
+                .bind(&key)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| internal(format!("store encryption key: {e}")))?;
+        }
+
+        // Default account + canonical marker. Record the default account id in
+        // settings (idempotent, backfill-safe) so callers resolve it explicitly
+        // rather than inferring it from account-list ordering.
+        let account_id: String = match db::query_scalar(
+            "SELECT account_id FROM accounts ORDER BY account_id LIMIT 1",
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| internal(format!("check accounts: {e}")))?
+        {
+            Some(id) => id,
+            None => {
+                let id = helpers::generate_account_id();
+                db::query(
+                    "INSERT OR IGNORE INTO accounts (account_id, account_name) VALUES (?, 'default')",
+                )
+                .bind(&id)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| internal(format!("create default account: {e}")))?;
+                id
+            }
+        };
+        db::query("INSERT OR IGNORE INTO settings (key, value) VALUES ('default_account_id', ?)")
+            .bind(&account_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| internal(format!("record default account id: {e}")))?;
+
+        // Admin user.
+        let username = admin_user
+            .filter(|s| !s.is_empty())
+            .unwrap_or("admin")
+            .to_owned();
+        let admin_exists: bool =
+            db::query_scalar("SELECT EXISTS(SELECT 1 FROM admin_users WHERE admin_name = ?)")
+                .bind(&username)
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|e| internal(format!("check admin user: {e}")))?;
+        if admin_exists {
+            return Ok(None);
+        }
+        let (password, from_env) = match admin_password.filter(|s| !s.is_empty()) {
+            Some(p) => (p.to_owned(), true),
+            None => (helpers::generate_random_password(), false),
+        };
+        let password_hash = helpers::hash_password_async(password.clone())
+            .await
+            .map_err(|e| internal(format!("hash admin password: {e:?}")))?;
+        db::query("INSERT INTO admin_users (admin_name, password_hash) VALUES (?, ?)")
+            .bind(&username)
+            .bind(&password_hash)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| internal(format!("create admin user: {e}")))?;
+
+        Ok(if from_env { None } else { Some(password) })
+    }
+
+    /// Current secondary-index propagation delay (ms); `0` means synchronous.
+    ///
+    /// Reads the `index_propagation_delay_ms` setting live from the catalog so
+    /// out-of-process changes (`extenddb settings set`) take effect on the
+    /// next write, not up to 30 s later when the poll worker refreshes the
+    /// cache. `DuckDB` is a local file, so this is an indexed point lookup with
+    /// negligible cost next to the write it precedes. On a read error the
+    /// cached value (still refreshed by the poll worker) is the fallback; on
+    /// success the cache is re-warmed so fallback reads stay fresh.
+    pub(crate) async fn index_propagation_delay(&self) -> u64 {
+        use std::sync::atomic::Ordering;
+        let live: Result<Option<(String,)>, _> = db::query_as(INDEX_PROPAGATION_DELAY_QUERY)
+            .fetch_optional(&self.pool)
+            .await;
+        match live {
+            Ok(row) => {
+                // Missing row means the default, matching poll_gsi_delay.
+                let ms = row
+                    .and_then(|(v,)| v.parse::<u64>().ok())
+                    .unwrap_or(crate::DEFAULT_INDEX_PROPAGATION_DELAY_MS);
+                self.index_propagation_delay_cache
+                    .store(ms, Ordering::Relaxed);
+                ms
+            }
+            Err(e) => {
+                tracing::debug!("index_propagation_delay: live read failed, using cache: {e:?}");
+                self.index_propagation_delay_cache.load(Ordering::Relaxed)
+            }
+        }
+    }
+
+    /// Milliseconds to pause between batches of a vector index backfill.
+    ///
+    /// Read live for the same reason the propagation delay is: a test sets it with
+    /// `settings set` and needs it to apply to the next backfill, not up to 30 s
+    /// later. Zero when unset or unparseable, which is the production value, so a
+    /// malformed setting cannot slow a real backfill down.
+    pub(crate) async fn vector_backfill_batch_delay(&self) -> u64 {
+        let live: Result<Option<(String,)>, _> =
+            db::query_as("SELECT value FROM settings WHERE key = ?")
+                .bind(extenddb_core::settings_keys::VECTOR_BACKFILL_BATCH_DELAY_MS)
+                .fetch_optional(&self.pool)
+                .await;
+        match live {
+            Ok(row) => row.and_then(|(v,)| v.parse::<u64>().ok()).unwrap_or(0),
+            Err(e) => {
+                tracing::debug!("vector_backfill_batch_delay: live read failed, using 0: {e:?}");
+                0
+            }
+        }
+    }
+
+    /// Minimum milliseconds an UpdateTable-created vector index stays `CREATING`
+    /// before its `ACTIVE` flip. See
+    /// [`extenddb_core::settings_keys::VECTOR_INDEX_MIN_CREATING_MS`] for why the
+    /// hold exists. Defaults to 1000 when unset or unparseable; zero disables it.
+    pub(crate) async fn vector_index_min_creating_ms(&self) -> u64 {
+        const DEFAULT_MS: u64 = 1_000;
+        let live: Result<Option<(String,)>, _> =
+            db::query_as("SELECT value FROM settings WHERE key = ?")
+                .bind(extenddb_core::settings_keys::VECTOR_INDEX_MIN_CREATING_MS)
+                .fetch_optional(&self.pool)
+                .await;
+        match live {
+            Ok(row) => row
+                .and_then(|(v,)| v.parse::<u64>().ok())
+                .unwrap_or(DEFAULT_MS),
+            Err(e) => {
+                tracing::debug!(
+                    "vector_index_min_creating_ms: live read failed, using {DEFAULT_MS}: {e:?}"
+                );
+                DEFAULT_MS
+            }
+        }
+    }
+
+    /// Handle to the GSI propagation notifier, woken after an enqueue.
+    pub(crate) fn gsi_notify(&self) -> Arc<tokio::sync::Notify> {
+        Arc::clone(&self.gsi_notify)
+    }
+
+    /// Defense-in-depth: reject `account_id` values unsafe for interpolation
+    /// into quoted SQL identifiers (`_ddb_*` data-table names embed `table_id`,
+    /// but `account_id` flows through the catalog and must stay clean).
+    /// See `docs/adr/0002-sql-injection-defense.md` in the extenddb repo.
+    pub(crate) fn validate_account_id(account_id: &str) -> Result<(), StorageError> {
+        if account_id.contains('"') || account_id.contains('\0') || !account_id.is_ascii() {
+            return Err(StorageError::Internal(
+                "account_id contains invalid characters for use in SQL identifiers".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Validate the on-disk catalog version matches the compiled expectation.
+    ///
+    /// # Errors
+    /// - [`StorageError::CatalogNotInitialized`] if the catalog is absent.
+    /// - [`StorageError::CatalogVersionMismatch`] if versions differ.
+    /// - [`StorageError::Internal`] if the stored version is malformed.
+    pub async fn check_catalog_version(&self) -> Result<(), StorageError> {
+        let exists: bool = db::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM duckdb_tables() WHERE table_name = 'settings')",
+        )
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| StorageError::Connection(e.to_string()))?;
+
+        if !exists {
+            return Err(StorageError::CatalogNotInitialized);
+        }
+
+        let found_str =
+            db::query_as::<(String,)>("SELECT value FROM settings WHERE key = 'catalog_version'")
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| StorageError::Connection(e.to_string()))?
+                .ok_or(StorageError::CatalogNotInitialized)?
+                .0;
+
+        let found = found_str
+            .parse::<extenddb_core::version::CatalogVersion>()
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        if found != CATALOG_VERSION {
+            return Err(StorageError::CatalogVersionMismatch {
+                expected: CATALOG_VERSION.to_string(),
+                found: found_str,
+            });
+        }
+        Ok(())
+    }
+
+    /// Read the configured data database name (the file path) for the startup
+    /// banner. Returns `"(not configured)"` when unset.
+    pub async fn data_database_info(&self) -> String {
+        db::query_as::<(String,)>("SELECT value FROM settings WHERE key = 'data_database_name'")
+            .fetch_optional(&self.pool)
+            .await
+            .ok()
+            .flatten()
+            .map_or_else(|| "(not configured)".to_owned(), |(v,)| v)
+    }
+}

--- a/crates/storage-duckdb/src/stream.rs
+++ b/crates/storage-duckdb/src/stream.rs
@@ -1,0 +1,497 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `StreamEngine` trait implementation for `DuckDbEngine`.
+//!
+//! Shards, records, and the sequence counter all live in the one DuckDB file,
+//! so `init_stream_shards` runs in the caller's catalog transaction.
+//! Monotonic sequence numbers come from the `seq_counters` table (there is no
+//! PostgreSQL sequence). Retention cleanup compares an RFC 3339 cutoff computed
+//! in Rust.
+
+use crate::db;
+use extenddb_core::types::{
+    DescribeStreamInput, SequenceNumberRange, Shard, StreamDescription, StreamRecord, StreamStatus,
+    StreamSummary, StreamViewType,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::{parse_stream_arn, stream_arn};
+use extenddb_storage::{StreamEngine, StreamListResult, StreamRecordsResult};
+use futures::future::BoxFuture;
+
+use crate::duckdb_util::format_timestamp;
+use crate::store::DuckDbEngine;
+
+/// Fixed shards per stream (hash-based partition-key assignment).
+const SHARDS_PER_STREAM: u32 = 4;
+
+impl DuckDbEngine {
+    /// Initialize stream shards and set `stream_label`, within the caller's
+    /// transaction. Returns the assigned stream label.
+    pub(crate) async fn init_stream_shards(
+        tx: &mut db::Transaction,
+        account_id: &str,
+        table_name: &str,
+        table_id: &str,
+    ) -> Result<String, StorageError> {
+        let label: String = db::query_scalar(
+            "UPDATE tables SET stream_label = strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S') \
+             WHERE account_id = ? AND table_name = ? RETURNING stream_label",
+        )
+        .bind(account_id)
+        .bind(table_name)
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        for i in 0..SHARDS_PER_STREAM {
+            // Zero-padded to 16 digits so the shard ID is always at
+            // least 28 characters (minimum length the AWS SDKs enforce for ShardId)
+            // even for the shortest legal table name.
+            let shard_id = format!("shardId-{table_name}-{i:016}");
+            let start_seq = format!("{:021}", 0);
+            db::query(
+                "INSERT INTO stream_shards (shard_id, table_id, starting_sequence_number) \
+                 VALUES (?, ?, ?)",
+            )
+            .bind(&shard_id)
+            .bind(table_id)
+            .bind(&start_seq)
+            .execute(&mut **tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        }
+        Ok(label)
+    }
+}
+
+impl StreamEngine for DuckDbEngine {
+    fn write_stream_record(
+        &self,
+        account_id: &str,
+        record: &StreamRecord,
+        shard_id: &str,
+        table_name: &str,
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let account_id = account_id.to_owned();
+        let record = record.clone();
+        let shard_id = shard_id.to_owned();
+        let table_name = table_name.to_owned();
+        Box::pin(async move {
+            let record_json = serde_json::to_string(&record)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let table_id: String = db::query_scalar(
+                "SELECT table_id FROM tables WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let _writer = self.write_lock.lock().await;
+            db::query(
+                "INSERT INTO stream_records (sequence_number, shard_id, table_id, event_name, record_data) \
+                 VALUES (?, ?, ?, ?, ?)",
+            )
+            .bind(&record.dynamodb.sequence_number)
+            .bind(&shard_id)
+            .bind(&table_id)
+            .bind(format!("{:?}", record.event_name))
+            .bind(&record_json)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(())
+        })
+    }
+
+    fn get_stream_records(
+        &self,
+        account_id: &str,
+        shard_id: &str,
+        after_sequence: Option<&str>,
+        limit: i64,
+    ) -> BoxFuture<'_, StreamRecordsResult> {
+        let account_id = account_id.to_owned();
+        let shard_id = shard_id.to_owned();
+        let after = after_sequence.map(str::to_owned);
+        Box::pin(async move {
+            // Ownership guard: only return records if the shard's backing table
+            // belongs to the calling account. DuckDB keeps shards and the table
+            // catalog in the same database, so ownership resolves in one join.
+            // A shard iterator resolves to a shard the caller does not own or
+            // one that does not exist. Real DynamoDB returns
+            // `ValidationException: Invalid ShardIterator` for a GetRecords
+            // iterator it did not issue, and does NOT distinguish "exists but
+            // not yours" from "does not exist" — so neither do we (both
+            // collapse here). Verified against DynamoDB Streams (us-east-1).
+            let owned: Option<(i32,)> = db::query_as(
+                "SELECT 1 FROM stream_shards s \
+                 JOIN tables t ON t.table_id = s.table_id \
+                 WHERE s.shard_id = ? AND t.account_id = ?",
+            )
+            .bind(&shard_id)
+            .bind(&account_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if owned.is_none() {
+                return Err(StorageError::Validation("Invalid ShardIterator".to_owned()));
+            }
+
+            let rows: Vec<(String,)> = if let Some(after) = after {
+                db::query_as(
+                    "SELECT record_data FROM stream_records \
+                     WHERE shard_id = ? AND sequence_number > ? ORDER BY sequence_number LIMIT ?",
+                )
+                .bind(&shard_id)
+                .bind(&after)
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await
+            } else {
+                db::query_as(
+                    "SELECT record_data FROM stream_records \
+                     WHERE shard_id = ? ORDER BY sequence_number LIMIT ?",
+                )
+                .bind(&shard_id)
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await
+            }
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let records: Vec<StreamRecord> = rows
+                .into_iter()
+                .map(|(d,)| {
+                    serde_json::from_str(&d).map_err(|e| StorageError::Internal(e.to_string()))
+                })
+                .collect::<Result<_, _>>()?;
+            let last = records.last().map(|r| r.dynamodb.sequence_number.clone());
+            Ok((records, last))
+        })
+    }
+
+    fn describe_stream(
+        &self,
+        account_id: &str,
+        input: &DescribeStreamInput,
+    ) -> BoxFuture<'_, Result<StreamDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        let stream_arn = input.stream_arn.clone();
+        let limit = input.limit.unwrap_or(100);
+        let start = input.exclusive_start_shard_id.clone();
+        Box::pin(async move {
+            let (table_name, stream_label) = parse_stream_arn(&stream_arn)?;
+            let row: Option<(String, Option<String>, String, String)> = db::query_as(
+                "SELECT key_schema, stream_specification, table_status, table_id \
+                 FROM tables WHERE account_id = ? AND table_name = ? AND stream_label = ?",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .bind(&stream_label)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let (ks_json, stream_spec_json, table_status, table_id) = row.ok_or_else(|| {
+                StorageError::TableNotFound(format!(
+                    "Requested resource not found: Stream: {stream_arn} not found."
+                ))
+            })?;
+
+            let key_schema = serde_json::from_str(&ks_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let stream_view_type = stream_spec_json
+                .as_deref()
+                .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+                .and_then(|v| {
+                    v.get("StreamViewType")
+                        .and_then(|sv| serde_json::from_value::<StreamViewType>(sv.clone()).ok())
+                })
+                .unwrap_or(StreamViewType::KeysOnly);
+
+            let shard_rows: Vec<(String, Option<String>, String, Option<String>)> =
+                if let Some(ref s) = start {
+                    db::query_as(
+                        "SELECT shard_id, parent_shard_id, starting_sequence_number, ending_sequence_number \
+                         FROM stream_shards WHERE table_id = ? AND shard_id > ? \
+                         ORDER BY shard_id LIMIT ?",
+                    )
+                    .bind(&table_id)
+                    .bind(s)
+                    .bind(limit + 1)
+                    .fetch_all(&self.pool)
+                    .await
+                } else {
+                    db::query_as(
+                        "SELECT shard_id, parent_shard_id, starting_sequence_number, ending_sequence_number \
+                         FROM stream_shards WHERE table_id = ? ORDER BY shard_id LIMIT ?",
+                    )
+                    .bind(&table_id)
+                    .bind(limit + 1)
+                    .fetch_all(&self.pool)
+                    .await
+                }
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            #[allow(clippy::cast_sign_loss)]
+            let limit_usize = limit.max(0) as usize;
+            let last_shard =
+                (shard_rows.len() > limit_usize).then(|| shard_rows[limit_usize - 1].0.clone());
+            let shards: Vec<Shard> = shard_rows
+                .into_iter()
+                .take(limit_usize)
+                .map(|(id, parent, start, end)| Shard {
+                    shard_id: id,
+                    parent_shard_id: parent,
+                    sequence_number_range: SequenceNumberRange {
+                        starting_sequence_number: start,
+                        ending_sequence_number: end,
+                    },
+                })
+                .collect();
+
+            let stream_status = if table_status == "DELETING" {
+                StreamStatus::Disabling
+            } else {
+                StreamStatus::Enabled
+            };
+
+            Ok(StreamDescription {
+                stream_arn,
+                stream_label,
+                stream_status,
+                stream_view_type,
+                table_name,
+                key_schema,
+                shards,
+                last_evaluated_shard_id: last_shard,
+            })
+        })
+    }
+
+    fn list_streams(
+        &self,
+        account_id: &str,
+        table_name: Option<&str>,
+        limit: i64,
+        exclusive_start_stream_arn: Option<&str>,
+    ) -> BoxFuture<'_, StreamListResult> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.map(str::to_owned);
+        let start_arn = exclusive_start_stream_arn.map(str::to_owned);
+        Box::pin(async move {
+            let rows: Vec<(String, String)> = match (table_name.as_deref(), start_arn.as_deref()) {
+                (Some(tn), Some(arn)) => {
+                    let (_, start_label) = parse_stream_arn(arn)?;
+                    db::query_as(
+                        "SELECT table_name, stream_label FROM tables \
+                         WHERE account_id = ? AND stream_label IS NOT NULL AND table_name = ? \
+                           AND stream_label > ? ORDER BY stream_label LIMIT ?",
+                    )
+                    .bind(&account_id)
+                    .bind(tn)
+                    .bind(&start_label)
+                    .bind(limit + 1)
+                    .fetch_all(&self.pool)
+                    .await
+                }
+                (Some(tn), None) => {
+                    db::query_as(
+                        "SELECT table_name, stream_label FROM tables \
+                     WHERE account_id = ? AND stream_label IS NOT NULL AND table_name = ? \
+                     ORDER BY stream_label LIMIT ?",
+                    )
+                    .bind(&account_id)
+                    .bind(tn)
+                    .bind(limit + 1)
+                    .fetch_all(&self.pool)
+                    .await
+                }
+                (None, Some(arn)) => {
+                    let (start_table, start_label) = parse_stream_arn(arn)?;
+                    db::query_as(
+                        "SELECT table_name, stream_label FROM tables \
+                         WHERE account_id = ? AND stream_label IS NOT NULL \
+                           AND (table_name, stream_label) > (?, ?) \
+                         ORDER BY table_name, stream_label LIMIT ?",
+                    )
+                    .bind(&account_id)
+                    .bind(&start_table)
+                    .bind(&start_label)
+                    .bind(limit + 1)
+                    .fetch_all(&self.pool)
+                    .await
+                }
+                (None, None) => {
+                    db::query_as(
+                        "SELECT table_name, stream_label FROM tables \
+                     WHERE account_id = ? AND stream_label IS NOT NULL \
+                     ORDER BY table_name, stream_label LIMIT ?",
+                    )
+                    .bind(&account_id)
+                    .bind(limit + 1)
+                    .fetch_all(&self.pool)
+                    .await
+                }
+            }
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            #[allow(clippy::cast_sign_loss)]
+            let limit_usize = limit.max(0) as usize;
+            let summaries: Vec<StreamSummary> = rows
+                .iter()
+                .take(limit_usize)
+                .map(|(tn, label)| StreamSummary {
+                    stream_arn: stream_arn(&self.region, &account_id, tn, label),
+                    stream_label: label.clone(),
+                    table_name: tn.clone(),
+                })
+                .collect();
+            let last = (rows.len() > limit_usize)
+                .then(|| summaries.last().map(|s| s.stream_arn.clone()))
+                .flatten();
+            Ok((summaries, last))
+        })
+    }
+
+    fn cleanup_expired_stream_records(
+        &self,
+        retention_hours: i64,
+    ) -> BoxFuture<'_, Result<u64, StorageError>> {
+        Box::pin(async move {
+            let cutoff = format_timestamp(
+                time::OffsetDateTime::now_utc() - time::Duration::hours(retention_hours),
+            );
+            let result = db::query("DELETE FROM stream_records WHERE created_at < ?")
+                .bind(&cutoff)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(result.rows_affected())
+        })
+    }
+
+    fn assign_shard(
+        &self,
+        account_id: &str,
+        table_name: &str,
+        partition_key: &str,
+    ) -> BoxFuture<'_, Result<String, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        let partition_key = partition_key.to_owned();
+        Box::pin(async move {
+            let table_id: String = db::query_scalar(
+                "SELECT table_id FROM tables WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let shards: Vec<(String,)> = db::query_as(
+                "SELECT shard_id FROM stream_shards WHERE table_id = ? ORDER BY shard_id",
+            )
+            .bind(&table_id)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if shards.is_empty() {
+                return Err(StorageError::Internal(format!(
+                    "No stream shards for table {table_name}"
+                )));
+            }
+            let idx = (crc32fast::hash(partition_key.as_bytes()) as usize) % shards.len();
+            Ok(shards[idx].0.clone())
+        })
+    }
+
+    fn next_sequence_number(&self, _shard_id: &str) -> BoxFuture<'_, Result<String, StorageError>> {
+        Box::pin(async move {
+            let _writer = self.write_lock.lock().await;
+            let mut tx = self
+                .pool
+                .begin()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            db::query("UPDATE seq_counters SET value = value + 1 WHERE name = 'stream'")
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let value: i64 =
+                db::query_scalar("SELECT value FROM seq_counters WHERE name = 'stream'")
+                    .fetch_one(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            tx.commit()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(format!("{value:021}"))
+        })
+    }
+
+    fn validate_shard(
+        &self,
+        account_id: &str,
+        stream_arn: &str,
+        shard_id: &str,
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let account_id = account_id.to_owned();
+        let stream_arn = stream_arn.to_owned();
+        let shard_id = shard_id.to_owned();
+        Box::pin(async move {
+            let (table_name, stream_label) = parse_stream_arn(&stream_arn)?;
+            let table_id: Option<String> = db::query_scalar(
+                "SELECT table_id FROM tables \
+                 WHERE account_id = ? AND table_name = ? AND stream_label = ?",
+            )
+            .bind(&account_id)
+            .bind(&table_name)
+            .bind(&stream_label)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let Some(table_id) = table_id else {
+                return Err(StorageError::TableNotFound(format!(
+                    "Requested resource not found: Stream: {stream_arn} not found."
+                )));
+            };
+            let exists: Option<(i64,)> =
+                db::query_as("SELECT 1 FROM stream_shards WHERE shard_id = ? AND table_id = ?")
+                    .bind(&shard_id)
+                    .bind(&table_id)
+                    .fetch_optional(&self.pool)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if exists.is_none() {
+                return Err(StorageError::TableNotFound(format!(
+                    "Requested resource not found: Stream: {stream_arn} not found."
+                )));
+            }
+            Ok(())
+        })
+    }
+
+    fn latest_sequence_number(
+        &self,
+        shard_id: &str,
+    ) -> BoxFuture<'_, Result<Option<String>, StorageError>> {
+        let shard_id = shard_id.to_owned();
+        Box::pin(async move {
+            let row: Option<(String,)> = db::query_as(
+                "SELECT sequence_number FROM stream_records \
+                 WHERE shard_id = ? ORDER BY sequence_number DESC LIMIT 1",
+            )
+            .bind(&shard_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Ok(row.map(|(s,)| s))
+        })
+    }
+}

--- a/crates/storage-duckdb/src/table_engine.rs
+++ b/crates/storage-duckdb/src/table_engine.rs
@@ -1,0 +1,144 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `TableEngine` trait implementation for `DuckDbEngine`.
+
+use crate::db;
+use extenddb_core::types::{
+    CreateTableInput, DeleteTableInput, DescribeTableInput, IndexInfo, ListTablesInput,
+    ListTablesOutput, TableDescription, TableKeyInfo, UpdateTableInput,
+};
+use extenddb_storage::TableEngine;
+use extenddb_storage::error::StorageError;
+use futures::future::BoxFuture;
+
+use crate::store::DuckDbEngine;
+
+impl TableEngine for DuckDbEngine {
+    fn create_table(
+        &self,
+        account_id: &str,
+        input: CreateTableInput,
+    ) -> BoxFuture<'_, Result<TableDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.create_table_impl(&account_id, input).await })
+    }
+
+    fn delete_table(
+        &self,
+        account_id: &str,
+        input: DeleteTableInput,
+    ) -> BoxFuture<'_, Result<TableDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.delete_table_impl(&account_id, input).await })
+    }
+
+    fn describe_table(
+        &self,
+        account_id: &str,
+        input: DescribeTableInput,
+    ) -> BoxFuture<'_, Result<TableDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move {
+            self.build_table_description(&account_id, &input.table_name)
+                .await
+        })
+    }
+
+    fn list_tables(
+        &self,
+        account_id: &str,
+        input: ListTablesInput,
+    ) -> BoxFuture<'_, Result<ListTablesOutput, StorageError>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move {
+            let limit = i64::from(input.limit.unwrap_or(100));
+            // DuckDB's default BINARY collation matches DynamoDB's UTF-8 byte
+            // order, so no COLLATE clause is needed. Fetch one extra to detect
+            // a continuation.
+            let rows: Vec<(String,)> = if let Some(start) = &input.exclusive_start_table_name {
+                db::query_as(
+                    "SELECT table_name FROM tables WHERE account_id = ? AND table_name > ? \
+                     ORDER BY table_name LIMIT ?",
+                )
+                .bind(&account_id)
+                .bind(start)
+                .bind(limit + 1)
+                .fetch_all(&self.pool)
+                .await
+            } else {
+                db::query_as(
+                    "SELECT table_name FROM tables WHERE account_id = ? \
+                     ORDER BY table_name LIMIT ?",
+                )
+                .bind(&account_id)
+                .bind(limit + 1)
+                .fetch_all(&self.pool)
+                .await
+            }
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let names: Vec<String> = rows.into_iter().map(|(n,)| n).collect();
+            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+            let limit_usize = limit.max(0) as usize;
+            if names.len() > limit_usize {
+                Ok(ListTablesOutput {
+                    last_evaluated_table_name: Some(names[limit_usize - 1].clone()),
+                    table_names: names[..limit_usize].to_vec(),
+                })
+            } else {
+                Ok(ListTablesOutput {
+                    table_names: names,
+                    last_evaluated_table_name: None,
+                })
+            }
+        })
+    }
+
+    fn update_table(
+        &self,
+        account_id: &str,
+        input: UpdateTableInput,
+    ) -> BoxFuture<'_, Result<TableDescription, StorageError>> {
+        let account_id = account_id.to_owned();
+        Box::pin(async move { self.update_table_impl(&account_id, input).await })
+    }
+
+    fn table_key_info(
+        &self,
+        account_id: &str,
+        table_name: &str,
+    ) -> BoxFuture<'_, Result<TableKeyInfo, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        Box::pin(async move { self.fetch_table_key_info(&account_id, &table_name).await })
+    }
+
+    fn index_info(
+        &self,
+        account_id: &str,
+        table_name: &str,
+        index_name: &str,
+    ) -> BoxFuture<'_, Result<IndexInfo, StorageError>> {
+        let account_id = account_id.to_owned();
+        let table_name = table_name.to_owned();
+        let index_name = index_name.to_owned();
+        Box::pin(async move {
+            self.fetch_index_info(&account_id, &table_name, &index_name)
+                .await
+        })
+    }
+
+    fn index_info_by_table_id(
+        &self,
+        table_id: &str,
+        index_name: &str,
+    ) -> BoxFuture<'_, Result<IndexInfo, StorageError>> {
+        let table_id = table_id.to_owned();
+        let index_name = index_name.to_owned();
+        Box::pin(async move {
+            self.fetch_index_info_by_table_id(&table_id, &index_name)
+                .await
+        })
+    }
+}

--- a/crates/storage-duckdb/src/table_helpers.rs
+++ b/crates/storage-duckdb/src/table_helpers.rs
@@ -1,0 +1,453 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Row types and helpers for `TableEngine`: catalog row mapping, building a
+//! `TableDescription`, and GSI backfill. JSON columns are stored as TEXT, so
+//! they are fetched as `String` and parsed here.
+
+use crate::db;
+use extenddb_core::types::{
+    AttributeDefinition, BillingMode, BillingModeSummary, GsiDescription, KeySchemaElement,
+    LsiDescription, Projection, ProvisionedThroughput, ProvisionedThroughputDescription,
+    SseDescription, SseType, TableDescription, TableStatus,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::{index_arn, stream_arn};
+
+use crate::data;
+use crate::duckdb_util::parse_timestamp;
+use crate::store::DuckDbEngine;
+
+/// Catalog `tables` row (JSON columns as TEXT, timestamp as RFC 3339 TEXT).
+pub(crate) struct TableRow {
+    pub table_name: String,
+    pub key_schema: String,
+    pub attribute_definitions: String,
+    pub billing_mode: String,
+    pub provisioned_throughput: Option<String>,
+    pub stream_specification: Option<String>,
+    pub table_status: String,
+    pub creation_date_time: String,
+    pub table_size_bytes: i64,
+    pub item_count: i64,
+    pub table_arn: String,
+    pub table_id: String,
+    pub deletion_protection_enabled: bool,
+    pub stream_label: Option<String>,
+    pub table_class: Option<String>,
+    pub sse_specification: Option<String>,
+    pub on_demand_throughput: Option<String>,
+}
+
+crate::impl_from_row!(TableRow {
+    table_name,
+    key_schema,
+    attribute_definitions,
+    billing_mode,
+    provisioned_throughput,
+    stream_specification,
+    table_status,
+    creation_date_time,
+    table_size_bytes,
+    item_count,
+    table_arn,
+    table_id,
+    deletion_protection_enabled,
+    stream_label,
+    table_class,
+    sse_specification,
+    on_demand_throughput
+});
+
+/// Catalog `indexes` row.
+pub(crate) struct IndexRow {
+    pub index_name: String,
+    #[allow(dead_code)]
+    pub index_id: String,
+    pub index_type: String,
+    pub key_schema: String,
+    pub projection: String,
+    pub index_status: String,
+    pub provisioned_throughput: Option<String>,
+}
+
+crate::impl_from_row!(IndexRow {
+    index_name,
+    index_id,
+    index_type,
+    key_schema,
+    projection,
+    index_status,
+    provisioned_throughput
+});
+
+/// A `vector_indexes` catalog row, in `FromRow` field order.
+pub(crate) struct VectorIndexRow {
+    pub index_name: String,
+    #[allow(dead_code)]
+    pub index_id: String,
+    pub dimensions: i64,
+    pub distance_function: String,
+    pub vector_attribute: String,
+    pub search_schema: Option<String>,
+    pub projection: String,
+    pub index_status: String,
+    pub backfilling: Option<i64>,
+}
+
+crate::impl_from_row!(VectorIndexRow {
+    index_name,
+    index_id,
+    dimensions,
+    distance_function,
+    vector_attribute,
+    search_schema,
+    projection,
+    index_status,
+    backfilling
+});
+
+/// Columns selected for a `VectorIndexRow`, in `FromRow` field order.
+pub(crate) const VECTOR_INDEX_COLUMNS: &str = "index_name, index_id, dimensions, \
+     distance_function, vector_attribute, search_schema, projection, index_status, backfilling";
+
+/// Columns selected for a `TableRow`, in `FromRow` field order.
+pub(crate) const TABLE_COLUMNS: &str = "table_name, key_schema, attribute_definitions, \
+     billing_mode, provisioned_throughput, stream_specification, table_status, \
+     creation_date_time, table_size_bytes, item_count, table_arn, table_id, \
+     deletion_protection_enabled, stream_label, table_class, sse_specification, \
+     on_demand_throughput";
+
+/// Columns selected for an `IndexRow`, in `FromRow` field order.
+pub(crate) const INDEX_COLUMNS: &str = "index_name, index_id, index_type, key_schema, \
+     projection, index_status, provisioned_throughput";
+
+fn parse_json<T: serde::de::DeserializeOwned>(s: &str, ctx: &str) -> Result<T, StorageError> {
+    serde_json::from_str(s).map_err(|e| StorageError::Internal(format!("{ctx}: {e}")))
+}
+
+impl DuckDbEngine {
+    /// Build a `TableDescription` by reading the catalog.
+    pub(crate) async fn build_table_description(
+        &self,
+        account_id: &str,
+        table_name: &str,
+    ) -> Result<TableDescription, StorageError> {
+        let row: Option<TableRow> = db::query_as(&format!(
+            "SELECT {TABLE_COLUMNS} FROM tables WHERE account_id = ? AND table_name = ?"
+        ))
+        .bind(account_id)
+        .bind(table_name)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let row = row.ok_or_else(|| StorageError::TableNotFound(table_name.to_owned()))?;
+
+        let index_rows: Vec<IndexRow> = db::query_as(&format!(
+            "SELECT {INDEX_COLUMNS} FROM indexes WHERE table_id = ?"
+        ))
+        .bind(&row.table_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let vector_rows: Vec<VectorIndexRow> = db::query_as(&format!(
+            "SELECT {VECTOR_INDEX_COLUMNS} FROM vector_indexes WHERE table_id = ?"
+        ))
+        .bind(&row.table_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let table_name_owned = row.table_name.clone();
+        let mut desc = self.build_table_description_from_row(account_id, row, index_rows)?;
+        desc.vector_indexes =
+            self.vector_index_descriptions(account_id, &table_name_owned, vector_rows)?;
+        Ok(desc)
+    }
+
+    pub(crate) fn build_table_description_from_row(
+        &self,
+        account_id: &str,
+        row: TableRow,
+        index_rows: Vec<IndexRow>,
+    ) -> Result<TableDescription, StorageError> {
+        let mut gsis: Vec<GsiDescription> = Vec::new();
+        let mut lsis: Vec<LsiDescription> = Vec::new();
+
+        for idx in index_rows {
+            let ks = parse_json(&idx.key_schema, "index key_schema")?;
+            let proj = parse_json(&idx.projection, "index projection")?;
+            if idx.index_type == "GSI" {
+                let pt = idx
+                    .provisioned_throughput
+                    .as_deref()
+                    .map(|s| parse_json::<ProvisionedThroughputDescription>(s, "index pt"))
+                    .transpose()?;
+                gsis.push(GsiDescription {
+                    index_name: idx.index_name.clone(),
+                    key_schema: ks,
+                    projection: proj,
+                    index_status: idx.index_status,
+                    provisioned_throughput: pt.or(Some(zero_throughput())),
+                    index_size_bytes: 0,
+                    item_count: 0,
+                    index_arn: index_arn(
+                        &self.region,
+                        account_id,
+                        &row.table_name,
+                        &idx.index_name,
+                    ),
+                });
+            } else {
+                lsis.push(LsiDescription {
+                    index_name: idx.index_name.clone(),
+                    key_schema: ks,
+                    projection: proj,
+                    index_size_bytes: 0,
+                    item_count: 0,
+                    index_arn: index_arn(
+                        &self.region,
+                        account_id,
+                        &row.table_name,
+                        &idx.index_name,
+                    ),
+                });
+            }
+        }
+
+        let key_schema = parse_json(&row.key_schema, "key_schema")?;
+        let attr_defs = parse_json(&row.attribute_definitions, "attribute_definitions")?;
+        let stream_spec = row
+            .stream_specification
+            .as_deref()
+            .map(|s| parse_json(s, "stream_specification"))
+            .transpose()?;
+
+        let (rcu, wcu) = match &row.provisioned_throughput {
+            Some(s) => {
+                let pt: ProvisionedThroughput = parse_json(s, "provisioned_throughput")?;
+                (pt.read_capacity_units, pt.write_capacity_units)
+            }
+            None => (0, 0),
+        };
+
+        let table_status = match row.table_status.as_str() {
+            "ACTIVE" => TableStatus::Active,
+            "CREATING" => TableStatus::Creating,
+            "DELETING" => TableStatus::Deleting,
+            "UPDATING" => TableStatus::Updating,
+            other => {
+                return Err(StorageError::Internal(format!(
+                    "unknown table status in database: {other}"
+                )));
+            }
+        };
+
+        let creation_epoch = parse_timestamp(&row.creation_date_time)
+            .map(|dt| dt.unix_timestamp() as f64)
+            .unwrap_or(0.0);
+
+        let billing_mode_summary = if row.billing_mode == "PAY_PER_REQUEST" {
+            Some(BillingModeSummary {
+                billing_mode: BillingMode::PayPerRequest,
+                last_update_to_pay_per_request_date_time: Some(creation_epoch),
+            })
+        } else {
+            None
+        };
+
+        let latest_stream_arn = row
+            .stream_label
+            .as_ref()
+            .map(|label| stream_arn(&self.region, account_id, &row.table_name, label));
+
+        let sse_description = row.sse_specification.as_deref().and_then(|spec| {
+            let enabled = serde_json::from_str::<serde_json::Value>(spec)
+                .ok()
+                .and_then(|v| v.get("Enabled").and_then(serde_json::Value::as_bool))
+                .unwrap_or(false);
+            enabled.then(|| SseDescription {
+                status: "ENABLED".to_owned(),
+                sse_type: Some(SseType::KMS),
+                kms_master_key_arn: Some(format!(
+                    "arn:aws:kms:{}:{}:key/default",
+                    self.region, account_id
+                )),
+            })
+        });
+
+        Ok(TableDescription {
+            table_name: row.table_name,
+            key_schema,
+            attribute_definitions: attr_defs,
+            table_status,
+            creation_date_time: creation_epoch,
+            table_size_bytes: row.table_size_bytes,
+            item_count: row.item_count,
+            table_arn: row.table_arn,
+            table_id: row.table_id,
+            provisioned_throughput: ProvisionedThroughputDescription {
+                read_capacity_units: rcu,
+                write_capacity_units: wcu,
+                number_of_decreases_today: 0,
+                last_increase_date_time: None,
+                last_decrease_date_time: None,
+            },
+            billing_mode_summary,
+            global_secondary_indexes: (!gsis.is_empty()).then_some(gsis),
+            local_secondary_indexes: (!lsis.is_empty()).then_some(lsis),
+            stream_specification: stream_spec,
+            latest_stream_arn,
+            latest_stream_label: row.stream_label,
+            deletion_protection_enabled: row.deletion_protection_enabled,
+            sse_description,
+            table_class_summary: row
+                .table_class
+                .as_ref()
+                .map(|tc| serde_json::json!({ "TableClass": tc })),
+            on_demand_throughput: row
+                .on_demand_throughput
+                .as_deref()
+                .and_then(|s| serde_json::from_str(s).ok()),
+            // Any core field this backend does not populate takes its default, so
+            // adding one does not break this build.
+            ..Default::default()
+        })
+    }
+
+    /// Build the vector index descriptions for a table.
+    ///
+    /// Separate from `build_table_description_from_row` so the shared builder
+    /// keeps one signature for every caller. Applied on the describe path, which
+    /// is where a client reads an index definition in order to search it.
+    pub(crate) fn vector_index_descriptions(
+        &self,
+        account_id: &str,
+        table_name: &str,
+        vector_rows: Vec<VectorIndexRow>,
+    ) -> Result<Option<Vec<extenddb_core::types::VectorIndexDescription>>, StorageError> {
+        let mut vector_index_descs: Vec<extenddb_core::types::VectorIndexDescription> = Vec::new();
+        for vi in vector_rows {
+            // Deliberately fails rather than defaulting on a bad parse: a vector
+            // index we cannot describe faithfully must not be reported as if we
+            // could, because a client uses the description to build a search.
+            let vector_attribute = parse_json(&vi.vector_attribute, "vector_attribute")?;
+            let search_schema = vi
+                .search_schema
+                .as_deref()
+                .map(|s| parse_json(s, "vector search_schema"))
+                .transpose()?;
+            let projection = parse_json(&vi.projection, "vector projection")?;
+            let distance_function = parse_json(
+                &format!("\"{}\"", vi.distance_function),
+                "distance_function",
+            )?;
+            let index_status = parse_json(&format!("\"{}\"", vi.index_status), "vector status")?;
+            let desc = extenddb_core::types::VectorIndexDescription {
+                index_name: vi.index_name.clone(),
+                vector_attribute,
+                dimensions: u32::try_from(vi.dimensions).map_err(|_| {
+                    StorageError::Internal(format!(
+                        "vector dimensions out of range: {}",
+                        vi.dimensions
+                    ))
+                })?,
+                search_schema,
+                distance_function,
+                index_status,
+                backfilling: vi.backfilling.map(|b| b != 0),
+                index_size_bytes: 0,
+                item_count: 0,
+                index_arn: index_arn(&self.region, account_id, table_name, &vi.index_name),
+                projection: Some(projection),
+            };
+            // The readiness rule is core's, applied here so a backend bug cannot
+            // emit a description the wire contract forbids. Cheaper to catch on
+            // the way out than to debug from a client.
+            desc.validate_readiness()
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            vector_index_descs.push(desc);
+        }
+
+        Ok((!vector_index_descs.is_empty()).then_some(vector_index_descs))
+    }
+
+    /// Backfill existing base-table items into a newly created GSI, batched to
+    /// bound memory.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn backfill_gsi(
+        tx: &mut db::Transaction,
+        table_id: &str,
+        index_id: &str,
+        index_key_schema: &[KeySchemaElement],
+        attr_defs: &[AttributeDefinition],
+        base_key_schema: &[KeySchemaElement],
+        base_attr_defs: &[AttributeDefinition],
+        projection: &Projection,
+    ) -> Result<(), StorageError> {
+        const BATCH: i64 = 500;
+        let base_table = data::data_table_name(table_id);
+        let idx_table = data::index_table_name(index_id);
+        let idx_sks = data::all_sort_key_info(index_key_schema, attr_defs);
+        let base_sks = data::all_sort_key_info(base_key_schema, base_attr_defs);
+
+        let sql = format!("SELECT item_data FROM {base_table} ORDER BY pk LIMIT ? OFFSET ?");
+        let mut offset: i64 = 0;
+        loop {
+            let rows: Vec<(String,)> = db::query_as(&sql)
+                .bind(BATCH)
+                .bind(offset)
+                .fetch_all(&mut **tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if rows.is_empty() {
+                break;
+            }
+            let len = rows.len() as i64;
+            for (item_json,) in rows {
+                let item: extenddb_core::types::Item = serde_json::from_str(&item_json)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                if !index_key_schema
+                    .iter()
+                    .all(|ks| item.contains_key(&ks.attribute_name))
+                {
+                    continue;
+                }
+                let projected = data::project_item_for_index(
+                    &item,
+                    index_key_schema,
+                    base_key_schema,
+                    projection,
+                );
+                data::insert_index_row_multi(
+                    tx,
+                    &idx_table,
+                    &item,
+                    &projected,
+                    index_key_schema,
+                    base_key_schema,
+                    &idx_sks,
+                    &base_sks,
+                )
+                .await?;
+            }
+            if len < BATCH {
+                break;
+            }
+            offset += len;
+        }
+        Ok(())
+    }
+}
+
+fn zero_throughput() -> ProvisionedThroughputDescription {
+    ProvisionedThroughputDescription {
+        read_capacity_units: 0,
+        write_capacity_units: 0,
+        number_of_decreases_today: 0,
+        last_increase_date_time: None,
+        last_decrease_date_time: None,
+    }
+}

--- a/crates/storage-duckdb/src/update_table.rs
+++ b/crates/storage-duckdb/src/update_table.rs
@@ -1,0 +1,1721 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `update_table` implementation for `DuckDbEngine` (REQ-CTRL-003).
+//!
+//! Mirrors the PostgreSQL backend: billing mode, provisioned throughput,
+//! deletion protection, stream specification, table class, on-demand
+//! throughput, and GSI create/delete. Single-pool; the engine write lock
+//! replaces `FOR UPDATE`. GSI data tables are created (and backfilled) or
+//! dropped after the catalog transaction commits, with catalog cleanup on
+//! a data-DDL failure.
+//!
+//! Vector index create/delete follows the same two-phase shape, with the
+//! backfill lifecycle the service was measured to report.
+
+use crate::db;
+use extenddb_core::types::{
+    AttributeDefinition, BillingMode, KeySchemaElement, TableDescription, UpdateTableInput,
+    VectorIndexSpecification,
+};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::effective_attribute_definitions;
+
+use crate::store::DuckDbEngine;
+
+impl DuckDbEngine {
+    pub(crate) async fn update_table_impl(
+        &self,
+        account_id: &str,
+        input: UpdateTableInput,
+    ) -> Result<TableDescription, StorageError> {
+        Self::validate_account_id(account_id)?;
+
+        let _writer = self.write_lock.lock().await;
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let row: Option<(String, String, String, String)> = db::query_as(
+            "SELECT table_status, table_id, key_schema, attribute_definitions \
+             FROM tables WHERE account_id = ? AND table_name = ?",
+        )
+        .bind(account_id)
+        .bind(&input.table_name)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let (status, table_id, ks_json, ad_json) =
+            row.ok_or_else(|| StorageError::TableNotFound(input.table_name.clone()))?;
+        if status != "ACTIVE" {
+            return Err(StorageError::TableNotActive(input.table_name.clone()));
+        }
+
+        // A table holding vector indexes cannot leave PAY_PER_REQUEST. Same
+        // message as CreateTable's rejection; measured 2026-08-13 by switching
+        // a live vector table to PROVISIONED.
+        if matches!(input.billing_mode, Some(BillingMode::Provisioned)) {
+            let vector_count: i64 =
+                db::query_scalar("SELECT COUNT(*) FROM vector_indexes WHERE table_id = ?")
+                    .bind(&table_id)
+                    .fetch_one(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if vector_count > 0 {
+                return Err(StorageError::Validation(
+                    extenddb_core::types::VECTOR_INDEX_REQUIRES_PAY_PER_REQUEST.to_owned(),
+                ));
+            }
+        }
+
+        // Reject ProvisionedThroughput when the effective billing mode is
+        // PAY_PER_REQUEST. The effective mode is the requested billing_mode when
+        // the request changes it, otherwise the table's current mode. Real
+        // DynamoDB returns "Neither ReadCapacityUnits nor WriteCapacityUnits can
+        // be specified when BillingMode is PAY_PER_REQUEST". Checked here, under
+        // the write transaction, because it depends on the table's current
+        // billing mode. Mirrors the PostgreSQL backend.
+        if input.provisioned_throughput.is_some() {
+            let effective_ppr = match input.billing_mode {
+                Some(BillingMode::PayPerRequest) => true,
+                Some(BillingMode::Provisioned) => false,
+                None => {
+                    let current_bm: Option<Option<String>> = db::query_scalar(
+                        "SELECT billing_mode FROM tables WHERE account_id = ? AND table_name = ?",
+                    )
+                    .bind(account_id)
+                    .bind(&input.table_name)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    current_bm.flatten().as_deref() == Some("PAY_PER_REQUEST")
+                }
+            };
+            if effective_ppr {
+                return Err(StorageError::Validation(
+                    "One or more parameter values were invalid: Neither ReadCapacityUnits nor WriteCapacityUnits can be specified when BillingMode is PAY_PER_REQUEST".to_owned(),
+                ));
+            }
+        }
+
+        // No-op rejection: same PROVISIONED throughput.
+        if matches!(input.billing_mode, Some(BillingMode::Provisioned))
+            && let Some(ref pt) = input.provisioned_throughput
+        {
+            let current: Option<(Option<String>, Option<String>)> = db::query_as(
+                "SELECT billing_mode, provisioned_throughput FROM tables \
+                 WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(account_id)
+            .bind(&input.table_name)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            if let Some((bm, cur_pt)) = current {
+                let is_prov = bm.as_deref() == Some("PROVISIONED") || bm.is_none();
+                let cur: serde_json::Value = cur_pt
+                    .as_deref()
+                    .and_then(|s| serde_json::from_str(s).ok())
+                    .unwrap_or_else(|| serde_json::json!({}));
+                let cur_rcu = cur
+                    .get("ReadCapacityUnits")
+                    .or_else(|| cur.get("read_capacity_units"))
+                    .and_then(serde_json::Value::as_i64)
+                    .unwrap_or(0);
+                let cur_wcu = cur
+                    .get("WriteCapacityUnits")
+                    .or_else(|| cur.get("write_capacity_units"))
+                    .and_then(serde_json::Value::as_i64)
+                    .unwrap_or(0);
+                if is_prov
+                    && cur_rcu == pt.read_capacity_units
+                    && cur_wcu == pt.write_capacity_units
+                {
+                    return Err(StorageError::NoOpUpdate(format!(
+                        "The provisioned throughput for the table will not change. \
+                         The requested value equals the current value. \
+                         Current ReadCapacityUnits provisioned for the table: {cur_rcu}. \
+                         Requested ReadCapacityUnits: {}. \
+                         Current WriteCapacityUnits provisioned for the table: {cur_wcu}. \
+                         Requested WriteCapacityUnits: {}.",
+                        pt.read_capacity_units, pt.write_capacity_units
+                    )));
+                }
+            }
+        }
+
+        if let Some(bm) = &input.billing_mode {
+            let s = match bm {
+                BillingMode::Provisioned => "PROVISIONED",
+                BillingMode::PayPerRequest => "PAY_PER_REQUEST",
+            };
+            update_col(&mut tx, account_id, &input.table_name, "billing_mode", s).await?;
+        }
+        if let Some(pt) = &input.provisioned_throughput {
+            let j = serde_json::to_string(pt).map_err(|e| StorageError::Internal(e.to_string()))?;
+            update_col(
+                &mut tx,
+                account_id,
+                &input.table_name,
+                "provisioned_throughput",
+                &j,
+            )
+            .await?;
+        }
+        if let Some(dp) = input.deletion_protection_enabled {
+            db::query(
+                "UPDATE tables SET deletion_protection_enabled = ? \
+                 WHERE account_id = ? AND table_name = ?",
+            )
+            .bind(dp)
+            .bind(account_id)
+            .bind(&input.table_name)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        }
+        if let Some(tc) = &input.table_class {
+            update_col(&mut tx, account_id, &input.table_name, "table_class", tc).await?;
+        }
+        if let Some(odt) = &input.on_demand_throughput {
+            let j =
+                serde_json::to_string(odt).map_err(|e| StorageError::Internal(e.to_string()))?;
+            update_col(
+                &mut tx,
+                account_id,
+                &input.table_name,
+                "on_demand_throughput",
+                &j,
+            )
+            .await?;
+        }
+        if let Some(spec) = &input.stream_specification {
+            let j =
+                serde_json::to_string(spec).map_err(|e| StorageError::Internal(e.to_string()))?;
+            update_col(
+                &mut tx,
+                account_id,
+                &input.table_name,
+                "stream_specification",
+                &j,
+            )
+            .await?;
+            if spec.stream_enabled {
+                let existing: Option<(String,)> =
+                    db::query_as("SELECT shard_id FROM stream_shards WHERE table_id = ? LIMIT 1")
+                        .bind(&table_id)
+                        .fetch_optional(&mut *tx)
+                        .await
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                if existing.is_none() {
+                    Self::init_stream_shards(&mut tx, account_id, &input.table_name, &table_id)
+                        .await?;
+                } else {
+                    let label: Option<String> = db::query_scalar(
+                        "SELECT stream_label FROM tables WHERE account_id = ? AND table_name = ?",
+                    )
+                    .bind(account_id)
+                    .bind(&input.table_name)
+                    .fetch_one(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    if label.is_none() {
+                        db::query(
+                            "UPDATE tables SET stream_label = strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S') \
+                             WHERE account_id = ? AND table_name = ?",
+                        )
+                        .bind(account_id)
+                        .bind(&input.table_name)
+                        .execute(&mut *tx)
+                        .await
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    }
+                }
+            }
+        }
+
+        // GSI create/delete.
+        let mut created: Vec<String> = Vec::new();
+        let mut deleted: Vec<String> = Vec::new();
+        // The merged attribute definitions persisted by this UpdateTable, carried
+        // out of the catalog transaction so the post-commit index DDL builds its
+        // columns from the same set the catalog now holds.
+        let mut merged_attr_defs_for_ddl: Option<Vec<AttributeDefinition>> = None;
+        if let Some(updates) = &input.global_secondary_index_updates {
+            for update in updates {
+                if let Some(create) = &update.create {
+                    let dup: Option<(String,)> = db::query_as(
+                        "SELECT index_name FROM indexes WHERE table_id = ? AND index_name = ?",
+                    )
+                    .bind(&table_id)
+                    .bind(&create.index_name)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    if dup.is_some() {
+                        return Err(StorageError::IndexAlreadyExists(create.index_name.clone()));
+                    }
+                    let ks = serde_json::to_string(&create.key_schema)
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    let proj = serde_json::to_string(&create.projection)
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    let pt = create
+                        .provisioned_throughput
+                        .as_ref()
+                        .map(serde_json::to_string)
+                        .transpose()
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    let index_id = uuid::Uuid::new_v4().to_string();
+                    db::query(
+                        "INSERT INTO indexes \
+                         (table_id, index_name, index_id, index_type, key_schema, projection, \
+                          index_status, provisioned_throughput) \
+                         VALUES (?, ?, ?, 'GSI', ?, ?, 'CREATING', ?)",
+                    )
+                    .bind(&table_id)
+                    .bind(&create.index_name)
+                    .bind(&index_id)
+                    .bind(&ks)
+                    .bind(&proj)
+                    .bind(&pt)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    created.push(index_id);
+                }
+                if let Some(delete) = &update.delete {
+                    let existing: Option<(String,)> = db::query_as(
+                        "SELECT index_id FROM indexes WHERE table_id = ? AND index_name = ?",
+                    )
+                    .bind(&table_id)
+                    .bind(&delete.index_name)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    let (del_id,) = existing
+                        .ok_or_else(|| StorageError::IndexNotFound(delete.index_name.clone()))?;
+                    db::query("DELETE FROM indexes WHERE table_id = ? AND index_name = ?")
+                        .bind(&table_id)
+                        .bind(&delete.index_name)
+                        .execute(&mut *tx)
+                        .await
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    deleted.push(del_id);
+                }
+            }
+            // Recompute attribute_definitions for the post-update table.
+            //
+            // The effective set is the stored definitions merged with the
+            // request's, then pruned to the attributes still referenced by the
+            // table key schema or by an index surviving this update. See
+            // effective_attribute_definitions for the measured behaviour and the
+            // reason merging alone is not enough (issue #259).
+            //
+            // This runs whether or not the request carried AttributeDefinitions,
+            // because a GSI deletion prunes without the request naming anything.
+            // The index rows were created and deleted above inside this BEGIN
+            // IMMEDIATE transaction, so `indexes` already holds exactly the
+            // surviving set and the read-modify-write is atomic.
+            let stored_attr_defs: Vec<AttributeDefinition> = serde_json::from_str(&ad_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let table_key_schema: Vec<KeySchemaElement> = serde_json::from_str(&ks_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let surviving_rows: Vec<(String,)> =
+                db::query_as("SELECT key_schema FROM indexes WHERE table_id = ?")
+                    .bind(&table_id)
+                    .fetch_all(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let mut surviving_index_key_schemas: Vec<Vec<KeySchemaElement>> =
+                Vec::with_capacity(surviving_rows.len());
+            for (ks_text,) in &surviving_rows {
+                surviving_index_key_schemas.push(
+                    serde_json::from_str(ks_text)
+                        .map_err(|e| StorageError::Internal(e.to_string()))?,
+                );
+            }
+
+            let effective = effective_attribute_definitions(
+                &stored_attr_defs,
+                input.attribute_definitions.as_deref().unwrap_or(&[]),
+                &table_key_schema,
+                &surviving_index_key_schemas,
+            );
+
+            if effective != stored_attr_defs {
+                let j = serde_json::to_string(&effective)
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                update_col(
+                    &mut tx,
+                    account_id,
+                    &input.table_name,
+                    "attribute_definitions",
+                    &j,
+                )
+                .await?;
+            }
+            merged_attr_defs_for_ddl = Some(effective);
+        }
+
+        // Vector index create/delete. Structured exactly like the GSI block above
+        // and for the same reason: the catalog row is committed first at CREATING,
+        // and the data table plus backfill happen after, so a crash in between
+        // leaves a CREATING row the startup reconciler rebuilds rather than an
+        // ACTIVE index with a partial table.
+        let mut vec_created: Vec<(String, VectorIndexSpecification)> = Vec::new();
+        let mut vec_deleted: Vec<String> = Vec::new();
+        if let Some(updates) = &input.vector_index_updates {
+            // Per-table count limit, evaluated on the NET effect of the whole
+            // request rather than per-action, so a delete+create against a full
+            // table passes regardless of the order the actions are listed in.
+            // DynamoDB's model is a set of index changes, not an ordered
+            // program, so list order must not decide acceptance. Deletes of
+            // indexes that do not exist fail below anyway, so counting every
+            // delete here cannot let an over-cap request through.
+            //
+            // UpdateTable reports the limit as LimitExceededException with
+            // different wording from CreateTable's ValidationException;
+            // measured 2026-08-13 by adding a sixth index to a five-index
+            // table. Counted inside the transaction under the write lock, so
+            // no concurrent request can change the answer.
+            let existing: i64 =
+                db::query_scalar("SELECT COUNT(*) FROM vector_indexes WHERE table_id = ?")
+                    .bind(&table_id)
+                    .fetch_one(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let creates = updates.iter().filter(|u| u.create.is_some()).count() as i64;
+            let deletes = updates.iter().filter(|u| u.delete.is_some()).count() as i64;
+            if existing + creates - deletes
+                > extenddb_core::types::MAX_VECTOR_INDEXES_PER_TABLE as i64
+            {
+                return Err(StorageError::LimitExceeded(
+                    extenddb_core::types::VECTOR_INDEX_COUNT_LIMIT_UPDATE.to_owned(),
+                ));
+            }
+
+            for update in updates {
+                if let Some(create) = &update.create {
+                    // The vector attribute cannot collide with a key attribute.
+                    // CreateTable reports this via the conflicting-definition
+                    // rule (the key must be declared there); on UpdateTable the
+                    // key is not re-declared, and the service instead reports a
+                    // redefinition message embedding both schemas, with the
+                    // vector reported as type L and its dimension count.
+                    // Measured 2026-08-13 with the confound removed (the first
+                    // probe failed on the SearchSchema rule instead).
+                    let key_schema: Vec<extenddb_core::types::KeySchemaElement> =
+                        serde_json::from_str(&ks_json)
+                            .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    let attr_defs: Vec<extenddb_core::types::AttributeDefinition> =
+                        serde_json::from_str(&ad_json)
+                            .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    let vec_attr_name = &create.vector_attribute.attribute_name;
+                    if let Some(ks) = key_schema
+                        .iter()
+                        .find(|ks| &ks.attribute_name == vec_attr_name)
+                    {
+                        let existing_type = attr_defs
+                            .iter()
+                            .find(|ad| &ad.attribute_name == vec_attr_name)
+                            .map_or("S", |ad| match ad.attribute_type {
+                                extenddb_core::types::ScalarAttributeType::S => "S",
+                                extenddb_core::types::ScalarAttributeType::N => "N",
+                                extenddb_core::types::ScalarAttributeType::B => "B",
+                            });
+                        let key_type = match ks.key_type {
+                            extenddb_core::types::KeyType::Hash => "HASH",
+                            extenddb_core::types::KeyType::Range => "RANGE",
+                        };
+                        return Err(StorageError::Validation(
+                            extenddb_core::types::vector_attribute_redefines_key(
+                                vec_attr_name,
+                                existing_type,
+                                key_type,
+                                create.dimensions,
+                            ),
+                        ));
+                    }
+
+                    // The per-table count limit is enforced on the request's
+                    // net effect before this loop; see above.
+
+                    // A create whose vector attribute an EXISTING index already
+                    // uses must agree with it on Dimensions: the attribute
+                    // stores one vector. Measured live 2026-08-24 (us-east-1):
+                    // the service answers the attribute-redefinition message
+                    // with both sides in the VectorIndexSchema shape, and
+                    // accepts the same attribute at the SAME dimensions.
+                    // Checked inside the transaction under the write lock, so a
+                    // concurrent create cannot slip a disagreeing sibling in.
+                    let existing_dims: Option<(i64,)> = db::query_as(
+                        "SELECT dimensions FROM vector_indexes \
+                         WHERE table_id = ? AND vector_attribute = ? \
+                           AND dimensions <> ? LIMIT 1",
+                    )
+                    .bind(&table_id)
+                    .bind(
+                        serde_json::to_string(&create.vector_attribute)
+                            .map_err(|e| StorageError::Internal(e.to_string()))?,
+                    )
+                    .bind(i64::from(create.dimensions))
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    if let Some((existing,)) = existing_dims {
+                        return Err(StorageError::Validation(
+                            extenddb_core::types::vector_attribute_redefines_vector(
+                                vec_attr_name,
+                                u32::try_from(existing).unwrap_or_default(),
+                                create.dimensions,
+                            ),
+                        ));
+                    }
+
+                    let dup: Option<(String,)> = db::query_as(
+                        "SELECT index_name FROM vector_indexes \
+                         WHERE table_id = ? AND index_name = ?",
+                    )
+                    .bind(&table_id)
+                    .bind(&create.index_name)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    if dup.is_some() {
+                        return Err(StorageError::IndexAlreadyExists(create.index_name.clone()));
+                    }
+                    let index_id = uuid::Uuid::new_v4().to_string();
+                    let vec_attr = serde_json::to_string(&create.vector_attribute)
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    let search_schema = create
+                        .search_schema
+                        .as_ref()
+                        .map(serde_json::to_string)
+                        .transpose()
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    let projection = serde_json::to_string(&create.projection)
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    let dimensions = i64::from(create.dimensions);
+                    let distance = serde_json::to_string(&create.distance_function)
+                        .map_err(|e| StorageError::Internal(e.to_string()))?
+                        .trim_matches('"')
+                        .to_owned();
+                    // `backfilling` starts at false rather than absent or true.
+                    // Measured against the service on 2026-08-06: the member appears
+                    // as false while the index exists but its backfill has not
+                    // started, flips to true during, and is removed once ACTIVE.
+                    db::query(
+                        "INSERT INTO vector_indexes \
+                         (table_id, index_id, index_name, dimensions, distance_function, \
+                          vector_attribute, search_schema, projection, index_status, backfilling) \
+                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'CREATING', 0)",
+                    )
+                    .bind(&table_id)
+                    .bind(&index_id)
+                    .bind(&create.index_name)
+                    .bind(dimensions)
+                    .bind(&distance)
+                    .bind(&vec_attr)
+                    .bind(&search_schema)
+                    .bind(&projection)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    vec_created.push((index_id, create.clone()));
+                }
+                if let Some(delete) = &update.delete {
+                    let existing: Option<(String,)> = db::query_as(
+                        "SELECT index_id FROM vector_indexes \
+                         WHERE table_id = ? AND index_name = ?",
+                    )
+                    .bind(&table_id)
+                    .bind(&delete.index_name)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    let (del_id,) = existing
+                        .ok_or_else(|| StorageError::IndexNotFound(delete.index_name.clone()))?;
+                    db::query("DELETE FROM vector_indexes WHERE table_id = ? AND index_name = ?")
+                        .bind(&table_id)
+                        .bind(&delete.index_name)
+                        .execute(&mut *tx)
+                        .await
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    vec_deleted.push(del_id);
+                }
+            }
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        // Data DDL after catalog commit.
+        if let Some(updates) = &input.global_secondary_index_updates {
+            let base_ks: Vec<KeySchemaElement> = serde_json::from_str(&ks_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let base_ad: Vec<AttributeDefinition> = serde_json::from_str(&ad_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            // Build index columns from the merged set, not the request's subset: a
+            // new index may key on an attribute the base table already defined, and
+            // the request is not required to re-declare it.
+            let effective_ad = merged_attr_defs_for_ddl.as_deref().unwrap_or(&base_ad);
+
+            let mut ci = 0usize;
+            let mut di = 0usize;
+            for update in updates {
+                if let Some(create) = &update.create {
+                    let idx_id = created[ci].clone();
+                    ci += 1;
+                    let result = async {
+                        let mut data_tx = self
+                            .pool
+                            .begin()
+                            .await
+                            .map_err(|e| StorageError::Internal(e.to_string()))?;
+                        Self::create_index_data_table(
+                            &mut data_tx,
+                            &idx_id,
+                            &create.key_schema,
+                            effective_ad,
+                            &base_ks,
+                            &base_ad,
+                        )
+                        .await?;
+                        Self::backfill_gsi(
+                            &mut data_tx,
+                            &table_id,
+                            &idx_id,
+                            &create.key_schema,
+                            effective_ad,
+                            &base_ks,
+                            &base_ad,
+                            &create.projection,
+                        )
+                        .await?;
+                        data_tx
+                            .commit()
+                            .await
+                            .map_err(|e| StorageError::Internal(e.to_string()))?;
+                        Ok::<(), StorageError>(())
+                    }
+                    .await;
+                    if let Err(e) = result {
+                        tracing::error!(
+                            "Failed to build GSI '{}' on '{}', cleaning up catalog: {e}",
+                            create.index_name,
+                            input.table_name
+                        );
+                        let _ =
+                            db::query("DELETE FROM indexes WHERE table_id = ? AND index_name = ?")
+                                .bind(&table_id)
+                                .bind(&create.index_name)
+                                .execute(&self.pool)
+                                .await;
+                        return Err(e);
+                    }
+                    // Backfill succeeded and the data table is populated, so the
+                    // index is now queryable: flip CREATING -> ACTIVE. DescribeTable
+                    // reports CREATING until this point (matching DynamoDB), so a
+                    // Query never hits a not-yet-populated index, and a crash before
+                    // here leaves a CREATING row the startup reconciler rebuilds.
+                    db::query(
+                        "UPDATE indexes SET index_status = 'ACTIVE' \
+                         WHERE table_id = ? AND index_id = ?",
+                    )
+                    .bind(&table_id)
+                    .bind(&idx_id)
+                    .execute(&self.pool)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                }
+                if update.delete.is_some() {
+                    let idx_id = deleted[di].clone();
+                    di += 1;
+                    let mut data_tx = self
+                        .pool
+                        .begin()
+                        .await
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                    Self::drop_index_data_table(&mut data_tx, &idx_id).await?;
+                    data_tx
+                        .commit()
+                        .await
+                        .map_err(|e| StorageError::Internal(e.to_string()))?;
+                }
+            }
+        }
+
+        // Vector index data DDL and backfill, after the catalog commit.
+        if !vec_created.is_empty() || !vec_deleted.is_empty() {
+            let base_ks: Vec<KeySchemaElement> = serde_json::from_str(&ks_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let base_ad: Vec<AttributeDefinition> = serde_json::from_str(&ad_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let effective_ad = input.attribute_definitions.as_deref().unwrap_or(&base_ad);
+
+            for (index_id, create) in &vec_created {
+                let result = self
+                    .build_vector_index(&table_id, index_id, create, &base_ks, effective_ad)
+                    .await;
+                if let Err(e) = result {
+                    tracing::error!(
+                        "Failed to build vector index '{}' on '{}', cleaning up catalog: {e}",
+                        create.index_name,
+                        input.table_name
+                    );
+                    // Same cleanup as the GSI path: leaving the CREATING row behind
+                    // would have the reconciler retry a build that just failed
+                    // deterministically, on every startup.
+                    let _ = db::query(
+                        "DELETE FROM vector_indexes WHERE table_id = ? AND index_name = ?",
+                    )
+                    .bind(&table_id)
+                    .bind(&create.index_name)
+                    .execute(&self.pool)
+                    .await;
+                    let _ =
+                        Self::drop_vector_data_table_by_id(&self.pool, &table_id, index_id).await;
+                    return Err(e);
+                }
+            }
+
+            for index_id in &vec_deleted {
+                Self::drop_vector_data_table_by_id(&self.pool, &table_id, index_id).await?;
+            }
+        }
+
+        self.build_table_description(account_id, &input.table_name)
+            .await
+    }
+
+    /// Create a vector index's data table and populate it, then mark it ready.
+    ///
+    /// The status sequence is the one measured against the service on 2026-08-06:
+    /// `CREATING` with `Backfilling: false`, then `CREATING` with `true` while the
+    /// scan runs, then `ACTIVE` with the member absent. Writing `false` first rather
+    /// than jumping straight to `true` matters because a client is documented to
+    /// read the value rather than test for presence, so an index that exists but
+    /// has not started backfilling must say so.
+    ///
+    /// The backfill is DETACHED and commits per batch, so the base table stays
+    /// writable while the index builds, as the service's does. This call returns with
+    /// the index still `CREATING`.
+    ///
+    /// That means a half-populated data table is now reachable in principle, so the
+    /// guarantee rests on the engine refusing to route a search to an index that is
+    /// not `ACTIVE` rather than, as before, on the backfill being one transaction.
+    async fn build_vector_index(
+        &self,
+        table_id: &str,
+        index_id: &str,
+        create: &VectorIndexSpecification,
+        base_ks: &[KeySchemaElement],
+        effective_ad: &[AttributeDefinition],
+    ) -> Result<(), StorageError> {
+        let mut data_tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        Self::create_vector_data_table(&mut data_tx, table_id, index_id, base_ks, effective_ad)
+            .await?;
+        data_tx
+            .commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        // The scan is about to start, so the member becomes true. Set outside the
+        // backfill transaction, otherwise no observer could see it: the whole point
+        // of the flag is to be readable while the scan is in progress.
+        db::query("UPDATE vector_indexes SET backfilling = 1 WHERE table_id = ? AND index_id = ?")
+            .bind(table_id)
+            .bind(index_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let mut meta_tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let metas =
+            crate::data::vector_index::fetch_vector_indexes_for_table(&mut meta_tx, table_id)
+                .await?
+                .into_iter()
+                .find(|m| m.index_id == index_id)
+                .ok_or_else(|| {
+                    StorageError::Internal(
+                        "the vector index catalog row vanished between commit and backfill"
+                            .to_owned(),
+                    )
+                })?;
+        meta_tx
+            .commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        // Everything the scan needs, owned, so it can outlive this call.
+        let pool = self.pool.clone();
+        let write_lock = std::sync::Arc::clone(&self.write_lock);
+        let batch_delay =
+            std::time::Duration::from_millis(self.vector_backfill_batch_delay().await);
+        // The floor on how long the index stays CREATING. Captured with the
+        // creation instant here rather than inside the task, so the hold
+        // measures from when the caller could first observe the index, and a
+        // live settings change mid-build does not move an in-flight deadline.
+        let min_creating =
+            std::time::Duration::from_millis(self.vector_index_min_creating_ms().await);
+        let created_at = tokio::time::Instant::now();
+        let owned_table_id = table_id.to_owned();
+        let owned_index_id = index_id.to_owned();
+        let owned_index_name = create.index_name.clone();
+        let owned_base_ks = base_ks.to_vec();
+        let owned_ad = effective_ad.to_vec();
+        let gsi_notify = self.gsi_notify();
+
+        // Registered BEFORE the spawn, so there is no instant where the catalog
+        // says CREATING and the registry disagrees while the task is viable. The
+        // guard deregisters on every exit path including a panic, which is the
+        // whole point: a CREATING index with no registry entry is provably
+        // orphaned, and the worker's recovery sweep may rebuild it.
+        self.vector_builds_running
+            .lock()
+            .expect("registry poisoned")
+            .insert(index_id.to_owned());
+        let registry = std::sync::Arc::clone(&self.vector_builds_running);
+
+        // Detached, so UpdateTable returns while the index is still CREATING. The
+        // service behaves this way, and it is the whole point: a table stays ACTIVE
+        // and writable throughout, taking over eight minutes on an empty table when
+        // measured, and searches against the index are refused until it is ACTIVE.
+        //
+        // Not awaited, so failures cannot be returned to the caller. They are logged
+        // and the index is deliberately LEFT in CREATING, which is the state the
+        // worker's recovery sweep repairs at runtime (and
+        // `reconcile_incomplete_vector_indexes` at startup). Flipping it to
+        // ACTIVE on error would publish a partially populated index, and there is no
+        // failure state on the wire for an index to sit in.
+        tokio::spawn(async move {
+            struct Deregister(
+                std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
+                String,
+            );
+            impl Drop for Deregister {
+                fn drop(&mut self) {
+                    if let Ok(mut set) = self.0.lock() {
+                        set.remove(&self.1);
+                    }
+                }
+            }
+            let _deregister = Deregister(registry, owned_index_id.clone());
+            let result = crate::data::vector_index::backfill_vector_index_in_batches(
+                &pool,
+                &write_lock,
+                &owned_table_id,
+                &metas,
+                &owned_base_ks,
+                &owned_ad,
+                batch_delay,
+            )
+            .await;
+            match result {
+                Ok(outcome) => {
+                    // The service's online-index machinery never finishes an
+                    // added index instantly, so the CREATING walk (`Backfilling`
+                    // false, then true, then ACTIVE with the member absent) is
+                    // always observable there. A local backfill over a small
+                    // table completes in milliseconds, which would collapse that
+                    // walk into an instant no DescribeTable poll can catch, so
+                    // the flip waits out the remainder of the configured floor.
+                    // Searches keep answering the documented not-ready rejection
+                    // and writes keep queuing behind the CREATING hold for the
+                    // duration, exactly as during a real backfill.
+                    tokio::time::sleep_until(created_at + min_creating).await;
+                    // Populated, so the index can serve. `backfilling` is cleared to
+                    // NULL rather than set to 0, because the service removes the
+                    // member once ACTIVE and the catalog CHECK constraint enforces
+                    // that pairing. The skipped count is recorded in the same flip,
+                    // but only in the catalog (and the log line below): DescribeTable
+                    // parity forbids inventing a response field for it, so an
+                    // operator diagnosing missing search results finds it by
+                    // querying the catalog, not through the API.
+                    let flip = db::query(
+                        "UPDATE vector_indexes SET index_status = 'ACTIVE', backfilling = NULL, \
+                         skipped_item_count = ? \
+                         WHERE table_id = ? AND index_id = ?",
+                    )
+                    .bind(i64::try_from(outcome.skipped).unwrap_or(i64::MAX))
+                    .bind(&owned_table_id)
+                    .bind(&owned_index_id)
+                    .execute(&pool)
+                    .await;
+                    match flip {
+                        Ok(_) => {
+                            tracing::info!(
+                                index_name = %owned_index_name,
+                                vectors_indexed = outcome.written,
+                                vectors_skipped = outcome.skipped,
+                                "vector index backfill complete"
+                            );
+                            // Writes that landed during the backfill were held by the
+                            // worker because this index was CREATING. It is ACTIVE
+                            // now, so wake the worker rather than leaving them to sit
+                            // until its next idle timeout.
+                            gsi_notify.notify_waiters();
+                        }
+                        Err(e) => tracing::error!(
+                            index_name = %owned_index_name,
+                            "vector index backfill finished but the ACTIVE flip failed, \
+                             leaving it CREATING for startup reconciliation: {e}"
+                        ),
+                    }
+                }
+                Err(e) => tracing::error!(
+                    index_name = %owned_index_name,
+                    "vector index backfill failed, leaving it CREATING for startup \
+                     reconciliation: {e}"
+                ),
+            }
+        });
+        Ok(())
+    }
+
+    /// Rebuild any GSI left in `CREATING` by a crash between the catalog commit
+    /// and the completion of its data-table backfill. Runs once at startup: for
+    /// each such index it drops any partial data table, recreates and backfills
+    /// it, then flips the catalog row to `ACTIVE`. This closes the non-atomic
+    /// create+backfill gap (an `ACTIVE` index with no/partial data table can
+    /// never be observed, and nothing is left permanently stuck in `CREATING`).
+    pub(crate) async fn reconcile_incomplete_gsis(&self) -> Result<usize, StorageError> {
+        let rows: Vec<(String, String, String, String, String, String)> = db::query_as(
+            "SELECT i.index_id, i.table_id, i.key_schema, i.projection, \
+                    t.key_schema, t.attribute_definitions \
+             FROM indexes i JOIN tables t ON i.table_id = t.table_id \
+             WHERE i.index_status = 'CREATING' AND i.index_type = 'GSI'",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let mut rebuilt = 0usize;
+        for (index_id, table_id, idx_ks_json, proj_json, base_ks_json, base_ad_json) in rows {
+            let index_key_schema: Vec<KeySchemaElement> = serde_json::from_str(&idx_ks_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let projection: extenddb_core::types::Projection = serde_json::from_str(&proj_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let base_key_schema: Vec<KeySchemaElement> = serde_json::from_str(&base_ks_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            let attr_defs: Vec<AttributeDefinition> = serde_json::from_str(&base_ad_json)
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let _writer = self.write_lock.lock().await;
+            let mut data_tx = self
+                .pool
+                .begin()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Self::drop_index_data_table(&mut data_tx, &index_id).await?;
+            Self::create_index_data_table(
+                &mut data_tx,
+                &index_id,
+                &index_key_schema,
+                &attr_defs,
+                &base_key_schema,
+                &attr_defs,
+            )
+            .await?;
+            Self::backfill_gsi(
+                &mut data_tx,
+                &table_id,
+                &index_id,
+                &index_key_schema,
+                &attr_defs,
+                &base_key_schema,
+                &attr_defs,
+                &projection,
+            )
+            .await?;
+            data_tx
+                .commit()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            db::query(
+                "UPDATE indexes SET index_status = 'ACTIVE' \
+                 WHERE table_id = ? AND index_id = ?",
+            )
+            .bind(&table_id)
+            .bind(&index_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+            rebuilt += 1;
+            tracing::info!("Reconciled incomplete GSI {index_id} on table {table_id}");
+        }
+        Ok(rebuilt)
+    }
+
+    /// Rebuild any vector index left in `CREATING` by a crash between the catalog
+    /// commit and the end of its backfill.
+    ///
+    /// Same contract as [`Self::reconcile_incomplete_gsis`]: an `ACTIVE` vector index
+    /// with a missing or partial data table can never be observed, and nothing is
+    /// left permanently stuck in `CREATING`. Idempotent, because the data table is
+    /// dropped and rebuilt rather than appended to; without the drop, a retry would
+    /// duplicate every row it had already written before the crash, and a search
+    /// would return the same item several times.
+    pub(crate) async fn reconcile_incomplete_vector_indexes(&self) -> Result<usize, StorageError> {
+        // `backfilling IS NOT NULL` scopes this to UpdateTable-created indexes,
+        // the only kind whose CREATING means an interrupted backfill. An index
+        // created WITH its table (backfilling NULL) is CREATING only because
+        // its table is; the control-plane worker activates both together, and
+        // rebuilding it here would publish it ACTIVE ahead of its own table.
+        let rows: Vec<(String, String, String, String)> = db::query_as(
+            "SELECT v.index_id, v.table_id, t.key_schema, t.attribute_definitions \
+             FROM vector_indexes v JOIN tables t ON v.table_id = t.table_id \
+             WHERE v.index_status = 'CREATING' AND v.backfilling IS NOT NULL",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let mut rebuilt = 0usize;
+        for (index_id, table_id, base_ks_json, base_ad_json) in rows {
+            let written = self
+                .rebuild_one_vector_index(&index_id, &table_id, &base_ks_json, &base_ad_json)
+                .await?;
+            rebuilt += 1;
+            tracing::info!(
+                vectors_indexed = written,
+                "Reconciled incomplete vector index {index_id} on table {table_id}"
+            );
+        }
+        Ok(rebuilt)
+    }
+
+    /// Index ids that are `CREATING` with no live backfill task right now.
+    ///
+    /// The worker's cheap per-pass probe. A single sighting is NOT proof of a
+    /// dead build: the catalog row commits before `build_vector_index` registers
+    /// the task, so a sweep landing in that window would see a healthy build as
+    /// orphaned. The worker therefore requires the same id on two consecutive
+    /// passes before invoking [`Self::recover_stuck_vector_builds`], which
+    /// re-checks the registry itself at execution time.
+    pub(crate) async fn stuck_vector_build_candidates(&self) -> Result<Vec<String>, StorageError> {
+        // `backfilling IS NOT NULL` scopes this to UpdateTable-created indexes,
+        // which are the only ones with a build task to lose. An index created
+        // WITH its table sits in CREATING (backfilling NULL) until the
+        // control-plane worker activates it beside the table; it has no task,
+        // and sweeping it here would rebuild it early and flip it ACTIVE ahead
+        // of its own table.
+        let ids: Vec<(String,)> = db::query_as(
+            "SELECT index_id FROM vector_indexes \
+             WHERE index_status = 'CREATING' AND backfilling IS NOT NULL",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let registry = self
+            .vector_builds_running
+            .lock()
+            .map_err(|_| StorageError::Internal("vector build registry poisoned".to_owned()))?;
+        Ok(ids
+            .into_iter()
+            .map(|(id,)| id)
+            .filter(|id| !registry.contains(id))
+            .collect())
+    }
+
+    /// Recover `CREATING` vector indexes whose backfill task is dead.
+    ///
+    /// A build can die without a trace on the wire: the spawned task panics, or
+    /// its terminal `ACTIVE` flip fails and is logged. The index then sits in
+    /// `CREATING`, which the worker treats as "hold every queued index write for
+    /// this table", so one dead build wedges ALL asynchronous index maintenance
+    /// for the table until a restart runs the startup reconciler. This is the
+    /// runtime half of the same repair: the GSI worker calls it on a sighting of
+    /// a `CREATING` index that has no live task in `vector_builds_running`.
+    ///
+    /// The registry is what makes the sweep safe to run at any time: a healthy
+    /// in-flight build is registered before its task is spawned and deregisters
+    /// by drop guard, so "CREATING and unregistered" cannot describe a build that
+    /// is still making progress in this process. Rebuilding rather than resuming,
+    /// for the reconciler's reason: rows already written would collide with the
+    /// backfill's deliberately plain `INSERT`.
+    ///
+    /// `confirmed` is the set of index ids the CALLER has seen stuck on two
+    /// consecutive passes, and only those are recovered. This is per index on
+    /// purpose: an early version gated only the decision to sweep, and then
+    /// recovered every currently-unregistered `CREATING` index, so one genuinely
+    /// stuck index could drag a just-created sibling (still inside its
+    /// commit-to-register window) into a rebuild while its live task was also
+    /// backfilling, double-populating the data table. The registry is re-checked
+    /// here per index as well, so an id whose task registered since the caller's
+    /// last pass is skipped even when named.
+    pub(crate) async fn recover_stuck_vector_builds(
+        &self,
+        confirmed: &std::collections::HashSet<String>,
+    ) -> Result<usize, StorageError> {
+        let rows: Vec<(String, String, String, String)> = db::query_as(
+            "SELECT v.index_id, v.table_id, t.key_schema, t.attribute_definitions \
+             FROM vector_indexes v JOIN tables t ON v.table_id = t.table_id \
+             WHERE v.index_status = 'CREATING'",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let mut recovered = 0usize;
+        for (index_id, table_id, base_ks_json, base_ad_json) in rows {
+            if !confirmed.contains(&index_id) {
+                continue;
+            }
+            let alive = self
+                .vector_builds_running
+                .lock()
+                .map(|set| set.contains(&index_id))
+                .unwrap_or(true);
+            if alive {
+                continue;
+            }
+            let written = self
+                .rebuild_one_vector_index(&index_id, &table_id, &base_ks_json, &base_ad_json)
+                .await?;
+            recovered += 1;
+            tracing::warn!(
+                vectors_indexed = written,
+                "Recovered vector index {index_id} on table {table_id}: it was CREATING \
+                 with no live backfill task"
+            );
+        }
+        if recovered > 0 {
+            // Writes held while the index was CREATING are claimable now.
+            self.gsi_notify.notify_waiters();
+        }
+        Ok(recovered)
+    }
+
+    /// Drop, recreate, backfill, and flip one vector index to `ACTIVE`.
+    ///
+    /// The shared body of startup reconciliation and the worker's runtime
+    /// recovery, factored so the two repairs cannot drift. The backfill runs on
+    /// the batched path, releasing the write lock between batches, so a recovery
+    /// on a large table cannot become a write-availability outage for every
+    /// other table.
+    async fn rebuild_one_vector_index(
+        &self,
+        index_id: &str,
+        table_id: &str,
+        base_ks_json: &str,
+        base_ad_json: &str,
+    ) -> Result<usize, StorageError> {
+        let base_key_schema: Vec<KeySchemaElement> = serde_json::from_str(base_ks_json)
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let attr_defs: Vec<AttributeDefinition> = serde_json::from_str(base_ad_json)
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        // Drop and recreate under the lock, then backfill BATCHED, releasing the
+        // lock between batches exactly as the normal create path does. An earlier
+        // version ran the whole backfill in one lock-held transaction, which on a
+        // large table blocked writes to EVERY table for the full rebuild: a
+        // write-availability outage as the price of recovering one index. The
+        // batched path is safe here for the same reasons it is safe on create:
+        // the index is CREATING throughout, so the worker holds this table's
+        // queue rows and searches are refused, and the rowid cursor tolerates
+        // concurrent base-table writes. Recovery uses no batch delay: the lever
+        // exists for tests, and recovery should finish as fast as batching
+        // allows.
+        let meta;
+        {
+            let _writer = self.write_lock.lock().await;
+            Self::drop_vector_data_table_by_id(&self.pool, table_id, index_id).await?;
+
+            let mut data_tx = self
+                .pool
+                .begin()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            Self::create_vector_data_table(
+                &mut data_tx,
+                table_id,
+                index_id,
+                &base_key_schema,
+                &attr_defs,
+            )
+            .await?;
+            // The definition is read from the catalog rather than reconstructed,
+            // because the request that created it is long gone.
+            meta = crate::data::vector_index::fetch_vector_indexes_for_table(
+                &mut data_tx,
+                table_id,
+            )
+            .await?
+            .into_iter()
+            .find(|m| m.index_id == index_id)
+            .ok_or_else(|| {
+                StorageError::Internal(format!(
+                    "vector index {index_id} was selected as CREATING but has no catalog row"
+                ))
+            })?;
+            data_tx
+                .commit()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+        }
+
+        let outcome = crate::data::vector_index::backfill_vector_index_in_batches(
+            &self.pool,
+            &self.write_lock,
+            table_id,
+            &meta,
+            &base_key_schema,
+            &attr_defs,
+            std::time::Duration::ZERO,
+        )
+        .await?;
+
+        db::query(
+            "UPDATE vector_indexes SET index_status = 'ACTIVE', backfilling = NULL, \
+             skipped_item_count = ? \
+             WHERE table_id = ? AND index_id = ?",
+        )
+        .bind(i64::try_from(outcome.skipped).unwrap_or(i64::MAX))
+        .bind(table_id)
+        .bind(index_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+        Ok(outcome.written)
+    }
+}
+
+/// Update a single string column on the `tables` row.
+async fn update_col(
+    tx: &mut db::Transaction,
+    account_id: &str,
+    table_name: &str,
+    column: &str,
+    value: &str,
+) -> Result<(), StorageError> {
+    // `column` is a compile-time constant from this module, never user input.
+    let sql = format!("UPDATE tables SET {column} = ? WHERE account_id = ? AND table_name = ?");
+    db::query(&sql)
+        .bind(value)
+        .bind(account_id)
+        .bind(table_name)
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod reconciler_tests {
+    use crate::DuckDbEngine;
+    use crate::db;
+    use serde_json::json;
+
+    /// A GSI left in `CREATING` by a crash (catalog row committed, but its data
+    /// table never finished backfilling) must be rebuilt on startup: the
+    /// reconciler recreates + backfills the data table and flips the row to
+    /// `ACTIVE`. A second run is a no-op (idempotent). The `ACTIVE` flip only
+    /// happens after create+backfill both succeed, so asserting `ACTIVE` proves
+    /// the full rebuild ran.
+    #[tokio::test]
+    async fn reconcile_rebuilds_creating_gsi_to_active() {
+        let engine = DuckDbEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+
+        let account = "000000000000";
+        db::query("INSERT INTO accounts (account_id, account_name) VALUES (?, 'default')")
+            .bind(account)
+            .execute(&engine.pool)
+            .await
+            .expect("account");
+
+        // Create the base table via the real path (this also creates its
+        // `_ddb_<table_id>` data table that backfill will scan).
+        let input: extenddb_core::types::CreateTableInput = serde_json::from_value(json!({
+            "TableName": "t",
+            "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "gsipk", "AttributeType": "S"}
+            ],
+            "BillingMode": "PAY_PER_REQUEST"
+        }))
+        .expect("input");
+        engine
+            .create_table_impl(account, input)
+            .await
+            .expect("create table");
+
+        let (table_id,): (String,) =
+            db::query_as("SELECT table_id FROM tables WHERE account_id = ? AND table_name = 't'")
+                .bind(account)
+                .fetch_one(&engine.pool)
+                .await
+                .expect("table_id");
+
+        // Simulate a crash mid-build: a CREATING GSI catalog row whose data table
+        // was never created.
+        let ks = json!([{"AttributeName": "gsipk", "KeyType": "HASH"}]).to_string();
+        let proj = json!({"ProjectionType": "ALL"}).to_string();
+        db::query(
+            "INSERT INTO indexes \
+             (table_id, index_id, index_name, index_type, key_schema, projection, index_status) \
+             VALUES (?, 'idx-1', 'gsi1', 'GSI', ?, ?, 'CREATING')",
+        )
+        .bind(&table_id)
+        .bind(&ks)
+        .bind(&proj)
+        .execute(&engine.pool)
+        .await
+        .expect("insert CREATING index");
+
+        // Reconcile rebuilds it.
+        let rebuilt = engine.reconcile_incomplete_gsis().await.expect("reconcile");
+        assert_eq!(rebuilt, 1, "one CREATING GSI should be rebuilt");
+
+        let (status,): (String,) = db::query_as(
+            "SELECT index_status FROM indexes WHERE table_id = ? AND index_id = 'idx-1'",
+        )
+        .bind(&table_id)
+        .fetch_one(&engine.pool)
+        .await
+        .expect("status");
+        assert_eq!(status, "ACTIVE", "reconciled GSI must be flipped to ACTIVE");
+
+        // Idempotent: nothing left in CREATING, so a second run rebuilds nothing.
+        assert_eq!(
+            engine
+                .reconcile_incomplete_gsis()
+                .await
+                .expect("second reconcile"),
+            0,
+            "reconciler must be idempotent"
+        );
+    }
+
+    /// A vector index left in `CREATING` by a crash must be rebuilt on startup and
+    /// flipped to `ACTIVE`, with `Backfilling` cleared.
+    ///
+    /// Asserts the rebuilt data table is POPULATED, not merely that the status
+    /// changed. Flipping the row to `ACTIVE` over an empty or missing data table
+    /// would satisfy a status-only assertion while every search returned nothing,
+    /// which is the exact failure the reconciler exists to prevent.
+    #[tokio::test]
+    async fn reconcile_rebuilds_a_creating_vector_index_and_populates_it() {
+        let engine = DuckDbEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+
+        let account = "000000000000";
+        db::query("INSERT INTO accounts (account_id, account_name) VALUES (?, 'default')")
+            .bind(account)
+            .execute(&engine.pool)
+            .await
+            .expect("account");
+
+        let input: extenddb_core::types::CreateTableInput = serde_json::from_value(json!({
+            "TableName": "t",
+            "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+            "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+            "BillingMode": "PAY_PER_REQUEST"
+        }))
+        .expect("input");
+        engine
+            .create_table_impl(account, input)
+            .await
+            .expect("create table");
+
+        let (table_id,): (String,) =
+            db::query_as("SELECT table_id FROM tables WHERE account_id = ? AND table_name = 't'")
+                .bind(account)
+                .fetch_one(&engine.pool)
+                .await
+                .expect("table_id");
+
+        // Two items already in the base table, so a rebuild has something to find.
+        let base_table = crate::data::data_table_name(&table_id);
+        for (pk, vec) in [("a", "[1,0]"), ("b", "[0,1]")] {
+            let item = format!(
+                r#"{{"pk":{{"S":"{pk}"}},"emb":{{"L":[{{"N":"{}"}},{{"N":"{}"}}]}}}}"#,
+                if vec == "[1,0]" { 1 } else { 0 },
+                if vec == "[1,0]" { 0 } else { 1 }
+            );
+            db::query(&format!(
+                "INSERT INTO {base_table} (pk, item_data) VALUES (?, ?)"
+            ))
+            .bind(pk)
+            .bind(&item)
+            .execute(&engine.pool)
+            .await
+            .expect("seed item");
+        }
+
+        // Simulate a crash mid-build: a CREATING row, mid-backfill, whose data table
+        // was never created.
+        db::query(
+            "INSERT INTO vector_indexes \
+             (table_id, index_id, index_name, dimensions, distance_function, vector_attribute, \
+              projection, index_status, backfilling) \
+             VALUES (?, 'vidx-1', 'vidx', 2, 'COSINE', ?, ?, 'CREATING', 1)",
+        )
+        .bind(&table_id)
+        .bind(json!({"AttributeName": "emb"}).to_string())
+        .bind(json!({"ProjectionType": "ALL"}).to_string())
+        .execute(&engine.pool)
+        .await
+        .expect("insert CREATING vector index");
+
+        let rebuilt = engine
+            .reconcile_incomplete_vector_indexes()
+            .await
+            .expect("reconcile");
+        assert_eq!(rebuilt, 1, "one CREATING vector index should be rebuilt");
+
+        let (status, backfilling): (String, Option<i64>) = db::query_as(
+            "SELECT index_status, backfilling FROM vector_indexes \
+             WHERE table_id = ? AND index_id = 'vidx-1'",
+        )
+        .bind(&table_id)
+        .fetch_one(&engine.pool)
+        .await
+        .expect("status");
+        assert_eq!(status, "ACTIVE");
+        assert_eq!(
+            backfilling, None,
+            "an ACTIVE index must not carry the Backfilling member"
+        );
+
+        // The rebuilt table must actually hold the rows.
+        let vec_table = crate::data::vector_table_name(&table_id, "vidx-1");
+        let (rows,): (i64,) = db::query_as(&format!("SELECT COUNT(*) FROM {vec_table}"))
+            .fetch_one(&engine.pool)
+            .await
+            .expect("count");
+        assert_eq!(rows, 2, "the rebuild must backfill both seeded items");
+
+        // Idempotent, and the second run must not duplicate the rows it already
+        // wrote: the reconciler drops and rebuilds rather than appending.
+        assert_eq!(
+            engine
+                .reconcile_incomplete_vector_indexes()
+                .await
+                .expect("second reconcile"),
+            0,
+            "reconciler must be idempotent"
+        );
+        let (rows_after,): (i64,) = db::query_as(&format!("SELECT COUNT(*) FROM {vec_table}"))
+            .fetch_one(&engine.pool)
+            .await
+            .expect("count again");
+        assert_eq!(rows_after, 2, "a second pass must not duplicate rows");
+    }
+
+    /// The crash that actually happens: the data table exists and holds SOME of the
+    /// rows, because the process died partway through the backfill.
+    ///
+    /// The reconciler must drop and rebuild rather than resume, or the rows already
+    /// written are written again and a search returns the same item twice. The
+    /// previous test cannot catch this: its simulated crash leaves no data table at
+    /// all, so the drop is a no-op there.
+    #[tokio::test]
+    async fn reconcile_rebuilds_a_partially_backfilled_vector_index_without_duplicating() {
+        let engine = DuckDbEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+        db::query("INSERT INTO accounts (account_id, account_name) VALUES (?, 'default')")
+            .bind("000000000000")
+            .execute(&engine.pool)
+            .await
+            .expect("account");
+        let input: extenddb_core::types::CreateTableInput = serde_json::from_value(json!({
+            "TableName": "t",
+            "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+            "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+            "BillingMode": "PAY_PER_REQUEST"
+        }))
+        .expect("input");
+        engine
+            .create_table_impl("000000000000", input)
+            .await
+            .expect("create table");
+        let (table_id,): (String,) =
+            db::query_as("SELECT table_id FROM tables WHERE table_name = 't'")
+                .fetch_one(&engine.pool)
+                .await
+                .expect("table_id");
+
+        let base_table = crate::data::data_table_name(&table_id);
+        for pk in ["a", "b"] {
+            db::query(&format!(
+                "INSERT INTO {base_table} (pk, item_data) VALUES (?, ?)"
+            ))
+            .bind(pk)
+            .bind(format!(
+                r#"{{"pk":{{"S":"{pk}"}},"emb":{{"L":[{{"N":"1"}},{{"N":"0"}}]}}}}"#
+            ))
+            .execute(&engine.pool)
+            .await
+            .expect("seed");
+        }
+
+        db::query(
+            "INSERT INTO vector_indexes \
+             (table_id, index_id, index_name, dimensions, distance_function, vector_attribute, \
+              projection, index_status, backfilling) \
+             VALUES (?, 'vidx-2', 'vidx', 2, 'COSINE', ?, ?, 'CREATING', 1)",
+        )
+        .bind(&table_id)
+        .bind(json!({"AttributeName": "emb"}).to_string())
+        .bind(json!({"ProjectionType": "ALL"}).to_string())
+        .execute(&engine.pool)
+        .await
+        .expect("insert CREATING");
+
+        // The partial state: the data table exists and already holds one of the two
+        // rows, exactly as a crash midway through the scan would leave it.
+        let ks = vec![extenddb_core::types::KeySchemaElement {
+            attribute_name: "pk".to_owned(),
+            key_type: extenddb_core::types::KeyType::Hash,
+        }];
+        let ad = vec![extenddb_core::types::AttributeDefinition {
+            attribute_name: "pk".to_owned(),
+            attribute_type: extenddb_core::types::ScalarAttributeType::S,
+        }];
+        let mut tx = engine.pool.begin().await.expect("tx");
+        DuckDbEngine::create_vector_data_table(&mut tx, &table_id, "vidx-2", &ks, &ad)
+            .await
+            .expect("create partial data table");
+        let meta = crate::data::vector_index::fetch_vector_indexes_for_table(&mut tx, &table_id)
+            .await
+            .expect("metas")
+            .into_iter()
+            .find(|m| m.index_id == "vidx-2")
+            .expect("meta");
+        let item: extenddb_core::types::Item =
+            serde_json::from_str(r#"{"pk":{"S":"a"},"emb":{"L":[{"N":"1"},{"N":"0"}]}}"#)
+                .expect("item");
+        crate::data::vector_index::insert_vector_row(
+            &mut tx,
+            &table_id,
+            &meta,
+            &item,
+            &ks,
+            &ad,
+            &["base_pk".to_owned()],
+            crate::data::vector_index::VectorRowConflict::Fail,
+        )
+        .await
+        .expect("partial row");
+        tx.commit().await.expect("commit");
+
+        let vec_table = crate::data::vector_table_name(&table_id, "vidx-2");
+        let (before,): (i64,) = db::query_as(&format!("SELECT COUNT(*) FROM {vec_table}"))
+            .fetch_one(&engine.pool)
+            .await
+            .expect("count before");
+        assert_eq!(before, 1, "the setup must leave a genuinely partial table");
+
+        engine
+            .reconcile_incomplete_vector_indexes()
+            .await
+            .expect("reconcile");
+
+        let (after,): (i64,) = db::query_as(&format!("SELECT COUNT(*) FROM {vec_table}"))
+            .fetch_one(&engine.pool)
+            .await
+            .expect("count after");
+        assert_eq!(
+            after, 2,
+            "the rebuild must drop the partial table, not append to it: 3 rows would mean \
+             item 'a' was indexed twice and a search would return it twice"
+        );
+    }
+
+    /// A CREATING vector index with no live backfill task must be recovered at
+    /// runtime, not just at startup.
+    ///
+    /// The failure this guards: the detached backfill task dies (panic, or its
+    /// terminal ACTIVE flip fails) and the index sits in CREATING forever. The
+    /// worker holds every queued index write for the table while any of its
+    /// vector indexes is CREATING, so without runtime recovery one dead build
+    /// wedges ALL asynchronous index maintenance for the table until a restart.
+    /// The orphan is simulated exactly as the reconciler tests simulate a crash:
+    /// a CREATING catalog row with no task, which is indistinguishable from the
+    /// real thing because a dead task leaves nothing else behind.
+    #[tokio::test]
+    async fn a_creating_index_with_no_live_build_task_is_recovered_at_runtime() {
+        let engine = DuckDbEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+        db::query("INSERT INTO accounts (account_id, account_name) VALUES (?, 'default')")
+            .bind("000000000000")
+            .execute(&engine.pool)
+            .await
+            .expect("account");
+        let input: extenddb_core::types::CreateTableInput = serde_json::from_value(json!({
+            "TableName": "t",
+            "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+            "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+            "BillingMode": "PAY_PER_REQUEST"
+        }))
+        .expect("input");
+        engine
+            .create_table_impl("000000000000", input)
+            .await
+            .expect("create table");
+        let (table_id,): (String,) =
+            db::query_as("SELECT table_id FROM tables WHERE table_name = 't'")
+                .fetch_one(&engine.pool)
+                .await
+                .expect("table_id");
+
+        let base_table = crate::data::data_table_name(&table_id);
+        db::query(&format!(
+            "INSERT INTO {base_table} (pk, item_data) VALUES ('a', ?)"
+        ))
+        .bind(r#"{"pk":{"S":"a"},"emb":{"L":[{"N":"1"},{"N":"0"}]}}"#)
+        .execute(&engine.pool)
+        .await
+        .expect("seed");
+
+        db::query(
+            "INSERT INTO vector_indexes \
+             (table_id, index_id, index_name, dimensions, distance_function, vector_attribute, \
+              projection, index_status, backfilling) \
+             VALUES (?, 'vidx-dead', 'vidx', 2, 'COSINE', ?, ?, 'CREATING', 1)",
+        )
+        .bind(&table_id)
+        .bind(json!({"AttributeName": "emb"}).to_string())
+        .bind(json!({"ProjectionType": "ALL"}).to_string())
+        .execute(&engine.pool)
+        .await
+        .expect("insert orphaned CREATING index");
+
+        // The probe must name it, and recovery must repair it.
+        let candidates = engine
+            .stuck_vector_build_candidates()
+            .await
+            .expect("candidates");
+        assert_eq!(candidates, vec!["vidx-dead".to_owned()]);
+        let confirmed: std::collections::HashSet<String> = candidates.iter().cloned().collect();
+        let recovered = engine
+            .recover_stuck_vector_builds(&confirmed)
+            .await
+            .expect("recover");
+        assert_eq!(recovered, 1, "the orphaned build must be recovered");
+
+        let (status, backfilling): (String, Option<i64>) = db::query_as(
+            "SELECT index_status, backfilling FROM vector_indexes WHERE index_id = 'vidx-dead'",
+        )
+        .fetch_one(&engine.pool)
+        .await
+        .expect("status");
+        assert_eq!(status, "ACTIVE");
+        assert_eq!(backfilling, None);
+
+        // Recovered means populated, not merely flipped: the seeded row must be
+        // in the rebuilt index, or the "recovery" published an empty index.
+        let vec_table = crate::data::vector_table_name(&table_id, "vidx-dead");
+        let (rows,): (i64,) = db::query_as(&format!("SELECT COUNT(*) FROM {vec_table}"))
+            .fetch_one(&engine.pool)
+            .await
+            .expect("count");
+        assert_eq!(rows, 1, "recovery must backfill the seeded row");
+    }
+
+    /// The discriminating control for the sweep: a CREATING index whose build IS
+    /// registered as alive must be left alone. Without this the previous test
+    /// would also pass for a sweep that rebuilds every CREATING index it sees,
+    /// which would corrupt a healthy in-flight build by dropping its data table
+    /// out from under the running backfill.
+    #[tokio::test]
+    async fn a_creating_index_with_a_live_build_task_is_left_alone() {
+        let engine = DuckDbEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+        db::query("INSERT INTO accounts (account_id, account_name) VALUES (?, 'default')")
+            .bind("000000000000")
+            .execute(&engine.pool)
+            .await
+            .expect("account");
+        let input: extenddb_core::types::CreateTableInput = serde_json::from_value(json!({
+            "TableName": "t",
+            "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+            "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+            "BillingMode": "PAY_PER_REQUEST"
+        }))
+        .expect("input");
+        engine
+            .create_table_impl("000000000000", input)
+            .await
+            .expect("create table");
+        let (table_id,): (String,) =
+            db::query_as("SELECT table_id FROM tables WHERE table_name = 't'")
+                .fetch_one(&engine.pool)
+                .await
+                .expect("table_id");
+
+        db::query(
+            "INSERT INTO vector_indexes \
+             (table_id, index_id, index_name, dimensions, distance_function, vector_attribute, \
+              projection, index_status, backfilling) \
+             VALUES (?, 'vidx-live', 'vidx', 2, 'COSINE', ?, ?, 'CREATING', 1)",
+        )
+        .bind(&table_id)
+        .bind(json!({"AttributeName": "emb"}).to_string())
+        .bind(json!({"ProjectionType": "ALL"}).to_string())
+        .execute(&engine.pool)
+        .await
+        .expect("insert CREATING index");
+
+        // The build is alive: exactly what build_vector_index records before it
+        // spawns the task.
+        engine
+            .vector_builds_running
+            .lock()
+            .expect("registry")
+            .insert("vidx-live".to_owned());
+
+        assert!(
+            engine
+                .stuck_vector_build_candidates()
+                .await
+                .expect("candidates")
+                .is_empty(),
+            "a registered build must not be a candidate"
+        );
+        // Named explicitly as confirmed-stuck, so the registry re-check alone
+        // must protect it: the strongest form of the control.
+        let confirmed: std::collections::HashSet<String> =
+            std::iter::once("vidx-live".to_owned()).collect();
+        assert_eq!(
+            engine
+                .recover_stuck_vector_builds(&confirmed)
+                .await
+                .expect("recover"),
+            0,
+            "a registered build must not be recovered"
+        );
+        let (status,): (String,) =
+            db::query_as("SELECT index_status FROM vector_indexes WHERE index_id = 'vidx-live'")
+                .fetch_one(&engine.pool)
+                .await
+                .expect("status");
+        assert_eq!(status, "CREATING", "the live build must be untouched");
+    }
+}

--- a/crates/storage-duckdb/src/vector_bench.rs
+++ b/crates/storage-duckdb/src/vector_bench.rs
@@ -1,0 +1,201 @@
+//! Measurement scaffolding for the vector scan, not part of the shipped surface.
+//!
+//! Ignored by default because it is a timing harness rather than an assertion:
+//! it exists so a performance claim about the scan can be backed by a number
+//! instead of by reading the code. Run it with
+//!
+//! ```text
+//! VB_ITEMS=20000 VB_DIMS=384 VB_PAYLOAD=2000 \
+//!   cargo test -p extenddb-storage-duckdb --lib vector_bench -- --ignored --nocapture
+//! ```
+//!
+//! # What this harness established
+//!
+//! The scan is bound by per-row overhead in the row-streaming layer, not by any
+//! vector-specific work. Measured at 10,000 items, 384 dimensions and a 2KB
+//! non-indexed attribute, roughly 30ms per search, about 3us per row:
+//!
+//! - Removing `item_data` from the projection entirely: no change.
+//! - Skipping the blob decode and the distance computation entirely: no change
+//!   (34ms with no per-row work at all, against 25 to 28ms doing all of it).
+//! - Replacing the indexed distance loops with iterator `zip`: no change.
+//!
+//! So the JSON parse of the stored item, which the scan performs for every row in
+//! the partition and which looked like the obvious cost because the item carries
+//! the vector as decimal strings, is free relative to streaming the row. Two
+//! changes were tried and reverted: deferring the parse until a candidate can
+//! enter the retained set, and scoring straight from the stored bytes into a
+//! reused buffer. Interleaved against the unmodified code over six alternating
+//! pairs, that version measured 48.6ms against 29.5ms with no overlap in range,
+//! so it was reproducibly slower while doing strictly less work, for a reason
+//! this harness did not isolate.
+//!
+//! # Measuring on a shared machine
+//!
+//! Take the minimum of many repetitions and interleave the two binaries under
+//! comparison, alternating between them. A median of seven on an eight-core box
+//! at load average 3 was not adequate: the unmodified code measured 59.1ms and
+//! then 32.7ms on two consecutive runs of the identical binary, which is a wider
+//! spread than any of the effects being investigated.
+//!
+//! `VB_PAYLOAD` is the width in bytes of a non-indexed attribute on each item.
+//! It was expected to be the variable that matters, since the scan reads
+//! `item_data` for every row in the partition. It is not: widening it from 200
+//! bytes to 2KB did not slow the scan down, and the two measured in the opposite
+//! order to the prediction.
+
+#[cfg(test)]
+mod tests {
+    use crate::db;
+    use extenddb_core::expression::ExpressionMaps;
+    use extenddb_core::types::{AttributeValue, Item};
+    use extenddb_storage::{DataEngine, VectorSearch};
+    use serde_json::json;
+    use std::time::Instant;
+
+    fn env_usize(key: &str, default: usize) -> usize {
+        std::env::var(key)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default)
+    }
+
+    /// Deterministic pseudo-random vector, so two runs of the harness measure the
+    /// same work and a before/after comparison is meaningful.
+    fn vector_for(seed: u64, dims: usize) -> Vec<f32> {
+        let mut s = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+        let mut v = Vec::with_capacity(dims);
+        for _ in 0..dims {
+            s = s.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+            #[allow(clippy::cast_precision_loss)]
+            v.push(((s >> 33) as f32 / u32::MAX as f32) - 0.5);
+        }
+        v
+    }
+
+    #[tokio::test]
+    #[ignore = "timing harness, run explicitly"]
+    async fn vector_bench_scan() {
+        let items = env_usize("VB_ITEMS", 5_000);
+        let dims = env_usize("VB_DIMS", 384);
+        let payload = env_usize("VB_PAYLOAD", 1_000);
+        let top_k = env_usize("VB_TOPK", 10);
+        let reps = env_usize("VB_REPS", 5);
+
+        let engine = crate::DuckDbEngine::new(":memory:", 1, "us-east-1", 4_096_000)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+        let account = "000000000000";
+        db::query("INSERT INTO accounts (account_id, account_name) VALUES (?, 'default')")
+            .bind(account)
+            .execute(&engine.pool)
+            .await
+            .expect("account");
+
+        // Zero delay so index maintenance applies inline with each write. The
+        // default is asynchronous, which would leave the index empty at search
+        // time and measure a scan over nothing.
+        db::query(
+            "INSERT INTO settings (key, value) VALUES ('index_propagation_delay_ms', '0')
+             ON CONFLICT(key) DO UPDATE SET value = '0'",
+        )
+        .execute(&engine.pool)
+        .await
+        .expect("delay 0");
+
+        let input: extenddb_core::types::CreateTableInput = serde_json::from_value(json!({
+            "TableName": "t",
+            "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+            "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+            "BillingMode": "PAY_PER_REQUEST",
+            "VectorIndexes": [{
+                "IndexName": "vidx",
+                "Dimensions": dims,
+                "DistanceFunction": "COSINE",
+                "VectorAttribute": {"AttributeName": "emb"},
+                "Projection": {"ProjectionType": "ALL"}
+            }]
+        }))
+        .expect("input");
+        engine
+            .create_table_impl(account, input)
+            .await
+            .expect("create table");
+
+        // CreateTable returns with the table CREATING and the ACTIVE flip owned by
+        // the control-plane worker, which this harness does not run. Flipped
+        // directly because the transition is not what is being measured. The
+        // vector index needs no flip: the inline create path sets it ACTIVE.
+        db::query("UPDATE tables SET table_status = 'ACTIVE' WHERE account_id = ?")
+            .bind(account)
+            .execute(&engine.pool)
+            .await
+            .expect("activate");
+
+        let key_info = engine
+            .fetch_table_key_info(account, "t")
+            .await
+            .expect("key info");
+        let maps = ExpressionMaps::default();
+
+        // Written through the real put path so the index rows are built exactly as
+        // production builds them; a hand-rolled INSERT could encode differently
+        // and measure something the server never does.
+        let filler: String = "x".repeat(payload);
+        for i in 0..items {
+            let mut item = Item::new();
+            item.insert("pk".to_owned(), AttributeValue::S(format!("k{i:07}")));
+            item.insert(
+                "emb".to_owned(),
+                AttributeValue::L(
+                    vector_for(i as u64, dims)
+                        .into_iter()
+                        .map(|f| AttributeValue::N(f.to_string()))
+                        .collect(),
+                ),
+            );
+            item.insert("filler".to_owned(), AttributeValue::S(filler.clone()));
+            engine
+                .put_item_impl(&key_info, item, false, None, &maps, None)
+                .await
+                .expect("put item");
+        }
+
+        let query = vector_for(u64::MAX, dims);
+        let search = || VectorSearch {
+            key_info: &key_info,
+            index_name: "vidx",
+            query_vector: &query,
+            top_k: i64::try_from(top_k).expect("top_k fits"),
+            hash_key: None,
+            filters: &[],
+        };
+        let vector_engine = engine.as_vector_search().expect("vector capable");
+
+        // Discarded: the first search warms DuckDB's page cache, so including it
+        // would report cache-miss cost as if it were steady state.
+        let _ = vector_engine.search_vectors(search()).await.expect("warm");
+
+        let mut times = Vec::with_capacity(reps);
+        for _ in 0..reps {
+            let started = Instant::now();
+            let out = vector_engine
+                .search_vectors(search())
+                .await
+                .expect("search");
+            let elapsed = started.elapsed();
+            assert_eq!(out.hits.len(), top_k.min(items), "unexpected hit count");
+            times.push(elapsed.as_secs_f64() * 1000.0);
+        }
+        times.sort_by(|a, b| a.partial_cmp(b).expect("finite"));
+
+        println!(
+            "VBENCH items={items} dims={dims} payload={payload} top_k={top_k} \
+             reps={reps} median_ms={:.2} min_ms={:.2} max_ms={:.2}",
+            times[times.len() / 2],
+            times[0],
+            times[times.len() - 1],
+        );
+    }
+}

--- a/crates/storage-duckdb/src/vector_search.rs
+++ b/crates/storage-duckdb/src/vector_search.rs
@@ -1,0 +1,518 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Vector similarity search: exact scan over one partition.
+//!
+//! Exact rather than approximate, and that is a measured decision rather than a
+//! placeholder. No DuckDB vector extension meets this backend's constraints: the
+//! static-musl `FROM scratch` build cannot `dlopen` a loadable extension, the one
+//! extension with a compatible licence and an in-database index (`duckdb-vec`) is
+//! brute force in every stable release anyway, and every option offering a real
+//! ANN index either stores it in a sidecar file, forbids transactions, or is not
+//! open source. See `docs/adr` for the full elimination.
+//!
+//! Measured cost on one core, warm cache, row-per-vector layout: roughly 213k to
+//! 334k vectors/sec at 256 dimensions, 94k to 103k at 1024, and 39k to 43k at
+//! 4096. So a partition stays inside a 10 ms budget up to about 1,000 vectors at
+//! 1024 dimensions, and inside 100 ms up to about 10,000. The scan is dominated by
+//! getting bytes out of DuckDB rather than by the arithmetic, which is why a
+//! zero-copy `&[f32]` view of the blob measured no faster than decoding per
+//! element.
+
+use crate::db;
+use extenddb_core::types::{AttributeValue, DistanceFunction, Item};
+use extenddb_storage::error::StorageError;
+use extenddb_storage::util::pk_to_text;
+use extenddb_storage::{
+    BoxedFuture, VectorHit, VectorSearch, VectorSearchEngine, VectorSearchOutput,
+    VectorSearchResult,
+};
+
+use crate::data::vector_table_name;
+use crate::store::DuckDbEngine;
+
+/// Partition value for an index that declares no HASH element.
+///
+/// Such an index searches the whole table, so every row shares one partition
+/// rather than the scan needing a second code path.
+///
+/// What makes this safe is **not** that the value is unguessable. `pk_to_text`
+/// stores an `S` attribute verbatim, so a caller could supply this exact string as
+/// a partition key. The guarantee is structural instead: the partition is chosen
+/// from the *index's* schema, not from the item, and each index has its own data
+/// table. So within one table either every row is keyed by a real hash value (the
+/// index declares a HASH element) or every row uses this sentinel (it does not).
+/// The two never coexist, so there is nothing for a collision to leak into.
+///
+/// The leading NUL is defence in depth for the day that invariant changes, for
+/// instance if several indexes ever shared one table. It is deliberately not what
+/// correctness rests on, because a reader who believed it was would then feel free
+/// to weaken it.
+pub(crate) const UNSCOPED_PARTITION: &str = "\u{0}all";
+
+/// The partition column value for a vector row.
+///
+/// Uses the same `pk_to_text` encoding as item partition keys, so a value written
+/// by the write path and a value derived from a search request are byte-identical.
+/// Getting this wrong would not fail loudly: it would silently return no hits.
+pub(crate) fn partition_value(
+    hash_key: Option<(&str, &AttributeValue)>,
+) -> Result<String, StorageError> {
+    match hash_key {
+        Some((_, value)) => Ok(pk_to_text(value)?.into_owned()),
+        None => Ok(UNSCOPED_PARTITION.to_owned()),
+    }
+}
+
+/// Decode a stored vector blob into `f32`s.
+///
+/// Rejects a truncated blob rather than reading a short vector, because a
+/// dimension mismatch would silently change every distance in the result.
+fn decode_vector(bytes: &[u8], dimensions: usize) -> Result<Vec<f32>, StorageError> {
+    if bytes.len() != dimensions * 4 {
+        return Err(StorageError::Internal(format!(
+            "stored vector is {} bytes, expected {} for {dimensions} dimensions",
+            bytes.len(),
+            dimensions * 4
+        )));
+    }
+    Ok(bytes
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect())
+}
+
+/// Score one candidate under the index's distance function.
+///
+/// Cosine and Euclidean are distances, so smaller is more similar; dot product is
+/// a similarity, so larger is. The caller must not compare scores across
+/// functions, which is why the output reports which one was used.
+fn score(
+    function: DistanceFunction,
+    query: &[f32],
+    query_norm: f32,
+    candidate: &[f32],
+    candidate_norm: f32,
+) -> f64 {
+    match function {
+        DistanceFunction::Cosine => {
+            if query_norm == 0.0 || candidate_norm == 0.0 {
+                // Undefined angle. Reported as maximally distant rather than as
+                // an error, matching how a zero vector is treated elsewhere.
+                return 1.0;
+            }
+            let mut dot = 0.0f32;
+            for i in 0..query.len() {
+                dot += query[i] * candidate[i];
+            }
+            // Clamped because the quotient can exceed 1 by a float epsilon when the
+            // vectors are identical, which made an exact self-match report a
+            // NEGATIVE distance (-1.19e-07 was measured against a stored item's own
+            // vector). Cosine distance has domain [0, 2], so a consumer that
+            // clamps, or takes a square root of the score, sees a value the metric
+            // cannot produce. The service returned +1.49e-08 for the same query.
+            let similarity = (dot / (query_norm * candidate_norm)).clamp(-1.0, 1.0);
+            f64::from(1.0 - similarity)
+        }
+        DistanceFunction::Euclidean => {
+            let mut sum = 0.0f32;
+            for i in 0..query.len() {
+                let d = query[i] - candidate[i];
+                sum += d * d;
+            }
+            f64::from(sum.sqrt())
+        }
+        DistanceFunction::DotProduct => {
+            let mut dot = 0.0f32;
+            for i in 0..query.len() {
+                dot += query[i] * candidate[i];
+            }
+            f64::from(dot)
+        }
+    }
+}
+
+/// Keeps the best `k` seen so far, ordered by the index's distance function.
+///
+/// A full sort of the partition would dominate the scan for a large partition and
+/// is unnecessary: only `k` rows are ever returned. Insertion into a `k`-sized
+/// vector is cheap because the common case after the first `k` candidates is a
+/// single comparison against the current worst.
+struct TopK {
+    k: usize,
+    function: DistanceFunction,
+    /// The decoded components ride along with each retained hit so the returned
+    /// attribute is rebuilt only for the `k` survivors. Rebuilding during the scan
+    /// would allocate a decimal string per component per row examined, which at
+    /// 4096 dimensions over a large partition would cost far more than the scan.
+    /// Moving the already-decoded vector in is free.
+    hits: Vec<(f64, Item, Vec<f32>)>,
+}
+
+impl TopK {
+    fn new(k: usize, function: DistanceFunction) -> Self {
+        Self {
+            k,
+            function,
+            hits: Vec::with_capacity(k.saturating_add(1)),
+        }
+    }
+
+    /// True when `a` should rank ahead of `b`.
+    fn ranks_before(&self, a: f64, b: f64) -> bool {
+        self.function.ranks_before(a, b)
+    }
+
+    fn offer(&mut self, candidate_score: f64, item: Item, components: Vec<f32>) {
+        if self.hits.len() < self.k {
+            let pos = self
+                .hits
+                .iter()
+                .position(|(s, _, _)| self.ranks_before(candidate_score, *s))
+                .unwrap_or(self.hits.len());
+            self.hits.insert(pos, (candidate_score, item, components));
+            return;
+        }
+        if self.k == 0 {
+            return;
+        }
+        let worst = self.hits[self.k - 1].0;
+        if !self.ranks_before(candidate_score, worst) {
+            return;
+        }
+        let pos = self
+            .hits
+            .iter()
+            .position(|(s, _, _)| self.ranks_before(candidate_score, *s))
+            .unwrap_or(self.k - 1);
+        self.hits.insert(pos, (candidate_score, item, components));
+        self.hits.truncate(self.k);
+    }
+}
+
+impl VectorSearchEngine for DuckDbEngine {
+    fn search_vectors(&self, req: VectorSearch<'_>) -> BoxedFuture<'_, VectorSearchResult> {
+        // The request borrows; own what the async body needs so the future is not
+        // tied to the caller's frame.
+        let table_id = req.key_info.table_id.clone();
+        let index_name = req.index_name.to_owned();
+        let query_vector = req.query_vector.to_vec();
+        let top_k = req.top_k;
+        let partition = partition_value(req.hash_key);
+        let filters: Vec<(String, AttributeValue)> = req
+            .filters
+            .iter()
+            .map(|(name, value)| ((*name).to_owned(), (*value).clone()))
+            .collect();
+
+        Box::pin(async move {
+            let partition = partition?;
+
+            // The index definition comes from the catalog rather than from
+            // TableKeyInfo, because the cached key info carries dimensions and the
+            // search schema but not the distance function, without which a score
+            // cannot be computed or ordered.
+            let row: Option<(String, i64, String, String)> = db::query_as(
+                "SELECT index_id, dimensions, distance_function, vector_attribute \
+                 FROM vector_indexes WHERE table_id = ? AND index_name = ?",
+            )
+            .bind(&table_id)
+            .bind(&index_name)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let (index_id, dimensions, distance_raw, vector_attribute_json) =
+                row.ok_or_else(|| StorageError::IndexNotFound(index_name.clone()))?;
+            // Stored as the serialized `VectorAttribute`, not a bare name, so it is
+            // deserialized exactly as the write path does. Treating the column as a
+            // plain string yields the key `{"AttributeName":"emb"}`.
+            let vector_attribute_name =
+                serde_json::from_str::<extenddb_core::types::VectorAttribute>(
+                    &vector_attribute_json,
+                )
+                .map_err(|e| StorageError::Internal(format!("vector_attribute: {e}")))?
+                .attribute_name;
+            let dimensions = usize::try_from(dimensions).map_err(|_| {
+                StorageError::Internal(format!("vector dimensions out of range: {dimensions}"))
+            })?;
+            let function: DistanceFunction = serde_json::from_str(&format!("\"{distance_raw}\""))
+                .map_err(|e| {
+                StorageError::Internal(format!("unknown distance function: {e}"))
+            })?;
+
+            if query_vector.len() != dimensions {
+                // Core validates this against the cached key info, so reaching
+                // here means the catalog and the cache disagree.
+                return Err(StorageError::Validation(format!(
+                    "query vector has {} dimensions, index expects {dimensions}",
+                    query_vector.len()
+                )));
+            }
+
+            let vec_table = vector_table_name(&table_id, &index_id);
+            let sql = format!("SELECT vec, nrm, item_data FROM {vec_table} WHERE part = ?");
+
+            let mut query_norm = 0.0f32;
+            for x in &query_vector {
+                query_norm += x * x;
+            }
+            let query_norm = query_norm.sqrt();
+
+            let k = usize::try_from(top_k.max(0)).unwrap_or(0);
+            let mut top = TopK::new(k, function);
+
+            // The SQLite backend streams these rows; the `db` facade materialises
+            // a result set on the blocking side before handing it over, so the
+            // partition is fetched in one call and scored in memory. The
+            // row-per-vector layout is kept for write-cost reasons (see
+            // `data::vector_table_name`).
+            let rows = db::query_as::<(Vec<u8>, f64, String)>(&sql)
+                .bind(&partition)
+                .fetch_all(&self.pool)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            for (blob, norm, item_json) in rows {
+                let candidate = decode_vector(&blob, dimensions)?;
+                let item: Item = serde_json::from_str(&item_json)
+                    .map_err(|e| StorageError::Internal(format!("stored item: {e}")))?;
+
+                // Inline-filter attributes are applied here rather than in SQL,
+                // because they are item attributes rather than columns. Equality
+                // only, which is all the wire surface admits today.
+                if !filters.is_empty()
+                    && !filters
+                        .iter()
+                        .all(|(name, expected)| item.get(name) == Some(expected))
+                {
+                    continue;
+                }
+
+                #[allow(clippy::cast_possible_truncation)]
+                let candidate_norm = norm as f32;
+                let candidate_score = score(
+                    function,
+                    &query_vector,
+                    query_norm,
+                    &candidate,
+                    candidate_norm,
+                );
+                top.offer(candidate_score, item, candidate);
+            }
+
+            Ok(VectorSearchOutput {
+                hits: top
+                    .hits
+                    .into_iter()
+                    .map(|(score, mut item, components)| {
+                        // Reinstated from the stored `f32`s rather than from a
+                        // second copy in the payload, so what comes back is the
+                        // narrowed value that was actually indexed. The engine drops
+                        // it again unless a `ProjectionExpression` names it, and the
+                        // billed byte count subtracts it, so putting it here does not
+                        // change either the default response or the metric.
+                        item.insert(
+                            vector_attribute_name.clone(),
+                            extenddb_core::validation::vector_item::vector_attribute(&components),
+                        );
+                        VectorHit { item, score }
+                    })
+                    .collect(),
+                distance_function: function,
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item() -> Item {
+        Item::new()
+    }
+
+    #[test]
+    fn cosine_of_identical_vectors_is_zero() {
+        let v = [1.0f32, 2.0, 3.0];
+        let n = (14.0f32).sqrt();
+        let s = score(DistanceFunction::Cosine, &v, n, &v, n);
+        assert!(s.abs() < 1e-6, "expected ~0.0, got {s}");
+    }
+
+    /// Cosine distance has domain [0, 2], and a self-match must land on the zero
+    /// end of it from ABOVE.
+    ///
+    /// This exists because the test above cannot catch the failure it was
+    /// nominally covering: it asserts `s.abs() < 1e-6`, which is satisfied by
+    /// -1.19e-07, the exact value a live self-match returned before the
+    /// similarity was clamped. Taking the absolute value discards the sign, which
+    /// was the only thing wrong.
+    ///
+    /// Many vectors are tried rather than one, because whether the f32 quotient
+    /// lands above 1 depends on the particular rounding of that vector's norm, so
+    /// a single hand-picked case would prove very little.
+    #[test]
+    fn cosine_distance_is_never_negative_for_a_self_match() {
+        let mut seed = 0x2026_0811_u64;
+        for _ in 0..2000 {
+            // xorshift, so the case set is fixed and reproducible.
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            let dim = 8 + (seed % 121) as usize;
+            let mut v = Vec::with_capacity(dim);
+            let mut s = seed;
+            for _ in 0..dim {
+                s = s.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+                v.push(((s >> 33) as f32 / u32::MAX as f32) - 0.5);
+            }
+            let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            if norm == 0.0 {
+                continue;
+            }
+            let d = score(DistanceFunction::Cosine, &v, norm, &v, norm);
+            assert!(
+                d >= 0.0,
+                "cosine distance left its domain for a self-match: {d} (dim {dim})"
+            );
+            assert!(d < 1e-6, "a self-match must still be ~0: {d}");
+        }
+    }
+
+    /// The clamp must hold even when the norms handed in understate the true ones,
+    /// which is the mechanism that pushed the quotient above 1 in the first place:
+    /// `norm * norm` can be strictly less than `sum(x*x)` in f32.
+    #[test]
+    fn cosine_clamps_when_the_supplied_norms_understate() {
+        let v = [0.6f32, 0.8];
+        // Deliberately 1% low, far beyond any real rounding error, so the
+        // unclamped expression would return roughly -0.02.
+        let understated = 0.99f32;
+        let d = score(DistanceFunction::Cosine, &v, understated, &v, understated);
+        assert!(d >= 0.0, "expected the clamp to hold, got {d}");
+    }
+
+    #[test]
+    fn cosine_of_opposite_vectors_is_two() {
+        let a = [1.0f32, 0.0];
+        let b = [-1.0f32, 0.0];
+        let s = score(DistanceFunction::Cosine, &a, 1.0, &b, 1.0);
+        assert!((s - 2.0).abs() < 1e-6, "expected ~2.0, got {s}");
+    }
+
+    #[test]
+    fn a_zero_vector_is_maximally_distant_rather_than_an_error() {
+        let a = [1.0f32, 0.0];
+        let z = [0.0f32, 0.0];
+        assert!((score(DistanceFunction::Cosine, &a, 1.0, &z, 0.0) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn euclidean_is_the_straight_line_distance() {
+        let a = [0.0f32, 0.0];
+        let b = [3.0f32, 4.0];
+        let s = score(DistanceFunction::Euclidean, &a, 0.0, &b, 5.0);
+        assert!((s - 5.0).abs() < 1e-6, "expected 5.0, got {s}");
+    }
+
+    #[test]
+    fn dot_product_is_reported_raw_and_can_be_negative() {
+        let a = [1.0f32, 0.0];
+        let b = [-2.0f32, 0.0];
+        let s = score(DistanceFunction::DotProduct, &a, 1.0, &b, 2.0);
+        assert!((s + 2.0).abs() < 1e-6, "expected -2.0, got {s}");
+    }
+
+    /// The direction of "better" is not uniform, so top-k must consult the
+    /// distance function. A single ordering would silently return the *worst*
+    /// matches for dot product.
+    #[test]
+    fn top_k_orders_distances_ascending_and_similarities_descending() {
+        let mut cosine = TopK::new(2, DistanceFunction::Cosine);
+        for s in [0.9, 0.1, 0.5] {
+            cosine.offer(s, item(), vec![]);
+        }
+        assert_eq!(
+            cosine.hits.iter().map(|(s, _, _)| *s).collect::<Vec<_>>(),
+            vec![0.1, 0.5]
+        );
+
+        let mut dot = TopK::new(2, DistanceFunction::DotProduct);
+        for s in [0.9, 0.1, 0.5] {
+            dot.offer(s, item(), vec![]);
+        }
+        assert_eq!(
+            dot.hits.iter().map(|(s, _, _)| *s).collect::<Vec<_>>(),
+            vec![0.9, 0.5]
+        );
+    }
+
+    /// Each retained hit must keep its *own* vector. The components are inserted at
+    /// a computed position alongside the score, so an off-by-one there would return
+    /// a neighbour's vector against this item's attributes: wrong data, no error.
+    #[test]
+    fn a_retained_hit_keeps_its_own_vector() {
+        let mut t = TopK::new(3, DistanceFunction::Cosine);
+        // Offered worst-first so every insert lands at the front and the pairing is
+        // exercised rather than incidentally correct.
+        for (score, tag) in [(0.9f64, 9.0f32), (0.5, 5.0), (0.1, 1.0)] {
+            t.offer(score, item(), vec![tag]);
+        }
+        let paired: Vec<(f64, f32)> = t
+            .hits
+            .iter()
+            .map(|(s, _, components)| (*s, components[0]))
+            .collect();
+        assert_eq!(paired, vec![(0.1, 1.0), (0.5, 5.0), (0.9, 9.0)]);
+    }
+
+    #[test]
+    fn top_k_of_zero_returns_nothing_rather_than_panicking() {
+        let mut t = TopK::new(0, DistanceFunction::Cosine);
+        t.offer(0.5, item(), vec![]);
+        assert!(t.hits.is_empty());
+    }
+
+    #[test]
+    fn a_truncated_stored_vector_is_rejected_rather_than_read_short() {
+        let err = decode_vector(&[0u8; 8], 3).expect_err("must reject");
+        assert!(
+            format!("{err:?}").contains("expected 12"),
+            "unexpected: {err:?}"
+        );
+    }
+
+    /// The partition is chosen from the index's schema, never from the item, which
+    /// is the invariant that makes the sentinel safe. Asserted as the property
+    /// rather than against one example: the previous version compared the sentinel
+    /// to `pk_to_text(S("all"))` only, and passed unchanged when the sentinel was
+    /// weakened to the ordinary string `"unscoped"`.
+    #[test]
+    fn the_partition_comes_from_the_index_schema_not_the_item() {
+        // No HASH element declared: the sentinel, whatever the item holds.
+        assert_eq!(partition_value(None).unwrap(), UNSCOPED_PARTITION);
+
+        // A HASH element declared: the item's value, verbatim for S.
+        for value in ["all", "unscoped", UNSCOPED_PARTITION, ""] {
+            let scoped =
+                partition_value(Some(("pk", &AttributeValue::S(value.to_owned())))).unwrap();
+            assert_eq!(
+                scoped, value,
+                "a scoped partition must be the attribute value itself"
+            );
+        }
+    }
+
+    /// The sentinel keeps a leading NUL as defence in depth. Not what correctness
+    /// rests on (see the constant's documentation), but weakening it to an ordinary
+    /// string should break a test rather than pass silently.
+    #[test]
+    fn the_unscoped_sentinel_keeps_its_unusual_prefix() {
+        assert!(
+            UNSCOPED_PARTITION.starts_with('\0'),
+            "sentinel must keep its NUL prefix: {UNSCOPED_PARTITION:?}"
+        );
+    }
+}

--- a/crates/storage-duckdb/src/worker.rs
+++ b/crates/storage-duckdb/src/worker.rs
@@ -1,0 +1,141 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `WorkerStore` trait implementation and control-plane transition processing.
+//!
+//! Tables in CREATING whose `status_transition_at` has passed become ACTIVE;
+//! tables in DELETING whose time has passed are removed (catalog row cascades
+//! to indexes/shards/records) and their `_ddb_*` data tables dropped. The
+//! engine write lock replaces PostgreSQL's `FOR UPDATE SKIP LOCKED`, and the
+//! `<= now` comparison binds an RFC 3339 cutoff computed in Rust.
+
+use crate::db;
+use extenddb_storage::WorkerStore;
+use extenddb_storage::error::StorageError;
+use futures::future::BoxFuture;
+
+use crate::duckdb_util::format_timestamp;
+use crate::store::DuckDbEngine;
+
+impl WorkerStore for DuckDbEngine {
+    fn process_control_plane_transitions(
+        &self,
+    ) -> BoxFuture<'_, Result<Vec<(String, &'static str)>, StorageError>> {
+        Box::pin(async move { Self::process_control_plane_transitions(self).await })
+    }
+}
+
+impl DuckDbEngine {
+    /// Process due control-plane transitions. Returns `(table_name, change)`
+    /// pairs for logging. Called by the background poller and at startup.
+    pub async fn process_control_plane_transitions(
+        &self,
+    ) -> Result<Vec<(String, &'static str)>, StorageError> {
+        let _writer = self.write_lock.lock().await;
+        let now = format_timestamp(time::OffsetDateTime::now_utc());
+        let mut transitions = Vec::new();
+
+        // CREATING → ACTIVE. The table flip and the with-table index flip below
+        // ride one transaction so no DescribeTable can observe the table ACTIVE
+        // with its own creation-time index still CREATING: measured against the
+        // service (2026-08-21, eu-west-2, three runs at 250ms), both reach
+        // ACTIVE in the same poll with no gap in either direction.
+        let mut activate_tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        let activated: Vec<(String,)> = db::query_as(
+            "UPDATE tables SET table_status = 'ACTIVE', status_transition_at = NULL \
+             WHERE table_status = 'CREATING' AND status_transition_at IS NOT NULL \
+               AND status_transition_at <= ? RETURNING table_name",
+        )
+        .bind(&now)
+        .fetch_all(&mut *activate_tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        // Vector indexes created WITH their table (backfilling IS NULL — the
+        // UpdateTable path writes `false` from the first instant, so it is
+        // never selected here). Written as a self-healing catch-all over every
+        // ACTIVE table rather than just the rows activated above, so a crash
+        // between a past table flip and its index flip cannot strand an index
+        // in CREATING forever; re-running it is a no-op.
+        db::query(
+            "UPDATE vector_indexes SET index_status = 'ACTIVE' \
+             WHERE index_status = 'CREATING' AND backfilling IS NULL \
+               AND table_id IN (SELECT table_id FROM tables WHERE table_status = 'ACTIVE')",
+        )
+        .execute(&mut *activate_tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+        activate_tx
+            .commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        for (name,) in activated {
+            transitions.push((name, "CREATING → active"));
+        }
+
+        // DELETING → removed.
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        let candidates: Vec<(String, String, String)> = db::query_as(
+            "SELECT table_name, table_arn, table_id FROM tables \
+             WHERE table_status = 'DELETING' AND status_transition_at IS NOT NULL \
+               AND status_transition_at <= ?",
+        )
+        .bind(&now)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        for (name, arn, table_id) in &candidates {
+            // Collect index ids before deleting the table row (CASCADE removes them).
+            let index_ids: Vec<(String,)> =
+                db::query_as("SELECT index_id FROM indexes WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_all(&mut *tx)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            db::query("DELETE FROM tags WHERE resource_arn = ?")
+                .bind(arn)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            crate::referential::delete_table_children(&mut tx, table_id)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+            db::query("DELETE FROM tables WHERE table_id = ?")
+                .bind(table_id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            for (idx_id,) in &index_ids {
+                Self::drop_index_data_table(&mut tx, idx_id).await?;
+            }
+            Self::drop_data_table(&mut tx, table_id).await?;
+            // Remove orphaned pending GSI rows in the same drop transaction.
+            db::query("DELETE FROM gsi_pending WHERE table_id = ?")
+                .bind(table_id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            transitions.push((name.clone(), "DELETING → deleted"));
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+        Ok(transitions)
+    }
+}

--- a/crates/storage-duckdb/src/workers.rs
+++ b/crates/storage-duckdb/src/workers.rs
@@ -1,0 +1,1363 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! DuckDB background workers: control-plane transition poller, table-size
+//! refresh, stream-record cleanup, idempotency-token cleanup, TTL sweep, the
+//! persistent GSI propagation worker, and the GSI-delay setting poller.
+//!
+//! GSI updates with a non-zero effective propagation delay are applied
+//! asynchronously via the `gsi_pending` queue (drained by an event-driven
+//! worker); LSIs and zero-delay GSIs are applied synchronously on the write
+//! path. There is a single connection pool (catalog and data co-locate).
+
+use crate::db;
+use std::sync::Arc;
+use std::time::Duration;
+
+use extenddb_core::metrics::{MetricsCollector, QuerySource};
+use extenddb_core::types::UserIdentity;
+use extenddb_storage::error::StorageError;
+use extenddb_storage::hooks::{CancellationToken, sleep_or_shutdown};
+use extenddb_storage::management_store::SettingsStore;
+use extenddb_storage::{DataEngine, MetadataEngine, StreamEngine, TableEngine};
+
+use crate::store::DuckDbEngine;
+
+pub(crate) async fn poll_control_plane_transitions<S: SettingsStore + ?Sized>(
+    storage: Arc<DuckDbEngine>,
+    notify: Arc<tokio::sync::Notify>,
+    settings: Arc<S>,
+    token: CancellationToken,
+) {
+    const ACTIVE_POLL: Duration = Duration::from_secs(1);
+    const IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+    const MARGIN_SECS: f64 = 5.0;
+
+    loop {
+        // Idle: wait for a wake signal, an idle timeout (defensive sweep), or
+        // shutdown.
+        let shutting_down = tokio::select! {
+            () = token.cancelled() => true,
+            _ = tokio::time::timeout(IDLE_TIMEOUT, notify.notified()) => false,
+        };
+        if shutting_down {
+            return;
+        }
+        let delay = settings
+            .get_setting("control_plane_delay_seconds")
+            .await
+            .ok()
+            .flatten()
+            .and_then(|v| v.parse::<f64>().ok())
+            .filter(|&v| v >= 0.0)
+            .unwrap_or(0.25);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs_f64(delay + MARGIN_SECS);
+        loop {
+            match storage.process_control_plane_transitions().await {
+                Ok(transitions) => {
+                    for (name, transition) in &transitions {
+                        tracing::info!("Table '{name}': {transition}");
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("Control plane transition poll failed: {e}");
+                    break;
+                }
+            }
+            if tokio::time::Instant::now() >= deadline {
+                break;
+            }
+            if !sleep_or_shutdown(&token, ACTIVE_POLL).await {
+                return;
+            }
+        }
+    }
+}
+
+pub(crate) async fn table_size_refresh_worker(
+    storage: Arc<DuckDbEngine>,
+    token: CancellationToken,
+) {
+    const INTERVAL: Duration = Duration::from_secs(300);
+    while sleep_or_shutdown(&token, INTERVAL).await {
+        let tables = match MetadataEngine::all_active_tables(&*storage).await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!("Size refresh worker: list tables failed: {e}");
+                continue;
+            }
+        };
+        for (account_id, table_name) in &tables {
+            if let Err(e) =
+                MetadataEngine::refresh_table_size(&*storage, account_id, table_name).await
+            {
+                tracing::warn!("Size refresh worker: {table_name}: {e}");
+            }
+        }
+    }
+}
+
+pub(crate) async fn stream_record_cleanup_worker(
+    storage: Arc<DuckDbEngine>,
+    metrics: Arc<MetricsCollector>,
+    token: CancellationToken,
+) {
+    const INTERVAL: Duration = Duration::from_secs(3600);
+    const RETENTION_HOURS: i64 = 24;
+    while sleep_or_shutdown(&token, INTERVAL).await {
+        let start = std::time::Instant::now();
+        match StreamEngine::cleanup_expired_stream_records(&*storage, RETENTION_HOURS).await {
+            Ok(n) => {
+                if n > 0 {
+                    tracing::info!("Stream cleanup worker: deleted {n} expired record(s)");
+                }
+                // Elapsed microseconds fit exactly in f64's 53-bit mantissa for
+                // the latency ranges recorded here (telemetry, not exact math).
+                #[allow(clippy::cast_precision_loss)]
+                metrics.record_worker_success(
+                    QuerySource::StreamCleanup,
+                    start.elapsed().as_micros() as f64,
+                );
+            }
+            Err(e) => {
+                tracing::error!("Stream record cleanup failed: {e}");
+                metrics.record_worker_error(QuerySource::StreamCleanup);
+            }
+        }
+    }
+}
+
+pub(crate) async fn idempotency_token_cleanup_worker(
+    storage: Arc<DuckDbEngine>,
+    metrics: Arc<MetricsCollector>,
+    token: CancellationToken,
+) {
+    const INTERVAL: Duration = Duration::from_secs(600);
+    const MAX_AGE_SECONDS: i64 = 600;
+    while sleep_or_shutdown(&token, INTERVAL).await {
+        let start = std::time::Instant::now();
+        match DataEngine::cleanup_expired_idempotency_tokens(&*storage, MAX_AGE_SECONDS).await {
+            Ok(n) => {
+                if n > 0 {
+                    tracing::info!("Idempotency cleanup worker: deleted {n} expired token(s)");
+                }
+                // Elapsed microseconds fit exactly in f64's 53-bit mantissa for
+                // the latency ranges recorded here (telemetry, not exact math).
+                #[allow(clippy::cast_precision_loss)]
+                metrics.record_worker_success(
+                    QuerySource::IdempotencyCleanup,
+                    start.elapsed().as_micros() as f64,
+                );
+            }
+            Err(e) => {
+                tracing::error!("Idempotency token cleanup failed: {e}");
+                metrics.record_worker_error(QuerySource::IdempotencyCleanup);
+            }
+        }
+    }
+}
+
+const TTL_SCAN_INTERVAL: Duration = Duration::from_secs(60);
+const TTL_BATCH: usize = 100;
+
+pub(crate) async fn ttl_cleanup_worker(
+    storage: Arc<DuckDbEngine>,
+    metrics: Arc<MetricsCollector>,
+    token: CancellationToken,
+) {
+    let region: Arc<str> = Arc::from(storage.region.as_str());
+    while sleep_or_shutdown(&token, TTL_SCAN_INTERVAL).await {
+        retry_pending_indexes(&storage).await;
+        sweep_expired_items(&storage, &metrics, &region).await;
+    }
+}
+
+async fn retry_pending_indexes(storage: &DuckDbEngine) {
+    let (Ok(pending), Ok(ready)) = (
+        MetadataEngine::all_tables_with_ttl(storage).await,
+        MetadataEngine::all_tables_with_ttl_index_ready(storage).await,
+    ) else {
+        return;
+    };
+    let ready_set: std::collections::HashSet<(&str, &str)> = ready
+        .iter()
+        .map(|(a, t, _)| (a.as_str(), t.as_str()))
+        .collect();
+    for (account_id, table_name, ttl_attr) in &pending {
+        if !ready_set.contains(&(account_id.as_str(), table_name.as_str()))
+            && let Err(e) =
+                MetadataEngine::create_ttl_index(storage, account_id, table_name, ttl_attr).await
+        {
+            tracing::debug!("TTL worker: index retry failed for {table_name}: {e}");
+        }
+    }
+}
+
+async fn sweep_expired_items(
+    storage: &DuckDbEngine,
+    metrics: &MetricsCollector,
+    region: &Arc<str>,
+) {
+    let ttl_identity = UserIdentity {
+        identity_type: "Service".to_owned(),
+        principal_id: "dynamodb.amazonaws.com".to_owned(),
+    };
+
+    let tables = match MetadataEngine::all_tables_with_ttl_index_ready(storage).await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!("TTL worker: list tables failed: {e}");
+            return;
+        }
+    };
+
+    let now_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    for (account_id, table_name, ttl_attribute) in &tables {
+        let items = match MetadataEngine::find_expired_items_indexed(
+            storage,
+            account_id,
+            table_name,
+            ttl_attribute,
+            TTL_BATCH,
+        )
+        .await
+        {
+            Ok(items) => items,
+            Err(e) => {
+                tracing::warn!("TTL worker: find expired failed for {table_name}: {e}");
+                continue;
+            }
+        };
+        if items.is_empty() {
+            continue;
+        }
+        let key_info = match TableEngine::table_key_info(storage, account_id, table_name).await {
+            Ok(ki) => ki,
+            Err(e) => {
+                tracing::warn!("TTL worker: key info failed for {table_name}: {e}");
+                continue;
+            }
+        };
+        let view_type = key_info.stream_specification.as_ref().and_then(|s| {
+            if s.stream_enabled {
+                s.stream_view_type
+            } else {
+                None
+            }
+        });
+        let (condition_expr, maps) = build_ttl_condition(ttl_attribute, now_epoch);
+
+        let mut deleted = 0usize;
+        for item in &items {
+            let staleness = item
+                .get(ttl_attribute.as_str())
+                .and_then(|av| match av {
+                    extenddb_core::types::AttributeValue::N(n) => n.parse::<u64>().ok(),
+                    _ => None,
+                })
+                .map(|ttl_val| now_epoch.saturating_sub(ttl_val));
+
+            let key: extenddb_core::types::Item = key_info
+                .key_schema
+                .iter()
+                .filter_map(|ks| {
+                    item.get(&ks.attribute_name)
+                        .map(|v| (ks.attribute_name.clone(), v.clone()))
+                })
+                .collect();
+
+            let stream = view_type.map(|vt| extenddb_storage::StreamCapture {
+                view_type: vt,
+                user_identity: Some(ttl_identity.clone()),
+                region: region.clone(),
+            });
+            match DataEngine::delete_item(
+                storage,
+                &key_info,
+                &key,
+                view_type.is_some(),
+                Some(&condition_expr),
+                &maps,
+                stream.as_ref(),
+            )
+            .await
+            {
+                Err(StorageError::ConditionFailed(_)) => {}
+                Err(e) => tracing::warn!("TTL worker: delete failed for {table_name}: {e}"),
+                Ok(_) => {
+                    deleted += 1;
+                    metrics.record_ttl_deletion(table_name);
+                    if let Some(s) = staleness {
+                        // Staleness seconds are small and well within f64's
+                        // exact-integer range; used only for telemetry.
+                        #[allow(clippy::cast_precision_loss)]
+                        metrics.record_ttl_staleness(table_name, s as f64);
+                    }
+                }
+            }
+        }
+        if deleted > 0 {
+            tracing::info!("TTL worker: deleted {deleted} expired item(s) from {table_name}");
+        }
+    }
+}
+
+/// `attribute_exists(#ttl) AND #ttl <= :now` — guards against deleting an item
+/// whose TTL was cleared or moved into the future between scan and delete.
+fn build_ttl_condition(
+    ttl_attribute: &str,
+    now_epoch: u64,
+) -> (
+    extenddb_core::expression::Expr,
+    extenddb_core::expression::ExpressionMaps,
+) {
+    use extenddb_core::expression::{CompareOp, Expr, ExpressionMaps, PathElement};
+    use std::collections::HashMap;
+
+    let ttl_path = vec![PathElement::Attribute("#ttl".to_owned())];
+    let condition = Expr::And(
+        Box::new(Expr::Function {
+            name: "attribute_exists".to_owned(),
+            args: vec![Expr::Path(ttl_path.clone())],
+        }),
+        Box::new(Expr::Compare {
+            left: Box::new(Expr::Path(ttl_path)),
+            op: CompareOp::Le,
+            right: Box::new(Expr::Placeholder("now".to_owned())),
+        }),
+    );
+    let mut names = HashMap::new();
+    names.insert("ttl".to_owned(), ttl_attribute.to_owned());
+    let mut values = HashMap::new();
+    values.insert(
+        "now".to_owned(),
+        extenddb_core::types::AttributeValue::N(now_epoch.to_string()),
+    );
+    (condition, ExpressionMaps::new(names, values))
+}
+
+/// Maximum `gsi_pending` rows claimed per worker batch.
+const GSI_BATCH: i64 = 100;
+
+/// Drains the persistent `gsi_pending` queue, applying async GSI updates whose
+/// `ready_at` has passed. A single worker suffices: all writes (and the
+/// claim+apply transaction) are serialized by the engine write lock.
+///
+/// The worker is event-driven — it wakes exactly when the next row becomes due
+/// (`MIN(ready_at)`) or when a write notifies it, never on a blind interval —
+/// so async GSI application latency tracks the configured propagation delay and
+/// the write path pays nothing beyond the in-transaction `gsi_pending` insert.
+pub(crate) async fn gsi_propagation_worker(
+    engine: Arc<DuckDbEngine>,
+    notify: Arc<tokio::sync::Notify>,
+    token: CancellationToken,
+) {
+    // Defensive cap on idle sleep so a missed notification can never strand a
+    // pending row indefinitely. Matches the PostgreSQL persistent-queue worker's
+    // 1s backstop (PR #128) so recovery from a missed wake is identical across
+    // backends; the worker is otherwise notify-driven and sleeps to MIN(ready_at).
+    const MAX_SLEEP: Duration = Duration::from_secs(1);
+    // Backoff after an error so a poison row cannot hot-loop the worker.
+    const ERROR_BACKOFF: Duration = Duration::from_secs(1);
+    // A CREATING vector index with no live backfill task, seen on the previous
+    // pass. Two consecutive sightings are required before recovery, because the
+    // catalog row commits before the build task registers itself: a single
+    // sighting can be a healthy build in that window, but one still unregistered
+    // a full pass later (at least MAX_SLEEP apart) is dead. Without recovery it
+    // wedges every queued index write for its table until a restart.
+    let mut stuck_last_pass: std::collections::HashSet<String> = std::collections::HashSet::new();
+    loop {
+        // Drain everything currently due.
+        let mut errored = false;
+        loop {
+            match process_gsi_batch(&engine).await {
+                Ok(n) if n > 0 => continue,
+                Ok(_) => break,
+                Err(e) => {
+                    tracing::error!("GSI propagation worker: batch error: {e}");
+                    errored = true;
+                    break;
+                }
+            }
+        }
+        // The stuck-build sweep. Cheap when nothing is CREATING, which is the
+        // steady state: one indexed catalog read per pass. Only ids seen stuck
+        // on TWO consecutive passes are recovered, per index: a first sighting
+        // can be a healthy build inside its commit-to-register window, and a
+        // stuck sibling must not drag it into a rebuild.
+        match engine.stuck_vector_build_candidates().await {
+            Ok(candidates) => {
+                let confirmed: std::collections::HashSet<String> = candidates
+                    .iter()
+                    .filter(|id| stuck_last_pass.contains(*id))
+                    .cloned()
+                    .collect();
+                if !confirmed.is_empty()
+                    && let Err(e) = engine.recover_stuck_vector_builds(&confirmed).await
+                {
+                    tracing::error!("GSI propagation worker: stuck-build recovery failed: {e}");
+                }
+                stuck_last_pass = candidates.into_iter().collect();
+            }
+            Err(e) => {
+                tracing::debug!("GSI worker: stuck-build probe error: {e}");
+            }
+        }
+        // Sleep until the next row is due (or a write wakes us early).
+        let wait = if errored {
+            ERROR_BACKOFF
+        } else {
+            match next_ready_delay(&engine).await {
+                Ok(Some(d)) => d.min(MAX_SLEEP),
+                Ok(None) => MAX_SLEEP,
+                Err(e) => {
+                    tracing::debug!("GSI worker: next_ready_delay error: {e}");
+                    MAX_SLEEP
+                }
+            }
+        };
+        // Sleep, waking early on a write notification, and return on shutdown.
+        // The queue is persistent (`gsi_pending`) and reconciled at startup, so
+        // stopping between drains loses nothing.
+        let shutting_down = tokio::select! {
+            () = token.cancelled() => true,
+            _ = tokio::time::timeout(wait, notify.notified()) => false,
+        };
+        if shutting_down {
+            return;
+        }
+    }
+}
+
+/// Time until the earliest pending row becomes due. `Some(ZERO)` means a row is
+/// already due (drain again immediately); `None` means the queue is empty.
+/// Runs on the shared read pool (no write lock, indexed `MIN` on
+/// `idx_gsi_pending_ready`) so it stays off the write path.
+async fn next_ready_delay(engine: &DuckDbEngine) -> Result<Option<Duration>, StorageError> {
+    let min_ready: Option<String> = db::query_scalar("SELECT MIN(ready_at) FROM gsi_pending")
+        .fetch_one(&engine.pool)
+        .await
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let Some(ready_at) = min_ready else {
+        return Ok(None);
+    };
+    let ready = crate::duckdb_util::parse_timestamp(&ready_at)
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let now = time::OffsetDateTime::now_utc();
+    if ready <= now {
+        Ok(Some(Duration::ZERO))
+    } else {
+        // Positive remainder; convert time::Duration → std::time::Duration.
+        Ok(Some((ready - now).try_into().unwrap_or(Duration::ZERO)))
+    }
+}
+
+/// Parse a claimed `gsi_pending` row and apply its index update within `tx`.
+/// Any error (malformed context or a non-recoverable apply failure) is returned
+/// to the caller, which drops the row rather than stalling the queue. A
+/// dropped-index race is handled inside the apply, for both index kinds, and
+/// returns `Ok`.
+/// Test-only fault injection: when armed, the next `apply_pending_row` call
+/// fails with `Transient` exactly once. A real SQLITE_BUSY cannot be produced
+/// mid-batch under the single-connection test pool (the batch already holds
+/// the write transaction), so the boundary is faulted directly; the classifier
+/// that produces `Transient` from real sqlx errors has its own unit tests.
+/// Serializes tests that drive `process_gsi_batch`: the one-shot transient
+/// injection below is process-global, so a concurrently running drain in
+/// another test can consume an armed injection (or absorb one meant for its
+/// sibling), which surfaced as an intermittent 2-test failure once a fourth
+/// concurrent caller existed. tokio's Mutex, because the guard is held across
+/// awaits.
+#[cfg(test)]
+static DRAIN_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+#[cfg(test)]
+static INJECT_TRANSIENT_ONCE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+async fn apply_pending_row(
+    tx: &mut db::Transaction,
+    old_json: &Option<String>,
+    new_json: &Option<String>,
+    ctx_json: &str,
+) -> Result<(), StorageError> {
+    #[cfg(test)]
+    if INJECT_TRANSIENT_ONCE.swap(false, std::sync::atomic::Ordering::SeqCst) {
+        return Err(StorageError::Transient(
+            "injected transient failure".to_owned(),
+        ));
+    }
+    let old: Option<extenddb_core::types::Item> = old_json
+        .as_deref()
+        .map(serde_json::from_str)
+        .transpose()
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    let new: Option<extenddb_core::types::Item> = new_json
+        .as_deref()
+        .map(serde_json::from_str)
+        .transpose()
+        .map_err(|e| StorageError::Internal(e.to_string()))?;
+    // One queue carries GSI and vector work; the context's shape says which.
+    let context: crate::data::PendingApplyContext =
+        serde_json::from_str(ctx_json).map_err(|e| StorageError::Internal(e.to_string()))?;
+    crate::data::apply_pending_context(tx, old.as_ref(), new.as_ref(), &context).await
+}
+
+/// Claim and apply one batch of due `gsi_pending` rows, one transaction per
+/// row (under the write lock). Each row's claiming `DELETE` and its index
+/// write share a transaction, so a crash rolls that row back and it is retried:
+/// at-least-once, and the index writes are idempotent. Returns the number of
+/// rows processed (applied or dropped).
+///
+/// The SQLite backend claims the whole batch in one transaction and isolates
+/// each row with a `SAVEPOINT`. DuckDB has no savepoints and a failed statement
+/// aborts the enclosing transaction, so the unit of isolation here is the
+/// transaction itself: a poison row rolls back alone and is then dropped, and
+/// every other row in the batch is untouched.
+async fn process_gsi_batch(engine: &DuckDbEngine) -> Result<usize, StorageError> {
+    let _writer = engine.write_lock.lock().await;
+
+    let now = crate::duckdb_util::format_timestamp(time::OffsetDateTime::now_utc());
+    // Select the oldest due rows in `id` order. Per-partition `ready_at` is
+    // monotonic, so `id` order is write order and applying in it preserves
+    // per-key FIFO across both index kinds.
+    //
+    // Rows for a table with a vector index still in CREATING are NOT claimed, so
+    // writes that land during a backfill accumulate and are applied only once the
+    // index goes ACTIVE. Without that hold, the backfill's snapshot could be written
+    // AFTER a newer queued write had already been applied, and because each apply
+    // replaces the row wholesale the index would converge on the stale generation
+    // until the next write to that key.
+    //
+    // The hold is deliberately per TABLE rather than per index, even though only the
+    // building index is at risk. Holding just the vector rows would let a GSI row and
+    // a vector row for the same item be applied out of order relative to each other,
+    // which is the cross-kind FIFO property this queue is documented to provide.
+    let rows: Vec<(i64, Option<String>, Option<String>, String)> = db::query_as(
+        "SELECT id, old_item, new_item, index_context FROM gsi_pending \
+         WHERE ready_at <= ? \
+           AND table_id NOT IN ( \
+               SELECT table_id FROM vector_indexes WHERE index_status = 'CREATING' \
+           ) \
+         ORDER BY id LIMIT ?",
+    )
+    .bind(&now)
+    .bind(GSI_BATCH)
+    .fetch_all(&engine.pool)
+    .await
+    .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+    if rows.is_empty() {
+        return Ok(0);
+    }
+
+    let mut count = 0usize;
+    for (id, old_json, new_json, ctx_json) in &rows {
+        let mut tx = engine
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?;
+        // Claim the row inside its own transaction. Zero rows means another
+        // pass consumed it between the select and now; nothing to do.
+        let claimed = db::query("DELETE FROM gsi_pending WHERE id = ?")
+            .bind(id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Internal(e.to_string()))?
+            .rows_affected();
+        if claimed == 0 {
+            drop(tx);
+            continue;
+        }
+        match apply_pending_row(&mut tx, old_json, new_json, ctx_json).await {
+            Ok(()) => {
+                tx.commit()
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                count += 1;
+            }
+            // Transient failures roll this row back WITHOUT dropping it and stop
+            // the pass: the claiming DELETE ran inside this transaction, so the
+            // row reappears in gsi_pending and the worker loop's error path
+            // retries next pass. Rows after it in the batch were never claimed.
+            // Before this distinction existed, an I/O hiccup here was
+            // indistinguishable from a poison row and the claimed row was
+            // dropped, silently losing its index write forever.
+            Err(e @ StorageError::Transient(_)) => {
+                tracing::warn!(
+                    "GSI worker: transient error applying row {id}; \
+                     rolling back for retry: {e}"
+                );
+                drop(tx);
+                return Err(e);
+            }
+            // A row that cannot be applied (bad context, or a persistent apply
+            // error) is rolled back and DROPPED in a statement of its own. This
+            // matches the PostgreSQL backend's log-and-drop: one poison row must
+            // not be re-claimed forever, which would stall ALL GSI propagation
+            // instance-wide. (A dropped-index race is handled inside the apply
+            // and returns Ok, so it is applied-as-skip, not dropped here.)
+            Err(e) => {
+                tracing::error!("GSI worker: dropping unprocessable gsi_pending row {id}: {e}");
+                drop(tx);
+                db::query("DELETE FROM gsi_pending WHERE id = ?")
+                    .bind(id)
+                    .execute(&engine.pool)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+                count += 1;
+            }
+        }
+    }
+
+    Ok(count)
+}
+
+/// Read the propagation-delay setting through the settings store, preferring the
+/// canonical key and falling back to the pre-rename one.
+///
+/// The raw-SQL read on the write path uses one query to express the same preference;
+/// this path goes through the `SettingsStore` trait, which fetches by exact key, so the
+/// fallback is two lookups instead. It runs once per poll interval, not per write.
+async fn read_index_propagation_delay<S: SettingsStore + ?Sized>(
+    settings: &S,
+) -> extenddb_storage::management_store::OpResult<Option<String>> {
+    if let Some(v) = settings
+        .get_setting(extenddb_core::settings_keys::INDEX_PROPAGATION_DELAY_MS)
+        .await?
+    {
+        return Ok(Some(v));
+    }
+    settings
+        .get_setting(extenddb_core::settings_keys::LEGACY_GSI_PROPAGATION_DELAY_MS)
+        .await
+}
+
+/// Refresh the cached secondary-index propagation delay from the
+/// `index_propagation_delay_ms` runtime setting, so changes take effect without a
+/// restart. Falls back to the pre-rename key for a catalog created before it.
+pub(crate) async fn poll_index_propagation_delay<S: SettingsStore + ?Sized>(
+    settings: Arc<S>,
+    index_delay_cache: Arc<std::sync::atomic::AtomicU64>,
+    token: CancellationToken,
+) {
+    use std::sync::atomic::Ordering;
+    const POLL: Duration = Duration::from_secs(30);
+    while sleep_or_shutdown(&token, POLL).await {
+        match read_index_propagation_delay(settings.as_ref()).await {
+            Ok(Some(v)) => {
+                if let Ok(ms) = v.parse::<u64>() {
+                    index_delay_cache.store(ms, Ordering::Relaxed);
+                }
+            }
+            Ok(None) => index_delay_cache
+                .store(crate::DEFAULT_INDEX_PROPAGATION_DELAY_MS, Ordering::Relaxed),
+            Err(e) => tracing::debug!("poll_gsi_delay: {e:?}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod poison_row_tests {
+    use crate::db;
+    /// A TRANSIENT failure mid-batch must abort the batch without consuming the
+    /// claimed rows: they reappear in `gsi_pending` and the next pass applies
+    /// them. This is the counterpart of the poison tests above, and the review
+    /// finding on this file: without the classification, a SQLITE_BUSY or I/O
+    /// hiccup was dropped exactly like a poison row, silently losing the index
+    /// write forever. Discriminating: under the pre-fix behaviour the row count
+    /// after the first pass is 0 and the second pass applies nothing.
+    #[tokio::test]
+    async fn transient_error_requeues_the_batch_instead_of_dropping_rows() {
+        let _serial = super::DRAIN_TEST_LOCK.lock().await;
+        let engine = DuckDbEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+
+        // A row whose context parses but whose target index is gone is
+        // applied-as-skip (Ok), so on the SECOND pass it drains cleanly.
+        db::query(
+            "INSERT INTO gsi_pending \
+             (table_id, worker_partition, old_item, new_item, index_context, ready_at) \
+             VALUES ('t-tr', 0, NULL, '{\"pk\":{\"S\":\"x\"}}', 'not-valid-json', \
+                     '2000-01-01T00:00:00.000Z')",
+        )
+        .execute(&engine.pool)
+        .await
+        .expect("insert row");
+
+        // Arm the one-shot transient fault: the first pass must FAIL and leave
+        // the row queued.
+        super::INJECT_TRANSIENT_ONCE.store(true, std::sync::atomic::Ordering::SeqCst);
+        let err = process_gsi_batch(&engine)
+            .await
+            .expect_err("transient failure must abort the batch");
+        assert!(
+            matches!(err, extenddb_storage::error::StorageError::Transient(_)),
+            "expected Transient, got {err:?}"
+        );
+        let remaining: (i64,) = db::query_as("SELECT COUNT(*) FROM gsi_pending")
+            .fetch_one(&engine.pool)
+            .await
+            .expect("count");
+        assert_eq!(
+            remaining.0, 1,
+            "the claimed row must be rolled back into the queue, not consumed"
+        );
+
+        // Injection disarmed: the second pass processes the row (as poison,
+        // which is this row's real classification) and the queue drains.
+        let processed = process_gsi_batch(&engine).await.expect("second pass");
+        assert_eq!(processed, 1, "the requeued row is retried");
+        let remaining: (i64,) = db::query_as("SELECT COUNT(*) FROM gsi_pending")
+            .fetch_one(&engine.pool)
+            .await
+            .expect("count");
+        assert_eq!(remaining.0, 0);
+    }
+
+    use super::process_gsi_batch;
+    use crate::DuckDbEngine;
+
+    /// A `gsi_pending` row that cannot be applied (here: `index_context` is not
+    /// valid JSON) must be logged-and-DROPPED so the batch commits and the queue
+    /// drains. Before the per-row SAVEPOINT fix, the apply error rolled back the
+    /// whole batch including the claim DELETE, so the same row was re-claimed
+    /// forever and ALL GSI propagation stalled instance-wide.
+    #[tokio::test]
+    async fn poison_row_is_dropped_not_stalled() {
+        let _serial = super::DRAIN_TEST_LOCK.lock().await;
+        let engine = DuckDbEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+
+        // Poison row: malformed index_context. ready_at defaults to now (due).
+        db::query(
+            "INSERT INTO gsi_pending \
+             (table_id, worker_partition, old_item, new_item, index_context, ready_at) \
+             VALUES ('t-poison', 0, NULL, '{\"pk\":{\"S\":\"x\"}}', 'not-valid-json', \
+                     '2000-01-01T00:00:00.000Z')",
+        )
+        .execute(&engine.pool)
+        .await
+        .expect("insert poison row");
+
+        // The batch claims and consumes the row (returns Ok, count = 1).
+        let processed = process_gsi_batch(&engine).await.expect("batch drains");
+        assert_eq!(processed, 1, "poison row should be claimed and consumed");
+
+        // The poison row is gone, not rolled back into the queue.
+        let remaining: (i64,) = db::query_as("SELECT COUNT(*) FROM gsi_pending")
+            .fetch_one(&engine.pool)
+            .await
+            .expect("count");
+        assert_eq!(remaining.0, 0, "poison row must be dropped, not re-queued");
+
+        // A second pass has nothing left to do (proves it was not re-claimed).
+        assert_eq!(
+            process_gsi_batch(&engine).await.expect("second pass"),
+            0,
+            "queue must stay empty (no infinite re-claim)"
+        );
+    }
+
+    /// A well-formed row alongside a poison row is still applied-as-skip when its
+    /// target index no longer exists (dropped-index race handled inside
+    /// apply_claimed_row), and both rows are consumed — one bad row does not
+    /// block the rest of the batch.
+    #[tokio::test]
+    async fn poison_row_does_not_block_sibling_rows() {
+        let _serial = super::DRAIN_TEST_LOCK.lock().await;
+        let engine = DuckDbEngine::new(":memory:", 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+
+        // Poison row (bad context) + a second poison row: both must drain.
+        db::query(
+            "INSERT INTO gsi_pending \
+             (table_id, worker_partition, old_item, new_item, index_context, ready_at) \
+             VALUES \
+             ('t-a', 0, NULL, '{\"pk\":{\"S\":\"1\"}}', 'not-json', '2000-01-01T00:00:00.000Z'), \
+             ('t-b', 1, NULL, '{\"pk\":{\"S\":\"2\"}}', 'also-not-json', '2000-01-01T00:00:00.000Z')",
+        )
+        .execute(&engine.pool)
+        .await
+        .expect("insert rows");
+
+        let processed = process_gsi_batch(&engine).await.expect("batch drains");
+        assert_eq!(processed, 2, "both rows claimed in one batch");
+
+        let remaining: (i64,) = db::query_as("SELECT COUNT(*) FROM gsi_pending")
+            .fetch_one(&engine.pool)
+            .await
+            .expect("count");
+        assert_eq!(remaining.0, 0, "both poison rows dropped");
+    }
+}
+
+#[cfg(test)]
+mod vector_propagation_tests {
+    use super::process_gsi_batch;
+    use crate::DuckDbEngine;
+    use crate::db;
+    use extenddb_core::types::{
+        AttributeDefinition, Item, KeySchemaElement, KeyType, ScalarAttributeType,
+    };
+    use serde_json::json;
+
+    const INDEX_ID: &str = "vidx-async";
+
+    fn base_ks() -> Vec<KeySchemaElement> {
+        vec![KeySchemaElement {
+            attribute_name: "pk".to_owned(),
+            key_type: KeyType::Hash,
+        }]
+    }
+
+    fn base_ad() -> Vec<AttributeDefinition> {
+        vec![AttributeDefinition {
+            attribute_name: "pk".to_owned(),
+            attribute_type: ScalarAttributeType::S,
+        }]
+    }
+
+    /// A real table with one unscoped vector index and its data table, built
+    /// through the engine rather than by hand so the catalog rows and the data
+    /// table are shaped exactly as production makes them.
+    async fn table_with_vector_index() -> (DuckDbEngine, String) {
+        table_with_vector_index_at(":memory:").await
+    }
+
+    async fn table_with_vector_index_at(db: &str) -> (DuckDbEngine, String) {
+        let engine = DuckDbEngine::new(db, 1, "us-east-1", 409_600)
+            .await
+            .expect("engine");
+        crate::schema::apply(&engine.pool).await.expect("schema");
+        db::query("INSERT INTO accounts (account_id, account_name) VALUES (?, 'default')")
+            .bind("000000000000")
+            .execute(&engine.pool)
+            .await
+            .expect("account");
+        let input: extenddb_core::types::CreateTableInput = serde_json::from_value(json!({
+            "TableName": "t",
+            "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+            "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+            "BillingMode": "PAY_PER_REQUEST"
+        }))
+        .expect("input");
+        engine
+            .create_table_impl("000000000000", input)
+            .await
+            .expect("create table");
+        let (table_id,): (String,) =
+            db::query_as("SELECT table_id FROM tables WHERE table_name = 't'")
+                .fetch_one(&engine.pool)
+                .await
+                .expect("table_id");
+
+        db::query(
+            "INSERT INTO vector_indexes \
+             (table_id, index_id, index_name, dimensions, distance_function, vector_attribute, \
+              projection, index_status) \
+             VALUES (?, ?, 'vidx', 2, 'COSINE', ?, ?, 'ACTIVE')",
+        )
+        .bind(&table_id)
+        .bind(INDEX_ID)
+        .bind(json!({"AttributeName": "emb"}).to_string())
+        .bind(json!({"ProjectionType": "ALL"}).to_string())
+        .execute(&engine.pool)
+        .await
+        .expect("insert vector index");
+
+        let mut tx = engine.pool.begin().await.expect("tx");
+        DuckDbEngine::create_vector_data_table(
+            &mut tx,
+            &table_id,
+            INDEX_ID,
+            &base_ks(),
+            &base_ad(),
+        )
+        .await
+        .expect("create vector data table");
+        tx.commit().await.expect("commit ddl");
+        (engine, table_id)
+    }
+
+    fn item(pk: &str, generation: i32) -> Item {
+        serde_json::from_value(json!({
+            "pk": {"S": pk},
+            "gen": {"N": generation.to_string()},
+            "emb": {"L": [{"N": "1"}, {"N": "0"}]},
+        }))
+        .expect("item")
+    }
+
+    /// Drive one write's vector maintenance the way a write path does, committing
+    /// it. Returns the number of pending rows enqueued.
+    async fn write(
+        engine: &DuckDbEngine,
+        table_id: &str,
+        old: Option<&Item>,
+        new: Option<&Item>,
+        delay_ms: u64,
+    ) -> usize {
+        let mut tx = engine.pool.begin().await.expect("tx");
+        let n = crate::data::vector_index::maintain_vector_indexes(
+            &mut tx,
+            table_id,
+            &base_ks(),
+            &base_ad(),
+            old,
+            new,
+            delay_ms,
+        )
+        .await
+        .expect("maintain");
+        tx.commit().await.expect("commit write");
+        n
+    }
+
+    async fn indexed_rows(engine: &DuckDbEngine, table_id: &str) -> Vec<String> {
+        let vec_table = crate::data::vector_table_name(table_id, INDEX_ID);
+        db::query_as::<(String,)>(&format!(
+            "SELECT item_data FROM {vec_table} ORDER BY base_pk"
+        ))
+        .fetch_all(&engine.pool)
+        .await
+        .expect("read vector rows")
+        .into_iter()
+        .map(|(json,)| json)
+        .collect()
+    }
+
+    async fn queue_depth(engine: &DuckDbEngine) -> i64 {
+        db::query_as::<(i64,)>("SELECT COUNT(*) FROM gsi_pending")
+            .fetch_one(&engine.pool)
+            .await
+            .expect("count")
+            .0
+    }
+
+    /// Mark every queued row due, so a drain can be tested without sleeping for the
+    /// propagation delay. Deliberately not a sleep: a test that waits out a real
+    /// delay is slow and still races a loaded machine.
+    async fn make_all_rows_due(engine: &DuckDbEngine) {
+        db::query("UPDATE gsi_pending SET ready_at = '2000-01-01T00:00:00.000Z'")
+            .execute(&engine.pool)
+            .await
+            .expect("backdate");
+    }
+
+    /// Crash durability of async propagation: an enqueued-but-unapplied index
+    /// write survives the death of the process that enqueued it, because the
+    /// `gsi_pending` INSERT rides the caller's transaction (`data/index.rs`)
+    /// and commits atomically with the base write. There is no in-memory queue
+    /// to lose.
+    ///
+    /// Two engine lifetimes on one database file: the first commits three
+    /// writes with a long propagation delay and is dropped with the queue full
+    /// and the index empty; the second is a cold start that sees only what
+    /// reached disk, and its drain converges the index to all three items.
+    ///
+    /// What this does and does not simulate: dropping the first engine closes
+    /// DuckDB cleanly, where SIGKILL would leave an uncheckpointed WAL. The
+    /// difference is below the property under test — DuckDB recovers committed
+    /// WAL transactions on the next open by design — so "committed" is the
+    /// boundary this test pins: everything committed before the crash is
+    /// applied after restart, and nothing here depends on process memory.
+    #[tokio::test]
+    async fn enqueued_propagation_survives_a_process_crash() {
+        let _serial = super::DRAIN_TEST_LOCK.lock().await;
+        let dir = std::env::temp_dir().join(format!(
+            "eb-vec-crash-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("test dir");
+        let db_path = dir.join("crash.db");
+        let db = db_path.to_str().expect("utf8 path");
+
+        // Lifetime 1: enqueue three writes, prove they are committed but
+        // unapplied, then die.
+        let table_id = {
+            let (engine, table_id) = table_with_vector_index_at(db).await;
+            for pk in ["a", "b", "c"] {
+                let enqueued = write(&engine, &table_id, None, Some(&item(pk, 1)), 60_000).await;
+                assert_eq!(enqueued, 1, "each write must enqueue exactly one row");
+            }
+            assert_eq!(queue_depth(&engine).await, 3, "all three rows queued");
+            assert!(
+                indexed_rows(&engine, &table_id).await.is_empty(),
+                "nothing may reach the index before the crash"
+            );
+            table_id
+            // `engine` dropped here: the only surviving state is the file.
+        };
+
+        // Lifetime 2: a cold start on the same file. The queue must have
+        // survived, and one due drain must converge the index.
+        let engine = DuckDbEngine::new(db, 1, "us-east-1", 409_600)
+            .await
+            .expect("engine restart");
+        assert_eq!(
+            queue_depth(&engine).await,
+            3,
+            "committed enqueues must survive the restart"
+        );
+        make_all_rows_due(&engine).await;
+        let processed = process_gsi_batch(&engine).await.expect("drain");
+        assert_eq!(
+            processed, 3,
+            "the restarted worker applies all lost-process work"
+        );
+        assert_eq!(queue_depth(&engine).await, 0, "queue drained");
+        assert_eq!(
+            indexed_rows(&engine, &table_id).await.len(),
+            3,
+            "the index converges to every item written before the crash"
+        );
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The whole point of the change: with a propagation delay, a write does not
+    /// touch the vector index at all. It queues, stays unapplied until it is due,
+    /// and only the worker applies it.
+    ///
+    /// All four claims are asserted in one test on purpose. Split apart, each half
+    /// passes for the wrong reason — "not indexed yet" is indistinguishable from
+    /// "never indexed", and "indexed after a drain" is indistinguishable from
+    /// "indexed by the write".
+    #[tokio::test]
+    async fn a_write_reaches_the_vector_index_only_through_the_worker() {
+        let _serial = super::DRAIN_TEST_LOCK.lock().await;
+        let (engine, table_id) = table_with_vector_index().await;
+
+        let enqueued = write(&engine, &table_id, None, Some(&item("a", 1)), 60_000).await;
+        assert_eq!(enqueued, 1, "the write must enqueue exactly one row");
+        assert!(
+            indexed_rows(&engine, &table_id).await.is_empty(),
+            "an async write must not index inline"
+        );
+        assert_eq!(queue_depth(&engine).await, 1, "the row must be durable");
+
+        // Not yet due: draining must leave it alone rather than apply it early.
+        assert_eq!(
+            process_gsi_batch(&engine).await.expect("drain"),
+            0,
+            "a row that is not due must not be claimed"
+        );
+        assert!(
+            indexed_rows(&engine, &table_id).await.is_empty(),
+            "the delay must be honoured, not merely recorded"
+        );
+
+        make_all_rows_due(&engine).await;
+        assert_eq!(
+            process_gsi_batch(&engine).await.expect("drain"),
+            1,
+            "the due row must be claimed"
+        );
+        let rows = indexed_rows(&engine, &table_id).await;
+        assert_eq!(rows.len(), 1, "the worker must index the item");
+        assert!(
+            rows[0].contains("\"gen\""),
+            "payload projected: {}",
+            rows[0]
+        );
+        assert_eq!(queue_depth(&engine).await, 0, "the queue must drain");
+    }
+
+    /// The other half of the branch. A zero delay is the documented way to ask for
+    /// synchronous maintenance, and it must apply in the caller's transaction and
+    /// enqueue nothing at all.
+    #[tokio::test]
+    async fn a_zero_delay_write_is_applied_inline_and_queues_nothing() {
+        let (engine, table_id) = table_with_vector_index().await;
+
+        let enqueued = write(&engine, &table_id, None, Some(&item("a", 1)), 0).await;
+        assert_eq!(enqueued, 0, "a synchronous write has nothing to enqueue");
+        assert_eq!(
+            indexed_rows(&engine, &table_id).await.len(),
+            1,
+            "a zero-delay write must index in its own transaction"
+        );
+        assert_eq!(queue_depth(&engine).await, 0, "and must not queue");
+    }
+
+    /// Two writes to one item must reach the index in write order, whatever jitter
+    /// each drew. The guarantee comes from the queue: both rows hash to the base
+    /// key's partition and `ready_at` is clamped monotonic within it, so draining in
+    /// `id` order cannot invert them.
+    ///
+    /// Asserted on the surviving payload rather than on timestamps, because the
+    /// property that matters is which write won, not what the clamp computed.
+    #[tokio::test]
+    async fn successive_writes_to_one_item_are_applied_in_write_order() {
+        let _serial = super::DRAIN_TEST_LOCK.lock().await;
+        let (engine, table_id) = table_with_vector_index().await;
+        let first = item("a", 1);
+        let second = item("a", 2);
+
+        write(&engine, &table_id, None, Some(&first), 60_000).await;
+        write(&engine, &table_id, Some(&first), Some(&second), 60_000).await;
+
+        let partitions: Vec<(i64,)> =
+            db::query_as("SELECT DISTINCT worker_partition FROM gsi_pending")
+                .fetch_all(&engine.pool)
+                .await
+                .expect("partitions");
+        assert_eq!(
+            partitions.len(),
+            1,
+            "both writes to one base key must share a partition, or ordering is not enforced"
+        );
+
+        make_all_rows_due(&engine).await;
+        assert_eq!(process_gsi_batch(&engine).await.expect("drain"), 2);
+
+        let rows = indexed_rows(&engine, &table_id).await;
+        assert_eq!(rows.len(), 1, "one base item indexes to one row");
+        assert!(
+            rows[0].contains("\"2\""),
+            "the later write must win, found: {}",
+            rows[0]
+        );
+    }
+
+    /// An item that loses its vector attribute must leave the index. This is why the
+    /// enqueue is unconditional: the row carries no vector to insert, so a write path
+    /// that skipped queueing "because there is nothing to index" would leave the
+    /// stale row searchable forever.
+    #[tokio::test]
+    async fn an_item_that_loses_its_vector_is_removed_from_the_index() {
+        let _serial = super::DRAIN_TEST_LOCK.lock().await;
+        let (engine, table_id) = table_with_vector_index().await;
+        let with_vector = item("a", 1);
+        let without_vector: Item =
+            serde_json::from_value(json!({"pk": {"S": "a"}, "gen": {"N": "2"}})).expect("item");
+
+        write(&engine, &table_id, None, Some(&with_vector), 60_000).await;
+        make_all_rows_due(&engine).await;
+        process_gsi_batch(&engine).await.expect("drain first");
+        assert_eq!(indexed_rows(&engine, &table_id).await.len(), 1);
+
+        let enqueued = write(
+            &engine,
+            &table_id,
+            Some(&with_vector),
+            Some(&without_vector),
+            60_000,
+        )
+        .await;
+        assert_eq!(
+            enqueued, 1,
+            "a write with no vector must still enqueue: the removal is the work"
+        );
+        make_all_rows_due(&engine).await;
+        process_gsi_batch(&engine).await.expect("drain second");
+        assert!(
+            indexed_rows(&engine, &table_id).await.is_empty(),
+            "the row must be removed once the item stops carrying a vector"
+        );
+    }
+
+    /// A delete removes the row, driven only by the old item.
+    #[tokio::test]
+    async fn a_delete_removes_the_indexed_row() {
+        let _serial = super::DRAIN_TEST_LOCK.lock().await;
+        let (engine, table_id) = table_with_vector_index().await;
+        let existing = item("a", 1);
+
+        write(&engine, &table_id, None, Some(&existing), 60_000).await;
+        make_all_rows_due(&engine).await;
+        process_gsi_batch(&engine).await.expect("drain put");
+        assert_eq!(indexed_rows(&engine, &table_id).await.len(), 1);
+
+        write(&engine, &table_id, Some(&existing), None, 60_000).await;
+        make_all_rows_due(&engine).await;
+        process_gsi_batch(&engine).await.expect("drain delete");
+        assert!(indexed_rows(&engine, &table_id).await.is_empty());
+    }
+
+    /// The index can be dropped while a row is in flight. The batch must still
+    /// commit and a sibling row in the same batch must still land: the batch shares
+    /// one transaction, so an unhandled failure would take the sibling down with it.
+    ///
+    /// Deliberately not claimed as a test of the missing-table tolerance in
+    /// `apply_vector_context`. Removing that tolerance leaves this test passing,
+    /// because the per-row savepoint rolls the row back and drops it, reaching the
+    /// same end state. The difference between the two paths is an ERROR log line, not
+    /// data, and this test cannot see it.
+    #[tokio::test]
+    async fn a_row_whose_index_was_dropped_does_not_take_the_batch_down() {
+        let _serial = super::DRAIN_TEST_LOCK.lock().await;
+        let (engine, table_id) = table_with_vector_index().await;
+        write(&engine, &table_id, None, Some(&item("a", 1)), 60_000).await;
+
+        // A second table and index, standing in for unrelated work in the same batch.
+        let survivor_index = "vidx-survivor";
+        db::query(
+            "INSERT INTO vector_indexes \
+             (table_id, index_id, index_name, dimensions, distance_function, vector_attribute, \
+              projection, index_status) \
+             VALUES (?, ?, 'vidx2', 2, 'COSINE', ?, ?, 'ACTIVE')",
+        )
+        .bind(&table_id)
+        .bind(survivor_index)
+        .bind(json!({"AttributeName": "emb"}).to_string())
+        .bind(json!({"ProjectionType": "ALL"}).to_string())
+        .execute(&engine.pool)
+        .await
+        .expect("insert survivor index");
+        let mut tx = engine.pool.begin().await.expect("tx");
+        DuckDbEngine::create_vector_data_table(
+            &mut tx,
+            &table_id,
+            survivor_index,
+            &base_ks(),
+            &base_ad(),
+        )
+        .await
+        .expect("create survivor table");
+        tx.commit().await.expect("commit ddl");
+
+        // This write enqueues for both indexes; then the first index's table is
+        // dropped out from under its queued row.
+        write(&engine, &table_id, None, Some(&item("b", 7)), 60_000).await;
+        let dropped = crate::data::vector_table_name(&table_id, INDEX_ID);
+        db::query(&format!("DROP TABLE {dropped}"))
+            .execute(&engine.pool)
+            .await
+            .expect("drop index data table");
+
+        make_all_rows_due(&engine).await;
+        let processed = process_gsi_batch(&engine).await.expect("drain");
+        assert_eq!(processed, 3, "every claimed row must be consumed");
+        assert_eq!(queue_depth(&engine).await, 0, "no row may be left behind");
+
+        let survivor = crate::data::vector_table_name(&table_id, survivor_index);
+        let (rows,): (i64,) = db::query_as(&format!("SELECT COUNT(*) FROM {survivor}"))
+            .fetch_one(&engine.pool)
+            .await
+            .expect("count survivor");
+        assert_eq!(
+            rows, 1,
+            "the sibling index must still be maintained when another index vanishes"
+        );
+    }
+
+    /// Applying the same claimed context twice must leave the same single row.
+    ///
+    /// The batch is at-least-once: claim and apply share a transaction, so a crash
+    /// mid-apply rolls back and the row is claimed again. That story is only safe if
+    /// an apply is idempotent, which is asserted here directly rather than by
+    /// implication.
+    ///
+    /// Being exact about its strength: this is a structural regression guard, not a
+    /// discriminating test. Its assertions cannot fail today without a schema change,
+    /// because the vector row's primary key is the base item key, so a replay can only
+    /// ever overwrite. Measured, not assumed: making the delete conditional on
+    /// `old_item` leaves this test PASSING, since the replayed insert then collides on
+    /// the primary key, the row is dropped by the savepoint, and the end state is the
+    /// same single row. The test below is the one that catches that refactor.
+    #[tokio::test]
+    async fn applying_the_same_row_twice_is_idempotent() {
+        let _serial = super::DRAIN_TEST_LOCK.lock().await;
+        let (engine, table_id) = table_with_vector_index().await;
+        write(&engine, &table_id, None, Some(&item("a", 1)), 60_000).await;
+
+        // Capture the claimed row's payload, then replay it a second time.
+        let claimed: (Option<String>, Option<String>, String) =
+            db::query_as("SELECT old_item, new_item, index_context FROM gsi_pending LIMIT 1")
+                .fetch_one(&engine.pool)
+                .await
+                .expect("read the queued row");
+
+        make_all_rows_due(&engine).await;
+        process_gsi_batch(&engine).await.expect("first apply");
+        let after_first = indexed_rows(&engine, &table_id).await;
+        assert_eq!(after_first.len(), 1, "first apply indexes the item");
+
+        // Re-enqueue the identical context, exactly as a rolled-back batch would
+        // leave it, and drain again.
+        db::query(
+            "INSERT INTO gsi_pending \
+             (table_id, worker_partition, old_item, new_item, index_context, ready_at) \
+             VALUES (?, 0, ?, ?, ?, '2000-01-01T00:00:00.000Z')",
+        )
+        .bind(&table_id)
+        .bind(&claimed.0)
+        .bind(&claimed.1)
+        .bind(&claimed.2)
+        .execute(&engine.pool)
+        .await
+        .expect("replay the row");
+        process_gsi_batch(&engine).await.expect("second apply");
+
+        let after_second = indexed_rows(&engine, &table_id).await;
+        assert_eq!(
+            after_second.len(),
+            1,
+            "a replayed apply must not duplicate the row"
+        );
+        assert_eq!(
+            after_first, after_second,
+            "a replayed apply must reach an identical end state"
+        );
+    }
+
+    /// A write that carries NO old image must still replace the indexed row.
+    ///
+    /// This is a real production path, not a contrived one: `put_item` only reads the
+    /// old image when a condition, a stream, `ReturnValues`, or a GSI needs it, so a
+    /// table whose only index is a vector index writes with `old_item = None` on the
+    /// common path. The apply therefore cannot rely on the old image to find the row
+    /// to displace, and keys the delete off `old_item.or(new_item)` because the base
+    /// key is immutable.
+    ///
+    /// This is the test that guards the invariant behind the plain `INSERT` in
+    /// `insert_vector_row`. Making the delete conditional on `old_item` fails it: the
+    /// second insert collides on the primary key, the savepoint drops the row, and the
+    /// STALE payload survives. That failure is silent in production, which is why it
+    /// is worth a dedicated test rather than leaving it to the idempotency case above.
+    #[tokio::test]
+    async fn a_write_with_no_old_image_still_replaces_the_indexed_row() {
+        let _serial = super::DRAIN_TEST_LOCK.lock().await;
+        let (engine, table_id) = table_with_vector_index().await;
+
+        write(&engine, &table_id, None, Some(&item("a", 1)), 60_000).await;
+        make_all_rows_due(&engine).await;
+        process_gsi_batch(&engine).await.expect("first apply");
+        assert!(
+            indexed_rows(&engine, &table_id).await[0].contains("\"1\""),
+            "precondition: the first generation is indexed"
+        );
+
+        // The second write supplies no old image, exactly as put_item does when
+        // nothing else needs it.
+        write(&engine, &table_id, None, Some(&item("a", 2)), 60_000).await;
+        make_all_rows_due(&engine).await;
+        process_gsi_batch(&engine).await.expect("second apply");
+
+        let rows = indexed_rows(&engine, &table_id).await;
+        assert_eq!(rows.len(), 1, "one base item indexes to one row: {rows:?}");
+        assert!(
+            rows[0].contains("\"2\""),
+            "the newer write must replace the row even with no old image, found: {}",
+            rows[0]
+        );
+    }
+}

--- a/devtools/run-tests
+++ b/devtools/run-tests
@@ -135,9 +135,9 @@ done
 
 # --- Validate: backend name ---
 case "$BACKEND" in
-    postgres|sqlite|mongodb) ;;
+    postgres|sqlite|mongodb|duckdb) ;;
     *)
-        echo "error: --backend must be 'postgres', 'sqlite' or 'mongodb' (got: $BACKEND)"
+        echo "error: --backend must be 'postgres', 'sqlite', 'mongodb' or 'duckdb' (got: $BACKEND)"
         exit 1
         ;;
 esac

--- a/docs/design/14-storage-duckdb.md
+++ b/docs/design/14-storage-duckdb.md
@@ -1,0 +1,216 @@
+# Design: DuckDB Storage Backend
+
+## 1. Overview
+
+The DuckDB backend (`extenddb-storage-duckdb`) implements the same trait surface as
+`extenddb-storage-postgres` and `extenddb-storage-sqlite`: the six engine traits
+(`TableEngine`, `DataEngine`, `MetadataEngine`, `StreamEngine`, `BackupEngine`,
+`WorkerStore`) and the catalog traits (`ManagementStore`, `AdminStore`,
+`SettingsStore`, `MetricsStore`, `RateLimitStore`, `AuthorizationStore`).
+
+**Driver:** `duckdb` (the official Rust binding, synchronous, statically linked via
+`libduckdb-sys` with the `bundled` and `json` features). No `sqlx` driver exists for
+DuckDB; the crate supplies its own thin async facade (§5.1).
+
+**Minimum DuckDB version:** whatever `libduckdb-sys` bundles (1.5.x at the time of
+writing). There is no external server and no runtime dependency.
+
+**Lineage.** The crate is a port of the SQLite backend: same catalog schema, same
+per-table data layout, same order-preserving `N` sort-key encoding, same persistent
+`gsi_pending` queue, same synchronous LSI / delayed GSI model, same in-memory and
+`dev-mode` contracts. This document covers only what changed. For everything else
+see `crates/storage-sqlite/docs/design-decisions.md` and the crate-local
+`crates/storage-duckdb/docs/design-decisions.md`.
+
+## 2. Database Layout
+
+One DuckDB database — a single file, or `:memory:` — holds the catalog and every
+per-table data table. Data tables are `_ddb_<table_id>` (items), `_ddb_<index_id>`
+(GSI / LSI projections), and `_vidx_<table_id>_<index_id>` (one row per vector).
+
+| Object                | Purpose                                              |
+|-----------------------|------------------------------------------------------|
+| `extenddb.duckdb`     | Catalog tables, IAM, settings, metrics, backups, stream shards/records, `gsi_pending`, and all data tables |
+| `extenddb.duckdb.wal` | DuckDB's write-ahead log; created and checkpointed by the engine |
+
+Both files are restricted to owner read/write on Unix, since the database stores the
+AES key that protects access-key secrets.
+
+## 3. Schema
+
+Identical to the SQLite catalog (`crates/storage-sqlite/src/schema.rs`) with the
+following type and syntax substitutions:
+
+| SQLite                                        | DuckDB                                                  | Why |
+|-----------------------------------------------|---------------------------------------------------------|-----|
+| `INTEGER`                                     | `BIGINT`                                                | DuckDB `INTEGER` is 32-bit; SQLite's is 64-bit |
+| `REAL`                                        | `DOUBLE`                                                | DuckDB `REAL` is a 32-bit float |
+| `INTEGER PRIMARY KEY AUTOINCREMENT`           | `BIGINT PRIMARY KEY DEFAULT nextval('gsi_pending_seq')` | No `AUTOINCREMENT`; sequences instead |
+| `strftime('%Y-%m-%dT%H:%M:%fZ','now')`        | `strftime(now()::TIMESTAMP, '%Y-%m-%dT%H:%M:%S.%gZ')`   | Different `strftime` signature; `%g` is milliseconds |
+| `CAST(strftime('%s','now') AS INTEGER)`       | `CAST(epoch(now()) AS BIGINT)`                          | |
+| `9e999` / `-9e999`                            | `'Infinity'::DOUBLE` / `'-Infinity'::DOUBLE`            | |
+| `CREATE INDEX ... WHERE <pred>`               | `CREATE INDEX ...`                                      | Partial indexes are not implemented |
+| `REFERENCES ... ON DELETE CASCADE`            | *(removed)*                                             | See §5.3 |
+| `sqlite_master`                               | `duckdb_tables()`                                       | |
+| `PRAGMA journal_mode / foreign_keys / ...`    | *(none)*                                                | No connection pragmas needed |
+| `BEGIN IMMEDIATE`                             | `BEGIN TRANSACTION`                                     | No reserved-lock concept |
+| `?1`, `?2` numbered parameters                | `$1`, `$2`                                              | |
+| `json_extract(item_data, p)`                  | `json_extract_string(item_data, p)` + `TRY_CAST`        | DuckDB's `json_extract` returns a quoted JSON scalar |
+
+Booleans remain 0/1 integer columns, and a Rust `bool` binds as `BIGINT` so
+`col = ?` compares like-for-like; DuckDB does not coerce a `BOOLEAN` parameter
+against an integer column, nor an integer parameter against a `TEXT` column.
+
+## 4. Data Path
+
+Unchanged from SQLite except:
+
+- **Parallel scan** still partitions on `rowid % total_segments`. DuckDB exposes
+  `rowid` on every base table.
+- **Vector backfill cursor** is `rowid > ?` starting from `-1`, because DuckDB
+  rowids start at 0 where SQLite's start at 1.
+- **Vector search** fetches a partition's rows in one call rather than streaming
+  them (the facade materialises result sets on the blocking side).
+
+## 5. Key Design Decisions
+
+### 5.1 Async facade over a synchronous driver
+
+`src/db.rs` reproduces the subset of the `sqlx` builder API the storage code uses:
+`query` / `query_as` / `query_scalar` / `raw_sql` with positional `.bind()`,
+`fetch_all` / `fetch_one` / `fetch_optional` / `execute`, `Pool::begin`, and a
+`Transaction` that commits explicitly and rolls back on drop.
+
+`duckdb::Connection` is `Send` but not `Sync`, and every call blocks. Each pooled
+connection lives in a `tokio::sync::Mutex<Option<Connection>>` slot. To run a
+statement the connection is taken out of its slot, moved onto a `spawn_blocking`
+thread for the call, and put back. A transaction holds its slot for its lifetime so
+every statement in it runs on the same connection. Rows come back as
+`Vec<duckdb::types::Value>` and are decoded into tuples or structs on the async side,
+so nothing borrowed from DuckDB crosses a thread boundary.
+
+Decoding is permissive where DuckDB's result types differ from SQLite's: `SUM` over
+`BIGINT` is `HUGEINT`, `EXISTS(...)` is `BOOLEAN`, `PRAGMA table_info` reports a
+boolean `pk` flag rather than a position. Every integer variant decodes into `i64`;
+`Boolean` decodes into `i64` and `bool`.
+
+### 5.2 One database instance per file per process
+
+DuckDB permits a single database instance per file per process. The SQLite backend
+opens independent pools over the same file for the engine, the catalog store, and
+the bootstrapper; here every pool over a path is a set of `try_clone()`s of one
+registered root connection, and the catalog pool is opened as a `sibling` of the
+engine pool. `destroy` forgets the registry entry before deleting the file so the
+lock is released.
+
+In-memory databases are not registered: each `Pool::open(":memory:")` is private
+(what the unit tests expect), but connections cloned from it share one database.
+The ephemeral mode therefore runs a real read pool where SQLite had to pin a single
+connection.
+
+### 5.3 Referential integrity in code
+
+DuckDB parses `FOREIGN KEY` but rejects `ON DELETE CASCADE` and refuses updates to
+rows that a foreign key references. The catalog declares no foreign keys.
+`src/referential.rs` supplies:
+
+- one child-delete function per parent (tables → indexes / vector_indexes /
+  stream_shards / stream_records; accounts → every IAM table; users → tags / access
+  keys / memberships; groups → memberships; roles → tags / sessions), called inside
+  the parent's delete transaction;
+- `ensure_{account,user,group,role}_exists` checks in the seven child-insert paths
+  that previously relied on a foreign-key violation to report `NotFound`.
+
+The pool-based deletes (`delete_user`, `delete_group`, `delete_role`,
+`delete_account`) become single transactions. Existence checks in autocommit paths
+are not atomic with the insert that follows; a lost race surfaces as `NotFound` from
+a later read rather than from a constraint, which is the outcome callers already
+handle.
+
+### 5.4 Concurrency and isolation
+
+Writers are serialized in-process by the engine `write_lock`, exactly as in SQLite;
+that is what makes condition-check-then-write atomic. DuckDB adds MVCC on top, so
+readers never block on the writer, and two connections updating the same row
+produce `TransactionContext Error: Conflict on update!` on the second — classified
+`Transient` by `map_db_err` as a backstop, not relied upon as the mechanism.
+
+A failed statement aborts a DuckDB transaction; every subsequent statement on it
+fails until `ROLLBACK`. Every path in the crate that catches a constraint error
+inside a transaction already returns the error and drops the transaction, and
+`db::Transaction` rolls back on drop, which is what keeps pooled connections clean.
+
+### 5.5 GSI queue without savepoints
+
+DuckDB has no `SAVEPOINT`, which the SQLite worker uses to isolate a poison row
+inside a batch transaction. The DuckDB worker claims and applies each `gsi_pending`
+row in its own transaction: `DELETE ... WHERE id = ?` (zero rows → already taken,
+skip), apply, `COMMIT`. A transient error rolls that row back and stops the pass;
+a poison row rolls back, is deleted in a statement of its own, and the pass
+continues. At-least-once delivery, per-key FIFO (`ORDER BY id`), and poison
+isolation are preserved.
+
+### 5.6 What was not changed
+
+- The `N` sort-key encoding (order-preserving TEXT). DuckDB's default collation is
+  binary, so the encoding orders correctly with no custom collation.
+- The persistent `gsi_pending` queue and the per-index propagation delay.
+- The catalog version gate (`catalog_version` setting).
+- The `dev-mode` contract and the `memory` feature.
+
+## 6. Crate Structure
+
+```
+crates/storage-duckdb/
+├── src/
+│   ├── db.rs               # async facade over duckdb (pool, queries, transactions)
+│   ├── referential.rs      # explicit cascades and existence checks
+│   ├── duckdb_util.rs      # path normalisation, timestamps, error classification
+│   ├── schema.rs           # catalog DDL (DuckDB dialect)
+│   └── ...                 # everything else mirrors storage-sqlite
+└── docs/design-decisions.md
+```
+
+## 7. Configuration
+
+```toml
+[storage]
+backend = "duckdb"
+
+[storage.duckdb]
+path = "extenddb.duckdb"   # or ":memory:"
+pool_size = 10
+```
+
+`extenddb init --backend duckdb --duckdb-path <path>` writes the path into the
+generated config. `EXTENDDB__STORAGE__DUCKDB__PATH` overrides it at serve time.
+
+Binary features: `duckdb` (file-backed default) and `duckdb-memory` (`:memory:` as
+the compiled-in default). Both are accepted by the `dev-mode` gate.
+
+## 8. Testing
+
+- Crate unit tests (`cargo test -p extenddb-storage-duckdb`): the SQLite suite,
+  retargeted. Plan-shape assertions (`EXPLAIN QUERY PLAN`) became index-definition
+  assertions (`duckdb_indexes()`), because DuckDB's optimizer picks a sequential
+  scan below a row-count threshold regardless of indexes.
+- `run-integration-duckdb` in `.github/workflows/integration.yml` runs the shared
+  Python conformance suite against a DuckDB-served instance, mirroring the SQLite
+  job.
+
+## 9. Known Limits
+
+- **Process-exclusive file lock.** DuckDB permits one process per database file
+  (read-write). While the server runs, `extenddb settings`, `catalog-check`, and
+  `verify` cannot open the file from a second process; run them with the server
+  stopped. The `test_gsi_async` integration module, which drives the server
+  out-of-band through `settings set`, is excluded from the DuckDB CI job for this
+  reason; the propagation logic it covers has crate-level unit tests.
+- **No TTL expression index.** DuckDB rejects indexes over extension functions
+  (`json_extract_string`), so `enable_ttl` records the table as ready without
+  building one and the sweep is a filtered scan.
+- Compiling DuckDB from source adds several minutes to a cold build.
+- DuckDB is optimised for analytical workloads; single-row point writes go through
+  the same columnar storage and are slower than SQLite's B-tree at high write
+  rates. The backend is correct before it is fast.
+- `EXPLAIN`-driven index assertions are not meaningful at test-table sizes.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -17,6 +17,8 @@ This directory contains the authoritative design documents for ExtendDB (extendd
 | 09 | [Testing](09-testing.md) | Test strategy, reference suites, golden files, multi-language test suites, coverage tracking |
 | 10 | [Licenses](10-dependency-licenses.md) | Licensing summary for third-party dependencies |
 | 11 | [Scaling](11-high-availability.md) | DRAFT document on scaling ExtendDB |
+| 13 | [MongoDB Backend](13-storage-mongodb.md) | MongoDB storage backend (`extenddb-storage-mongodb` crate) |
+| 14 | [DuckDB Backend](14-storage-duckdb.md) | DuckDB storage backend: async facade, no-FK integrity, dialect mapping (`extenddb-storage-duckdb` crate) |
 
 
 ## How to Use These Docs

--- a/extenddb.sample.toml
+++ b/extenddb.sample.toml
@@ -29,7 +29,7 @@
 # run_dir = "~/.extenddb/run"  # Directory for PID file (~ is expanded to $HOME)
 
 [storage]
-# backend = "postgres"         # Storage backend: "postgres" (default), "mongodb", or "sqlite".
+# backend = "postgres"         # Storage backend: "postgres" (default), "mongodb", "sqlite", or "duckdb".
 
 # --- SQLite backend (developer mode) ---
 # Select with `extenddb init --backend sqlite`. The database path can be given
@@ -39,6 +39,15 @@
 # Use ":memory:" for an ephemeral in-memory database (data lost on shutdown).
 # [storage.sqlite]
 # path = "extenddb.sqlite"
+
+# --- DuckDB backend (embedded, columnar) ---
+# Select with `extenddb init --backend duckdb`. The database path can be given
+# at init time (`extenddb init --duckdb-path <path>`, written into this file)
+# or set here. At serve time, the EXTENDDB__STORAGE__DUCKDB__PATH environment
+# variable overrides this value.
+# Use ":memory:" for an ephemeral in-memory database (data lost on shutdown).
+# [storage.duckdb]
+# path = "extenddb.duckdb"
 
 [storage.postgres]
 # Connection string points to the CATALOG database.


### PR DESCRIPTION
## Forward

This is the fourth time.

[#54](https://github.com/ExtendDB/extenddb/pull/54) put the items in Route 53. [#174](https://github.com/ExtendDB/extenddb/pull/174) put them in S3 Object Annotations. [#205](https://github.com/ExtendDB/extenddb/pull/205) put them in DynamoDB, which was the anti-joke, and which was closed, which was the joke.

Then Amazon acquired DuckDB Labs.

I have no inside information about the deal and I'm not going to invent any. I only know that a DynamoDB-compatible database whose maintainers were ex-AWS engineers now has, available to it, an embedded analytics engine owned by the company that makes DynamoDB. Declining to wire those together would have been the one irresponsible option.

This PR adds DuckDB as a storage backend. Your key-value store is now a columnar OLAP engine wearing a key-value costume. Nobody at the acquiring company asked for this. That is the traditional posture of this series.

## What is actually in here

Unlike three of its four siblings, this backend works. `cargo build -p extenddb --no-default-features --features duckdb`, `init`, `serve`, point boto3 at it. 932 tests in the main suite and 331 in the comprehensive suite pass against a DuckDB-served instance. Zero failures.

It is a port of the SQLite backend, which is the most flattering thing I can say about the SQLite backend: it survived transplant into an engine that disagrees with SQLite about nearly everything below the SQL grammar.

The disagreements are the content of the PR.

**DuckDB has no `sqlx` driver.** The SQLite crate is 17,500 lines of `sqlx::query(...).bind(...).fetch_all(&pool)`. So `src/db.rs` is a small async facade that impersonates the exact slice of `sqlx` the crate uses: a pool, the three query builders, and a transaction that rolls back on drop. `duckdb::Connection` is `Send` but not `Sync` and every call blocks, so each statement lifts the connection out of its slot, runs it on a `spawn_blocking` thread, and puts it back. The port then becomes, mostly, `sqlx::` → `db::`. I would like to say this was the plan from the start. It was the plan from about twenty minutes in.

**DuckDB does not cascade deletes.** It will parse `ON DELETE CASCADE`. It will then tell you, at `CREATE TABLE`, that it does not do that. The catalog relied on cascades in eleven places, so the schema now has no foreign keys at all and `src/referential.rs` is a file that does, by hand, what a database is for.

**DuckDB has no `SAVEPOINT`.** The GSI propagation worker used one per queued row so a poison row couldn't roll back its siblings. It now runs one transaction per row. Same guarantees, more commits, a ritual repeated a hundred times per batch.

**DuckDB's `INTEGER` is 32 bits.** `table_size_bytes INTEGER` would have overflowed at 2 GiB, which is the kind of bug that ships. Every integer is now `BIGINT`. `REAL` is a 32-bit float, so it's `DOUBLE`. `char()` is `chr()`, which took `begins_with` down until it wasn't. SQLite's scalar `MIN(a, b)` is an aggregate in DuckDB and is not allowed in an `UPDATE`; the metrics upsert now says `LEAST`. `rowid` starts at 0. Every one of these was found by a failing test, which is the argument for having tests.

**DuckDB will not index an expression that calls an extension function.** The TTL sweep wanted an index on `json_extract_string(item_data, '$.ttl.N')`. Left alone, the engine retried that index forever and never marked the table TTL-ready, and nothing ever expired. Now it doesn't try. TTL is a filtered scan. Analytics engine; it can scan.

## Why this is not as deranged as it sounds

- The file on disk is a real DuckDB database. `duckdb extenddb.duckdb` then `SELECT COUNT(*) FROM "_ddb_..." GROUP BY ...` and you are doing analytics against your DynamoDB-compatible table with no export step, no Iceberg, no ETL, and no invoice. This is the single most useful property of any backend in this series and I resent that.
- In-memory mode is better than SQLite's. A DuckDB in-memory database is shared by every connection cloned from it, so `:memory:` gets a real read pool where SQLite had to pin one connection.
- MVCC. Readers never block on the writer. SQLite's `BEGIN IMMEDIATE` dance is gone.
- It is a second embedded backend, and it found real semantics the storage seam had been letting SQLite define by default. That's what a second implementation is for.

These are defensible reasons to merge this PR, which is as usual damaging to the artistic intent.

## Why it is exactly as deranged as it sounds

- DuckDB is a vectorized columnar engine tuned for scanning billions of rows. Every `PutItem` is a one-row `INSERT ... ON CONFLICT DO UPDATE` into that engine. It is a combine harvester being used to trim a bonsai.
- **One process at a time.** DuckDB takes a process-exclusive lock on the file. While the server is running, `extenddb settings set` from another shell cannot open the database. Not "returns stale data." Cannot open it. The CLI and the server now have to take turns, which is a concurrency model I last encountered in a household with one bathroom.
- The catalog has no foreign keys because the database refused to enforce them, so the Rust code enforces them, so the database has been demoted to a place where the Rust code keeps its files.
- A cold build compiles DuckDB from source. Budget several minutes. It is cached afterward, in the same sense that the acquisition is cached.
- This backend's only dependency is now owned by the company whose product it exists to impersonate. The supply chain is a loop.

## Known limits

Documented in `crates/storage-duckdb/README.md` and `docs/design/14-storage-duckdb.md`: the process lock (run `settings`/`catalog-check`/`verify` with the server stopped), no TTL expression index, cold build time. The `test_gsi_async` module, which drives the server out-of-band through `settings set`, is excluded from the DuckDB CI job for the lock reason; the paths it exercises have crate-level unit tests.
