### PR TITLE
chore: redirect the legacy GitHub Pages URL to extenddb.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<!-- Copyright 2026 ExtendDB contributors. Licensed under the Apache License, Version 2.0. -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>ExtendDB</title>
+    <meta http-equiv="refresh" content="0; url=https://extenddb.org/">
+    <link rel="canonical" href="https://extenddb.org/">
+    <meta name="robots" content="noindex">
+  </head>
+  <body>
+    <p>The ExtendDB documentation lives at <a href="https://extenddb.org/">extenddb.org</a>.</p>
+  </body>
+</html>


### PR DESCRIPTION
## What

Adds a root `index.html` that redirects the legacy GitHub Pages URL (`extenddb.github.io/extenddb`) to https://extenddb.org/.

## Why

https://extenddb.org/ is the only authoritative source for ExtendDB documentation. The legacy Pages site is being deleted and archived; this redirect points any remaining visitors and bookmarks to extenddb.org in the interim. An admin can then disable Pages in the repo settings (Settings -> Pages -> Source: None).

Closes n/a

## Testing done

Verified the page locally in a browser: it redirects immediately to https://extenddb.org/. `noindex` keeps the legacy URL out of search results.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`) - no Rust changes
- [x] Code is formatted (`cargo fmt --check`) - no Rust changes
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`) - no Rust changes
- [x] I have added or updated tests for new functionality - n/a
- [x] I have updated documentation if behavior changed - n/a
- [x] Breaking changes are noted below (if any) - none

ADR / RFC: n/a

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.