### PR TITLE
ci(actions): settle windows must tolerate a stale previous digest

### DIFF
--- a/.github/actions/copy-artifact/action.yml
+++ b/.github/actions/copy-artifact/action.yml
@@ -81,11 +81,17 @@ runs:
         # immediate read 404s — failed the v0.1.8 dev propagation live).
         # Retry is only correct after our own write; the existence DECISION
         # above stays a strict single probe.
+        # A mismatch immediately after our own write can be the stale
+        # previous value (registries lag in both directions), so retry
+        # inside the window and only fail once it expires. The existence
+        # DECISION above stays a strict single probe.
+        LAST='(never read)'
         for _ in 1 2 3 4 5 6; do
           set +e; GOT=$(probe "${DST}:${TAG}"); rc=$?; set -e
           [[ $rc == 0 && "$GOT" == "$WANT" ]] && exit 0
-          [[ $rc == 0 && "$GOT" != "$WANT" ]] && { echo "::error::${DST}:${TAG} resolves to ${GOT}, expected ${WANT}"; exit 1; }
+          [[ $rc == 0 ]] && LAST="$GOT"
+          [[ $rc == 9 ]] && LAST='MISSING'
           sleep 5
         done
-        echo "::error::${DST}:${TAG} not visible with expected digest after settle window"
+        echo "::error::${DST}:${TAG} did not settle on ${WANT} within the window; last seen ${LAST}"
         exit 1

--- a/.github/actions/promote-registry/action.yml
+++ b/.github/actions/promote-registry/action.yml
@@ -99,20 +99,29 @@ runs:
         }
 
         # settle(): post-WRITE assertion with a bounded settle window. ECR
-        # Public exhibits read-after-write lag (observed live: a copy's own
-        # log confirms the write, the immediate read 404s, and the tag is
-        # visible seconds later — this failed the v0.1.8 dev propagation).
-        # Retrying is ONLY correct after our own write; state DECISIONS
-        # (exists/absent/verify) stay strict single probes.
+        # Public exhibits read-after-write lag in BOTH directions:
+        #   * a newly created tag reads as absent for a few seconds
+        #     (failed the v0.1.8 dev propagation), and
+        #   * an OVERWRITTEN tag — `latest` moving to a new release — keeps
+        #     reading as the PREVIOUS digest for a few seconds (failed the
+        #     v0.1.10 dev propagation, after correctly writing every tag).
+        # So a mismatch immediately after our own write is not evidence of a
+        # wrong artifact; it is the stale value we just replaced. Both cases
+        # therefore retry inside the window and only fail once it expires,
+        # reporting the last value seen. Retrying is ONLY correct after our
+        # own write: state DECISIONS (exists/absent, verify-before-tag) stay
+        # strict single probes, so nothing here weakens the fail-closed
+        # guarantees.
         settle() {
-          local ref="$1" want="$2" got rc
+          local ref="$1" want="$2" got rc last='(never read)'
           for _ in 1 2 3 4 5 6; do
             set +e; got=$(probe "$ref"); rc=$?; set -e
             [[ $rc == 0 && "$got" == "$want" ]] && return 0
-            [[ $rc == 0 && "$got" != "$want" ]] && { echo "::error::${ref} resolves to ${got}, expected ${want}" >&2; return 1; }
+            [[ $rc == 0 ]] && last="$got"
+            [[ $rc == 9 ]] && last='MISSING'
             sleep 5
           done
-          echo "::error::${ref} not visible with expected digest after settle window" >&2
+          echo "::error::${ref} did not settle on ${want} within the window; last seen ${last}" >&2
           return 1
         }
 


### PR DESCRIPTION
## What

Both composite actions' post-write settle windows now retry when the read
returns a **different** digest, not only when it returns *absent* — failing
only once the window expires, and reporting the last value seen.

## Why

The v0.1.10 dev propagation ([run 33429520838](https://github.com/ExtendDB/extenddb/actions/runs/33429520838))
wrote every ECR tag **correctly** — version tag, `latest`, and signature all
verify on all three registries right now — and then failed its own
assertion: `public.ecr.aws/…/extenddb-dev:latest` still read as the 0.1.8
digest seconds after being overwritten, and `settle()` treated any reachable
mismatch as immediate hard failure with no retry.

That was my error in #300: I fixed the lag direction we had observed (a new
tag reading absent, from v0.1.8) and left the other direction — an
**overwritten** tag reading as its previous value — failing fast. A
mismatch immediately after our own write is not evidence of a wrong
artifact; it is the value we just replaced.

**This matters beyond the dev image:** `promote-image`'s GHCR and ECR legs
move `latest` exactly the same way, so the next postgres promotion would
hit the same false failure. Worth landing before it runs.

State decisions — exists/absent classification and verify-before-tag —
remain strict single probes, so nothing here weakens the fail-closed
guarantees that stop unsigned or wrong artifacts from being tagged.

## Testing done

- `yaml.safe_load` passes on both actions.
- Live evidence for the diagnosis: all three registries currently serve
  dev `0.1.10` and `latest` at `sha256:9c2f78cd…` with a verifying
  signature, i.e. the failing run's writes were all correct and only its
  read was stale.
- Failure path preserved: an artifact that genuinely never converges still
  fails, now after ~30s with the last observed digest in the message
  (strictly more diagnostic than before).
- Not executable pre-merge (main-only environments); the next propagation
  or promotion exercises it, and it fails closed if wrong.

## Checklist

- [ ] Tests / fmt / clippy — not applicable, CI only
- [x] Added or updated tests — the failure mode is registry timing; the fix is bounded and fails closed on expiry
- [x] Documentation — both actions' comments now describe lag in both directions and why decision probes stay strict
- [x] Breaking changes noted below

ADR / RFC: n/a — CI tooling only.

## Breaking changes

None.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
