### PR TITLE
feat(dev-mode): always seed the example pair; vend extras via EXTENDDB_DEV_*

### DIFF
--- a/crates/app/src/cmd_serve.rs
+++ b/crates/app/src/cmd_serve.rs
@@ -172,16 +172,7 @@ pub fn run(args: &ServeArgs, build: BuildInfo) -> anyhow::Result<()> {
         println!("{banner_line2}");
     }
     if cfg!(feature = "dev-mode") {
-        let msg = format!(
-            "  DEVELOPER MODE: plain HTTP on loopback, authorization open \
-             (SigV4 still enforced). Serving storage: {}. Not for production.",
-            config::redact_password(app_config.storage.connection_config()),
-        );
-        if args.foreground {
-            eprintln!("{msg}");
-        } else {
-            println!("{msg}");
-        }
+        print_dev_mode_banner(&app_config, args.foreground)?;
     }
 
     // D-3: A PID file lets `extenddb status` and `extenddb stop` find the
@@ -269,6 +260,49 @@ pub fn run(args: &ServeArgs, build: BuildInfo) -> anyhow::Result<()> {
                 })
                 .with_dev_mode(cfg!(feature = "dev-mode")),
         ))
+}
+
+/// Print the developer-mode banner lines: the mode notice, the credentials to
+/// sign with, and an advisory when an ambient `AWS_ACCESS_KEY_ID` would not
+/// verify.
+///
+/// Resolving here (not just in `serve()`) fails fast on a misconfigured
+/// `EXTENDDB_DEV_*` pair before daemonizing, and gives the invoking user the
+/// credentials without digging through logs. The built-in example pair is
+/// printed in full: it is public AWS documentation, not a secret. An
+/// operator-supplied secret is never printed.
+fn print_dev_mode_banner(app_config: &config::AppConfig, foreground: bool) -> anyhow::Result<()> {
+    use extenddb_server::dev_credentials;
+
+    let dev_creds = dev_credentials::resolve()?;
+    let mut lines = vec![
+        format!(
+            "  DEVELOPER MODE: plain HTTP on loopback, authorization open \
+             (SigV4 still enforced). Serving storage: {}. Not for production.",
+            config::redact_password(app_config.storage.connection_config()),
+        ),
+        format!(
+            "  Sign requests with: {}",
+            dev_credentials::describe(&dev_creds)
+        ),
+    ];
+    if let Some(ignored) = dev_credentials::ignored_aws_env_key(&dev_creds) {
+        lines.push(format!(
+            "  Note: AWS_ACCESS_KEY_ID is set but not adopted; requests signed with \
+             '{ignored}' will be rejected. Set EXTENDDB_DEV_ACCESS_KEY_ID and \
+             EXTENDDB_DEV_SECRET_ACCESS_KEY to seed an additional credential."
+        ));
+    }
+    // Same stream split as the main banner: stdout for the daemon parent,
+    // stderr in foreground mode so supervisors capture one stream.
+    for msg in lines {
+        if foreground {
+            eprintln!("{msg}");
+        } else {
+            println!("{msg}");
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/server/src/dev_credentials.rs
+++ b/crates/server/src/dev_credentials.rs
@@ -1,0 +1,376 @@
+// Copyright 2026 ExtendDB contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Developer-mode credential vending.
+//!
+//! Dev mode verifies `SigV4` exactly like production, so the server must know
+//! every credential an SDK may sign with. The contract is "always the example
+//! pair, plus at most one explicit extra":
+//!
+//! * The built-in credential is AWS's documented example pair. It is seeded on
+//!   every dev-mode boot, unconditionally, so tools that hardcode it (`NoSQL
+//!   Workbench`'s `ExtendDB` connection type, the `@extenddb/dev` launchers, the
+//!   docs and CI) keep working regardless of operator configuration. An SDK
+//!   must know a credential up front (it cannot read a printed banner), which
+//!   is why the default is well-known rather than generated. The pair is
+//!   public AWS documentation, recognised by secret scanners as non-live, so
+//!   it is safe in banners, fixtures, and syslog.
+//! * `EXTENDDB_DEV_ACCESS_KEY_ID` / `EXTENDDB_DEV_SECRET_ACCESS_KEY` (both or
+//!   neither) seed one additional credential. The dedicated names follow the
+//!   `EXTENDDB_DEV_ALLOW_ANY_BIND` precedent: dev-only levers get dev-only
+//!   variables, read only when `dev-mode` is compiled in.
+//! * The standard `AWS_*` variables are never read for seeding. Adopting them
+//!   meant a shell holding real long-lived credentials silently copied them
+//!   into the dev catalog, a shell holding SSO session credentials (`ASIA*`)
+//!   failed the boot, and a dev credential could authenticate against real
+//!   AWS when an endpoint was misconfigured. When `AWS_ACCESS_KEY_ID` is set
+//!   and matches no seeded key, [`ignored_aws_env_key`] lets callers warn
+//!   that requests signed with it will be rejected.
+//!
+//! Seeding is env-authoritative per boot: if a key id already exists with a
+//! different secret (a file-backed store whose operator rotated the variable),
+//! the stored secret is replaced. Tolerating `AlreadyExists` silently, as
+//! earlier versions did, pinned the first-ever secret forever and turned a
+//! rotation into per-request `InvalidSignatureException` with no boot-time
+//! indication.
+
+use extenddb_storage::CatalogStore;
+use extenddb_storage::management_store::OpError;
+
+/// Access key id of AWS's documented example credential. Always seeded in dev
+/// mode; public contract for every tool that hardcodes the pair.
+pub const EXAMPLE_ACCESS_KEY_ID: &str = "AKIAIOSFODNN7EXAMPLE";
+/// Secret half of AWS's documented example credential. Public documentation,
+/// not a secret: safe to print and to commit in fixtures.
+pub const EXAMPLE_SECRET_ACCESS_KEY: &str = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+
+const ENV_ACCESS_KEY_ID: &str = "EXTENDDB_DEV_ACCESS_KEY_ID";
+const ENV_SECRET_ACCESS_KEY: &str = "EXTENDDB_DEV_SECRET_ACCESS_KEY";
+
+/// A credential the dev server seeds and verifies `SigV4` against.
+pub struct DevCredential {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    /// True for the built-in example pair. Callers use this to decide whether
+    /// the secret may be echoed: the example secret is public documentation,
+    /// an operator-supplied secret must never reach a banner or syslog.
+    pub is_builtin: bool,
+}
+
+// Manual impl so an operator-supplied secret cannot leak through debug
+// formatting; the built-in secret is public documentation and prints as-is.
+impl std::fmt::Debug for DevCredential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DevCredential")
+            .field("access_key_id", &self.access_key_id)
+            .field(
+                "secret_access_key",
+                if self.is_builtin {
+                    &self.secret_access_key
+                } else {
+                    &"<redacted>"
+                },
+            )
+            .field("is_builtin", &self.is_builtin)
+            .finish()
+    }
+}
+
+/// Resolve the dev-mode credential set from the process environment.
+///
+/// Element 0 is always the built-in example pair; element 1, when present, is
+/// the operator's `EXTENDDB_DEV_*` pair.
+///
+/// # Errors
+///
+/// Returns an error when only one of the two variables is set, when the key id
+/// is not AKIA-shaped, or when it collides with the built-in key id.
+pub fn resolve() -> anyhow::Result<Vec<DevCredential>> {
+    resolve_from(
+        non_empty_env(ENV_ACCESS_KEY_ID),
+        non_empty_env(ENV_SECRET_ACCESS_KEY),
+    )
+}
+
+fn non_empty_env(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|s| !s.is_empty())
+}
+
+fn resolve_from(
+    custom_key_id: Option<String>,
+    custom_secret: Option<String>,
+) -> anyhow::Result<Vec<DevCredential>> {
+    let mut credentials = vec![DevCredential {
+        access_key_id: EXAMPLE_ACCESS_KEY_ID.to_owned(),
+        secret_access_key: EXAMPLE_SECRET_ACCESS_KEY.to_owned(),
+        is_builtin: true,
+    }];
+
+    let (key_id, secret) = match (custom_key_id, custom_secret) {
+        (None, None) => return Ok(credentials),
+        (Some(k), Some(s)) => (k, s),
+        (Some(_), None) => anyhow::bail!(
+            "{ENV_ACCESS_KEY_ID} is set but {ENV_SECRET_ACCESS_KEY} is not; \
+             set both to seed an additional dev credential, or neither."
+        ),
+        (None, Some(_)) => anyhow::bail!(
+            "{ENV_SECRET_ACCESS_KEY} is set but {ENV_ACCESS_KEY_ID} is not; \
+             set both to seed an additional dev credential, or neither."
+        ),
+    };
+
+    // The access-key prefix is a credential-type discriminator across the auth
+    // layer: `AKIA*` keys are long-lived IAM user keys, `ASIA*` are temporary
+    // role session credentials (session token, expiry, role-scoped
+    // invalidation), and anything else is unknown to credential lookup. The
+    // dev credential is a long-lived key on a user, so it must be AKIA-shaped.
+    // This also matches real AWS, which rejects fabricated key ids with
+    // UnrecognizedClientException rather than authenticating them.
+    if !key_id.starts_with("AKIA") {
+        anyhow::bail!(
+            "{ENV_ACCESS_KEY_ID} must be AKIA-shaped (got '{key_id}'). The built-in \
+             example pair {EXAMPLE_ACCESS_KEY_ID} is always seeded; clients migrating \
+             from DynamoDB Local dummy credentials can sign with it instead."
+        );
+    }
+    if key_id == EXAMPLE_ACCESS_KEY_ID {
+        anyhow::bail!(
+            "{ENV_ACCESS_KEY_ID} matches the built-in example key id, which is always \
+             seeded with its documented secret; choose a different key id."
+        );
+    }
+
+    credentials.push(DevCredential {
+        access_key_id: key_id,
+        secret_access_key: secret,
+        is_builtin: false,
+    });
+    Ok(credentials)
+}
+
+/// The value of `AWS_ACCESS_KEY_ID` when it is set, non-empty, and matches no
+/// seeded credential. Dev mode used to adopt the `AWS_*` pair, so a caller
+/// should warn: requests signed with this key will get
+/// `UnrecognizedClientException`.
+#[must_use]
+pub fn ignored_aws_env_key(credentials: &[DevCredential]) -> Option<String> {
+    ignored_aws_env_key_from(non_empty_env("AWS_ACCESS_KEY_ID"), credentials)
+}
+
+fn ignored_aws_env_key_from(
+    aws_key_id: Option<String>,
+    credentials: &[DevCredential],
+) -> Option<String> {
+    aws_key_id.filter(|id| credentials.iter().all(|c| c.access_key_id != *id))
+}
+
+/// Seed the resolved credentials onto the `dev` user of the default account.
+///
+/// Idempotent, and env-authoritative for the secret: an existing key whose
+/// stored secret differs from the resolved one is deleted and re-imported.
+///
+/// # Errors
+///
+/// Returns an error when the catalog has no default account (not
+/// bootstrapped), or when any create/lookup/import/delete step fails.
+pub async fn seed(
+    catalog_store: &dyn CatalogStore,
+    credential_store: &dyn extenddb_auth::CredentialStore,
+    credentials: &[DevCredential],
+) -> anyhow::Result<()> {
+    // Attach the dev user to the deployment's recorded default account (set at
+    // bootstrap) rather than inferring it from account-list ordering.
+    let account_id = catalog_store
+        .default_account_id()
+        .await
+        .map_err(|e| anyhow::anyhow!("dev mode: failed to read default account: {e:?}"))?
+        .ok_or_else(|| {
+            anyhow::anyhow!("dev mode: no default account recorded (catalog not bootstrapped)")
+        })?;
+
+    match catalog_store.create_user(&account_id, "dev", None).await {
+        Ok(()) | Err(OpError::AlreadyExists(_)) => {}
+        Err(e) => anyhow::bail!("dev mode: failed to create dev user: {e:?}"),
+    }
+
+    for credential in credentials {
+        let key_id = credential.access_key_id.as_str();
+        match catalog_store
+            .import_access_key(&account_id, "dev", key_id, &credential.secret_access_key)
+            .await
+        {
+            Ok(()) => {}
+            Err(OpError::AlreadyExists(_)) => {
+                let stored = credential_store
+                    .lookup_credential(key_id)
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!(
+                            "dev mode: failed to look up existing credential {key_id}: {e:?}"
+                        )
+                    })?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "dev mode: credential {key_id} reported as existing but not found"
+                        )
+                    })?;
+                if stored.secret_key != credential.secret_access_key {
+                    // Rotated secret: the environment is authoritative.
+                    // Keeping the stored secret, as earlier versions did,
+                    // meant the old secret kept verifying and the new one
+                    // failed with InvalidSignatureException on every request.
+                    catalog_store
+                        .delete_access_key(&account_id, "dev", key_id)
+                        .await
+                        .map_err(|e| {
+                            anyhow::anyhow!(
+                                "dev mode: failed to delete stale credential {key_id}: {e:?}"
+                            )
+                        })?;
+                    catalog_store
+                        .import_access_key(
+                            &account_id,
+                            "dev",
+                            key_id,
+                            &credential.secret_access_key,
+                        )
+                        .await
+                        .map_err(|e| {
+                            anyhow::anyhow!(
+                                "dev mode: failed to re-import rotated credential {key_id}: {e:?}"
+                            )
+                        })?;
+                    tracing::info!(
+                        "dev credential {key_id}: stored secret differed from the environment; replaced"
+                    );
+                }
+            }
+            Err(e) => anyhow::bail!("dev mode: failed to import dev credential {key_id}: {e:?}"),
+        }
+    }
+    Ok(())
+}
+
+/// One-line description of the seeded credentials for banners and logs.
+///
+/// The built-in pair is printed in full (public documentation); a custom
+/// credential contributes its key id only, so an operator-supplied secret
+/// never reaches stdout or syslog.
+#[must_use]
+pub fn describe(credentials: &[DevCredential]) -> String {
+    credentials
+        .iter()
+        .map(|c| {
+            if c.is_builtin {
+                format!(
+                    "{} / {} (AWS documented example pair, always seeded)",
+                    c.access_key_id, c.secret_access_key
+                )
+            } else {
+                format!(
+                    "{} (from {ENV_ACCESS_KEY_ID}, secret not shown)",
+                    c.access_key_id
+                )
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_env_yields_builtin_only() {
+        let creds = resolve_from(None, None).unwrap();
+        assert_eq!(creds.len(), 1);
+        assert!(creds[0].is_builtin);
+        assert_eq!(creds[0].access_key_id, EXAMPLE_ACCESS_KEY_ID);
+        assert_eq!(creds[0].secret_access_key, EXAMPLE_SECRET_ACCESS_KEY);
+    }
+
+    #[test]
+    fn custom_pair_is_added_after_builtin() {
+        let creds = resolve_from(
+            Some("AKIADEVTEAMKEY000001".into()),
+            Some("team-secret".into()),
+        )
+        .unwrap();
+        assert_eq!(creds.len(), 2);
+        assert!(creds[0].is_builtin);
+        assert!(!creds[1].is_builtin);
+        assert_eq!(creds[1].access_key_id, "AKIADEVTEAMKEY000001");
+        assert_eq!(creds[1].secret_access_key, "team-secret");
+    }
+
+    #[test]
+    fn half_set_pair_is_rejected_naming_the_missing_var() {
+        let err = resolve_from(Some("AKIADEVTEAMKEY000001".into()), None).unwrap_err();
+        assert!(
+            err.to_string().contains("EXTENDDB_DEV_SECRET_ACCESS_KEY"),
+            "{err}"
+        );
+        let err = resolve_from(None, Some("team-secret".into())).unwrap_err();
+        assert!(
+            err.to_string().contains("EXTENDDB_DEV_ACCESS_KEY_ID"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn non_akia_key_is_rejected_pointing_at_the_builtin_pair() {
+        let err = resolve_from(Some("test".into()), Some("test".into())).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("AKIA-shaped"), "{msg}");
+        assert!(msg.contains(EXAMPLE_ACCESS_KEY_ID), "{msg}");
+    }
+
+    #[test]
+    fn builtin_key_id_collision_is_rejected() {
+        let err = resolve_from(
+            Some(EXAMPLE_ACCESS_KEY_ID.into()),
+            Some("different-secret".into()),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("always seeded"), "{err}");
+    }
+
+    #[test]
+    fn aws_env_key_is_flagged_only_when_foreign() {
+        let creds = resolve_from(
+            Some("AKIADEVTEAMKEY000001".into()),
+            Some("team-secret".into()),
+        )
+        .unwrap();
+        // Unset or empty: nothing to warn about.
+        assert_eq!(ignored_aws_env_key_from(None, &creds), None);
+        // Matches a seeded credential (either of them): no warning.
+        assert_eq!(
+            ignored_aws_env_key_from(Some(EXAMPLE_ACCESS_KEY_ID.into()), &creds),
+            None
+        );
+        assert_eq!(
+            ignored_aws_env_key_from(Some("AKIADEVTEAMKEY000001".into()), &creds),
+            None
+        );
+        // Foreign key, including ASIA session keys: flagged for the advisory.
+        assert_eq!(
+            ignored_aws_env_key_from(Some("ASIAFOREIGNSESSION01".into()), &creds),
+            Some("ASIAFOREIGNSESSION01".into())
+        );
+    }
+
+    #[test]
+    fn describe_prints_builtin_secret_but_never_custom_secret() {
+        let creds = resolve_from(
+            Some("AKIADEVTEAMKEY000001".into()),
+            Some("team-secret".into()),
+        )
+        .unwrap();
+        let text = describe(&creds);
+        assert!(text.contains(EXAMPLE_SECRET_ACCESS_KEY), "{text}");
+        assert!(text.contains("AKIADEVTEAMKEY000001"), "{text}");
+        assert!(!text.contains("team-secret"), "{text}");
+    }
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -11,6 +11,7 @@
 pub(crate) mod authorization;
 pub mod authz_cache;
 pub mod console;
+pub mod dev_credentials;
 mod handler;
 mod import_export_paths;
 pub mod key_info_cache;

--- a/crates/server/src/serve.rs
+++ b/crates/server/src/serve.rs
@@ -293,17 +293,29 @@ async fn serve_inner(params: ServeParams, port: u16) -> anyhow::Result<()> {
     let cred_store = components.credential_store;
     let runtime_hooks = components.runtime_hooks;
 
-    // Dev mode: adopt the credential the SDK will sign with (from the standard
-    // AWS_* env) and verify against it. Seeded here so it works for both
-    // file-backed and bootstrap-on-serve (in-memory) deployments. SigV4
-    // verification is unchanged; only the IAM policy decision is opened.
+    // Dev mode: seed the credentials the SDK may sign with and verify against
+    // them (see `dev_credentials` for the vending contract). Seeded here so it
+    // works for both file-backed and bootstrap-on-serve (in-memory)
+    // deployments. SigV4 verification is unchanged; only the IAM policy
+    // decision is opened.
     if dev_mode {
-        let dev_access_key = seed_dev_credential(catalog_store.as_ref()).await?;
+        let dev_creds = crate::dev_credentials::resolve()?;
+        crate::dev_credentials::seed(catalog_store.as_ref(), cred_store.as_ref(), &dev_creds)
+            .await?;
         tracing::warn!(
             "DEVELOPER MODE active — plain HTTP, authorization open (SigV4 still \
-             enforced). Storage: {}. Signing credential: {dev_access_key}",
+             enforced). Storage: {}. Signing credentials: {}",
             config::redact_password(app_config.storage.connection_config()),
+            crate::dev_credentials::describe(&dev_creds),
         );
+        if let Some(ignored) = crate::dev_credentials::ignored_aws_env_key(&dev_creds) {
+            tracing::warn!(
+                "AWS_ACCESS_KEY_ID is set in the environment but dev mode does not adopt \
+                 it; requests signed with '{ignored}' will get UnrecognizedClientException. \
+                 Set EXTENDDB_DEV_ACCESS_KEY_ID and EXTENDDB_DEV_SECRET_ACCESS_KEY to seed \
+                 an additional credential, or sign with the built-in example pair."
+            );
+        }
     }
 
     // Build SwrCacheConfig values from the [auth.cache] TOML section.
@@ -678,78 +690,4 @@ pub fn log_to_syslog_raw(msg: &str) {
 #[cfg(not(unix))]
 pub fn log_to_syslog_raw(msg: &str) {
     eprintln!("{msg}");
-}
-
-/// Seed (or refresh) the developer-mode credential and return its access key id.
-///
-/// Dev mode verifies SigV4 exactly like production, so the server must know the
-/// credential the SDK signs with. To stay a drop-in for local development:
-///
-///  * If `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` are set in the server's
-///    environment, the server **adopts and verifies against them**. In the
-///    common CI case the SDK and the co-located server read the same env, so
-///    the user changes nothing but the endpoint URL.
-///  * Otherwise it seeds AWS's documented example credential as a well-known
-///    default the user can point any SDK at.
-///
-/// This mirrors the admin-credential pattern (env-or-default), differing only in
-/// that the default is well-known rather than randomly generated, because an SDK
-/// must know the credential up front (it cannot read a printed banner). Seeding
-/// goes through the generic management surface, so it is backend-agnostic.
-async fn seed_dev_credential(
-    catalog_store: &dyn extenddb_storage::CatalogStore,
-) -> anyhow::Result<String> {
-    use extenddb_storage::management_store::OpError;
-
-    // AWS's documented example credential (recognised everywhere and allowlisted
-    // by secret scanners): the zero-config default users point their SDK at.
-    const DEFAULT_ACCESS_KEY_ID: &str = "AKIAIOSFODNN7EXAMPLE";
-    const DEFAULT_SECRET: &str = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
-
-    let access_key_id = std::env::var("AWS_ACCESS_KEY_ID")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| DEFAULT_ACCESS_KEY_ID.to_owned());
-    let secret = std::env::var("AWS_SECRET_ACCESS_KEY")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| DEFAULT_SECRET.to_owned());
-
-    // The access-key prefix is a credential-type discriminator across the auth
-    // layer: `AKIA*` = long-lived IAM user keys, `ASIA*` = temporary role
-    // session credentials (they carry `is_session`, are subject to
-    // ExpiredTokenException, and are invalidated with their role). The dev
-    // credential is a long-lived key on a *user*, so require the AKIA shape; an
-    // ASIA-shaped key here would be a user credential the rest of the system
-    // treats as a role session credential (e.g. user-delete invalidation
-    // matches `AKIA*`, not `ASIA*`).
-    if !access_key_id.starts_with("AKIA") {
-        anyhow::bail!(
-            "dev credential AWS_ACCESS_KEY_ID must be AKIA-shaped (got '{access_key_id}'); \
-             use e.g. AKIAIOSFODNN7EXAMPLE, or unset it to use the default."
-        );
-    }
-
-    // Attach the dev user to the deployment's recorded default account (set at
-    // bootstrap) rather than inferring it from account-list ordering.
-    let account_id = catalog_store
-        .default_account_id()
-        .await
-        .map_err(|e| anyhow::anyhow!("dev mode: failed to read default account: {e:?}"))?
-        .ok_or_else(|| {
-            anyhow::anyhow!("dev mode: no default account recorded (catalog not bootstrapped)")
-        })?;
-
-    match catalog_store.create_user(&account_id, "dev", None).await {
-        Ok(()) | Err(OpError::AlreadyExists(_)) => {}
-        Err(e) => anyhow::bail!("dev mode: failed to create dev user: {e:?}"),
-    }
-    match catalog_store
-        .import_access_key(&account_id, "dev", &access_key_id, &secret)
-        .await
-    {
-        Ok(()) | Err(OpError::AlreadyExists(_)) => {}
-        Err(e) => anyhow::bail!("dev mode: failed to import dev credential: {e:?}"),
-    }
-    Ok(access_key_id)
 }

--- a/docs/dev-image.md
+++ b/docs/dev-image.md
@@ -27,12 +27,18 @@ zero-friction local use:
 - **Plain HTTP.** No TLS, so SDKs need no custom trust store.
 - **A seeded, well-known credential.** The server seeds AWS's documented
   example key pair (`AKIAIOSFODNN7EXAMPLE` /
-  `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`) on startup and prints it in the
-  logs; sign requests with it. It is recognised by secret scanners as an
-  example credential, so committing it in test fixtures is safe. To use a
-  different key, pass `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` to the
-  container. Authorization is open: whoever holds the credential can do
-  everything.
+  `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`) on every startup and prints it
+  in the logs; sign requests with it. It is recognised by secret scanners as
+  an example credential, so committing it in test fixtures is safe. To seed
+  one additional key pair, pass `EXTENDDB_DEV_ACCESS_KEY_ID` and
+  `EXTENDDB_DEV_SECRET_ACCESS_KEY` to the container (the key id must start
+  with `AKIA`; its secret is never printed). The example pair keeps working
+  alongside it, so tools that hardcode it (NoSQL Workbench, the launchers)
+  are unaffected by the override. The standard `AWS_*` variables are ignored
+  by the server, so real or SSO credentials in the environment are never
+  copied into the dev catalog; a startup notice calls out an
+  `AWS_ACCESS_KEY_ID` that would not verify. Authorization is open: whoever
+  holds a seeded credential can do everything.
 
 Because of that, the server must not be reachable from other machines. The
 image binds `0.0.0.0` **inside** the container (required for port publishing to


### PR DESCRIPTION
## What

Reworks how the dev build vends signing credentials, keeping full SigV4 verification. The contract is now "always the example pair, plus at most one explicit extra":

- AWS's documented example pair (`AKIAIOSFODNN7EXAMPLE`) is seeded on every dev-mode boot, unconditionally, so tools that hardcode it (NoSQL Workbench's ExtendDB connection type, the `@extenddb/dev` launcher, docs, CI) keep working regardless of operator configuration.
- `EXTENDDB_DEV_ACCESS_KEY_ID` / `EXTENDDB_DEV_SECRET_ACCESS_KEY` (both or neither, AKIA-shaped, following the `EXTENDDB_DEV_ALLOW_ANY_BIND` naming precedent) seed one additional credential alongside it.
- The standard `AWS_*` variables are no longer read for seeding. When `AWS_ACCESS_KEY_ID` is set and matches no seeded key, a boot advisory explains that requests signed with it will get `UnrecognizedClientException` and names the fix.
- Seeding is env-authoritative: an existing key whose stored secret differs from the environment is deleted and re-imported, instead of silently keeping the first-ever secret.
- The startup banner and the dev-mode warn now print the example pair in full (public AWS documentation, safe for stdout and syslog). An operator-supplied secret is never echoed, including through `Debug`.

New module `crates/server/src/dev_credentials.rs` carries the contract; `seed_dev_credential` in `serve.rs` is replaced by it; the `cmd_serve` banner grows the credential lines via a helper (which also brings `run()` under its previous pedantic line count); `docs/dev-image.md` documents the new override.

## Why

The old contract adopted `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` from the server's environment, coupling the dev server to whatever identity happened to be in the invoking shell:

- Real long-lived credentials were silently imported into the dev catalog, and a misconfigured endpoint would then authenticate against real AWS.
- SSO session credentials (`ASIA*`) failed the boot, so logging into AWS for unrelated work broke local development.
- An override replaced the example pair rather than adding to it, silently breaking every client that hardcodes it.
- `AlreadyExists` tolerance pinned the first-ever secret on file-backed stores, turning a rotation into per-request `InvalidSignatureException` with no boot-time indication.
- The secret half of the pair was undiscoverable from the banner.

SigV4 verification, the AKIA/ASIA prefix discriminator in credential lookup, and the wire error surface are unchanged: fabricated key ids (for example DynamoDB Local's habitual `test`/`test`) still get `UnrecognizedClientException`, exactly as real AWS answers them; the fail-fast error for a non-AKIA `EXTENDDB_DEV_ACCESS_KEY_ID` points those migrations at the always-seeded example pair.

Closes #

## Testing done

- `cargo test -p extenddb-server -p extenddb-app --features extenddb-app/dev-mode`: all green, including 7 new unit tests for credential resolution, the foreign-key advisory, and banner redaction.
- `cargo fmt --check` and `cargo clippy --all-targets -- -W clippy::pedantic`: no findings in the touched files; the pre-existing `too_many_lines` on `cmd_serve::run` improves from 141 to 132 lines.
- End-to-end against the sqlite dev build (`--features sqlite,dev-mode`), all verified with the aws CLI over loopback:
  - Boot with a foreign ASIA key in the server environment: boots cleanly (previously bailed), advisory logged once, example pair authenticates, unknown keys get `UnrecognizedClientException`.
  - Boot with `EXTENDDB_DEV_*`: custom pair and example pair both authenticate; a negative log search confirms the custom secret never appears.
  - Restart the same file-backed store with a rotated `EXTENDDB_DEV_SECRET_ACCESS_KEY`: new secret authenticates, old secret gets `InvalidSignatureException` (previously the old secret silently won).
  - Non-AKIA and half-set pairs fail fast before daemonize with actionable messages.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any)
- [ ] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: none yet; happy to write a short ADR for the vending contract if wanted before merge.

## Breaking changes

Dev-mode only: the server no longer adopts `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` from its environment. Anyone passing a custom pair to the dev container that way must rename the variables to `EXTENDDB_DEV_ACCESS_KEY_ID`/`EXTENDDB_DEV_SECRET_ACCESS_KEY`. The boot advisory names the exact change when the old pattern is detected. Existing file-backed dev stores may still contain a previously adopted key; a fresh volume clears it.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
