### PR TITLE
feat(app): ASCII wordmark in the startup banner

### DIFF
--- a/crates/app/src/cmd_serve.rs
+++ b/crates/app/src/cmd_serve.rs
@@ -159,16 +159,10 @@ pub fn run(args: &ServeArgs, build: BuildInfo) -> anyhow::Result<()> {
     // The wordmark is pure 7-bit ASCII on purpose: it renders identically in
     // dumb terminals, container log viewers, and syslog-adjacent collectors
     // that mangle wide Unicode. It prints once per boot, never per request.
-    let wordmark = concat!(
-        "    ______     __                 ______  ____\n",
-        "   / ____/  __/ /____  ____  ____/ / __ \\/ __ )\n",
-        "  / __/ | |/_/ __/ _ \\/ __ \\/ __  / / / / __  |\n",
-        " / /____>  </ /_/  __/ / / / /_/ / /_/ / /_/ /\n",
-        "/_____/_/|_|\\__/\\___/_/ /_/\\__,_/_____/_____/\n",
-        "\n",
-        "  DynamoDB-compatible: any SDK, CLI, or tool, unchanged.\n",
-        "\n",
-    );
+    // Color is applied only when the destination stream is an interactive
+    // terminal (and NO_COLOR/TERM=dumb are respected), so pipes, `docker
+    // logs`, and supervisors always receive the plain form.
+    let wordmark = render_wordmark(banner_colors_enabled(args.foreground));
     let banner_line1 = format!(
         "extenddb {} (catalog {}) starting on {}",
         build.version, catalog_version, bind_addr,
@@ -276,6 +270,66 @@ pub fn run(args: &ServeArgs, build: BuildInfo) -> anyhow::Result<()> {
                 })
                 .with_dev_mode(cfg!(feature = "dev-mode")),
         ))
+}
+
+/// The five wordmark rows (figlet slant), without trailing newlines.
+const WORDMARK_LINES: [&str; 5] = [
+    "    ______     __                 ______  ____",
+    "   / ____/  __/ /____  ____  ____/ / __ \\/ __ )",
+    "  / __/ | |/_/ __/ _ \\/ __ \\/ __  / / / / __  |",
+    " / /____>  </ /_/  __/ / / / /_/ / /_/ / /_/ /",
+    "/_____/_/|_|\\__/\\___/_/ /_/\\__,_/_____/_____/",
+];
+const TAGLINE: &str = "  DynamoDB-compatible: any SDK, CLI, or tool, unchanged.";
+
+/// Whether the banner's destination stream is an interactive terminal that
+/// wants color: never for pipes and `docker logs`, and both the NO_COLOR
+/// convention (<https://no-color.org>) and `TERM=dumb` opt out.
+fn banner_colors_enabled(foreground: bool) -> bool {
+    use std::io::IsTerminal;
+
+    if std::env::var_os("NO_COLOR").is_some() {
+        return false;
+    }
+    if std::env::var("TERM").is_ok_and(|t| t == "dumb") {
+        return false;
+    }
+    // Match the banner's stream split: stderr in foreground mode, stdout for
+    // the daemon parent.
+    if foreground {
+        std::io::stderr().is_terminal()
+    } else {
+        std::io::stdout().is_terminal()
+    }
+}
+
+/// Render the wordmark block: five art rows, a blank line, the tagline, and a
+/// closing blank line. With color, the rows fade gold to deep orange
+/// (256-color codes, an ANSI level every interactive terminal supports) and
+/// the tagline dims; without, the output is byte-identical to the historical
+/// plain form.
+fn render_wordmark(color: bool) -> String {
+    // Gold fading to deep orange, one shade per row.
+    const ROW_COLORS: [u8; 5] = [220, 214, 208, 202, 166];
+
+    let mut out = String::new();
+    for (i, line) in WORDMARK_LINES.iter().enumerate() {
+        if color {
+            out.push_str(&format!("\x1b[38;5;{}m{line}\x1b[0m\n", ROW_COLORS[i]));
+        } else {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out.push('\n');
+    if color {
+        out.push_str(&format!("\x1b[2m{TAGLINE}\x1b[0m\n"));
+    } else {
+        out.push_str(TAGLINE);
+        out.push('\n');
+    }
+    out.push('\n');
+    out
 }
 
 /// Print the developer-mode banner lines: the mode notice, the credentials to

--- a/crates/app/src/cmd_serve.rs
+++ b/crates/app/src/cmd_serve.rs
@@ -155,6 +155,20 @@ pub fn run(args: &ServeArgs, build: BuildInfo) -> anyhow::Result<()> {
     // it to stderr so a process supervisor receives banner and tracing logs
     // on the same stream — mixing stdout and stderr makes container log
     // capture noisier than necessary.
+    //
+    // The wordmark is pure 7-bit ASCII on purpose: it renders identically in
+    // dumb terminals, container log viewers, and syslog-adjacent collectors
+    // that mangle wide Unicode. It prints once per boot, never per request.
+    let wordmark = concat!(
+        "    ______     __                 ______  ____\n",
+        "   / ____/  __/ /____  ____  ____/ / __ \\/ __ )\n",
+        "  / __/ | |/_/ __/ _ \\/ __ \\/ __  / / / / __  |\n",
+        " / /____>  </ /_/  __/ / / / /_/ / /_/ / /_/ /\n",
+        "/_____/_/|_|\\__/\\___/_/ /_/\\__,_/_____/_____/\n",
+        "\n",
+        "  DynamoDB-compatible: any SDK, CLI, or tool, unchanged.\n",
+        "\n",
+    );
     let banner_line1 = format!(
         "extenddb {} (catalog {}) starting on {}",
         build.version, catalog_version, bind_addr,
@@ -165,9 +179,11 @@ pub fn run(args: &ServeArgs, build: BuildInfo) -> anyhow::Result<()> {
         config::redact_password(app_config.storage.connection_config()),
     );
     if args.foreground {
+        eprint!("{wordmark}");
         eprintln!("{banner_line1}");
         eprintln!("{banner_line2}");
     } else {
+        print!("{wordmark}");
         println!("{banner_line1}");
         println!("{banner_line2}");
     }


### PR DESCRIPTION
## What

Adds an ASCII wordmark (figlet slant) plus the README's compatibility tagline to the startup banner, printed once per boot ahead of the version line through the existing stdout-or-stderr split.

Pure 7-bit ASCII on purpose: renders identically in dumb terminals, container log viewers, and syslog-adjacent collectors that mangle wide Unicode. Under 80 columns.

On an interactive terminal the wordmark rows fade gold to deep orange (256-color SGR) with a dimmed tagline. Color is gated on the destination stream being a TTY and respects `NO_COLOR` and `TERM=dumb`, so pipes, `docker logs`, CI capture, and supervisors always receive the plain form byte-identical to the uncolored output. No dependency added.

## Why

The dev image's first impression is `docker logs`. A recognizable wordmark makes the boot output scannable and gives the project a face. No behavioral change.

Stacked on #328 because both touch the same banner region of `cmd_serve.rs`; will retarget to main when #328 lands.

Closes #

## Screenshot

Interactive terminal (colored; piped output and `docker logs` receive the plain form, and `NO_COLOR`/`TERM=dumb` opt out):

![Colored ExtendDB startup banner](https://raw.githubusercontent.com/ExtendDB/extenddb/pr-assets/pr-329/startup-banner.png)

## Testing done

- `cargo test -p extenddb-app --features dev-mode`, `cargo fmt --check`, clippy clean.
- Booted the sqlite dev build in the foreground: wordmark, tagline, version line, dev-mode notice, and credential lines render in order under 80 columns.
- Color gating verified three ways: piped boot output is byte-identical plain ASCII, a PTY boot shows the SGR fade (escape codes inspected), and `NO_COLOR=1` on a PTY forces plain.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality (cosmetic output only; no logic to test)
- [x] I have updated documentation if behavior changed (no behavior change)
- [x] Breaking changes are noted below (none)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface, an RFC has been accepted or is linked below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a (cosmetic)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and I agree to the Developer Certificate of Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
