### PR TITLE
chore: bump workspace version to 0.1.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "extenddb-app",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-app"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-auth"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "axum",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-cache"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "futures",
  "moka",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-config"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "config",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-core"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-engine"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "base64 0.22.1",
  "crc32fast",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-server"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-mongodb"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-postgres"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "extenddb-storage-sqlite"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SOFTWARE-LICENSE-NOTICES-DEV.html
+++ b/SOFTWARE-LICENSE-NOTICES-DEV.html
@@ -7085,16 +7085,16 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage-sqlite ">extenddb-storage-sqlite 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage-sqlite ">extenddb-storage-sqlite 0.1.11</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.103</a></li>
                     <li><a href=" https://github.com/andylokandy/arraydeque ">arraydeque 0.5.1</a></li>

--- a/SOFTWARE-LICENSE-NOTICES.html
+++ b/SOFTWARE-LICENSE-NOTICES.html
@@ -6666,16 +6666,16 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage-postgres ">extenddb-storage-postgres 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage-postgres ">extenddb-storage-postgres 0.1.11</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.103</a></li>
                     <li><a href=" https://github.com/andylokandy/arraydeque ">arraydeque 0.5.1</a></li>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -215,7 +215,7 @@ extenddb runs as a daemon (background process) and logs to syslog. On startup it
 
 ```bash
 ./target/release/extenddb serve --config extenddb.toml
-# extenddb 0.1.10 (catalog 0.0.3) starting on 127.0.0.1:18443
+# extenddb 0.1.11 (catalog 0.0.3) starting on 127.0.0.1:18443
 #   storage: postgres (postgresql://extenddb:***@localhost:5432/extenddb_catalog)
 ```
 
@@ -1293,7 +1293,7 @@ Each runner requires its tools to be installed. The runner checks prerequisites 
 
 ```bash
 ./target/release/extenddb version
-# extenddb 0.1.10
+# extenddb 0.1.11
 # catalog 0.0.3 (postgres)
 # commit abc1234
 # built 2026-04-17T12:00:00Z

--- a/docs/manuals/04-quickstart-setup-guide.md
+++ b/docs/manuals/04-quickstart-setup-guide.md
@@ -129,7 +129,7 @@ Check the version:
 
 ```bash
 ./target/release/extenddb version
-# extenddb 0.1.10
+# extenddb 0.1.11
 # catalog 0.0.3 (postgres)
 # commit abc1234
 # built 2026-04-17T12:00:00Z

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extenddb/dev",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "ExtendDB dev server launcher: a DynamoDB-compatible database for local development and CI. Spawns the extenddb dev binary (file-backed by default, in-memory with --memory) and hands back an endpoint plus credentials any AWS SDK accepts.",
   "license": "Apache-2.0",
   "repository": {
@@ -25,10 +25,10 @@
     "test": "node test/launcher.test.js"
   },
   "optionalDependencies": {
-    "@extenddb/linux-x64": "0.1.10",
-    "@extenddb/linux-arm64": "0.1.10",
-    "@extenddb/darwin-x64": "0.1.10",
-    "@extenddb/darwin-arm64": "0.1.10",
-    "@extenddb/win32-x64": "0.1.10"
+    "@extenddb/linux-x64": "0.1.11",
+    "@extenddb/linux-arm64": "0.1.11",
+    "@extenddb/darwin-x64": "0.1.11",
+    "@extenddb/darwin-arm64": "0.1.11",
+    "@extenddb/win32-x64": "0.1.11"
   }
 }


### PR DESCRIPTION
Release prep for v0.1.11. Bumped together, the Cargo.toml workspace version, the npm launcher manifest (package version plus the five platform optionalDependencies pins), Cargo.lock, and both licence notices files.

Both notices `--check` gates exit 0. `cargo check` clean on the default (postgres) and `sqlite,dev-mode` feature sets. Branch sits on top of #329 so the tag tree carries the startup banner.