### PR TITLE
fix(backup): report point-in-time recovery as unsupported

### DIFF
--- a/crates/core/src/error/mod.rs
+++ b/crates/core/src/error/mod.rs
@@ -70,6 +70,27 @@ pub enum DynamoDbError {
     /// Returned when a shard iterator has expired (older than 15 minutes).
     #[error("{0}")]
     ExpiredIteratorException(String),
+    /// SP-ERR-002: HTTP 400. Returned when continuous backups (point-in-time
+    /// recovery) cannot be enabled. The service models this exception on
+    /// `UpdateContinuousBackups`; ExtendDB returns it there for
+    /// `PointInTimeRecoveryEnabled: true`, because no storage backend
+    /// implements point-in-time recovery.
+    #[error("{0}")]
+    ContinuousBackupsUnavailableException(String),
+    /// SP-ERR-002: HTTP 400. Returned by `RestoreTableToPointInTime` when
+    /// point-in-time recovery is not enabled for the source table, which in
+    /// ExtendDB is always: no storage backend implements point-in-time
+    /// recovery. The service models this exception on the restore operation,
+    /// distinct from `ContinuousBackupsUnavailableException`, which it models
+    /// on `UpdateContinuousBackups`.
+    #[error("{0}")]
+    PointInTimeRecoveryUnavailableException(String),
+    /// SP-ERR-002: HTTP 400. Backup-family table-not-found, distinct from
+    /// `ResourceNotFoundException`. Returned by `RestoreTableToPointInTime`
+    /// for a source table that does not exist in the caller's account,
+    /// matching the live service.
+    #[error("{0}")]
+    TableNotFoundException(String),
     #[error("{0}")]
     ServiceUnavailable(String),
     /// SP-ERR-002: Concurrent modification of the same item in a transaction.
@@ -123,6 +144,9 @@ impl DynamoDbError {
             | Self::AccessDeniedException(_)
             | Self::ExpiredTokenException(_)
             | Self::ExpiredIteratorException(_)
+            | Self::ContinuousBackupsUnavailableException(_)
+            | Self::PointInTimeRecoveryUnavailableException(_)
+            | Self::TableNotFoundException(_)
             | Self::TransactionConflictException(_)
             | Self::ProvisionedThroughputExceededException(_)
             | Self::ThrottlingException(_)
@@ -169,6 +193,13 @@ impl DynamoDbError {
             Self::UnrecognizedClientException(_) => "UnrecognizedClientException",
             Self::ExpiredTokenException(_) => "ExpiredTokenException",
             Self::ExpiredIteratorException(_) => "ExpiredIteratorException",
+            Self::ContinuousBackupsUnavailableException(_) => {
+                "ContinuousBackupsUnavailableException"
+            }
+            Self::PointInTimeRecoveryUnavailableException(_) => {
+                "PointInTimeRecoveryUnavailableException"
+            }
+            Self::TableNotFoundException(_) => "TableNotFoundException",
             Self::ServiceUnavailable(_) => "ServiceUnavailable",
             Self::TransactionConflictException(_) => "TransactionConflictException",
             Self::ProvisionedThroughputExceededException(_) => {
@@ -234,6 +265,9 @@ impl DynamoDbError {
             | Self::UnrecognizedClientException(m)
             | Self::ExpiredTokenException(m)
             | Self::ExpiredIteratorException(m)
+            | Self::ContinuousBackupsUnavailableException(m)
+            | Self::PointInTimeRecoveryUnavailableException(m)
+            | Self::TableNotFoundException(m)
             | Self::ServiceUnavailable(m)
             | Self::TransactionConflictException(m)
             | Self::ProvisionedThroughputExceededException(m)
@@ -343,6 +377,15 @@ mod tests {
             (DynamoDbError::ValidationException(String::new()), 400),
             (DynamoDbError::ExpiredTokenException(String::new()), 400),
             (DynamoDbError::ExpiredIteratorException(String::new()), 400),
+            (
+                DynamoDbError::ContinuousBackupsUnavailableException(String::new()),
+                400,
+            ),
+            (
+                DynamoDbError::PointInTimeRecoveryUnavailableException(String::new()),
+                400,
+            ),
+            (DynamoDbError::TableNotFoundException(String::new()), 400),
             (DynamoDbError::InvalidSignatureException(String::new()), 400),
         ];
         for (err, expected) in cases {

--- a/crates/engine/src/backup.rs
+++ b/crates/engine/src/backup.rs
@@ -190,7 +190,81 @@ pub(crate) async fn handle_restore_table_from_backup(
     serialize_output(&json!({ "TableDescription": desc }))
 }
 
+/// The one message every point-in-time recovery refusal carries.
+const PITR_UNSUPPORTED_MESSAGE: &str =
+    "Point-in-time recovery is not supported by this storage backend";
+
+/// The typed refusal for enabling point-in-time recovery.
+///
+/// `ContinuousBackupsUnavailableException` is the exception the service models
+/// on `UpdateContinuousBackups`, so every SDK surfaces it as a typed error a
+/// caller can match on, unlike a generic `ValidationException` whose meaning
+/// lives only in the message text.
+fn pitr_unsupported_error() -> DynamoDbError {
+    DynamoDbError::ContinuousBackupsUnavailableException(PITR_UNSUPPORTED_MESSAGE.to_owned())
+}
+
+/// The typed refusal for `RestoreTableToPointInTime`.
+///
+/// The service models `PointInTimeRecoveryUnavailableException` on this
+/// operation and returns it whenever recovery is not enabled on the source
+/// table, which for ExtendDB is always. The message mirrors the live service's
+/// shape ("Point in time recovery is not enabled for table '<name>'").
+fn pitr_restore_unavailable_error(table_name: &str) -> DynamoDbError {
+    DynamoDbError::PointInTimeRecoveryUnavailableException(format!(
+        "Point in time recovery is not enabled for table '{table_name}'"
+    ))
+}
+
+/// The continuous-backups description every table reports.
+///
+/// `ContinuousBackupsStatus` is always `ENABLED`, matching the service, which
+/// reports `ENABLED` unconditionally. `PointInTimeRecoveryStatus` is always
+/// `DISABLED` because no storage backend implements point-in-time recovery,
+/// and the restorable-time fields are omitted, as the service omits them for
+/// a table whose recovery is disabled. Owned by the engine rather than the
+/// backends: the answer does not depend on stored state, so no backend is
+/// consulted and all three report identically.
+fn disabled_continuous_backups_description() -> extenddb_core::types::ContinuousBackupsDescription {
+    extenddb_core::types::ContinuousBackupsDescription {
+        continuous_backups_status: "ENABLED".to_owned(),
+        point_in_time_recovery_description: Some(
+            extenddb_core::types::PointInTimeRecoveryDescription {
+                point_in_time_recovery_status: "DISABLED".to_owned(),
+                earliest_restorable_date_time: None,
+                latest_restorable_date_time: None,
+            },
+        ),
+    }
+}
+
+/// Verify a table exists in the caller's account, in any lifecycle status.
+///
+/// The continuous-backups operations answer for CREATING and DELETING tables
+/// too, so this goes through `describe_table` rather than `table_key_info`,
+/// which only resolves ACTIVE tables.
+async fn require_table_exists(
+    ctx: &OperationContext,
+    table_name: &str,
+) -> Result<(), DynamoDbError> {
+    ctx.storage
+        .describe_table(
+            &ctx.account_id,
+            extenddb_core::types::DescribeTableInput {
+                table_name: table_name.to_owned(),
+            },
+        )
+        .await
+        .map_err(storage_err_to_dynamo)?;
+    Ok(())
+}
+
 /// Handle `DescribeContinuousBackups`.
+///
+/// Point-in-time recovery is not supported by any storage backend, so the
+/// engine answers directly: continuous backups report `ENABLED` (the service
+/// reports this unconditionally) with `PointInTimeRecoveryStatus: DISABLED`
+/// and no restorable-time window.
 pub(crate) async fn handle_describe_continuous_backups(
     body: Value,
     ctx: &OperationContext,
@@ -206,16 +280,20 @@ pub(crate) async fn handle_describe_continuous_backups(
             )
         })?;
 
-    let desc = ctx
-        .storage
-        .describe_continuous_backups(&ctx.account_id, table_name)
-        .await
-        .map_err(storage_err_to_dynamo)?;
+    require_table_exists(ctx, table_name).await?;
 
-    serialize_output(&json!({ "ContinuousBackupsDescription": desc }))
+    serialize_output(
+        &json!({ "ContinuousBackupsDescription": disabled_continuous_backups_description() }),
+    )
 }
 
 /// Handle `UpdateContinuousBackups`.
+///
+/// Enabling point-in-time recovery is refused with
+/// `ContinuousBackupsUnavailableException`, because no storage backend
+/// implements it and reporting it as enabled would promise a restore that can
+/// never happen. Disabling it is a no-op that returns the description already
+/// reported by `DescribeContinuousBackups`.
 pub(crate) async fn handle_update_continuous_backups(
     body: Value,
     ctx: &OperationContext,
@@ -237,32 +315,68 @@ pub(crate) async fn handle_update_continuous_backups(
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
 
-    let desc = ctx
-        .storage
-        .update_continuous_backups(&ctx.account_id, table_name, pitr_enabled)
-        .await
-        .map_err(storage_err_to_dynamo)?;
+    require_table_exists(ctx, table_name).await?;
 
-    serialize_output(&json!({ "ContinuousBackupsDescription": desc }))
+    if pitr_enabled {
+        return Err(pitr_unsupported_error());
+    }
+
+    serialize_output(
+        &json!({ "ContinuousBackupsDescription": disabled_continuous_backups_description() }),
+    )
 }
 
 /// Handle `RestoreTableToPointInTime`.
 ///
-/// Point-in-time recovery is not yet implemented. The previous implementation
-/// faked a restore by snapshotting the current table state (ignoring
-/// `RestoreDateTime`), which violates tenet 1 (fidelity over features).
-/// Until real PITR is implemented, return an error.
+/// Point-in-time recovery is not supported by any storage backend. The source
+/// table is resolved first, so a missing table reports `TableNotFoundException`
+/// exactly as the live service does; an existing table is refused with
+/// `PointInTimeRecoveryUnavailableException`, the exception the service models
+/// on this operation (`ContinuousBackupsUnavailableException` belongs to
+/// `UpdateContinuousBackups`). A previous implementation faked a restore by
+/// snapshotting the current table state and ignoring `RestoreDateTime`, which
+/// violates tenet 1 (fidelity over features): a restore that silently returns
+/// the wrong data is worse than a refusal the caller can act on.
 pub(crate) async fn handle_restore_table_to_point_in_time(
-    _body: Value,
-    _ctx: &OperationContext,
+    body: Value,
+    ctx: &OperationContext,
 ) -> Result<Value, DynamoDbError> {
-    // TODO(fidelity): Implement real PITR using PostgreSQL temporal/history
-    // table approach — item_history table capturing every mutation, DISTINCT ON
-    // query to reconstruct state at time T, 35-day retention via background
-    // pruning.
-    Err(DynamoDbError::ValidationException(
-        "Point-in-time recovery restore is not yet supported".to_owned(),
-    ))
+    let source_table_name = body
+        .get("SourceTableName")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            DynamoDbError::ValidationException(
+                "1 validation error detected: Value null at 'sourceTableName' \
+                 failed to satisfy constraint: Member must not be null"
+                    .to_owned(),
+            )
+        })?;
+
+    // The live service resolves the source table before the recovery check, so
+    // a missing table reports TableNotFoundException rather than the
+    // unavailability error. describe_table rather than table_key_info, so
+    // tables in any lifecycle status resolve.
+    if let Err(e) = ctx
+        .storage
+        .describe_table(
+            &ctx.account_id,
+            extenddb_core::types::DescribeTableInput {
+                table_name: source_table_name.to_owned(),
+            },
+        )
+        .await
+    {
+        return Err(match e {
+            extenddb_storage::error::StorageError::TableNotFound(_) => {
+                DynamoDbError::TableNotFoundException(format!(
+                    "Table not found: {source_table_name}"
+                ))
+            }
+            other => storage_err_to_dynamo(other),
+        });
+    }
+
+    Err(pitr_restore_unavailable_error(source_table_name))
 }
 
 /// Convert storage errors to `DynamoDB` errors.
@@ -301,7 +415,10 @@ fn storage_err_to_dynamo(e: extenddb_storage::error::StorageError) -> DynamoDbEr
 
 #[cfg(test)]
 mod tests {
-    use super::{backup_arn_field, storage_err_to_dynamo};
+    use super::{
+        backup_arn_field, disabled_continuous_backups_description, pitr_restore_unavailable_error,
+        pitr_unsupported_error, storage_err_to_dynamo,
+    };
     use extenddb_core::error::DynamoDbError;
     use extenddb_storage::error::StorageError;
     use serde_json::json;
@@ -389,5 +506,61 @@ mod tests {
         // A shorter account id that is a prefix of the caller's must not pass.
         let body = json!({ "BackupArn": arn("12345678901") });
         assert!(backup_arn_field(&body, ACCOUNT).is_err());
+    }
+
+    /// The description reports continuous backups ENABLED (the service reports
+    /// this unconditionally) with point-in-time recovery DISABLED, and omits
+    /// both restorable-time fields on the wire: a disabled recovery has no
+    /// window, so serializing the members as null would diverge from the
+    /// service, which drops them entirely.
+    #[test]
+    fn the_continuous_backups_description_is_enabled_with_recovery_disabled() {
+        let desc = disabled_continuous_backups_description();
+        let wire = serde_json::to_value(&desc).expect("serializes");
+        assert_eq!(wire["ContinuousBackupsStatus"], "ENABLED");
+        let pitr = &wire["PointInTimeRecoveryDescription"];
+        assert_eq!(pitr["PointInTimeRecoveryStatus"], "DISABLED");
+        assert!(
+            pitr.get("EarliestRestorableDateTime").is_none(),
+            "a disabled recovery must not report an earliest restorable time"
+        );
+        assert!(
+            pitr.get("LatestRestorableDateTime").is_none(),
+            "a disabled recovery must not report a latest restorable time"
+        );
+    }
+
+    /// The enable refusal is the typed exception the service models on
+    /// `UpdateContinuousBackups`, on HTTP 400, under the standard `DynamoDB`
+    /// wire prefix, with a message naming the reason.
+    #[test]
+    fn the_enable_refusal_is_the_typed_continuous_backups_exception() {
+        let err = pitr_unsupported_error();
+        assert_eq!(err.status_code(), 400);
+        assert_eq!(
+            err.full_error_type(),
+            "com.amazonaws.dynamodb.v20120810#ContinuousBackupsUnavailableException"
+        );
+        assert_eq!(
+            err.message(),
+            "Point-in-time recovery is not supported by this storage backend"
+        );
+    }
+
+    /// The restore refusal is the typed exception the service models on
+    /// `RestoreTableToPointInTime`, distinct from the enable refusal, with a
+    /// message following the live service's shape.
+    #[test]
+    fn the_restore_refusal_is_the_typed_point_in_time_recovery_exception() {
+        let err = pitr_restore_unavailable_error("Music");
+        assert_eq!(err.status_code(), 400);
+        assert_eq!(
+            err.full_error_type(),
+            "com.amazonaws.dynamodb.v20120810#PointInTimeRecoveryUnavailableException"
+        );
+        assert_eq!(
+            err.message(),
+            "Point in time recovery is not enabled for table 'Music'"
+        );
     }
 }

--- a/crates/storage-mongodb/src/backup_engine.rs
+++ b/crates/storage-mongodb/src/backup_engine.rs
@@ -21,9 +21,8 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 use extenddb_core::types::{
-    AttributeDefinition, BackupDescription, BackupDetails, BackupSummary,
-    ContinuousBackupsDescription, GsiInput, KeySchemaElement, LsiInput,
-    PointInTimeRecoveryDescription, Projection, ProvisionedThroughput, SourceTableDetails,
+    AttributeDefinition, BackupDescription, BackupDetails, BackupSummary, GsiInput,
+    KeySchemaElement, LsiInput, Projection, ProvisionedThroughput, SourceTableDetails,
     TableDescription,
 };
 use extenddb_storage::BackupEngine;
@@ -707,115 +706,6 @@ impl BackupEngine for MongoEngine {
             // DynamoDB restore lifecycle while allowing the request to return
             // before potentially hundreds of thousands of index writes finish.
 
-            Ok(desc)
-        })
-    }
-
-    fn describe_continuous_backups(
-        &self,
-        account_id: &str,
-        table_name: &str,
-    ) -> BoxFuture<'_, Result<ContinuousBackupsDescription, StorageError>> {
-        let account_id = account_id.to_string();
-        let table_name = table_name.to_string();
-        Box::pin(async move {
-            let tables_coll = self.catalog_db.collection::<Document>("tables");
-            let exists = tables_coll
-                .find_one(doc! { "_id": { "account_id": &account_id, "table_name": &table_name } })
-                .await
-                .map_err(|e| StorageError::Internal(e.to_string()))?;
-
-            if exists.is_none() {
-                return Err(StorageError::TableNotFound(table_name));
-            }
-
-            let cb_coll = self.catalog_db.collection::<Document>("continuous_backups");
-            let pitr_doc = cb_coll
-                .find_one(doc! { "account_id": &account_id, "table_name": &table_name })
-                .await
-                .map_err(|e| StorageError::Internal(e.to_string()))?;
-
-            let pitr_enabled = pitr_doc
-                .as_ref()
-                .and_then(|d| d.get_bool("pitr_enabled").ok())
-                .unwrap_or(false);
-
-            let now_epoch = now_epoch_secs();
-
-            Ok(ContinuousBackupsDescription {
-                continuous_backups_status: "ENABLED".to_owned(),
-                point_in_time_recovery_description: Some(PointInTimeRecoveryDescription {
-                    point_in_time_recovery_status: if pitr_enabled {
-                        "ENABLED".to_owned()
-                    } else {
-                        "DISABLED".to_owned()
-                    },
-                    earliest_restorable_date_time: if pitr_enabled {
-                        Some(now_epoch - 35.0 * 24.0 * 3600.0)
-                    } else {
-                        None
-                    },
-                    latest_restorable_date_time: if pitr_enabled { Some(now_epoch) } else { None },
-                }),
-            })
-        })
-    }
-
-    fn update_continuous_backups(
-        &self,
-        account_id: &str,
-        table_name: &str,
-        pitr_enabled: bool,
-    ) -> BoxFuture<'_, Result<ContinuousBackupsDescription, StorageError>> {
-        let account_id = account_id.to_string();
-        let table_name = table_name.to_string();
-        Box::pin(async move {
-            let tables_coll = self.catalog_db.collection::<Document>("tables");
-            let exists = tables_coll
-                .find_one(doc! { "_id": { "account_id": &account_id, "table_name": &table_name } })
-                .await
-                .map_err(|e| StorageError::Internal(e.to_string()))?;
-
-            if exists.is_none() {
-                return Err(StorageError::TableNotFound(table_name.clone()));
-            }
-
-            let cb_coll = self.catalog_db.collection::<Document>("continuous_backups");
-            cb_coll
-                .update_one(
-                    doc! { "account_id": &account_id, "table_name": &table_name },
-                    doc! { "$set": {
-                        "account_id": &account_id,
-                        "table_name": &table_name,
-                        "pitr_enabled": pitr_enabled,
-                    }},
-                )
-                .upsert(true)
-                .await
-                .map_err(|e| StorageError::Internal(e.to_string()))?;
-
-            self.describe_continuous_backups(&account_id, &table_name)
-                .await
-        })
-    }
-
-    fn restore_table_to_point_in_time(
-        &self,
-        account_id: &str,
-        source_table_name: &str,
-        target_table_name: &str,
-    ) -> BoxFuture<'_, Result<TableDescription, StorageError>> {
-        let account_id = account_id.to_string();
-        let source_table_name = source_table_name.to_string();
-        let target_table_name = target_table_name.to_string();
-        Box::pin(async move {
-            let backup = self
-                .create_backup(&account_id, &source_table_name, "__pitr_restore__")
-                .await?;
-            let desc = self
-                .restore_table_from_backup(&account_id, &target_table_name, &backup.backup_arn)
-                .await?;
-            let _ = self.delete_backup(&account_id, &backup.backup_arn).await;
             Ok(desc)
         })
     }

--- a/crates/storage-mongodb/src/bootstrapper.rs
+++ b/crates/storage-mongodb/src/bootstrapper.rs
@@ -207,7 +207,6 @@ impl Bootstrapper for MongoBootstrapper {
             "metrics",
             "login_attempts",
             "backups",
-            "continuous_backups",
         ];
 
         for coll_name in collections {

--- a/crates/storage-postgres/migrations/003_drop_continuous_backups.sql
+++ b/crates/storage-postgres/migrations/003_drop_continuous_backups.sql
@@ -1,0 +1,22 @@
+-- Copyright 2026 ExtendDB contributors
+-- SPDX-License-Identifier: Apache-2.0
+-- Migration 003: drop the continuous_backups table (catalog version 0.0.4).
+--
+-- Point-in-time recovery is reported as unsupported: DescribeContinuousBackups
+-- always answers PointInTimeRecoveryStatus DISABLED, UpdateContinuousBackups
+-- refuses to enable it, and RestoreTableToPointInTime refuses, all served by
+-- the engine without consulting storage. The pitr_enabled flag this table
+-- stored no longer drives any behavior, so the table is removed.
+--
+-- Written to tolerate a replay, like 002: the runner applies a migration and
+-- records it in `schema_history` as two separate commits, so a crash in
+-- between leaves this file applied but unrecorded, and the next migrate runs
+-- it again. DROP TABLE IF EXISTS and the version UPDATE are both idempotent.
+
+BEGIN;
+
+DROP TABLE IF EXISTS continuous_backups;
+
+UPDATE settings SET value = '0.0.4' WHERE key = 'catalog_version';
+
+COMMIT;

--- a/crates/storage-postgres/src/backup_engine.rs
+++ b/crates/storage-postgres/src/backup_engine.rs
@@ -1,11 +1,10 @@
 // Copyright 2026 ExtendDB contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Backup and point-in-time recovery implementation for `PostgreSQL` storage.
+//! Backup implementation for `PostgreSQL` storage.
 
 use extenddb_core::types::{
-    BackupDescription, BackupDetails, BackupSummary, ContinuousBackupsDescription,
-    PointInTimeRecoveryDescription, SourceTableDetails, TableDescription,
+    BackupDescription, BackupDetails, BackupSummary, SourceTableDetails, TableDescription,
 };
 use extenddb_storage::BackupEngine;
 use extenddb_storage::error::StorageError;
@@ -611,131 +610,6 @@ impl BackupEngine for PostgresEngine {
 
             // Return CREATING — the API response shows the initial status,
             // but the table is already ACTIVE by the time the caller polls.
-            Ok(desc)
-        })
-    }
-
-    fn describe_continuous_backups(
-        &self,
-        account_id: &str,
-        table_name: &str,
-    ) -> BoxFuture<'_, Result<ContinuousBackupsDescription, StorageError>> {
-        let account_id = account_id.to_string();
-        let table_name = table_name.to_string();
-        Box::pin(async move {
-            let exists: bool = sqlx::query_scalar(
-                "SELECT EXISTS(SELECT 1 FROM tables WHERE account_id = $1 AND table_name = $2)",
-            )
-            .bind(&account_id)
-            .bind(&table_name)
-            .fetch_one(&self.pool)
-            .await
-            .map_err(|e| StorageError::Internal(format!("Database error: {e}")))?;
-
-            if !exists {
-                return Err(StorageError::TableNotFound(format!(
-                    "Table not found: {table_name}"
-                )));
-            }
-
-            let pitr_row: Option<(bool,)> = sqlx::query_as(
-                "SELECT pitr_enabled FROM continuous_backups \
-             WHERE account_id = $1 AND table_name = $2",
-            )
-            .bind(&account_id)
-            .bind(&table_name)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(|e| StorageError::Internal(format!("Database error: {e}")))?;
-
-            let pitr_enabled = pitr_row.is_some_and(|r| r.0);
-
-            #[allow(clippy::cast_precision_loss)]
-            let now_epoch = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs() as f64;
-
-            Ok(ContinuousBackupsDescription {
-                continuous_backups_status: "ENABLED".to_owned(),
-                point_in_time_recovery_description: Some(PointInTimeRecoveryDescription {
-                    point_in_time_recovery_status: if pitr_enabled {
-                        "ENABLED".to_owned()
-                    } else {
-                        "DISABLED".to_owned()
-                    },
-                    earliest_restorable_date_time: if pitr_enabled {
-                        Some(now_epoch - 35.0 * 24.0 * 3600.0)
-                    } else {
-                        None
-                    },
-                    latest_restorable_date_time: if pitr_enabled { Some(now_epoch) } else { None },
-                }),
-            })
-        })
-    }
-
-    fn update_continuous_backups(
-        &self,
-        account_id: &str,
-        table_name: &str,
-        pitr_enabled: bool,
-    ) -> BoxFuture<'_, Result<ContinuousBackupsDescription, StorageError>> {
-        let account_id = account_id.to_string();
-        let table_name = table_name.to_string();
-        Box::pin(async move {
-            let exists: bool = sqlx::query_scalar(
-                "SELECT EXISTS(SELECT 1 FROM tables WHERE account_id = $1 AND table_name = $2)",
-            )
-            .bind(&account_id)
-            .bind(&table_name)
-            .fetch_one(&self.pool)
-            .await
-            .map_err(|e| StorageError::Internal(format!("Database error: {e}")))?;
-
-            if !exists {
-                return Err(StorageError::TableNotFound(format!(
-                    "Table not found: {table_name}"
-                )));
-            }
-
-            sqlx::query(
-                "INSERT INTO continuous_backups (account_id, table_name, pitr_enabled) \
-             VALUES ($1, $2, $3) \
-             ON CONFLICT (account_id, table_name) DO UPDATE SET pitr_enabled = $3",
-            )
-            .bind(&account_id)
-            .bind(&table_name)
-            .bind(pitr_enabled)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| StorageError::Internal(format!("Database error: {e}")))?;
-
-            self.describe_continuous_backups(&account_id, &table_name)
-                .await
-        })
-    }
-
-    // TODO(cleanup): This method is unreachable — the engine handler returns
-    // ValidationException("not yet supported") before calling storage. Remove
-    // when real PITR is implemented or during the next storage trait cleanup.
-    fn restore_table_to_point_in_time(
-        &self,
-        account_id: &str,
-        source_table_name: &str,
-        target_table_name: &str,
-    ) -> BoxFuture<'_, Result<TableDescription, StorageError>> {
-        let account_id = account_id.to_string();
-        let source_table_name = source_table_name.to_string();
-        let target_table_name = target_table_name.to_string();
-        Box::pin(async move {
-            let backup = self
-                .create_backup(&account_id, &source_table_name, "__pitr_restore__")
-                .await?;
-            let desc = self
-                .restore_table_from_backup(&account_id, &target_table_name, &backup.backup_arn)
-                .await?;
-            let _ = self.delete_backup(&account_id, &backup.backup_arn).await;
             Ok(desc)
         })
     }

--- a/crates/storage-postgres/src/lib.rs
+++ b/crates/storage-postgres/src/lib.rs
@@ -135,7 +135,7 @@ use sqlx::postgres::PgPoolOptions;
 ///
 /// The tuple is the single source of truth. Use `CATALOG_VERSION.to_string()`
 /// wherever a string representation is needed.
-pub const CATALOG_VERSION: CatalogVersion = CatalogVersion::new(0, 0, 3);
+pub const CATALOG_VERSION: CatalogVersion = CatalogVersion::new(0, 0, 4);
 
 /// Minimum number of connections allowed per pool.
 ///

--- a/crates/storage-postgres/src/migrations.rs
+++ b/crates/storage-postgres/src/migrations.rs
@@ -16,6 +16,10 @@ pub(crate) const CATALOG_MIGRATIONS: &[(&str, &str)] = &[
         "002_vector_indexes.sql",
         include_str!("../../storage-postgres/migrations/002_vector_indexes.sql"),
     ),
+    (
+        "003_drop_continuous_backups.sql",
+        include_str!("../../storage-postgres/migrations/003_drop_continuous_backups.sql"),
+    ),
 ];
 
 /// Run catalog migrations, skipping already-applied ones.
@@ -311,10 +315,10 @@ mod tests {
     fn the_migration_count_and_the_catalog_version_agree() {
         assert_eq!(
             CATALOG_MIGRATIONS.len(),
-            2,
+            3,
             "a catalog migration was added or removed; update CATALOG_VERSION and this count"
         );
-        assert_eq!(CATALOG_VERSION.to_string(), "0.0.3");
+        assert_eq!(CATALOG_VERSION.to_string(), "0.0.4");
     }
 
     /// The version the binary expects must be the version the schema writes.

--- a/crates/storage-postgres/src/migrations.rs
+++ b/crates/storage-postgres/src/migrations.rs
@@ -22,6 +22,12 @@ pub(crate) const CATALOG_MIGRATIONS: &[(&str, &str)] = &[
     ),
 ];
 
+/// The runner's convergence write, executed after the walk over
+/// [`CATALOG_MIGRATIONS`]. Same statement shape as the files' own in-file
+/// writes, parameterized on the compiled version.
+pub(crate) const SET_CATALOG_VERSION_SQL: &str =
+    "UPDATE settings SET value = $1 WHERE key = 'catalog_version'";
+
 /// Run catalog migrations, skipping already-applied ones.
 pub(crate) async fn run_catalog_migrations(pool: &PgPool) -> OpResult<()> {
     println!("--- Running catalog migrations...");
@@ -45,6 +51,20 @@ pub(crate) async fn run_catalog_migrations(pool: &PgPool) -> OpResult<()> {
         // another migration lands.
         record_migration(pool, filename).await?;
     }
+    // The runner owns the final version write. Each file still writes the
+    // version it introduces, but a replay can re-apply an EARLIER file while a
+    // later one stays recorded and skipped: the re-applied file's in-file write
+    // then leaves the stored version behind the schema actually present, the
+    // startup gate refuses the catalog, and a second migrate finds nothing
+    // unrecorded and writes nothing, stranding the deployment. Converging on
+    // the compiled version after every completed walk closes that gap. The
+    // in-file writes stay until #221 moves version ownership into the runner
+    // entirely.
+    sqlx::query(SET_CATALOG_VERSION_SQL)
+        .bind(crate::CATALOG_VERSION.to_string())
+        .execute(pool)
+        .await
+        .map_err(|e| OpError::Internal(format!("Write catalog_version: {e}")))?;
     println!("    Migrations applied.");
     Ok(())
 }
@@ -337,6 +357,19 @@ mod tests {
             sql.contains("catalog_version") && sql.contains(&expected),
             "{filename} must set catalog_version to {expected}"
         );
+    }
+
+    /// The convergence write must target the cell the startup gate reads.
+    ///
+    /// The runner converges the stored version on the compiled constant after
+    /// every walk, so a replay of an earlier file cannot leave the version
+    /// behind the schema actually present. That only holds while this statement
+    /// writes the same settings row the files write and the gate reads, so the
+    /// statement text is pinned against a rename of the key or the table.
+    #[test]
+    fn the_runner_convergence_write_targets_the_catalog_version_cell() {
+        assert!(super::SET_CATALOG_VERSION_SQL.starts_with("UPDATE settings"));
+        assert!(super::SET_CATALOG_VERSION_SQL.contains("key = 'catalog_version'"));
     }
 
     /// Each migration is registered under the filename it is stored as.

--- a/crates/storage-sqlite/src/backup.rs
+++ b/crates/storage-sqlite/src/backup.rs
@@ -5,15 +5,12 @@
 //!
 //! A backup snapshots every item's `item_data` into `backup_items`. Restore
 //! recreates the table via `create_table` and upserts the snapshot under the
-//! engine write lock. `RestoreTableToPointInTime` is implemented as a
-//! snapshot-then-restore (then discard the temporary backup), matching the
-//! PostgreSQL backend's behaviour.
+//! engine write lock.
 
 use extenddb_core::types::{
     AttributeDefinition, BackupDescription, BackupDetails, BackupSummary, BillingMode,
-    ContinuousBackupsDescription, CreateTableInput, KeySchemaElement,
-    PointInTimeRecoveryDescription, ProvisionedThroughput, SourceTableDetails, TableDescription,
-    TableKeyInfo,
+    CreateTableInput, KeySchemaElement, ProvisionedThroughput, SourceTableDetails,
+    TableDescription, TableKeyInfo,
 };
 use extenddb_storage::error::StorageError;
 use extenddb_storage::{BackupEngine, TableEngine};
@@ -422,116 +419,6 @@ impl BackupEngine for SqliteEngine {
                 .await
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
 
-            Ok(desc)
-        })
-    }
-
-    fn describe_continuous_backups(
-        &self,
-        account_id: &str,
-        table_name: &str,
-    ) -> BoxFuture<'_, Result<ContinuousBackupsDescription, StorageError>> {
-        let account_id = account_id.to_owned();
-        let table_name = table_name.to_owned();
-        Box::pin(async move {
-            let exists: bool = sqlx::query_scalar(
-                "SELECT EXISTS(SELECT 1 FROM tables WHERE account_id = ? AND table_name = ?)",
-            )
-            .bind(&account_id)
-            .bind(&table_name)
-            .fetch_one(&self.pool)
-            .await
-            .map_err(|e| StorageError::Internal(e.to_string()))?;
-            if !exists {
-                return Err(StorageError::TableNotFound(table_name));
-            }
-
-            let pitr: Option<(bool,)> = sqlx::query_as(
-                "SELECT pitr_enabled FROM continuous_backups WHERE account_id = ? AND table_name = ?",
-            )
-            .bind(&account_id)
-            .bind(&table_name)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(|e| StorageError::Internal(e.to_string()))?;
-            let enabled = pitr.is_some_and(|r| r.0);
-
-            #[allow(clippy::cast_precision_loss)]
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs() as f64;
-
-            Ok(ContinuousBackupsDescription {
-                continuous_backups_status: "ENABLED".to_owned(),
-                point_in_time_recovery_description: Some(PointInTimeRecoveryDescription {
-                    point_in_time_recovery_status: if enabled { "ENABLED" } else { "DISABLED" }
-                        .to_owned(),
-                    earliest_restorable_date_time: enabled.then_some(now - 35.0 * 24.0 * 3600.0),
-                    latest_restorable_date_time: enabled.then_some(now),
-                }),
-            })
-        })
-    }
-
-    fn update_continuous_backups(
-        &self,
-        account_id: &str,
-        table_name: &str,
-        pitr_enabled: bool,
-    ) -> BoxFuture<'_, Result<ContinuousBackupsDescription, StorageError>> {
-        let account_id = account_id.to_owned();
-        let table_name = table_name.to_owned();
-        Box::pin(async move {
-            let exists: bool = sqlx::query_scalar(
-                "SELECT EXISTS(SELECT 1 FROM tables WHERE account_id = ? AND table_name = ?)",
-            )
-            .bind(&account_id)
-            .bind(&table_name)
-            .fetch_one(&self.pool)
-            .await
-            .map_err(|e| StorageError::Internal(e.to_string()))?;
-            if !exists {
-                return Err(StorageError::TableNotFound(table_name));
-            }
-            {
-                // D1: every writer holds the engine write lock. Scoped so the
-                // read-only describe below runs after release.
-                let _writer = self.write_lock.lock().await;
-                sqlx::query(
-                    "INSERT INTO continuous_backups (account_id, table_name, pitr_enabled) \
-                     VALUES (?, ?, ?) \
-                     ON CONFLICT (account_id, table_name) DO UPDATE SET pitr_enabled = excluded.pitr_enabled",
-                )
-                .bind(&account_id)
-                .bind(&table_name)
-                .bind(pitr_enabled)
-                .execute(&self.pool)
-                .await
-                .map_err(|e| StorageError::Internal(e.to_string()))?;
-            }
-            self.describe_continuous_backups(&account_id, &table_name)
-                .await
-        })
-    }
-
-    fn restore_table_to_point_in_time(
-        &self,
-        account_id: &str,
-        source_table_name: &str,
-        target_table_name: &str,
-    ) -> BoxFuture<'_, Result<TableDescription, StorageError>> {
-        let account_id = account_id.to_owned();
-        let source_table_name = source_table_name.to_owned();
-        let target_table_name = target_table_name.to_owned();
-        Box::pin(async move {
-            let backup = self
-                .create_backup(&account_id, &source_table_name, "__pitr_restore__")
-                .await?;
-            let desc = self
-                .restore_table_from_backup(&account_id, &target_table_name, &backup.backup_arn)
-                .await?;
-            let _ = self.delete_backup(&account_id, &backup.backup_arn).await;
             Ok(desc)
         })
     }

--- a/crates/storage-sqlite/src/schema.rs
+++ b/crates/storage-sqlite/src/schema.rs
@@ -27,7 +27,7 @@ use sqlx::SqlitePool;
 /// Compiled-in catalog version. Single source of truth for the SQLite backend;
 /// mirrors the PostgreSQL backend's `CATALOG_VERSION`.
 pub const CATALOG_VERSION: extenddb_core::version::CatalogVersion =
-    extenddb_core::version::CatalogVersion::new(0, 0, 3);
+    extenddb_core::version::CatalogVersion::new(0, 0, 4);
 
 /// Complete catalog schema, applied once on a fresh database.
 ///
@@ -375,15 +375,10 @@ CREATE TABLE IF NOT EXISTS backup_items (
 
 CREATE INDEX IF NOT EXISTS idx_backup_items_arn ON backup_items (backup_arn);
 
--- Continuous backups / PITR status.
-CREATE TABLE IF NOT EXISTS continuous_backups (
-    account_id TEXT NOT NULL,
-    table_name TEXT NOT NULL,
-    pitr_enabled INTEGER NOT NULL DEFAULT 0,
-    earliest_restorable TEXT,
-    latest_restorable TEXT,
-    PRIMARY KEY (account_id, table_name)
-);
+-- Point-in-time recovery is not supported, so no state is stored for it. A
+-- database created before catalog 0.0.4 carried a `continuous_backups` table;
+-- it is dropped here so a migrated database converges on the fresh shape.
+DROP TABLE IF EXISTS continuous_backups;
 
 -- Persistent queue for async GSI propagation. A row is inserted inside the
 -- base write transaction (zero crash window) and consumed by a background
@@ -426,7 +421,7 @@ INSERT OR IGNORE INTO seq_counters (name, value)
 -- never advance, so a migration could add objects and still leave the server
 -- refusing to start on a version mismatch. Must stay in step with
 -- `CATALOG_VERSION` above; they are checked against each other in a test.
-INSERT INTO settings (key, value) VALUES ('catalog_version', '0.0.3')
+INSERT INTO settings (key, value) VALUES ('catalog_version', '0.0.4')
     ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 INSERT OR IGNORE INTO settings (key, value) VALUES ('control_plane_delay_seconds', '0.25');
 INSERT OR IGNORE INTO settings (key, value) VALUES ('index_propagation_delay_ms', '10');

--- a/crates/storage-sqlite/src/store.rs
+++ b/crates/storage-sqlite/src/store.rs
@@ -602,25 +602,4 @@ mod d1_write_lock_tests {
         )
         .await;
     }
-
-    #[tokio::test]
-    async fn update_continuous_backups_waits_for_the_write_lock() {
-        use extenddb_storage::BackupEngine;
-        let engine = engine().await;
-        // The table must exist before the lock window: the pre-lock existence
-        // check returns TableNotFound otherwise, completing without reaching
-        // the write under test.
-        create_table(&engine, "d1-pitr-t").await;
-        let e = engine.clone();
-        assert_serialized(
-            &engine,
-            async move {
-                BackupEngine::update_continuous_backups(&e, "000000000000", "d1-pitr-t", true)
-                    .await
-                    .expect("update continuous backups");
-            },
-            "update_continuous_backups",
-        )
-        .await;
-    }
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -642,7 +642,11 @@ pub trait WorkerStore: Send + Sync {
     ) -> BoxFuture<'_, Result<Vec<(String, &'static str)>, StorageError>>;
 }
 
-/// Backup and point-in-time recovery operations.
+/// Backup operations.
+///
+/// Point-in-time recovery is deliberately absent: no backend implements it, so
+/// the engine answers `DescribeContinuousBackups`, `UpdateContinuousBackups`,
+/// and `RestoreTableToPointInTime` itself without consulting storage.
 pub trait BackupEngine: Send + Sync {
     /// Create a backup of a table, snapshotting all items.
     fn create_backup(
@@ -691,32 +695,6 @@ pub trait BackupEngine: Send + Sync {
         account_id: &str,
         target_table_name: &str,
         backup_arn: &str,
-    ) -> BoxFuture<'_, Result<TableDescription, StorageError>>;
-
-    /// Describe continuous backups / PITR status for a table.
-    fn describe_continuous_backups(
-        &self,
-        account_id: &str,
-        table_name: &str,
-    ) -> BoxFuture<'_, Result<extenddb_core::types::ContinuousBackupsDescription, StorageError>>;
-
-    /// Update continuous backups (enable/disable PITR).
-    fn update_continuous_backups(
-        &self,
-        account_id: &str,
-        table_name: &str,
-        pitr_enabled: bool,
-    ) -> BoxFuture<'_, Result<extenddb_core::types::ContinuousBackupsDescription, StorageError>>;
-
-    /// Restore a table to a point in time.
-    // TODO(cleanup): This method is unreachable — the engine handler returns
-    // ValidationException("not yet supported") before calling storage. Remove
-    // when real PITR is implemented or during the next storage trait cleanup.
-    fn restore_table_to_point_in_time(
-        &self,
-        account_id: &str,
-        source_table_name: &str,
-        target_table_name: &str,
     ) -> BoxFuture<'_, Result<TableDescription, StorageError>>;
 }
 

--- a/docs/design/15-backup-restore.md
+++ b/docs/design/15-backup-restore.md
@@ -1,0 +1,311 @@
+# Design Spec: Off-Host Backup and Restore for ExtendDB
+
+Status: Draft for maintainer review, 2026-09-10. Target: v1.0. Baseline: main at 4fd2c5f8.
+
+## Summary
+
+ExtendDB backups today are rows inside the same database that holds the data, in a shape private to each storage backend. This spec replaces that with a single portable backup format written to a configured backup store, either a local directory or an S3 bucket, driven by the engine rather than by each backend. The DynamoDB API contract does not change: CreateBackup, DescribeBackup, ListBackups, DeleteBackup, and RestoreTableFromBackup keep their request and response shapes. Backends gain one new obligation, a consistent snapshot iterator over a table, and lose the obligation to implement backup storage themselves. The format is the DynamoDB S3 export layout plus one ExtendDB manifest, so a backup restores into any backend, imports into Amazon DynamoDB with ImportTable, and a DynamoDB export restores into ExtendDB.
+
+The spec also settles point-in-time recovery for v1: unsupported, reported honestly, with the format designed so a later change-log archive can add it.
+
+## Motivation
+
+The v1 readiness analysis (v1gaps-backup-dr.md, v1gaps-data-integrity.md) found:
+
+1. Every backup shares the failure domain of its data. Host, disk, or database loss takes the backups with it. No off-host mechanism exists.
+2. PostgreSQL backup drops the sort key of every composite-key table because it checks for a column literally named sk (backup_engine.rs:100, :548); restore then wedges the table in CREATING.
+3. SQLite and PostgreSQL restore drop GSIs, LSIs, throughput, table class, and encryption settings. SQLite silently drops vector indexes (F-19). MongoDB preserves what it supports. The three backends disagree on what a restore produces.
+4. Backups cannot cross backends or versions because each backend stores its own shape.
+5. Point-in-time recovery reports ENABLED with a 35-day window and can never restore.
+6. Export is not a consistent snapshot (issue #57, PR #80 open).
+7. Loss of the catalog destroys the ability to find or restore backups.
+
+Three separate per-backend fixes would leave items 1, 4, and 7 open. One engine-owned path with a portable format closes all seven.
+
+## Goals
+
+- Backups survive loss of the ExtendDB host and of the backend database when the store is S3.
+- One backup format for all backends; a backup taken on any backend restores on any backend.
+- Restore reproduces what Amazon DynamoDB reproduces: items, key schema, attribute definitions, GSIs, LSIs, billing mode and throughput, table class, and the vector index set. Streams settings, TTL, tags, and PITR settings are not restored, matching DynamoDB.
+- A backup is a consistent snapshot of the table as of one instant.
+- CreateBackup and RestoreTableFromBackup are asynchronous with DynamoDB status transitions; a crash mid-operation leaves state a startup reconciler resolves.
+- The catalog can be rebuilt from the store.
+- Existing API request and response shapes are unchanged.
+
+## Non-goals
+
+- Point-in-time recovery. Phase 3 describes how the format supports it later.
+- Cross-account restore. The backup ARN account must equal the caller account, as today.
+- Backup encryption inside ExtendDB. Encryption at rest is the store's job (S3 SSE-S3 or SSE-KMS, filesystem encryption). The spec states this in the deployment guide.
+- Scheduled backups. Operators schedule CreateBackup externally in v1. Phase 3 adds a scheduler.
+- Multi-instance coordination beyond what the single-instance lease from the readiness plan already provides.
+
+## Detailed design
+
+### 1. Backup format
+
+A backup is a prefix in the store containing:
+
+```
+<root>/<account_id>/<table_name>/<backup_id>/
+  extenddb-manifest.json          written last; its presence means the backup is complete
+  manifest-summary.json           DynamoDB export summary shape
+  manifest-files.json             DynamoDB export file list shape, one JSON object per line
+  data/<part>.json.gz             DynamoDB JSON, one {"Item": {...}} per line, gzip
+```
+
+`manifest-summary.json` and `manifest-files.json` follow the shapes Amazon DynamoDB writes for ExportTableToPointInTime with exportFormat DYNAMODB_JSON, so the `data/` prefix is a valid ImportTable source for the real service and for ExtendDB's own ImportTable. `manifest-files.json` carries per-file `itemCount`, `md5Checksum`, and `dataFileS3Key`, which restore verifies before applying.
+
+`extenddb-manifest.json` is the ExtendDB extension and the commit record:
+
+```json
+{
+  "format_version": 1,
+  "backup_arn": "arn:aws:dynamodb:<region>:<account>:table/<table>/backup/<id>",
+  "backup_name": "...",
+  "backup_creation_date_time": 1757500000.123,
+  "backup_size_bytes": 123456,
+  "source_backend": "postgres",
+  "source_extenddb_version": "0.1.11",
+  "snapshot": { "kind": "postgres_repeatable_read", "marker": "..." },
+  "source_table": {
+    "table_name": "...", "table_id": "...", "table_arn": "...",
+    "table_creation_date_time": 1757400000.0,
+    "key_schema": [...], "attribute_definitions": [...],
+    "billing_mode": "PROVISIONED", "provisioned_throughput": {...}, "on_demand_throughput": null,
+    "table_class": "STANDARD", "sse_specification": {...},
+    "global_secondary_indexes": [...], "local_secondary_indexes": [...],
+    "vector_indexes": [...],
+    "item_count": 100000, "table_size_bytes": 123456
+  },
+  "data_files": [ { "key": "data/000001.json.gz", "item_count": 50000, "sha256": "...", "bytes": 61728 } ],
+  "manifest_sha256": "..."
+}
+```
+
+Rules:
+- The `data/` prefix contains only data files, so ImportTable against that prefix never sees a manifest.
+- `extenddb-manifest.json` is written after every data file and both DynamoDB manifests succeed. A prefix without it is an incomplete backup and is invisible to ListBackups after `backup sync`.
+- `format_version` is checked on restore; unknown versions refuse with a clear error.
+- `vector_indexes` is present when the source backend supports vector search; a restore target without vector support refuses the restore with the existing message ("restoring a table with vector indexes is not supported by this storage backend") rather than dropping them. This closes F-19 uniformly.
+- Numbers are DynamoDB JSON strings, so the 38-digit precision survives the file. A restore into MongoDB of a value beyond Decimal128's 34 digits fails item validation with ValidationException and the restore reports FAILED (see 5.3); it never rounds.
+
+### 2. Backup store abstraction
+
+New crate `crates/backup-store` with one trait and two implementations:
+
+```rust
+pub trait BackupStore: Send + Sync {
+    fn put(&self, key: &str, body: ByteStream) -> BoxFuture<Result<(), StoreError>>;
+    fn get(&self, key: &str) -> BoxFuture<Result<ByteStream, StoreError>>;
+    fn head(&self, key: &str) -> BoxFuture<Result<Option<ObjectMeta>, StoreError>>;
+    fn list(&self, prefix: &str) -> BoxStream<Result<ObjectMeta, StoreError>>;
+    fn delete_prefix(&self, prefix: &str) -> BoxFuture<Result<u64, StoreError>>;
+}
+```
+
+- `FilesystemStore`: root directory from config. Keys map to paths under the root; the existing export-path sandboxing rules apply (canonicalize, refuse traversal, refuse symlinks that resolve outside the root). Writes go to a temporary name and rename into place so a crash never leaves a truncated file under its final name.
+- `S3Store`: bucket, prefix, region, optional endpoint and path-style flag for S3-compatible stores, credentials from the standard AWS SDK chain (environment, shared config, IMDS, IRSA, container credentials). Uploads over `upload_part_size_bytes` use multipart; failed multipart uploads are aborted. Dependency: the official `aws-sdk-s3` crate, chosen over `object_store` because it inherits the SDK credential chain, IRSA support, and retry behavior that operators already configure for other AWS tooling. The dependency adds to the licenses check (Apache-2.0, no notice change expected).
+
+Both implementations are exercised by the same conformance test module in the crate.
+
+### 3. Storage trait changes
+
+`BackupEngine` on the storage trait is reduced to what only a backend can do. Removed: `create_backup`, `describe_backup`, `list_backups`, `delete_backup`, `restore_table_from_backup`, `restore_table_to_point_in_time`. The engine owns those now. Added:
+
+```rust
+pub trait SnapshotEngine: Send + Sync {
+    /// Open a consistent read snapshot of one table and stream every item in it.
+    /// The stream observes the table as of a single instant; writes committed after
+    /// the snapshot opens are not visible. `SnapshotInfo` records how the snapshot
+    /// was taken for the manifest.
+    fn snapshot_items(
+        &self, account_id: &str, table_name: &str,
+    ) -> BoxFuture<Result<(SnapshotInfo, BoxStream<Result<Item, StorageError>>), StorageError>>;
+}
+```
+
+Per-backend implementation:
+- PostgreSQL: a read-only transaction at REPEATABLE READ with a server-side cursor fetched in batches. `SnapshotInfo.marker` records `pg_current_snapshot()`. One transaction per backup, held for the duration of the upload. Long transactions delay vacuum on the table; the deployment guide states this and the worker logs snapshot age.
+- SQLite: a read transaction on a pool connection. In WAL mode a read transaction sees the database as of its first read for its whole duration. The writer lock is not taken, so writes continue.
+- MongoDB: a session with snapshot read concern and a cursor over the base collection. Snapshot history is bounded server-side (`minSnapshotHistoryWindowInSeconds`, default 300), so a slow upload of a large collection can fail with SnapshotTooOld. Mitigation in v1: the worker reads the collection in batches under the snapshot session while buffering to the store; if the cursor fails with SnapshotTooOld the backup fails and the operator raises the server window (documented). Alternative considered: a server-side `$out` copy to a scratch collection, then a plain stream from the copy; rejected for v1 because it doubles storage per backup and the existing restore path already uses `$out` for a different reason. Revisit if operators hit the window.
+- Cassandra: out of scope for this spec. The backend is Experimental at v1 and implements the trait when it graduates.
+
+The continuous-backups methods (describe and update) and the point-in-time restore method leave the trait in the PITR PR; the engine serves those three operations itself (section 6).
+
+Existing in-catalog backup tables (`backups` and per-backend item copies) stay readable for one minor release: `describe_backup`, `list_backups`, and `restore_table_from_backup` on the engine first consult the new catalog index, then fall back to a `LegacyBackupReader` per backend that wraps the current code. `create_backup` never writes the legacy shape again. The upgrade manual tells operators to restore or delete legacy backups before the release that removes the reader.
+
+### 4. Catalog index
+
+The engine keeps a `backups` catalog row per backup as the fast index for Describe and List, and as the state machine record:
+
+```
+backup_id, account_id, table_name, backup_arn, backup_name,
+status            CREATING | AVAILABLE | DELETED | FAILED (internal; surfaced as DELETED)
+store_kind        filesystem | s3
+store_root        the configured root at creation time
+store_key_prefix  <account>/<table>/<backup_id>/
+size_bytes, item_count, created_at, completed_at, failure_reason,
+source_table_details_json
+```
+
+The store is the source of truth; the row is a cache. `extenddb backup sync` lists `<root>/<account>/` prefixes, reads every `extenddb-manifest.json`, and upserts rows, marking rows whose prefix is gone as DELETED and prefixes with no row as AVAILABLE. This is the recovery path when the catalog is lost and the store survives, and it is how a fresh ExtendDB adopts a bucket of backups from another instance.
+
+The ARN encodes account, table, and backup id, and the key prefix is derived from those three fields deterministically, so `describe_backup(arn)` works from the store alone after a sync.
+
+### 5. Operations
+
+#### 5.1 CreateBackup
+
+1. Validate table exists and is ACTIVE for the account (existing checks).
+2. Insert catalog row with status CREATING and a fresh backup id; return `BackupDetails` with BackupStatus CREATING. This matches DynamoDB, where CreateBackup returns CREATING and the backup becomes AVAILABLE shortly after.
+3. Enqueue a backup job. The job runner is a new worker in `crates/server/src/workers`, following the pattern of the existing workers, with the single-instance lease from the readiness plan guaranteeing one runner per catalog.
+4. The job: open the snapshot, stream items into gzip-compressed data files of at most `data_file_target_bytes` (default 64 MiB uncompressed), computing sha256 and md5 and item count per file, upload each as it completes, write `manifest-files.json` and `manifest-summary.json`, write `extenddb-manifest.json`, update the row to AVAILABLE with size and count.
+5. On any failure: abort in-flight multipart uploads, `delete_prefix` the partial backup, set the row FAILED with the reason, log at error level with the request id. DescribeBackup returns the backup as DELETED (DynamoDB has no FAILED status); ListBackups omits it. A metric `backup_jobs_failed_total` increments.
+6. Crash mid-job: on startup the reconciler finds CREATING rows older than `stale_job_after_secs` (default 3600) with no running job, checks the store for a complete manifest (present means AVAILABLE, update the row), otherwise performs step 5.
+
+#### 5.2 DescribeBackup, ListBackups, DeleteBackup
+
+Served from the catalog index with the legacy fallback. DeleteBackup sets the row DELETED, then `delete_prefix` on the store; if the store delete fails the row stays AVAILABLE and the API returns InternalServerError, so a backup is never reported deleted while its bytes remain. The request returns the description with BackupStatus DELETED after both succeed.
+
+#### 5.3 RestoreTableFromBackup
+
+1. Resolve the ARN to a row or, if absent, to a store prefix; read `extenddb-manifest.json`, verify `manifest_sha256`, verify `format_version`.
+2. Validate the target: name free in the account, the target backend supports every feature in `source_table` (vector indexes, table class); refuse before creating anything otherwise.
+3. Create the target table with `defer_active` (the pattern PR #311 introduced for MongoDB, generalized to all backends): base table exists, status CREATING, indexes registered CREATING, no writes accepted. Return `TableDescription` with TableStatus CREATING. DynamoDB returns CREATING from RestoreTableFromBackup as well.
+4. Enqueue a restore job that, per data file, downloads, verifies checksum and item count, validates each item against the key schema and attribute definitions (the ImportTable validation path), and writes items through the backend's bulk-load path with stream capture and TTL disabled (the table has no stream and no TTL at restore). Progress (files completed) is recorded on the job row so a restart resumes at the next file; files are idempotent to re-apply because writes are keyed puts.
+5. After all files: mark the restore backfill pending so the existing GSI, LSI, and vector backfill workers populate indexes (PostgreSQL gsi_pending, MongoDB restore-mode backfill, SQLite inline path), then the table transitions to ACTIVE when every index is ACTIVE. This reuses the deferred activation machinery from #311 and gives every backend the same lifecycle.
+6. Failure: the job marks the restore FAILED, deletes the partially created table (the existing DeleteTable path), and logs the reason with the backup ARN. Crash mid-restore: the reconciler finds CREATING tables with a restore job row and resumes from the recorded file index; a restore job row with no store prefix reachable fails and cleans up.
+
+Restore overrides (`BillingModeOverride`, `ProvisionedThroughputOverride`, `GlobalSecondaryIndexOverride`, `LocalSecondaryIndexOverride`, `SSESpecificationOverride`) are accepted and applied at step 3, matching the DynamoDB request shape; today they are ignored.
+
+#### 5.4 ExportTableToPointInTime and ImportTable
+
+Export gains the store as a target and uses `snapshot_items`, which fixes the inconsistent-snapshot defect (issue #57, PR #80) with the same code. The request's `S3Bucket` and `S3Prefix` are honored when the store is S3 and the bucket matches the configured one (a different bucket is refused with ValidationException naming the configured bucket, since the server holds credentials for one bucket); with a filesystem store the existing path behavior remains. Import gains the same store as a source. The missing sibling operations DescribeExport, ListExports, DescribeImport, ListImports are added over the same job rows so SDK poll loops work (v1gaps-api-fidelity.md gap 6). Export continues to ignore ExportTime and incremental export in v1 and now says so with ValidationException instead of silently ignoring them.
+
+### 6. Point-in-time recovery in v1
+
+- DescribeContinuousBackups returns ContinuousBackupsStatus ENABLED (DynamoDB always reports this) and PointInTimeRecoveryDescription with PointInTimeRecoveryStatus DISABLED and no EarliestRestorableDateTime.
+- UpdateContinuousBackups with PointInTimeRecoveryEnabled true returns ContinuousBackupsUnavailableException, the typed DynamoDB exception modeled on that operation. With false it returns the DISABLED description.
+- RestoreTableToPointInTime first checks that the source table exists (TableNotFoundException otherwise, as the live service does), then returns PointInTimeRecoveryUnavailableException, the typed exception the service models and returns on that operation (live service message: "Point in time recovery is not enabled for table '<name>'").
+- The differences doc gains a row stating PITR is not supported and pointing at on-demand backups.
+- The per-backend `describe_continuous_backups`, `update_continuous_backups`, and `restore_table_to_point_in_time` trait methods and their `continuous_backups` catalog columns are removed.
+
+### 7. Configuration
+
+```toml
+[backup]
+store = "filesystem"                  # "filesystem" | "s3"; filesystem is the default
+data_file_target_bytes = 67108864     # 64 MiB uncompressed per data file
+stale_job_after_secs = 3600
+
+[backup.filesystem]
+path = "/var/lib/extenddb/backups"    # required when store = "filesystem"
+
+[backup.s3]
+bucket = "my-extenddb-backups"        # required when store = "s3"
+prefix = "extenddb/"                  # optional
+region = "us-east-1"                  # optional; SDK chain otherwise
+endpoint = "http://minio:9000"        # optional; S3-compatible stores
+force_path_style = false
+upload_part_size_bytes = 8388608
+max_concurrent_uploads = 4
+```
+
+`deny_unknown_fields` applies, matching the other sections. `extenddb init` writes the `[backup]` section with the filesystem default and a commented S3 example. The startup banner prints the backup store kind and root. A filesystem store keeps the same-host failure domain and the deployment guide says so in the first sentence of the backup section, with S3 as the production recommendation.
+
+Startup validates the store: filesystem root exists and is writable; S3 bucket answers HeadBucket with the configured credentials. Failure is a startup error, not a runtime surprise at the first CreateBackup.
+
+### 8. Security
+
+- Credentials for S3 come from the SDK chain; ExtendDB never stores them in its catalog. The deployment guide gives least-privilege bucket policy examples (PutObject, GetObject, DeleteObject, ListBucket, AbortMultipartUpload on the prefix).
+- Object keys are prefixed by account id, so a tenant's backups are separable by bucket policy or lifecycle rule. The engine refuses any ARN whose account differs from the caller before touching the store.
+- Filesystem store keys are validated with the export-path rules; no key component may be `..` or contain a path separator beyond the fixed layout.
+- Checksums on every data file and on the manifest are verified before any item is written on restore. A checksum mismatch fails the restore and names the file.
+- Backup contents are plaintext DynamoDB JSON inside gzip. Encryption at rest is the store's responsibility and the docs state it. Bucket versioning and object lock are recommended for ransomware resistance; ExtendDB does not depend on either.
+- Management actions (CreateBackup, DeleteBackup, RestoreTableFromBackup, `backup sync`) are audit-logged with account, ARN, and request id.
+
+### 9. Observability
+
+Metrics: `backup_jobs_total{outcome}`, `backup_job_duration_seconds`, `backup_bytes_uploaded_total`, `restore_jobs_total{outcome}`, `restore_job_duration_seconds`, `backup_snapshot_age_seconds` (gauge while a job runs), `backup_store_errors_total{op}`. Logs: one info line at job start and completion with ARN, item count, bytes, duration; one error line per failure with the reason. The `/health` readiness work from the operations report should include store reachability as a component, not as a hard failure (a backup store outage should not take the data plane out of rotation).
+
+### 10. Documentation
+
+- New `docs/manuals/14-backup-and-restore.md`: strategy, RPO and RTO statements per store kind (RPO equals backup interval, no PITR; RTO measured in the acceptance tests and published), configuration, IAM policy example, restore drill procedure, catalog loss recovery with `backup sync`, migrating legacy backups, what a restore preserves and what it does not (the table from the readiness discussion), moving a backup to or from Amazon DynamoDB with ImportTable and export.
+- Corrections: admin guide database names, usage guide "backups not supported" line, differences doc PITR row, limits doc backup rows.
+- Design doc `docs/design/15-backup-restore.md` derived from this spec after review.
+
+## Phasing and work breakdown
+
+Each task is sized for one implementer with an independent review pass after it. Tasks within a phase are independent unless noted.
+
+Phase 0, honesty (S, one PR):
+- T0.1 PITR surface per section 6, with tests for the three operations on all backends. Removes the trait methods and columns.
+
+Phase 1, portable format and store (the v1 blocker):
+- T1.1 `crates/backup-store`: trait, `FilesystemStore`, `S3Store`, conformance tests against a temp dir and a MinIO container. Acceptance: put/get/head/list/delete_prefix round-trip, multipart above the threshold, abort on failure, traversal refused.
+- T1.2 Manifest types and serde in `crates/core`: `extenddb-manifest.json`, DynamoDB `manifest-summary.json` and `manifest-files.json` writers and readers, checksum helpers, `format_version` gate. Acceptance: golden-file tests against a real DynamoDB export captured once and checked in.
+- T1.3 `SnapshotEngine` on PostgreSQL, SQLite, MongoDB with a shared consistency test: a writer thread increments a per-item version while a snapshot streams; every item in the snapshot has a version at or below the snapshot marker and no item is missing or duplicated. PostgreSQL variant must include composite-key tables (the sk regression). Depends on nothing.
+- T1.4 Catalog index table and migration, engine-side Describe, List, Delete with the legacy reader fallback per backend. Acceptance: existing backup tests pass unchanged against legacy backups created by the previous binary.
+- T1.5 CreateBackup job and worker per 5.1, including the reconciler. Acceptance: backup of a 100k-item composite-key table with GSIs on each backend; SIGKILL mid-upload leaves no prefix without a manifest after restart; failure cleans the prefix. Depends on T1.1 to T1.4.
+- T1.6 Restore job per 5.3 with deferred activation generalized to all backends and the override parameters. Acceptance: round trip on each backend preserves items, key schema, GSIs, LSIs, throughput, table class, vector indexes where supported; cross-backend matrix (each source into each target, nine cells, MongoDB targets refuse vector manifests with the documented error); SIGKILL mid-restore resumes; checksum tamper fails before any write. Depends on T1.5.
+- T1.7 `extenddb backup sync` CLI. Acceptance: drop the catalog rows, run sync, Describe and List and Restore work; a prefix without a manifest is not listed.
+- T1.8 Configuration, init template, startup validation, banner line. Acceptance: bad bucket fails startup with the bucket name in the message; config display shows the store.
+- T1.9 CI: MinIO service in the integration workflows, backup and restore suites unfiltered on every backend, the cross-backend matrix on a nightly schedule. Depends on T1.1.
+- T1.10 Documentation per section 10.
+
+Phase 2, unify export and import (v1 if time allows, otherwise v1.1):
+- T2.1 Export through the store with `snapshot_items`; closes #57 and supersedes PR #80. ImportTable from the store. Explicit ValidationException for ExportTime and incremental export.
+- T2.2 DescribeExport, ListExports, DescribeImport, ListImports over job rows.
+- T2.3 Live compatibility check, measured not asserted: import an ExtendDB backup's `data/` prefix into an Amazon DynamoDB table with ImportTable and compare item counts and a sampled item set; restore a real DynamoDB export into ExtendDB. Results recorded in the backup manual.
+
+Phase 3, later (v1.x):
+- Scheduled backups with retention (a cron-like setting per table or account, DeleteBackup after N days).
+- Point-in-time recovery: an internal change-log archive of stream records to `<root>/<account>/<table>/changelog/`, a periodic base snapshot through the Phase 1 path, and restore-to-time as snapshot plus replay. The format reserves the `changelog/` prefix and the manifest reserves a `snapshot.marker` field for this.
+
+## Testing summary
+
+- Unit: manifest serde and golden files, key mapping and ARN parsing, store conformance.
+- Integration, every backend, every PR: round trip with full configuration preservation, composite keys, GSIs and LSIs, vector indexes where supported, legacy fallback, PITR surface.
+- Consistency: concurrent-writer snapshot test on every backend.
+- Crash: SIGKILL during upload and during restore, verified by the reconciler tests. These extend the SIGKILL harness the migration tests already use.
+- Cross-backend matrix: nightly.
+- Live DynamoDB: Phase 2, measured.
+- Performance: backup and restore of a 1M-item table per backend, and of a 1M-item table carrying a vector index on the backends that support one, duration and peak memory recorded as the published RTO baseline; memory must stay flat with table size (streaming, never materializing the table). Index contents are not stored in the backup; every index is rebuilt from the items on restore, so the vector cell measures the dominant restore cost.
+
+## Review checklist for implementation PRs
+
+- No data file is uploaded outside a snapshot; the snapshot is opened before the first read and closed after the last.
+- `extenddb-manifest.json` is written last and only after every other object succeeded.
+- Every failure path deletes the prefix or leaves it unreachable from List, and the row never says AVAILABLE for an incomplete prefix.
+- Restore writes nothing before checksums verify, and refuses before creating the table when the target cannot represent the manifest.
+- Account scoping is checked on the ARN before any store access.
+- No credential, bucket name with credentials, or presigned URL appears in a log line.
+- New workers stop on the shutdown signal within the drain window.
+- Tests create composite-key tables, not only hash-only tables.
+
+## Drawbacks
+
+- Backups are asynchronous where the current implementation is synchronous; clients that assumed AVAILABLE on return must poll, which is what they do against DynamoDB.
+- Long snapshot transactions on PostgreSQL delay vacuum for the backup duration; MongoDB snapshot windows bound backup duration by server configuration.
+- A new dependency on the AWS S3 SDK and a MinIO service in CI.
+- Two code paths for one release while legacy backups remain readable.
+
+## Alternatives considered
+
+- Per-backend fixes to the existing in-catalog backups. Leaves the failure domain, cross-backend, and catalog-loss problems open. Rejected.
+- Backend-native tooling (pg_dump, mongodump, sqlite backup API) documented as the strategy. Cluster-scoped, operator-driven, not per-table, and disconnected from the DynamoDB API. Rejected as the primary path; the manual still mentions it for whole-instance disaster recovery.
+- `object_store` crate instead of `aws-sdk-s3`. Smaller and multi-cloud, but a second credential chain implementation for operators to learn. Rejected for v1; the `BackupStore` trait keeps the option open.
+- A custom binary format instead of the DynamoDB export layout. Faster to parse, but loses ImportTable compatibility in both directions. Rejected.
+
+## Decisions taken 2026-09-10
+
+1. The filesystem store is the default. Local development and the npm launcher keep working with no configuration; the backup manual states in its first sentence that a filesystem store shares the host's failure domain and recommends S3 for production.
+2. The legacy PostgreSQL backup reader is fixed to recover sort keys (the column-named-sk defect) so backups taken before this work restore correctly, in PR 5.
+3. The legacy in-catalog reader ships for one minor release after this work lands, then is removed.
+4. MongoDB snapshots read in batches under a snapshot-read-concern session; the server's snapshot history window is documented as an operator setting. The scratch-copy approach is deferred until an operator hits the window.
+5. This document lands in the repository as `docs/design/15-backup-restore.md` in the first PR; later PRs reference it instead of opening a separate RFC.
+
+## Resolved from the open questions above
+
+Question 1: filesystem default (decision 1). Question 2: batch under snapshot (decision 4). Question 3: a non-configured export bucket is refused with ValidationException naming the configured bucket. Question 4: one minor release (decision 3).

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -17,6 +17,7 @@ This directory contains the authoritative design documents for ExtendDB (extendd
 | 09 | [Testing](09-testing.md) | Test strategy, reference suites, golden files, multi-language test suites, coverage tracking |
 | 10 | [Licenses](10-dependency-licenses.md) | Licensing summary for third-party dependencies |
 | 11 | [Scaling](11-high-availability.md) | DRAFT document on scaling ExtendDB |
+| 15 | [Backup and Restore](15-backup-restore.md) | Off-host portable backup format, backup store abstraction, snapshot engine, restore lifecycle, point-in-time recovery reported as unsupported |
 
 
 ## How to Use These Docs

--- a/docs/differences-from-dynamodb.md
+++ b/docs/differences-from-dynamodb.md
@@ -38,6 +38,12 @@ adaptation when switching between ExtendDB and the real service.
 | Import execution | Asynchronous (background job) | Synchronous (completes before returning) |
 | Export execution | Point-in-time snapshot | Current snapshot, synchronous |
 
+## Backup and Restore
+
+| Area | DynamoDB | ExtendDB |
+|------|----------|------|
+| Point-in-time recovery (PITR) | UpdateContinuousBackups enables continuous backups; RestoreTableToPointInTime restores to any second in the retention window | Not supported. DescribeContinuousBackups reports `ContinuousBackupsStatus: ENABLED` (the service reports this unconditionally) with `PointInTimeRecoveryStatus: DISABLED` and no restorable-time window. UpdateContinuousBackups with `PointInTimeRecoveryEnabled: true` returns `ContinuousBackupsUnavailableException`. RestoreTableToPointInTime resolves the source table first (`TableNotFoundException` for a missing table, as the service reports) and then returns `PointInTimeRecoveryUnavailableException`, the exception the service models on that operation. Use on-demand backups instead: CreateBackup and RestoreTableFromBackup are supported on every backend. |
+
 ## Control Plane
 
 | Area | DynamoDB | ExtendDB |

--- a/docs/dynamodb-limits.md
+++ b/docs/dynamodb-limits.md
@@ -95,8 +95,8 @@ Source: [AWS DynamoDB Service Quotas](https://docs.aws.amazon.com/amazondynamodb
 |-------|---------------|--------|-------|
 | Simultaneous shard readers | 2 (1 for global tables) | Not enforced | No concurrent reader tracking |
 | Max write capacity with streams (provisioned) | 40,000 WCU | Enforced | Same as table WCU limit |
-| GetRecords: max records per call | 1,000 | Not enforced | No per-call record count limit |
-| Shard iterator lifetime | 15 minutes | Not enforced | No shard iterator expiration |
+| GetRecords: max records per call | 1,000 | Enforced | `Limit` is capped at 1,000; a request without a limit reads at most 1,000 records |
+| Shard iterator lifetime | 15 minutes | Enforced | Iterators older than 15 minutes are rejected with `ExpiredIteratorException` |
 
 ## API-Level Limits
 
@@ -128,7 +128,7 @@ Source: [AWS DynamoDB Service Quotas](https://docs.aws.amazon.com/amazondynamodb
 
 | Limit | DynamoDB Value | Status | Notes |
 |-------|---------------|--------|-------|
-| Concurrent restores | 50 | N/A | ExtendDB does not support backup/restore |
+| Concurrent restores | 50 | Not enforced | On-demand backup and restore are supported; no concurrent-restore cap is applied. Point-in-time recovery is not supported. |
 
 ## Global Tables
 
@@ -156,12 +156,12 @@ Source: [AWS DynamoDB Service Quotas](https://docs.aws.amazon.com/amazondynamodb
 | Query/Scan | 2 | 0 | 5 | 0 |
 | Batch Operations | 3 | 0 | 2 | 0 |
 | Transactions | 3 | 0 | 1 | 0 |
-| Streams | 1 | 0 | 3 | 0 |
+| Streams | 3 | 0 | 1 | 0 |
 | API-Level | 1 | 0 | 3 | 1 |
-| Import/Export/Backup | 0 | 0 | 0 | 8 |
+| Import/Export/Backup | 0 | 0 | 1 | 7 |
 | Global Tables | 0 | 0 | 0 | 2 |
 | Contributor Insights | 0 | 0 | 0 | 1 |
-| **Total** | **29** | **0** | **17** | **14** |
+| **Total** | **31** | **0** | **16** | **13** |
 
 ### Unenforced Limits Requiring Tracking
 
@@ -174,10 +174,8 @@ The following unenforced limits are tracked in `docs/technical-debt.md`:
 5. **BatchGetItem response size** (16 MB) — requires aggregate response size tracking
 6. **BatchWriteItem request size** (16 MB) — requires aggregate request size tracking
 7. **Transaction request size** (4 MB) — requires aggregate request size tracking
-8. **GetRecords max per call** (1,000) — requires record count limit in streams
-9. **Shard iterator lifetime** (15 minutes) — requires timestamp tracking on shard iterators
-10. **Tag count per resource** (50) — requires count validation in TagResource
-11. **Tag key/value length** (128/256 chars) — requires length validation in TagResource
+8. **Tag count per resource** (50): requires count validation in TagResource
+9. **Tag key/value length** (128/256 chars): requires length validation in TagResource
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -199,7 +199,7 @@ You should see all checks pass:
 --- Checking catalog connection...
   OK: Connected to catalog.
 --- Checking catalog version...
-  OK: Catalog version 0.0.3
+  OK: Catalog version 0.0.4
 --- Checking data database...
   OK: Connected to data database 'extenddb_catalog_data'.
 --- Enumerating tables...
@@ -215,7 +215,7 @@ extenddb runs as a daemon (background process) and logs to syslog. On startup it
 
 ```bash
 ./target/release/extenddb serve --config extenddb.toml
-# extenddb 0.1.11 (catalog 0.0.3) starting on 127.0.0.1:18443
+# extenddb 0.1.11 (catalog 0.0.4) starting on 127.0.0.1:18443
 #   storage: postgres (postgresql://extenddb:***@localhost:5432/extenddb_catalog)
 ```
 
@@ -1294,7 +1294,7 @@ Each runner requires its tools to be installed. The runner checks prerequisites 
 ```bash
 ./target/release/extenddb version
 # extenddb 0.1.11
-# catalog 0.0.3 (postgres)
+# catalog 0.0.4 (postgres)
 # commit abc1234
 # built 2026-04-17T12:00:00Z
 ```

--- a/docs/manuals/01-architecture-guide.md
+++ b/docs/manuals/01-architecture-guide.md
@@ -172,7 +172,7 @@ extenddb uses a dual-database architecture:
 - **Catalog database** (e.g., `extenddb_catalog`): Stores table metadata, account/user/group/role/policy definitions, access keys, settings, stream metadata, and metrics. Shared across all accounts.
 - **Data database** (e.g., `extenddb_catalog_data`): Stores user items, GSI/LSI data, and stream records. Each table gets its own PostgreSQL table.
 
-The catalog version is 0.0.3 on PostgreSQL and SQLite, stored in the `settings` table under the key `catalog_version` and checked at startup.
+The catalog version is 0.0.4 on PostgreSQL and SQLite, stored in the `settings` table under the key `catalog_version` and checked at startup.
 The MongoDB backend tracks its own catalog version, 0.0.2. <!-- version-literal-ok: MongoDB's backend has its own catalog version, deliberately not the compiled-in constant the documentation guard checks -->
 A mismatch between the compiled-in version and the stored one prevents the server from starting; run `extenddb migrate` to upgrade.
 

--- a/docs/manuals/04-quickstart-setup-guide.md
+++ b/docs/manuals/04-quickstart-setup-guide.md
@@ -130,7 +130,7 @@ Check the version:
 ```bash
 ./target/release/extenddb version
 # extenddb 0.1.11
-# catalog 0.0.3 (postgres)
+# catalog 0.0.4 (postgres)
 # commit abc1234
 # built 2026-04-17T12:00:00Z
 ```
@@ -171,7 +171,7 @@ Expected output:
 --- Checking catalog connection...
   OK: Connected to catalog.
 --- Checking catalog version...
-  OK: Catalog version 0.0.3
+  OK: Catalog version 0.0.4
 --- Checking data database...
   OK: Connected to data database 'extenddb_catalog_data'.
 --- Enumerating tables...

--- a/docs/manuals/07-upgrade-manual.md
+++ b/docs/manuals/07-upgrade-manual.md
@@ -4,9 +4,9 @@
 
 ## Current Status
 
-Catalog 0.0.3 is current. The 0.0.2 to 0.0.3 upgrade is the first in-place catalog upgrade ExtendDB has, and **every existing PostgreSQL deployment must run it**, including deployments that never use vector indexes: the server refuses to start against a catalog version it was not built for.
+Catalog 0.0.4 is current. **Every existing PostgreSQL and SQLite deployment must run the upgrade**: the server refuses to start against a catalog version it was not built for.
 
-See [Catalog 0.0.3](#catalog-003-current) below for what changes and the exact sequence.
+See [Catalog 0.0.4](#catalog-004-current) below for what changes and the exact sequence.
 
 ## How Catalog Upgrades Work
 
@@ -15,8 +15,9 @@ See [Catalog 0.0.3](#catalog-003-current) below for what changes and the exact s
 Migrations are SQL files in `crates/storage-postgres/migrations/`, applied in filename order:
 
 ```
-001_schema.sql            ← the complete initial schema
-002_vector_indexes.sql    ← vector index metadata, catalog 0.0.3
+001_schema.sql                    ← the complete initial schema
+002_vector_indexes.sql            ← vector index metadata, catalog 0.0.3
+003_drop_continuous_backups.sql   ← drops the unused PITR table, catalog 0.0.4
 ```
 
 The `schema_history` table tracks which files have been applied. When `extenddb migrate` runs, it:
@@ -181,7 +182,31 @@ psql -d extenddb_catalog -f catalog_backup_YYYYMMDD.sql
 
 ## Version History
 
-### Catalog 0.0.3 (Current)
+### Catalog 0.0.4 (Current)
+
+Drops the `continuous_backups` table.
+
+Point-in-time recovery is now reported honestly as unsupported. `DescribeContinuousBackups` always answers `PointInTimeRecoveryStatus: DISABLED`, `UpdateContinuousBackups` with `PointInTimeRecoveryEnabled: true` returns `ContinuousBackupsUnavailableException`, and `RestoreTableToPointInTime` resolves the source table (`TableNotFoundException` when it does not exist) and then returns `PointInTimeRecoveryUnavailableException`, the exception the service models on that operation. The engine answers these operations without consulting storage, so the per-table `pitr_enabled` flag the table stored drove nothing and the table is removed.
+
+**This release changes wire behavior.** Before 0.0.4, `UpdateContinuousBackups` accepted an enable request and `DescribeContinuousBackups` then reported `ENABLED` with a 35-day window, even though `RestoreTableToPointInTime` could never restore. Any client or infrastructure template that enables point-in-time recovery (for example a Terraform resource with `point_in_time_recovery = true`) now receives `ContinuousBackupsUnavailableException` and must stop requesting it, and a restore attempt now receives `PointInTimeRecoveryUnavailableException` instead of a generic `ValidationException`. Use on-demand backups (`CreateBackup`, `RestoreTableFromBackup`) instead.
+
+**Every PostgreSQL deployment must apply this**, because the server refuses to start against a catalog version it was not built for. Upgrade sequence:
+
+```bash
+extenddb stop --config extenddb.toml
+extenddb migrate --yes --config extenddb.toml
+extenddb serve --config extenddb.toml
+```
+
+Run `extenddb migrate` without `--yes` first to see what is pending; it reports `catalog 0.0.3 -> 0.0.4` and changes nothing.
+
+SQLite deployments upgrade the same way: `extenddb migrate` re-applies the catalog schema, which drops the `continuous_backups` table and records catalog 0.0.4.
+
+MongoDB deployments need no action. The backend tracks its own catalog version, which does not change; the bootstrapper simply no longer creates the `continuous_backups` collection. An existing deployment keeps an orphaned, unread collection that is harmless to leave in place and safe to drop by hand (`db.getSiblingDB("extenddb_catalog").continuous_backups.drop()`).
+
+The upgrade is not reversible in place: a 0.0.3 binary refuses to start against a 0.0.4 catalog, by the same check in the other direction. Roll back by restoring the catalog backup taken before the upgrade, as described above. No data of value is lost either way: the dropped table held only the meaningless per-table enable flag.
+
+### Catalog 0.0.3
 
 Adds vector index metadata:
 

--- a/docs/manuals/07-upgrade-manual.md
+++ b/docs/manuals/07-upgrade-manual.md
@@ -200,6 +200,8 @@ extenddb serve --config extenddb.toml
 
 Run `extenddb migrate` without `--yes` first to see what is pending; it reports `catalog 0.0.3 -> 0.0.4` and changes nothing.
 
+Starting with this release, the migration runner writes the final catalog version itself after each run, so an upgrade interrupted between applying a migration and recording it converges on the current version when `extenddb migrate` is run again.
+
 SQLite deployments upgrade the same way: `extenddb migrate` re-applies the catalog schema, which drops the `continuous_backups` table and records catalog 0.0.4.
 
 MongoDB deployments need no action. The backend tracks its own catalog version, which does not change; the bootstrapper simply no longer creates the `continuous_backups` collection. An existing deployment keeps an orphaned, unread collection that is harmless to leave in place and safe to drop by hand (`db.getSiblingDB("extenddb_catalog").continuous_backups.drop()`).

--- a/docs/manuals/08-install-linux.md
+++ b/docs/manuals/08-install-linux.md
@@ -118,7 +118,7 @@ Expected:
 ```
 === extenddb verify ===
 ...
-  OK: Catalog version 0.0.3
+  OK: Catalog version 0.0.4
 ...
 === HEALTHY: All checks passed ===
 ```

--- a/docs/manuals/09-install-macos.md
+++ b/docs/manuals/09-install-macos.md
@@ -96,7 +96,7 @@ Expected:
 ```
 === extenddb verify ===
 ...
-  OK: Catalog version 0.0.3
+  OK: Catalog version 0.0.4
 ...
 === HEALTHY: All checks passed ===
 ```

--- a/tests/rust/src/backup_restore.rs
+++ b/tests/rust/src/backup_restore.rs
@@ -225,18 +225,36 @@ async fn describe_continuous_backups() {
         .send()
         .await
         .unwrap();
-    assert!(resp.continuous_backups_description().is_some());
+    let desc = resp.continuous_backups_description().unwrap();
+    assert_eq!(desc.continuous_backups_status().as_str(), "ENABLED");
+    let pitr = desc.point_in_time_recovery_description().unwrap();
+    assert_eq!(
+        pitr.point_in_time_recovery_status().unwrap().as_str(),
+        "DISABLED"
+    );
+    assert!(
+        pitr.earliest_restorable_date_time().is_none(),
+        "a disabled recovery must not report an earliest restorable time"
+    );
+    assert!(
+        pitr.latest_restorable_date_time().is_none(),
+        "a disabled recovery must not report a latest restorable time"
+    );
 
     c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]
-async fn enable_point_in_time_recovery() {
+async fn enable_point_in_time_recovery_is_refused() {
     let c = client();
     let table = format!("PITREnable_{}", ts());
     make_table(&table).await;
 
-    c.update_continuous_backups()
+    // Point-in-time recovery is not supported by any storage backend, so
+    // enabling it must fail with the typed exception rather than report a
+    // recovery capability that can never restore.
+    let err = c
+        .update_continuous_backups()
         .table_name(&table)
         .point_in_time_recovery_specification(
             PointInTimeRecoverySpecification::builder()
@@ -246,8 +264,14 @@ async fn enable_point_in_time_recovery() {
         )
         .send()
         .await
-        .unwrap();
+        .unwrap_err();
+    assert_eq!(
+        err_code(&err),
+        Some("ContinuousBackupsUnavailableException"),
+        "unexpected error: {err:?}"
+    );
 
+    // The refusal must not have changed anything.
     let resp = c
         .describe_continuous_backups()
         .table_name(&table)
@@ -261,19 +285,55 @@ async fn enable_point_in_time_recovery() {
         .unwrap();
     assert_eq!(
         pitr.point_in_time_recovery_status().unwrap().as_str(),
-        "ENABLED"
+        "DISABLED"
     );
 
     c.delete_table().table_name(&table).send().await.ok();
 }
 
 #[tokio::test]
-async fn restore_table_to_point_in_time() {
+async fn disable_point_in_time_recovery_reports_disabled() {
+    let c = client();
+    let table = format!("PITRDisable_{}", ts());
+    make_table(&table).await;
+
+    // Disabling recovery that was never enabled is a no-op that succeeds and
+    // returns the same description DescribeContinuousBackups reports.
+    let resp = c
+        .update_continuous_backups()
+        .table_name(&table)
+        .point_in_time_recovery_specification(
+            PointInTimeRecoverySpecification::builder()
+                .point_in_time_recovery_enabled(false)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let desc = resp.continuous_backups_description().unwrap();
+    assert_eq!(desc.continuous_backups_status().as_str(), "ENABLED");
+    assert_eq!(
+        desc.point_in_time_recovery_description()
+            .unwrap()
+            .point_in_time_recovery_status()
+            .unwrap()
+            .as_str(),
+        "DISABLED"
+    );
+
+    c.delete_table().table_name(&table).send().await.ok();
+}
+
+#[tokio::test]
+async fn restore_table_to_point_in_time_is_refused() {
     let c = client();
     let table = format!("PITRRestore_{}", ts());
     make_table(&table).await;
 
-    // PITR restore is not yet implemented — should return an error.
+    // Point-in-time recovery is not supported, so the restore must fail with
+    // the typed exception the service models on this operation rather than
+    // fabricate a restore of current state.
     let restored = format!("PITRRestored_{}", ts());
     let err = c
         .restore_table_to_point_in_time()
@@ -281,8 +341,13 @@ async fn restore_table_to_point_in_time() {
         .target_table_name(&restored)
         .use_latest_restorable_time(true)
         .send()
-        .await;
-    assert!(err.is_err(), "RestoreTableToPointInTime should return an error (not yet supported)");
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err_code(&err),
+        Some("PointInTimeRecoveryUnavailableException"),
+        "unexpected error: {err:?}"
+    );
 
     c.delete_table().table_name(&table).send().await.ok();
 }

--- a/tests/test_cli_vector_catalog_migration.py
+++ b/tests/test_cli_vector_catalog_migration.py
@@ -1,12 +1,15 @@
 # Copyright 2026 ExtendDB contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Catalog migration tests for the vector index schema (catalog 0.0.2 -> 0.0.3).
+"""Catalog migration tests against a live PostgreSQL deployment.
 
-These exercise the migration against a live deployment rather than asserting the
-SQL text: init one, roll its catalog back to the pre-vector shape, and check that
-the binary refuses to serve it, that `extenddb migrate` upgrades it, and that the
-upgraded deployment then serves.
+These exercise the migration chain end to end rather than asserting the SQL
+text: init a deployment, roll its catalog back to the pre-vector shape, and
+check that the binary refuses to serve it, that `extenddb migrate` upgrades it,
+and that the upgraded deployment then serves.
+
+The version the binary expects is pinned once in `CURRENT_CATALOG_VERSION`; a
+release that adds a catalog migration updates that one constant.
 
 Shared lifecycle helpers and the `cli_env` fixture live in `lifecycle_helpers.py`.
 Like the other CLI lifecycle tests these require a PostgreSQL instance
@@ -29,6 +32,14 @@ from lifecycle_helpers import (
 )
 
 VECTOR_MIGRATION = "002_vector_indexes.sql"
+CONTINUOUS_BACKUPS_MIGRATION = "003_drop_continuous_backups.sql"
+
+# The version the binary expects, written by the last catalog migration. Every
+# current-version assertion reads it from here so the next bump is one edit.
+CURRENT_CATALOG_VERSION = "0.0.4"
+
+# A version no release has reached, for the symmetric version-gate test.
+FUTURE_CATALOG_VERSION = "0.0.5"
 
 
 def _catalog_conn(cli_env):
@@ -80,7 +91,7 @@ def _roll_catalog_back_to_pre_vector(cli_env):
     """Turn a freshly initialised catalog into the shape 0.0.2 deployments have.
 
     Reproduces an upgrade rather than a fresh install, which is the case that
-    matters: a fresh install applies both migrations in order and reaches the same
+    matters: a fresh install applies the migrations in order and reaches the same
     end state trivially.
     """
     conn = _catalog_conn(cli_env)
@@ -89,8 +100,20 @@ def _roll_catalog_back_to_pre_vector(cli_env):
         with conn.cursor() as cur:
             cur.execute("DROP TABLE IF EXISTS vector_indexes")
             cur.execute("ALTER TABLE backups DROP COLUMN IF EXISTS vector_indexes")
+            # A 0.0.2 deployment still has the continuous_backups table (created
+            # by 001, dropped by 003 at init), so put it back the way 001 made it.
             cur.execute(
-                "DELETE FROM schema_history WHERE filename = %s", (VECTOR_MIGRATION,)
+                "CREATE TABLE IF NOT EXISTS continuous_backups ("
+                "account_id TEXT NOT NULL, "
+                "table_name TEXT NOT NULL, "
+                "pitr_enabled BOOLEAN NOT NULL DEFAULT false, "
+                "earliest_restorable TIMESTAMPTZ, "
+                "latest_restorable TIMESTAMPTZ, "
+                "PRIMARY KEY (account_id, table_name))"
+            )
+            cur.execute(
+                "DELETE FROM schema_history WHERE filename IN (%s, %s)",
+                (VECTOR_MIGRATION, CONTINUOUS_BACKUPS_MIGRATION),
             )
             cur.execute("UPDATE settings SET value = '0.0.2' WHERE key = 'catalog_version'")
     finally:
@@ -98,10 +121,10 @@ def _roll_catalog_back_to_pre_vector(cli_env):
 
 
 class TestVectorCatalogMigration:
-    """Catalog version 0.0.3: the vector index table and the backup snapshot."""
+    """Migrations from the pre-vector catalog shape to the current version."""
 
-    def test_init_creates_the_vector_catalog_at_0_0_3(self, cli_env):
-        """A fresh init applies both catalog migrations and records the version.
+    def test_init_creates_the_catalog_at_the_current_version(self, cli_env):
+        """A fresh init applies every catalog migration and records the version.
 
         The version is what the binary checks at startup, so a migration that
         creates the table without moving the version, or the reverse, would leave
@@ -109,7 +132,7 @@ class TestVectorCatalogMigration:
         """
         _init(cli_env)
 
-        assert _catalog_version(cli_env) == "0.0.3"
+        assert _catalog_version(cli_env) == CURRENT_CATALOG_VERSION
         assert _vector_table_exists(cli_env) is True
         assert _backups_has_vector_column(cli_env) is True
 
@@ -124,6 +147,7 @@ class TestVectorCatalogMigration:
         # deployment that is already current. The statements are idempotent too,
         # so a replay after a crash between applying and recording is harmless.
         assert VECTOR_MIGRATION in tracked, tracked
+        assert CONTINUOUS_BACKUPS_MIGRATION in tracked, tracked
 
     def test_migrate_upgrades_a_pre_vector_deployment(self, cli_env):
         """A 0.0.2 deployment is refused, upgraded by migrate, and then serves."""
@@ -148,7 +172,7 @@ class TestVectorCatalogMigration:
             ) from None
         combined = refused_serve.stdout + refused_serve.stderr
         assert refused_serve.returncode != 0, combined
-        assert "0.0.3" in combined and "0.0.2" in combined, combined
+        assert CURRENT_CATALOG_VERSION in combined and "0.0.2" in combined, combined
 
         # Without --yes, migrate reports the pending upgrade and changes nothing.
         pending = _run_extenddb(
@@ -156,7 +180,7 @@ class TestVectorCatalogMigration:
         )
         pending_output = pending.stdout + pending.stderr
         assert pending.returncode != 0, pending_output
-        assert "0.0.2 -> 0.0.3" in pending_output, pending_output
+        assert f"0.0.2 -> {CURRENT_CATALOG_VERSION}" in pending_output, pending_output
         assert _vector_table_exists(cli_env) is False
         assert _catalog_version(cli_env) == "0.0.2"
 
@@ -164,7 +188,7 @@ class TestVectorCatalogMigration:
             "migrate", "--yes", *_pg_args(), config=cli_env["config_path"], check=False
         )
         assert applied.returncode == 0, applied.stdout + applied.stderr
-        assert _catalog_version(cli_env) == "0.0.3"
+        assert _catalog_version(cli_env) == CURRENT_CATALOG_VERSION
         assert _vector_table_exists(cli_env) is True
         assert _backups_has_vector_column(cli_env) is True
 
@@ -270,7 +294,8 @@ class TestVectorCatalogMigration:
             conn.autocommit = True
             with conn.cursor() as cur:
                 cur.execute(
-                    "UPDATE settings SET value = '0.0.4' WHERE key = 'catalog_version'"
+                    "UPDATE settings SET value = %s WHERE key = 'catalog_version'",
+                    (FUTURE_CATALOG_VERSION,),
                 )
         finally:
             conn.close()
@@ -285,8 +310,9 @@ class TestVectorCatalogMigration:
         except subprocess.TimeoutExpired:
             _run_extenddb("stop", config=cli_env["config_path"], check=False)
             raise AssertionError(
-                "serve started against a 0.0.4 catalog; the version gate is not symmetric"
+                f"serve started against a {FUTURE_CATALOG_VERSION} catalog; "
+                "the version gate is not symmetric"
             ) from None
         combined = refused.stdout + refused.stderr
         assert refused.returncode != 0, combined
-        assert "0.0.3" in combined and "0.0.4" in combined, combined
+        assert CURRENT_CATALOG_VERSION in combined and FUTURE_CATALOG_VERSION in combined, combined

--- a/tests/test_cli_vector_catalog_migration.py
+++ b/tests/test_cli_vector_catalog_migration.py
@@ -70,6 +70,12 @@ def _vector_table_exists(cli_env):
     )
 
 
+def _continuous_backups_table_exists(cli_env):
+    return _catalog_query(
+        cli_env, "SELECT to_regclass('public.continuous_backups') IS NOT NULL"
+    )
+
+
 def _backups_has_vector_column(cli_env):
     return _catalog_query(
         cli_env,
@@ -226,8 +232,15 @@ class TestVectorCatalogMigration:
         ledger row missing, which is exactly the state a crash leaves behind.
         Without idempotent statements the replay fails on "relation already
         exists" and no later migration can ever be applied.
+
+        The end state must be the current version even though the replayed file
+        writes an older one, because the runner converges the stored version
+        after the walk. Without that, re-applying 002 while 003 stays recorded
+        would leave the catalog at 0.0.3 with 003's schema applied, and the
+        startup gate would refuse a deployment no further migrate can repair.
         """
         _init(cli_env)
+        _patch_config_port(cli_env["config_path"], cli_env["port"])
         assert _vector_table_exists(cli_env) is True
 
         conn = _catalog_conn(cli_env)
@@ -259,7 +272,7 @@ class TestVectorCatalogMigration:
         assert f"Migration {VECTOR_MIGRATION} failed" not in output, output
 
         # The replay leaves the same end state, and the ledger is repaired.
-        assert _catalog_version(cli_env) == "0.0.3"
+        assert _catalog_version(cli_env) == CURRENT_CATALOG_VERSION
         assert _vector_table_exists(cli_env) is True
         assert _backups_has_vector_column(cli_env) is True
         conn = _catalog_conn(cli_env)
@@ -268,6 +281,64 @@ class TestVectorCatalogMigration:
                 cur.execute(
                     "SELECT COUNT(*) FROM schema_history WHERE filename = %s",
                     (VECTOR_MIGRATION,),
+                )
+                assert cur.fetchone()[0] == 1
+        finally:
+            conn.close()
+
+        # The converged version is what lets the deployment serve again, which
+        # is the point of the convergence: a crash during an upgrade must not
+        # strand the catalog behind the version gate.
+        served = _run_extenddb("serve", config=cli_env["config_path"])
+        assert served.returncode == 0, served.stdout + served.stderr
+        try:
+            assert _wait_for_server(cli_env["port"]), "replayed deployment did not serve"
+        finally:
+            _run_extenddb("stop", config=cli_env["config_path"], check=False)
+            time.sleep(1)
+
+    def test_migrate_survives_an_applied_but_unrecorded_final_migration(self, cli_env):
+        """A replay of the latest migration converges the same way.
+
+        Mirror of the test above for the last file in the chain: 003's schema
+        applied (the table is already gone), its ledger row missing, and the
+        stored version rolled back so the runner walks the list. The replay must
+        re-apply the idempotent drop, repair the ledger, and land the catalog on
+        the current version.
+        """
+        _init(cli_env)
+        assert _continuous_backups_table_exists(cli_env) is False
+
+        conn = _catalog_conn(cli_env)
+        try:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM schema_history WHERE filename = %s",
+                    (CONTINUOUS_BACKUPS_MIGRATION,),
+                )
+                cur.execute(
+                    "UPDATE settings SET value = '0.0.3' WHERE key = 'catalog_version'"
+                )
+        finally:
+            conn.close()
+
+        replayed = _run_extenddb(
+            "migrate", "--yes", *_pg_args(), config=cli_env["config_path"], check=False
+        )
+        output = replayed.stdout + replayed.stderr
+        assert replayed.returncode == 0, output
+        assert f"Applying {CONTINUOUS_BACKUPS_MIGRATION}" in output, output
+        assert f"Migration {CONTINUOUS_BACKUPS_MIGRATION} failed" not in output, output
+
+        assert _catalog_version(cli_env) == CURRENT_CATALOG_VERSION
+        assert _continuous_backups_table_exists(cli_env) is False
+        conn = _catalog_conn(cli_env)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT COUNT(*) FROM schema_history WHERE filename = %s",
+                    (CONTINUOUS_BACKUPS_MIGRATION,),
                 )
                 assert cur.fetchone()[0] == 1
         finally:

--- a/tests/test_continuous_backups.py
+++ b/tests/test_continuous_backups.py
@@ -1,0 +1,110 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Continuous backups and point-in-time recovery surface.
+
+ExtendDB deliberately diverges from real DynamoDB here (see
+docs/differences-from-dynamodb.md): DescribeContinuousBackups always reports
+PointInTimeRecoveryStatus DISABLED, UpdateContinuousBackups refuses to enable
+recovery with ContinuousBackupsUnavailableException, and
+RestoreTableToPointInTime refuses with PointInTimeRecoveryUnavailableException
+after resolving the source table. These tests pin that divergence, so they run
+only against ExtendDB.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from botocore.exceptions import ClientError
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("EXTENDDB_TEST_ENDPOINT", "").strip(),
+    reason="pins ExtendDB's documented divergence: point-in-time recovery is unsupported",
+)
+
+
+def test_describe_continuous_backups_reports_recovery_disabled(
+    dynamodb_client, create_and_cleanup_table, unique_table_name
+):
+    """ContinuousBackupsStatus is ENABLED, recovery is DISABLED, no window."""
+    create_and_cleanup_table()
+    resp = dynamodb_client.describe_continuous_backups(TableName=unique_table_name)
+    desc = resp["ContinuousBackupsDescription"]
+    assert desc["ContinuousBackupsStatus"] == "ENABLED"
+    pitr = desc["PointInTimeRecoveryDescription"]
+    assert pitr["PointInTimeRecoveryStatus"] == "DISABLED"
+    assert "EarliestRestorableDateTime" not in pitr
+    assert "LatestRestorableDateTime" not in pitr
+
+
+def test_enable_point_in_time_recovery_is_refused(
+    dynamodb_client, create_and_cleanup_table, unique_table_name
+):
+    """Enabling recovery fails with the typed exception and changes nothing."""
+    create_and_cleanup_table()
+    with pytest.raises(ClientError) as excinfo:
+        dynamodb_client.update_continuous_backups(
+            TableName=unique_table_name,
+            PointInTimeRecoverySpecification={"PointInTimeRecoveryEnabled": True},
+        )
+    assert (
+        excinfo.value.response["Error"]["Code"]
+        == "ContinuousBackupsUnavailableException"
+    )
+
+    resp = dynamodb_client.describe_continuous_backups(TableName=unique_table_name)
+    assert (
+        resp["ContinuousBackupsDescription"]["PointInTimeRecoveryDescription"][
+            "PointInTimeRecoveryStatus"
+        ]
+        == "DISABLED"
+    )
+
+
+def test_disable_point_in_time_recovery_reports_disabled(
+    dynamodb_client, create_and_cleanup_table, unique_table_name
+):
+    """Disabling recovery that was never enabled succeeds as a no-op."""
+    create_and_cleanup_table()
+    resp = dynamodb_client.update_continuous_backups(
+        TableName=unique_table_name,
+        PointInTimeRecoverySpecification={"PointInTimeRecoveryEnabled": False},
+    )
+    desc = resp["ContinuousBackupsDescription"]
+    assert desc["ContinuousBackupsStatus"] == "ENABLED"
+    assert (
+        desc["PointInTimeRecoveryDescription"]["PointInTimeRecoveryStatus"]
+        == "DISABLED"
+    )
+
+
+def test_restore_to_point_in_time_is_refused(
+    dynamodb_client, create_and_cleanup_table, unique_table_name
+):
+    """Restore on an existing table fails with the restore-modeled exception."""
+    create_and_cleanup_table()
+    with pytest.raises(ClientError) as excinfo:
+        dynamodb_client.restore_table_to_point_in_time(
+            SourceTableName=unique_table_name,
+            TargetTableName=f"{unique_table_name}-restored",
+            UseLatestRestorableTime=True,
+        )
+    err = excinfo.value.response["Error"]
+    assert err["Code"] == "PointInTimeRecoveryUnavailableException"
+    assert unique_table_name in err["Message"]
+
+
+def test_restore_to_point_in_time_missing_source_table(dynamodb_client):
+    """Restore resolves the source table first: a missing table reports
+    TableNotFoundException, not the recovery-unavailable error."""
+    missing = f"extenddb-missing-{uuid.uuid4().hex[:12]}"
+    with pytest.raises(ClientError) as excinfo:
+        dynamodb_client.restore_table_to_point_in_time(
+            SourceTableName=missing,
+            TargetTableName=f"{missing}-restored",
+            UseLatestRestorableTime=True,
+        )
+    assert excinfo.value.response["Error"]["Code"] == "TableNotFoundException"


### PR DESCRIPTION
## What

Reports point-in-time recovery honestly as unsupported, served by the engine for all three backends:

- `DescribeContinuousBackups` returns `ContinuousBackupsStatus: ENABLED` (the service reports this unconditionally) with `PointInTimeRecoveryStatus: DISABLED` and no `EarliestRestorableDateTime` or `LatestRestorableDateTime`.
- `UpdateContinuousBackups` with `PointInTimeRecoveryEnabled: true` returns `ContinuousBackupsUnavailableException` (HTTP 400, `__type com.amazonaws.dynamodb.v20120810#ContinuousBackupsUnavailableException`), the exception the service models on that operation. With `false` it returns the DISABLED description.
- `RestoreTableToPointInTime` resolves the source table first, returning `TableNotFoundException` for a missing table as the live service does, then returns `PointInTimeRecoveryUnavailableException` (HTTP 400, `__type com.amazonaws.dynamodb.v20120810#PointInTimeRecoveryUnavailableException`), the exception the service models on the restore operation, with the live service's message shape ("Point in time recovery is not enabled for table '<name>'").

The `describe_continuous_backups`, `update_continuous_backups`, and `restore_table_to_point_in_time` methods are removed from the `BackupEngine` storage trait and their implementations deleted from the PostgreSQL, SQLite, and MongoDB backends. The stored per-table `pitr_enabled` flag drove nothing, so its storage is removed with the catalog moving to 0.0.4: PostgreSQL migration `003_drop_continuous_backups.sql` drops the `continuous_backups` table, SQLite's schema replaces the CREATE TABLE with `DROP TABLE IF EXISTS`, and MongoDB no longer creates the collection (an existing deployment keeps an orphaned collection that is harmless and safe to drop by hand; the upgrade manual says so).

Doc corrections: `docs/differences-from-dynamodb.md` gains a Backup and Restore section pointing at on-demand backups; `docs/dynamodb-limits.md` fixes three rows that contradicted the code (backup/restore is implemented, the GetRecords 1,000-record cap is enforced, the 15-minute shard iterator expiry is enforced). The upgrade manual no longer states which catalog version is current or what each migration file does: a new section quotes the tooling that reports the installed and expected versions (`extenddb verify`, `extenddb migrate` without `--yes`, and the startup mismatch error), the migrations directory is the reference for per-file purposes, and the wire behavior change is recorded under Behavior Changes by Release. The architecture guide loses its catalog version literals the same way, and the upgrade manual's exemption from the `doc_version_literals` guard is removed so the guard now covers it.

## Why

Point-in-time recovery reported a capability that did not exist. `DescribeContinuousBackups` answered ENABLED with a 35-day window, `UpdateContinuousBackups` accepted an enable request, and `RestoreTableToPointInTime` either returned a generic `ValidationException` or, at the backend layer, fabricated a restore of current state ignoring the requested timestamp. A restore that silently returns the wrong data is worse than a refusal the caller can act on. This is phase 0 (T0.1) of the backup and restore design, which lands as its own PR.

## Testing done

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test --workspace`: 1160 passed, 0 failed across 27 test binaries. Includes unit tests pinning the description shape (restorable-time fields absent on the wire) and each refusal's status, `__type`, and message, plus the migration tripwire tests updated for catalog 0.0.4. The `doc_version_literals` guard passes with the upgrade manual now covered.
- `cargo +1.88.0 check --workspace --locked`: clean.
- New `tests/test_continuous_backups.py` pins the surface through boto3 on every backend: describe shape, enable refused with `ContinuousBackupsUnavailableException`, disable returns DISABLED, restore on an existing table refused with `PointInTimeRecoveryUnavailableException`, restore on a missing table returns `TableNotFoundException`. The rewritten Rust integration tests pin the same behavior through the Rust SDK.
- `devtools/run-tests --extenddb --rust-integration --pytest --backend sqlite --filter backup` against a fresh SQLite deployment (server started on catalog 0.0.4): rust integration 19 passed, 0 failed; pytest 5 passed, 3 skipped (MongoDB-gated).
- Same against a fresh PostgreSQL 16 deployment (fresh init ran migrations 001 through 003): rust integration 19 passed, 0 failed; pytest 5 passed, 3 skipped (MongoDB-gated).
- `devtools/run-mongodb-tests -- --rust-integration --pytest --filter backup` (mongo:7 replica set in Docker, `mongodb-test-hooks` release build): rust integration 19 passed, 0 failed; pytest 8 passed, 0 failed (the 5 new tests plus the MongoDB backup metadata suite).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: the backup and restore design spec PR (section 6, Point-in-time recovery in v1)

## Breaking changes

- **Storage trait**: `BackupEngine` loses `describe_continuous_backups`, `update_continuous_backups`, and `restore_table_to_point_in_time`. Out-of-tree backends implementing these methods must drop them; the engine now answers the three operations without consulting storage.
- **Wire behavior**: `UpdateContinuousBackups` with `PointInTimeRecoveryEnabled: true` previously succeeded and `DescribeContinuousBackups` then reported ENABLED with a 35-day window; both now report DISABLED and the enable request fails with `ContinuousBackupsUnavailableException`. `RestoreTableToPointInTime` moves from a generic `ValidationException` to `TableNotFoundException` for a missing source table and `PointInTimeRecoveryUnavailableException` otherwise. Clients or templates that enable point-in-time recovery (for example Terraform `point_in_time_recovery = true`) will now receive an error and must stop requesting it.
- **Catalog**: version moves to 0.0.4 on PostgreSQL and SQLite (the unused `continuous_backups` table is dropped). Existing deployments must run `extenddb migrate` before the new binary serves; see the upgrade manual. Note for the sqlx migration-runner work: `003_drop_continuous_backups.sql` carries its own `BEGIN`/`COMMIT` and version `UPDATE` for the current runner; a port to a runner that owns transactions and version writes must strip both, the same treatment already prescribed for 002.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
