### PR TITLE
chore(licenses): regenerate MongoDB notices for workspace version 0.1.11

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -7,29 +7,21 @@
 # so it goes stale on any version bump or dependency change. Each production
 # backend has its own manifest because its feature set has its own dependency
 # closure. Until now the only check lived in release-image's gate, so a PR could merge fully green
-# while leaving main unreleasable — exactly what happened with the 0.1.6
+# while leaving main unreleasable, which is what happened with the 0.1.6
 # bump (#271, fixed by #272). This runs the SAME script with the SAME pinned
 # cargo-about (the script refuses any other version), so PR-time and
 # release-time can never disagree.
 #
-# Path-filtered to the generator's actual inputs; the release gate remains
-# the unconditional backstop.
+# The pull_request and merge_group triggers are unconditional because the
+# notices-current job is a required status check: a path-filtered required
+# check never reports on a PR outside its paths, and that PR can never merge.
+# The job takes under three minutes. The push trigger keeps the path filter,
+# since it only reports on main and gates nothing.
 
 name: Licenses
 
 on:
   pull_request:
-    paths:
-      - '**/Cargo.toml'
-      - 'Cargo.lock'
-      - 'SOFTWARE-LICENSE-NOTICES.html'
-      - 'SOFTWARE-LICENSE-NOTICES-MONGODB.html'
-      - 'SOFTWARE-LICENSE-NOTICES-DEV.html'
-      - 'about.toml'
-      - 'about.hbs'
-      - 'devtools/generate-software-license-notices'
-      - 'devtools/generate-dev-license-notices'
-      - '.github/workflows/licenses.yml'
   merge_group:
   push:
     branches: [main]

--- a/SOFTWARE-LICENSE-NOTICES-MONGODB.html
+++ b/SOFTWARE-LICENSE-NOTICES-MONGODB.html
@@ -7113,16 +7113,16 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage-mongodb ">extenddb-storage-mongodb 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage-mongodb ">extenddb-storage-mongodb 0.1.11</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.103</a></li>
                     <li><a href=" https://github.com/andylokandy/arraydeque ">arraydeque 0.5.1</a></li>


### PR DESCRIPTION
## What

Two commits.

1. Regenerates `SOFTWARE-LICENSE-NOTICES-MONGODB.html` with `devtools/generate-software-license-notices --backend mongodb`. Ten lines change, all of them the workspace's own crates moving from 0.1.10 to 0.1.11. No third-party dependency or license text changed.

2. Removes the path filters from the Licenses workflow's `pull_request` and `merge_group` triggers (the `push` trigger keeps its filter). The job takes under three minutes.

## Why

The `Licenses / notices-current` workflow fails on main since the #331 merge (`30ccf1f5`): its "MongoDB notices must be current" step reports the file stale. The file was generated on the #331 branch, which was cut before #332 bumped the workspace version to 0.1.11.

The merge queue accepted #331 with that workflow failing because branch protection required only `test`, `fmt`, and `clippy`. The second commit removes the path filter from the pull_request and merge_group triggers so `notices-current` reports on every PR, which is the precondition for making it a required check. Branch protection now requires `integration`, `mongodb-integration`, and `notices-current` in addition to the three it had; those three aggregate jobs run unconditionally on every pull request and merge group.

## Testing done

```
devtools/generate-software-license-notices --check --backend mongodb    SOFTWARE-LICENSE-NOTICES-MONGODB.html is current
devtools/generate-software-license-notices --check                      SOFTWARE-LICENSE-NOTICES.html is current
git diff | grep -vE '0\.1\.1[01]'                                        no lines other than the version change
```

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`) (no code change)
- [x] Code is formatted (`cargo fmt --check`) (no code change)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`) (no code change)
- [x] I have added or updated tests for new functionality (n/a, generated notices only)
- [x] I have updated documentation if behavior changed (n/a)
- [x] Breaking changes are noted below (if any) (none)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
