### PR TITLE
fix(mongodb): retry the commit, not the transaction, on UnknownTransactionCommitResult

### DIFF
--- a/crates/core/src/settings_keys.rs
+++ b/crates/core/src/settings_keys.rs
@@ -53,6 +53,21 @@ pub const VECTOR_BACKFILL_BATCH_DELAY_MS: &str = "vector_backfill_batch_delay_ms
 /// from claiming one another's gate. Production MongoDB builds do not compile
 /// the hook.
 pub const GSI_BACKFILL_TEST_GATE: &str = "gsi_backfill_test_gate";
+
+/// Test-only gate for the MongoDB commit-retry tests.
+///
+/// A MongoDB test-hook build uses keys of the form
+/// `unknown_commit_test_gate:<table-name>` and the values `armed` and `idle`.
+/// While armed for a table, the next write commit of an UpdateItem on that
+/// table performs the real commit and then reports a synthetic error carrying
+/// the UnknownTransactionCommitResult label, once, then flips itself back to
+/// `idle`. This is the only way a test can place a client-visible write on the
+/// commit-outcome-unknown path deterministically: the real trigger is a
+/// network fault or election in the instant between sending commitTransaction
+/// and reading its reply, a window a test cannot hit on purpose. Production
+/// MongoDB builds do not compile the hook.
+pub const UNKNOWN_COMMIT_TEST_GATE: &str = "unknown_commit_test_gate";
+
 /// Minimum milliseconds an UpdateTable-created vector index stays in `CREATING`
 /// before its `ACTIVE` flip.
 ///

--- a/crates/server/src/management/ops_settings.rs
+++ b/crates/server/src/management/ops_settings.rs
@@ -83,18 +83,33 @@ fn validate_backfill_test_gate(value: &str) -> Result<(), &'static str> {
 }
 
 #[cfg(feature = "mongodb-test-hooks")]
-fn is_table_scoped_backfill_gate_key(key: &str) -> bool {
-    let Some(table_name) = key
-        .strip_prefix(extenddb_core::settings_keys::GSI_BACKFILL_TEST_GATE)
-        .and_then(|suffix| suffix.strip_prefix(':'))
-    else {
-        return false;
-    };
+fn validate_unknown_commit_test_gate(value: &str) -> Result<(), &'static str> {
+    match value {
+        "armed" | "idle" => Ok(()),
+        _ => Err("must be one of: armed, idle"),
+    }
+}
 
-    !table_name.is_empty()
+#[cfg(feature = "mongodb-test-hooks")]
+fn table_scoped_gate_table_name<'a>(key: &'a str, prefix: &str) -> Option<&'a str> {
+    let table_name = key.strip_prefix(prefix)?.strip_prefix(':')?;
+    let valid = !table_name.is_empty()
         && table_name
             .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'));
+    valid.then_some(table_name)
+}
+
+#[cfg(feature = "mongodb-test-hooks")]
+fn is_table_scoped_backfill_gate_key(key: &str) -> bool {
+    table_scoped_gate_table_name(key, extenddb_core::settings_keys::GSI_BACKFILL_TEST_GATE)
+        .is_some()
+}
+
+#[cfg(feature = "mongodb-test-hooks")]
+fn is_table_scoped_unknown_commit_gate_key(key: &str) -> bool {
+    table_scoped_gate_table_name(key, extenddb_core::settings_keys::UNKNOWN_COMMIT_TEST_GATE)
+        .is_some()
 }
 
 fn validate_bool(value: &str) -> Result<(), &'static str> {
@@ -144,9 +159,15 @@ pub async fn set_setting(
         .find(|(k, _)| *k == key)
         .map(|(_, validator)| *validator);
     #[cfg(feature = "mongodb-test-hooks")]
-    let known = known.or_else(|| {
-        is_table_scoped_backfill_gate_key(key).then_some(validate_backfill_test_gate as Validator)
-    });
+    let known = known
+        .or_else(|| {
+            is_table_scoped_backfill_gate_key(key)
+                .then_some(validate_backfill_test_gate as Validator)
+        })
+        .or_else(|| {
+            is_table_scoped_unknown_commit_gate_key(key)
+                .then_some(validate_unknown_commit_test_gate as Validator)
+        });
 
     if let Some(validator) = known {
         validator(value).map_err(|reason| {

--- a/crates/storage-mongodb/src/data_engine.rs
+++ b/crates/storage-mongodb/src/data_engine.rs
@@ -529,13 +529,12 @@ impl MongoEngine {
             .await;
 
             match attempt_res {
-                Ok(return_val) => match session.commit_transaction().await {
-                    Ok(()) => return Ok(return_val),
-                    Err(e) if is_transient_write_conflict(&e) => {
+                Ok(return_val) => match self.commit_write_transaction(&mut session, None).await? {
+                    CommitOutcome::Committed => return Ok(return_val),
+                    CommitOutcome::RerunBody => {
                         backoff_sleep(attempt).await;
                         continue;
                     }
-                    Err(e) => return Err(StorageError::Internal(e.to_string())),
                 },
                 Err(TxErr::Transient) => {
                     let _ = session.abort_transaction().await;
@@ -705,13 +704,12 @@ impl MongoEngine {
             .await;
 
             match attempt_res {
-                Ok(return_val) => match session.commit_transaction().await {
-                    Ok(()) => return Ok(return_val),
-                    Err(e) if is_transient_write_conflict(&e) => {
+                Ok(return_val) => match self.commit_write_transaction(&mut session, None).await? {
+                    CommitOutcome::Committed => return Ok(return_val),
+                    CommitOutcome::RerunBody => {
                         backoff_sleep(attempt).await;
                         continue;
                     }
-                    Err(e) => return Err(StorageError::Internal(e.to_string())),
                 },
                 Err(TxErr::Transient) => {
                     let _ = session.abort_transaction().await;
@@ -1008,14 +1006,18 @@ impl MongoEngine {
             .await;
 
             match attempt_res {
-                Ok(AttemptOk::Committed(old, new)) => match session.commit_transaction().await {
-                    Ok(()) => return Ok((old, new)),
-                    Err(e) if is_transient_write_conflict(&e) => {
-                        backoff_sleep(attempt).await;
-                        continue;
+                Ok(AttemptOk::Committed(old, new)) => {
+                    match self
+                        .commit_write_transaction(&mut session, Some(&key_info.table_name))
+                        .await?
+                    {
+                        CommitOutcome::Committed => return Ok((old, new)),
+                        CommitOutcome::RerunBody => {
+                            backoff_sleep(attempt).await;
+                            continue;
+                        }
                     }
-                    Err(e) => return Err(StorageError::Internal(e.to_string())),
-                },
+                }
                 Ok(AttemptOk::Stale) => {
                     let _ = session.abort_transaction().await;
                     backoff_sleep(attempt).await;
@@ -2310,14 +2312,15 @@ impl MongoEngine {
             .await;
 
             match outcome {
-                Ok(AttemptOutcome::Committed) => match session.commit_transaction().await {
-                    Ok(()) => return Ok(()),
-                    Err(e) if is_transient_write_conflict(&e) => {
-                        backoff_sleep(attempt).await;
-                        continue;
+                Ok(AttemptOutcome::Committed) => {
+                    match self.commit_write_transaction(&mut session, None).await? {
+                        CommitOutcome::Committed => return Ok(()),
+                        CommitOutcome::RerunBody => {
+                            backoff_sleep(attempt).await;
+                            continue;
+                        }
                     }
-                    Err(e) => return Err(StorageError::Internal(e.to_string())),
-                },
+                }
                 Ok(AttemptOutcome::CanceledReasons(reasons)) => {
                     let _ = session.abort_transaction().await;
                     return Err(StorageError::TransactionCanceled(reasons));
@@ -3237,12 +3240,9 @@ impl MongoEngine {
             .await;
 
             match attempt_result {
-                Ok(true) => match session.commit_transaction().await {
-                    Ok(()) => return Ok(()),
-                    Err(e) if is_transient_write_conflict(&e) => {
-                        backoff_sleep(attempt).await;
-                    }
-                    Err(e) => return Err(StorageError::Internal(e.to_string())),
+                Ok(true) => match self.commit_write_transaction(&mut session, None).await? {
+                    CommitOutcome::Committed => return Ok(()),
+                    CommitOutcome::RerunBody => backoff_sleep(attempt).await,
                 },
                 Ok(false) => {
                     let _ = session.abort_transaction().await;
@@ -3338,6 +3338,113 @@ impl MongoEngine {
             }
         }
     }
+    /// Commit a write transaction, retrying the commit itself when its
+    /// outcome is unknown.
+    ///
+    /// `Committed` means the commit applied; `RerunBody` means the
+    /// transaction aborted without committing and the caller's loop may
+    /// re-run its body. On UnknownTransactionCommitResult this loop
+    /// retries `commitTransaction`, which is idempotent, and never the
+    /// body. The driver already retries the commit once internally; this
+    /// bounded loop sits on top. If the retries are exhausted while the
+    /// outcome is still unknown, the returned error says so: the
+    /// transaction was not re-run, so the write applied at most once.
+    ///
+    /// `gate_table` names the table for the unknown-commit test gate and
+    /// is only passed by UpdateItem, the operation the gate is specified
+    /// for. It is ignored in builds without the `test-hooks` feature.
+    async fn commit_write_transaction(
+        &self,
+        session: &mut mongodb::ClientSession,
+        gate_table: Option<&str>,
+    ) -> Result<CommitOutcome, StorageError> {
+        #[cfg(not(feature = "test-hooks"))]
+        let _ = gate_table;
+        for attempt in 0..TRANSIENT_RETRY_ATTEMPTS {
+            let commit_res = session.commit_transaction().await;
+            #[cfg(feature = "test-hooks")]
+            let commit_res = self
+                .inject_unknown_commit_result(commit_res, gate_table)
+                .await;
+            match commit_res {
+                Ok(()) => return Ok(CommitOutcome::Committed),
+                Err(e) => match classify_commit_error(&e) {
+                    CommitErrorClass::RetryCommit => backoff_sleep(attempt).await,
+                    CommitErrorClass::RerunBody => return Ok(CommitOutcome::RerunBody),
+                    CommitErrorClass::Fatal => {
+                        return Err(StorageError::Internal(e.to_string()));
+                    }
+                },
+            }
+        }
+        Err(StorageError::Internal(
+            "commitTransaction outcome is unknown after retries; the transaction was not re-run"
+                .to_owned(),
+        ))
+    }
+
+    /// Consume the unknown-commit test gate for `table_name` if it is armed.
+    ///
+    /// Returns true at most once per arming: the claim is an atomic
+    /// armed-to-idle update, so concurrent commits cannot both win. The gate
+    /// is controlled through the authenticated management settings API and is
+    /// inert unless a test explicitly sets it to `armed`.
+    #[cfg(feature = "test-hooks")]
+    async fn take_unknown_commit_test_gate(&self, table_name: &str) -> bool {
+        let settings = self.catalog_db.collection::<Document>("settings");
+        let key = format!(
+            "{}:{table_name}",
+            extenddb_core::settings_keys::UNKNOWN_COMMIT_TEST_GATE
+        );
+        let armed = settings
+            .find_one(doc! { "_id": &key, "value": "armed" })
+            .await
+            .ok()
+            .flatten();
+        if armed.is_none() {
+            return false;
+        }
+        settings
+            .update_one(
+                doc! { "_id": &key, "value": "armed" },
+                doc! { "$set": { "value": "idle" } },
+            )
+            .await
+            .map(|r| r.modified_count == 1)
+            .unwrap_or(false)
+    }
+
+    /// Test hook: after a successful commit, report the outcome as unknown.
+    ///
+    /// When the unknown-commit gate is armed for `gate_table`, a successful
+    /// `commitTransaction` is replaced by a synthetic error carrying the
+    /// UnknownTransactionCommitResult label, the shape the driver produces
+    /// when the commit was sent but its reply was lost. The commit itself has
+    /// applied, so whatever the caller does next must not apply the
+    /// transaction body again.
+    #[cfg(feature = "test-hooks")]
+    async fn inject_unknown_commit_result(
+        &self,
+        commit_res: mongodb::error::Result<()>,
+        gate_table: Option<&str>,
+    ) -> mongodb::error::Result<()> {
+        let Some(table_name) = gate_table else {
+            return commit_res;
+        };
+        match commit_res {
+            Ok(()) => {
+                if self.take_unknown_commit_test_gate(table_name).await {
+                    Err(synthetic_error_with_labels(
+                        "test hook: commit applied but its outcome was reported unknown",
+                        &[mongodb::error::UNKNOWN_TRANSACTION_COMMIT_RESULT],
+                    ))
+                } else {
+                    Ok(())
+                }
+            }
+            err => err,
+        }
+    }
 }
 
 /// Progress from one `backfill_gsi_batch` invocation.
@@ -3413,10 +3520,14 @@ impl From<StorageError> for TxErr {
 /// abstract labels the raw `WriteConflict` (code 112) still shows up
 /// when a same-document collision surfaces on the write itself rather
 /// than at commit — check that too. RFC-0003 §4.1 / §4.3.
+///
+/// This is the body-level classifier: it answers "may the whole
+/// transaction body be re-run?" and therefore must never match the
+/// UnknownTransactionCommitResult label, under which the commit may
+/// already have applied. Commit errors are classified by
+/// `classify_commit_error` instead.
 fn is_transient_write_conflict(e: &mongodb::error::Error) -> bool {
-    if e.contains_label(mongodb::error::TRANSIENT_TRANSACTION_ERROR)
-        || e.contains_label(mongodb::error::UNKNOWN_TRANSACTION_COMMIT_RESULT)
-    {
+    if e.contains_label(mongodb::error::TRANSIENT_TRANSACTION_ERROR) {
         return true;
     }
     matches!(*e.kind, mongodb::error::ErrorKind::Command(ref c) if c.code == 112)
@@ -3426,6 +3537,47 @@ fn is_transient_write_conflict(e: &mongodb::error::Error) -> bool {
                 mongodb::error::WriteError { code: 112, .. }
             ))
         )
+}
+
+/// How a failed `commitTransaction` must be handled.
+///
+/// MongoDB's contract for transaction commit errors:
+/// UnknownTransactionCommitResult means the commit may already have
+/// applied, and the only safe action is to retry commitTransaction
+/// itself, which is idempotent. TransientTransactionError means nothing
+/// committed and the whole transaction body may be re-run. Re-running
+/// the body after an applied commit applies a non-idempotent write such
+/// as ADD a second time while the client sees a single success.
+enum CommitErrorClass {
+    /// Retry `commitTransaction` itself. Never re-run the body.
+    RetryCommit,
+    /// Nothing committed. The transaction body may be re-run.
+    RerunBody,
+    /// Neither label: surface the error to the caller.
+    Fatal,
+}
+
+/// Classify an error returned by `commitTransaction`.
+///
+/// The unknown label takes precedence: when both labels are present the
+/// commit may have applied, so the body must not be re-run.
+fn classify_commit_error(e: &mongodb::error::Error) -> CommitErrorClass {
+    if e.contains_label(mongodb::error::UNKNOWN_TRANSACTION_COMMIT_RESULT) {
+        CommitErrorClass::RetryCommit
+    } else if e.contains_label(mongodb::error::TRANSIENT_TRANSACTION_ERROR) {
+        CommitErrorClass::RerunBody
+    } else {
+        CommitErrorClass::Fatal
+    }
+}
+
+/// Result of `commit_write_transaction` for the caller's retry loop.
+enum CommitOutcome {
+    /// The transaction committed. Return the attempt's success value.
+    Committed,
+    /// The transaction aborted without committing. The caller may re-run
+    /// its body in the next loop iteration.
+    RerunBody,
 }
 
 /// Detect a duplicate-key error (E11000, code 11000). Used at
@@ -3439,6 +3591,26 @@ fn is_duplicate_key(e: &mongodb::error::Error) -> bool {
             mongodb::error::WriteError { code: 11000, .. }
         ))
     )
+}
+
+/// Build a `mongodb::error::Error` carrying the given error labels.
+///
+/// The driver's `Error::new` is crate private, but `Error::new` copies the
+/// labels of a write concern error into the top-level label set, and
+/// `WriteConcernError` deserializes its labels from the `errorLabels` field.
+/// Deserializing a synthetic write concern error is therefore the one public
+/// route to a labeled error, which the test hook and the classifier unit
+/// tests both need.
+#[cfg(any(test, feature = "test-hooks"))]
+fn synthetic_error_with_labels(message: &str, labels: &[&str]) -> mongodb::error::Error {
+    let wc: mongodb::error::WriteConcernError = bson::from_document(doc! {
+        "code": 64,
+        "codeName": "WriteConcernTimeout",
+        "errmsg": message,
+        "errorLabels": labels.iter().map(|l| (*l).to_owned()).collect::<Vec<_>>(),
+    })
+    .expect("static WriteConcernError document deserializes");
+    mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteConcernError(wc)).into()
 }
 
 /// Exponential-backoff sleep with random jitter. Used inside the OCC
@@ -3860,6 +4032,80 @@ fn project_item(
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Build a labelless server command error with the given code.
+    fn command_error(code: i32) -> mongodb::error::Error {
+        let command_error: mongodb::error::CommandError = bson::from_document(doc! {
+            "code": code,
+            "codeName": "SyntheticTestError",
+            "errmsg": "synthetic command error",
+        })
+        .expect("static CommandError document deserializes");
+        mongodb::error::ErrorKind::Command(command_error).into()
+    }
+
+    #[test]
+    fn unknown_commit_label_retries_the_commit_not_the_body() {
+        let e = synthetic_error_with_labels(
+            "unknown commit outcome",
+            &[mongodb::error::UNKNOWN_TRANSACTION_COMMIT_RESULT],
+        );
+        assert!(matches!(
+            classify_commit_error(&e),
+            CommitErrorClass::RetryCommit
+        ));
+        assert!(
+            !is_transient_write_conflict(&e),
+            "the body-level classifier must not match the unknown commit label"
+        );
+    }
+
+    #[test]
+    fn transient_label_reruns_the_body() {
+        let e = synthetic_error_with_labels(
+            "transaction aborted",
+            &[mongodb::error::TRANSIENT_TRANSACTION_ERROR],
+        );
+        assert!(matches!(
+            classify_commit_error(&e),
+            CommitErrorClass::RerunBody
+        ));
+        assert!(is_transient_write_conflict(&e));
+    }
+
+    #[test]
+    fn unknown_label_takes_precedence_when_both_labels_are_present() {
+        let e = synthetic_error_with_labels(
+            "both labels",
+            &[
+                mongodb::error::TRANSIENT_TRANSACTION_ERROR,
+                mongodb::error::UNKNOWN_TRANSACTION_COMMIT_RESULT,
+            ],
+        );
+        // The commit-site decision is what protects against a double
+        // apply, so the unknown label must win there. The body-level
+        // classifier still matches the transient label; only commit
+        // sites see the unknown label, and they never consult it.
+        assert!(matches!(
+            classify_commit_error(&e),
+            CommitErrorClass::RetryCommit
+        ));
+        assert!(is_transient_write_conflict(&e));
+    }
+
+    #[test]
+    fn write_conflict_code_reruns_the_body_but_never_the_commit() {
+        let e = command_error(112);
+        assert!(is_transient_write_conflict(&e));
+        assert!(matches!(classify_commit_error(&e), CommitErrorClass::Fatal));
+    }
+
+    #[test]
+    fn unrelated_command_error_is_fatal() {
+        let e = command_error(11600);
+        assert!(matches!(classify_commit_error(&e), CommitErrorClass::Fatal));
+        assert!(!is_transient_write_conflict(&e));
+    }
 
     #[derive(Default)]
     struct RecordingGsiIndexWriter {

--- a/tests/test_mongodb_commit_outcome.py
+++ b/tests/test_mongodb_commit_outcome.py
@@ -1,0 +1,134 @@
+# Copyright 2026 ExtendDB contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""MongoDB-specific check: a committed write whose commit outcome is
+reported as unknown must be applied exactly once.
+
+MongoDB signals a lost commitTransaction reply with the
+UnknownTransactionCommitResult error label. The commit may already have
+applied, so the server must retry the commit itself (idempotent) and must
+not re-run the transaction body; re-running the body duplicates a
+non-idempotent write such as ADD. The window is a network fault in the
+instant between sending the commit and reading its reply, which a test
+cannot hit on purpose, so a test-hook gate makes the next UpdateItem
+commit on an armed table succeed and then report the unknown label once.
+
+Requires a server built with mongodb-test-hooks; the tests self-skip when
+not run under devtools/run-mongodb-tests.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import requests
+
+from conftest import wait_for_active, wait_for_deleted
+
+UNKNOWN_COMMIT_TEST_GATE = "unknown_commit_test_gate"
+
+
+@pytest.fixture()
+def mongodb_container() -> str:
+    container = os.environ.get("EXTENDDB_TEST_MONGODB_CONTAINER", "").strip()
+    if not container:
+        pytest.skip("requires devtools/run-mongodb-tests")
+    return container
+
+
+def _gate_url(table_name: str) -> str:
+    endpoint = os.environ.get("EXTENDDB_TEST_ENDPOINT", "").strip()
+    if not endpoint:
+        pytest.skip("requires EXTENDDB_TEST_ENDPOINT")
+    gate_key = f"{UNKNOWN_COMMIT_TEST_GATE}:{table_name}"
+    return f"{endpoint.rstrip('/')}/management/settings/{gate_key}"
+
+
+def _admin_auth() -> tuple[str, str]:
+    user = os.environ.get("EXTENDDB_ADMIN_USER", "admin")
+    password = os.environ.get("EXTENDDB_ADMIN_PASSWORD", "").strip()
+    if not password:
+        pytest.fail("EXTENDDB_ADMIN_PASSWORD is required for the commit gate")
+    return user, password
+
+
+def _set_gate(table_name: str, value: str) -> None:
+    response = requests.put(
+        _gate_url(table_name),
+        auth=_admin_auth(),
+        json={"value": value},
+        timeout=30,
+        verify=False,
+    )
+    if not response.ok:
+        pytest.fail(
+            f"setting unknown-commit gate failed: {response.status_code}: {response.text}"
+        )
+
+
+def _get_gate(table_name: str) -> str:
+    response = requests.get(
+        _gate_url(table_name),
+        auth=_admin_auth(),
+        timeout=30,
+        verify=False,
+    )
+    if not response.ok:
+        pytest.fail(
+            f"reading unknown-commit gate failed: {response.status_code}: {response.text}"
+        )
+    return response.json().get("value", "")
+
+
+def _cleanup_table(client, table_name: str) -> None:
+    try:
+        client.delete_table(TableName=table_name)
+    except client.exceptions.ResourceNotFoundException:
+        return
+    wait_for_deleted(client, table_name)
+
+
+def test_update_item_applied_once_when_commit_outcome_unknown(
+    dynamodb_client, unique_table_name, mongodb_container
+):
+    """One successful ADD must increment by exactly one, even when the
+    first commit's outcome is reported as unknown after it applied."""
+    dynamodb_client.create_table(
+        TableName=unique_table_name,
+        AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    wait_for_active(dynamodb_client, unique_table_name)
+
+    try:
+        _set_gate(unique_table_name, "armed")
+
+        # ReturnValues forces the transactional path; the no-transaction
+        # fast path for unconditional updates never reaches a commit.
+        response = dynamodb_client.update_item(
+            TableName=unique_table_name,
+            Key={"pk": {"S": "counter"}},
+            UpdateExpression="ADD #c :one",
+            ExpressionAttributeNames={"#c": "count"},
+            ExpressionAttributeValues={":one": {"N": "1"}},
+            ReturnValues="ALL_OLD",
+        )
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        # The gate must have been consumed, otherwise the update never
+        # took the guarded commit path and the test proves nothing.
+        assert _get_gate(unique_table_name) == "idle"
+
+        item = dynamodb_client.get_item(
+            TableName=unique_table_name,
+            Key={"pk": {"S": "counter"}},
+            ConsistentRead=True,
+        )["Item"]
+        assert item["count"]["N"] == "1", (
+            f"counter is {item['count']['N']}, the increment was applied "
+            "more than once after a commit whose outcome was reported unknown"
+        )
+    finally:
+        _cleanup_table(dynamodb_client, unique_table_name)


### PR DESCRIPTION
## What

Makes the MongoDB backend handle a lost `commitTransaction` reply correctly: on the `UnknownTransactionCommitResult` label it retries the commit itself and never re-runs the transaction body.

- `is_transient_write_conflict` now recognizes only the `TransientTransactionError` label and WriteConflict code 112, the two signals that a transaction aborted without committing.
- New `classify_commit_error` (`RetryCommit` for the unknown label, which takes precedence; `RerunBody` for the transient label; `Fatal` otherwise) and one helper, `commit_write_transaction`, that retries `commitTransaction` with backoff on `RetryCommit` and reports `RerunBody` or an error to the caller. If the retries are exhausted while the outcome is still unknown, the request fails with an error that says the transaction was not re-run.
- The five write commit sites (PutItem, DeleteItem, UpdateItem, TransactWriteItems, GSI backfill guard) go through the helper. `TxErr::Transient` and `AttemptOk::Stale` handling is unchanged. The read-only TransactGetItems transaction is untouched.
- Test hook, compiled only with `mongodb-test-hooks`: settings key `unknown_commit_test_gate:<table>` (`armed` or `idle`, validated in the management settings API). While armed, the next UpdateItem commit on that table performs the real commit and then reports a synthetic error carrying the unknown label, once, then disarms itself.
- New `tests/test_mongodb_commit_outcome.py` arms the gate, issues one `UpdateItem ADD 1`, and asserts the counter is exactly 1.

## Why

Closes #342.

MongoDB attaches one of two labels to a failed commit. `TransientTransactionError` means nothing committed and the whole transaction may be re-run. `UnknownTransactionCommitResult` means the reply to `commitTransaction` was lost and the commit may already have applied; the driver contract is to retry `commitTransaction` (idempotent), never the body. The classifier treated both labels the same, so every write commit site re-ran the body after a possibly applied commit. That duplicates a non-idempotent write while returning one success to the client.

The MongoDB Integration Tests merge-group run 34602913585 for #331 showed the symptom: `test_concurrency.py::TestAtomicCounter::test_atomic_counter` finished at 5014 after 5000 successful `UpdateItem ADD` calls. The trigger is a network fault or election in the instant between sending the commit and reading its reply, so it is timing dependent; the same commit passed on the post-merge main run.

## Testing done

Failing-first: with the gate infrastructure in place but the classifier unchanged, `test_mongodb_commit_outcome.py` fails with the counter at 2 (body re-run after an applied commit). With the fix it passes with the counter at 1.

```
cargo fmt --all -- --check                      clean
cargo clippy --all-targets -- -D warnings       clean
cargo test -p extenddb-storage-mongodb          96 + 18 + 20 passed, 0 failed (new classification tests included)
cargo test --workspace                          1181 passed, 0 failed
cargo +1.88.0 check --workspace --locked        clean (MSRV)
```

MongoDB suite as CI runs it (`cargo build --release --no-default-features --features mongodb-test-hooks`, then `devtools/run-mongodb-tests -- --pytest --comprehensive --parallel`):

```
pytest suite            980 passed, 22 skipped, 1 xfailed
comprehensive suite     331 passed
tests/test_concurrency.py, three further runs    7 passed, 7 passed, 7 passed
tests/test_mongodb_commit_outcome.py             1 passed
```

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy -- -W clippy::pedantic`)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed (doc comments on the classifier and helper state the contract)
- [x] Breaking changes are noted below (if any) (none)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk
      format, or public CLI surface, an RFC has been accepted or is linked
      below. Otherwise, an ADR captures the decision (link below).

ADR / RFC: n/a. Bug fix within the MongoDB backend's transaction retry path; no wire, trait, auth, on-disk, or CLI change. The new settings key exists only in `mongodb-test-hooks` builds.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
