### PR TITLE
ci: restore integration.yml loading; run and satisfy notices-current

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -283,11 +283,11 @@ jobs:
           EXTENDDB_TEST_PG_CONNECTION_STRING: postgresql://postgres:devpass@127.0.0.1:5432
         run: cargo test --release -p extenddb-storage-postgres --test vector_control_plane
 
-       # The daemonized server logs to syslog; dump it so server-side failures
+      # The daemonized server logs to syslog; dump it so server-side failures
       # are diagnosable from the job log.
       - name: Dump server syslog on failure
         if: failure()
-       run: sudo journalctl -t extenddb --no-pager -n 500 || true
+        run: sudo journalctl -t extenddb --no-pager -n 500 || true
 
   # The runtime-detection proof: the same binary, against a PostgreSQL with no
   # pgvector, must refuse vector indexes over the wire. Today the job above runs
@@ -357,11 +357,11 @@ jobs:
           devtools/run-tests --extenddb --rust-integration --release
           --filter vector_index_unsupported
 
-       # The daemonized server logs to syslog; dump it so server-side failures
+      # The daemonized server logs to syslog; dump it so server-side failures
       # are diagnosable from the job log.
       - name: Dump server syslog on failure
         if: failure()
-       run: sudo journalctl -t extenddb --no-pager -n 500 || true
+        run: sudo journalctl -t extenddb --no-pager -n 500 || true
 
       # No storage-level step here on purpose. Those tests build their own
       # extension-free scratch databases, so they behave identically on either

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -7,29 +7,21 @@
 # so it goes stale on any version bump or dependency change. Each production
 # backend has its own manifest because its feature set has its own dependency
 # closure. Until now the only check lived in release-image's gate, so a PR could merge fully green
-# while leaving main unreleasable — exactly what happened with the 0.1.6
+# while leaving main unreleasable, which is what happened with the 0.1.6
 # bump (#271, fixed by #272). This runs the SAME script with the SAME pinned
 # cargo-about (the script refuses any other version), so PR-time and
 # release-time can never disagree.
 #
-# Path-filtered to the generator's actual inputs; the release gate remains
-# the unconditional backstop.
+# The pull_request and merge_group triggers are unconditional because the
+# notices-current job is a required status check: a path-filtered required
+# check never reports on a PR outside its paths, and that PR can never merge.
+# The job takes under three minutes. The push trigger keeps the path filter,
+# since it only reports on main and gates nothing.
 
 name: Licenses
 
 on:
   pull_request:
-    paths:
-      - '**/Cargo.toml'
-      - 'Cargo.lock'
-      - 'SOFTWARE-LICENSE-NOTICES.html'
-      - 'SOFTWARE-LICENSE-NOTICES-MONGODB.html'
-      - 'SOFTWARE-LICENSE-NOTICES-DEV.html'
-      - 'about.toml'
-      - 'about.hbs'
-      - 'devtools/generate-software-license-notices'
-      - 'devtools/generate-dev-license-notices'
-      - '.github/workflows/licenses.yml'
   merge_group:
   push:
     branches: [main]

--- a/SOFTWARE-LICENSE-NOTICES-MONGODB.html
+++ b/SOFTWARE-LICENSE-NOTICES-MONGODB.html
@@ -7113,16 +7113,16 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.10</a></li>
-                    <li><a href=" https://crates.io/crates/extenddb-storage-mongodb ">extenddb-storage-mongodb 0.1.10</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-app ">extenddb-app 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-auth ">extenddb-auth 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb ">extenddb 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-cache ">extenddb-cache 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-config ">extenddb-config 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-core ">extenddb-core 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-engine ">extenddb-engine 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-server ">extenddb-server 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage ">extenddb-storage 0.1.11</a></li>
+                    <li><a href=" https://crates.io/crates/extenddb-storage-mongodb ">extenddb-storage-mongodb 0.1.11</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.103</a></li>
                     <li><a href=" https://github.com/andylokandy/arraydeque ">arraydeque 0.5.1</a></li>


### PR DESCRIPTION
## What

Three commits, one fix for each link in a circle of required checks that could not report or could not pass:

1. `ci(integration)`: restores four lines of indentation in `.github/workflows/integration.yml` (two syslog-dump comment lines and the two `run: sudo journalctl ...` lines in `run-rust-integration` and `run-rust-integration-postgres-novector`). #312 moved them one column left, so `run:` no longer aligned with its sibling `if:` and `name:` keys and the file stopped parsing.
2. `chore(licenses)`: regenerates `SOFTWARE-LICENSE-NOTICES-MONGODB.html` for workspace version 0.1.11 (cherry-picked from #341, authorship preserved).
3. `ci(licenses)`: removes the `paths:` filter from the `pull_request` and `merge_group` triggers of `licenses.yml` so `notices-current` reports on every pull request (cherry-picked from #341).

This PR supersedes #341, whose two commits it carries unchanged.

## Why

Since #312 merged (10:41 UTC, 2026-09-11) GitHub has been unable to load `integration.yml`: every run is a zero-job failure named by the file path. `main` requires the `integration` status, so every PR opened since is `BLOCKED` with all other checks green. The merge queue merged #312, #291, and #313 without the check because a workflow that fails to load never starts a check run on the merge group, and the queue waits only for checks that start.

Fixing `integration.yml` alone was blocked by `notices-current`: its workflow is path-filtered and did not run here, so the required check sat at Expected. Carrying the trigger change made it run, and it then failed correctly because the MongoDB notices file on `main` is stale. Both of those are #341's fixes, and #341 is blocked on the first commit here. One PR has to carry all three.

Closes #

## Testing done

Both workflow files parsed with PyYAML: `integration.yml` on `main` fails with "while parsing a block collection"; the fixed file loads with all seven jobs; `licenses.yml` loads with unfiltered `pull_request` and `merge_group` triggers.

End to end on this PR: the first commit alone produced a complete "Integration Tests" run with all six jobs passing (15:51 to 16:11 UTC), the first since the breakage. The `notices-current` job ran on the second revision and reported the stale notices file, which the cherry-picked regeneration fixes. This revision's checks are the proof for all three.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] All tests pass (`cargo test --workspace`) (no Rust change)
- [x] Code is formatted (`cargo fmt --check`) (no Rust change)
- [x] Clippy is clean (no Rust change)
- [x] I have added or updated tests for new functionality (n/a, CI configuration and a generated notices file)
- [x] I have updated documentation if behavior changed (n/a)
- [x] Breaking changes are noted below (none)
- [x] If this changes the wire protocol, `Storage` trait, auth model, on-disk format, or public CLI surface, an RFC has been accepted or is linked below. Otherwise, an ADR captures the decision (link below). (n/a)

ADR / RFC: n/a

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.