### PR TITLE
fix(container): pin database sidecars and retry compose pulls

### DIFF
--- a/ci/smoke-test-container.sh
+++ b/ci/smoke-test-container.sh
@@ -87,6 +87,24 @@ compose() {
     "${COMPOSE[@]}" -p "$PROJECT" "$@"
 }
 
+compose_pull_with_retry() {
+    local max_attempts=4
+    local attempt
+
+    for attempt in $(seq 1 "$max_attempts"); do
+        if compose pull "$@"; then
+            return 0
+        fi
+        if (( attempt == max_attempts )); then
+            echo "error: Compose pull failed after $max_attempts attempts" >&2
+            return 1
+        fi
+        local delay=$((5 << (attempt - 1)))
+        echo "warning: Compose pull failed; retrying in ${delay}s (attempt $((attempt + 1))/$max_attempts)" >&2
+        sleep "$delay"
+    done
+}
+
 wait_for_health() {
     local container_id="$1"
     local status=""
@@ -115,6 +133,7 @@ echo "  project: $PROJECT"
 echo "  image:   $EXTENDDB_IMAGE"
 echo "  version: $EXTENDDB_VERSION"
 echo "  commit:  $VCS_REF"
+compose_pull_with_retry postgres
 if [[ "$PREBUILT_IMAGE" == "true" ]]; then
     echo "  mode:    prebuilt (build disabled)"
     compose up -d --no-build

--- a/ci/smoke-test-mongodb-container.sh
+++ b/ci/smoke-test-mongodb-container.sh
@@ -63,6 +63,24 @@ compose() {
     "${COMPOSE[@]}" -f "$COMPOSE_FILE" -p "$PROJECT" "$@"
 }
 
+compose_pull_with_retry() {
+    local max_attempts=4
+    local attempt
+
+    for attempt in $(seq 1 "$max_attempts"); do
+        if compose pull "$@"; then
+            return 0
+        fi
+        if (( attempt == max_attempts )); then
+            echo "error: Compose pull failed after $max_attempts attempts" >&2
+            return 1
+        fi
+        local delay=$((5 << (attempt - 1)))
+        echo "warning: Compose pull failed; retrying in ${delay}s (attempt $((attempt + 1))/$max_attempts)" >&2
+        sleep "$delay"
+    done
+}
+
 wait_for_health() {
     local container_id="$1"
     local status=""
@@ -89,6 +107,7 @@ host_port() {
 echo "=== Building and starting MongoDB container stack ==="
 echo "  project: $PROJECT"
 echo "  image:   $EXTENDDB_MONGODB_IMAGE"
+compose_pull_with_retry mongodb mongodb-rs-init
 if [[ "$PREBUILT_IMAGE" == true ]]; then
     compose up -d --no-build
 else

--- a/docker-compose.mongodb.yml
+++ b/docker-compose.mongodb.yml
@@ -22,7 +22,7 @@ x-extenddb-hardening: &extenddb-hardening
 
 services:
   mongodb:
-    image: ${MONGODB_IMAGE:-mongo:7.0}
+    image: ${MONGODB_IMAGE:-docker.io/library/mongo:7.0@sha256:b096b4cb9269f3ebcf363be63f1c50920f786879d03a1890347a3bf33f1f0df0}
     command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
     healthcheck:
       test:
@@ -34,7 +34,7 @@ services:
       - mongodb-data:/data/db
 
   mongodb-rs-init:
-    image: ${MONGODB_IMAGE:-mongo:7.0}
+    image: ${MONGODB_IMAGE:-docker.io/library/mongo:7.0@sha256:b096b4cb9269f3ebcf363be63f1c50920f786879d03a1890347a3bf33f1f0df0}
     depends_on:
       mongodb:
         condition: service_healthy


### PR DESCRIPTION
## What

Pin the default MongoDB sidecar image to an immutable multi-platform digest, matching the existing PostgreSQL compose configuration. Add bounded exponential retry handling around database sidecar image pulls in both PostgreSQL and MongoDB smoke tests.

## Why

Mutable container tags can resolve to different images over time. Pinning the MongoDB image makes smoke tests reproducible. Docker Hub rate limits can also cause intermittent release failures. Retrying the sidecar pulls makes both smoke tests more resilient. This comes from the comment in #331: https://github.com/ExtendDB/extenddb/pull/331#pullrequestreview-5177631201

Closes #<issue-number>

## Testing done

Passed:

```text
git diff --check
bash -n ci/smoke-test-container.sh
bash -n ci/smoke-test-mongodb-container.sh
cargo fmt --all -- --check
docker compose -f docker-compose.yml config
docker compose -f docker-compose.mongodb.yml config

Ran:
ci/smoke-test-mongodb-container.sh
ci/smoke-test-container.sh
cargo test --workspace
```

## Checklist

- [x] I have read ../CONTRIBUTING.md
- [x] All tests pass (cargo test --workspace)
- [x] Code is formatted (cargo fmt --check)
- [x] Clippy is clean (cargo clippy -- -W clippy::pedantic)
- [x] I have added or updated tests for new functionality
- [x] I have updated documentation if behavior changed
- [x] Breaking changes are noted below (if any)

ADR / RFC: n/a

## Breaking changes

None.

———
By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache License 2.0 and I agree to the Developer Certificate of
Origin (DCO). See ../CONTRIBUTING.md for details.